### PR TITLE
fix: hoist @trigger.dev/sdk to root for Docker builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "dependencies": {
         "@infisical/sdk": "^3.0.91",
+        "@trigger.dev/sdk": "4.4.0",
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "highlight.js": "^11.11.1",
@@ -76,50 +77,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "apps/ai-agent/node_modules/@trigger.dev/sdk": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.4.0.tgz",
-      "integrity": "sha512-cW0amtiKsyEcK/aI5QP65i+Ln9/4+YS8GUWXWW09u1Q8gP7oB4Kl9ivJya8SAT2dd2pjhqgeynduah9uSy5mTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/semantic-conventions": "1.36.0",
-        "@trigger.dev/core": "4.4.0",
-        "chalk": "^5.2.0",
-        "cronstrue": "^2.21.0",
-        "debug": "^4.3.4",
-        "evt": "^2.4.13",
-        "slug": "^6.0.0",
-        "ulid": "^2.3.0",
-        "uncrypto": "^0.1.3",
-        "uuid": "^9.0.0",
-        "ws": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "ai": "^4.2.0 || ^5.0.0 || ^6.0.0",
-        "zod": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ai": {
-          "optional": true
-        }
-      }
-    },
-    "apps/ai-agent/node_modules/@trigger.dev/sdk/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "apps/ai-agent/node_modules/eslint": {
@@ -796,50 +753,6 @@
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
-      }
-    },
-    "apps/webapp/node_modules/@trigger.dev/sdk": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.4.0.tgz",
-      "integrity": "sha512-cW0amtiKsyEcK/aI5QP65i+Ln9/4+YS8GUWXWW09u1Q8gP7oB4Kl9ivJya8SAT2dd2pjhqgeynduah9uSy5mTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/semantic-conventions": "1.36.0",
-        "@trigger.dev/core": "4.4.0",
-        "chalk": "^5.2.0",
-        "cronstrue": "^2.21.0",
-        "debug": "^4.3.4",
-        "evt": "^2.4.13",
-        "slug": "^6.0.0",
-        "ulid": "^2.3.0",
-        "uncrypto": "^0.1.3",
-        "uuid": "^9.0.0",
-        "ws": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "ai": "^4.2.0 || ^5.0.0 || ^6.0.0",
-        "zod": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ai": {
-          "optional": true
-        }
-      }
-    },
-    "apps/webapp/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "apps/webapp/node_modules/lucide-react": {
@@ -10779,6 +10692,50 @@
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@trigger.dev/sdk": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.4.0.tgz",
+      "integrity": "sha512-cW0amtiKsyEcK/aI5QP65i+Ln9/4+YS8GUWXWW09u1Q8gP7oB4Kl9ivJya8SAT2dd2pjhqgeynduah9uSy5mTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/semantic-conventions": "1.36.0",
+        "@trigger.dev/core": "4.4.0",
+        "chalk": "^5.2.0",
+        "cronstrue": "^2.21.0",
+        "debug": "^4.3.4",
+        "evt": "^2.4.13",
+        "slug": "^6.0.0",
+        "ulid": "^2.3.0",
+        "uncrypto": "^0.1.3",
+        "uuid": "^9.0.0",
+        "ws": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "ai": "^4.2.0 || ^5.0.0 || ^6.0.0",
+        "zod": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trigger.dev/sdk/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@types/aws-lambda": {
@@ -31326,50 +31283,6 @@
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
-      }
-    },
-    "packages/tasks/node_modules/@trigger.dev/sdk": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.4.0.tgz",
-      "integrity": "sha512-cW0amtiKsyEcK/aI5QP65i+Ln9/4+YS8GUWXWW09u1Q8gP7oB4Kl9ivJya8SAT2dd2pjhqgeynduah9uSy5mTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/semantic-conventions": "1.36.0",
-        "@trigger.dev/core": "4.4.0",
-        "chalk": "^5.2.0",
-        "cronstrue": "^2.21.0",
-        "debug": "^4.3.4",
-        "evt": "^2.4.13",
-        "slug": "^6.0.0",
-        "ulid": "^2.3.0",
-        "uncrypto": "^0.1.3",
-        "uuid": "^9.0.0",
-        "ws": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "ai": "^4.2.0 || ^5.0.0 || ^6.0.0",
-        "zod": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ai": {
-          "optional": true
-        }
-      }
-    },
-    "packages/tasks/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/ui-components": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@infisical/sdk": "^3.0.91",
+    "@trigger.dev/sdk": "4.4.0",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Summary
- Webapp is crash-looping in production with `Cannot find package '@trigger.dev/sdk'`
- npm's hoisting algorithm was placing `@trigger.dev/sdk` in workspace-level `node_modules/` instead of the root
- The Dockerfile only copies root `node_modules/` to the production image, so the SDK was missing at runtime
- Fix: add `@trigger.dev/sdk` to root `package.json` dependencies to force hoisting

## Test plan
- [ ] Verify `@trigger.dev/sdk` exists in `node_modules/@trigger.dev/sdk/` after `npm ci`
- [ ] Deploy to Fly.io and confirm webapp starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)