### PR TITLE
fix emoji/numeric toggle in grades view

### DIFF
--- a/apps/webapp/app/routes/admin.$class.grades/GradesTable.jsx
+++ b/apps/webapp/app/routes/admin.$class.grades/GradesTable.jsx
@@ -198,15 +198,11 @@ const GradesTable = props => {
           <Checkbox checked={showComments} onChange={() => setShowComments(!showComments)}>
             Show Comments
           </Checkbox>
-          {showIssues && (
-            <>
-              <div className="h-[30px] w-[1px] bg-gray-300" />
-              <Radio.Group value={view} onChange={e => setView(e.target.value)} size="small">
-                <Radio.Button value="Emoji">🎨 Emoji</Radio.Button>
-                <Radio.Button value="Numeric">🔢 Numeric</Radio.Button>
-              </Radio.Group>
-            </>
-          )}
+          <div className="h-[30px] w-[1px] bg-gray-300" />
+          <Radio.Group value={view} onChange={e => setView(e.target.value)} size="small">
+            <Radio.Button value="Emoji">🎨 Emoji</Radio.Button>
+            <Radio.Button value="Numeric">🔢 Numeric</Radio.Button>
+          </Radio.Group>
         </div>
       </PageHeader>
 

--- a/apps/webapp/app/routes/admin.$class.grades/columns/assignmentColumns.jsx
+++ b/apps/webapp/app/routes/admin.$class.grades/columns/assignmentColumns.jsx
@@ -244,6 +244,14 @@ export const createAssignmentColumns = (modules, view, showAssignments, emojiMap
             return <span className="text-gray-500 italic">None</span>;
           }
 
+          if (view === 'Emoji') {
+            const allGrades = repository.assignments?.flatMap(a => a.grades || []) || [];
+            if (allGrades.length === 0) {
+              return <span className="text-gray-500 italic">None</span>;
+            }
+            return <EmojisDisplay grades={allGrades} />;
+          }
+
           let grade = calculateRepositoryGrade(
             repository.assignments,
             emojiMappings,


### PR DESCRIPTION
Module columns always showed numeric GradeBadge regardless of the emoji/numeric toggle. Now when emoji mode is selected, module columns display the actual emoji grades from assignments. Also made the toggle always visible instead of hidden behind "Show Assignments" checkbox.