### PR TITLE
fix: bundle non-hoisted deps in production SSR build

### DIFF
--- a/apps/webapp/vite.config.js
+++ b/apps/webapp/vite.config.js
@@ -5,10 +5,16 @@ import { envOnlyMacros } from 'vite-env-only';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import tailwindcss from '@tailwindcss/vite';
 
-export default () => {
+export default ({ command }) => {
+  const isBuild = command === 'build';
   return defineConfig({
     ssr: {
-      noExternal: ['use-sound'],
+      // In production builds, bundle workspace-local node_modules that npm doesn't
+      // hoist to the root — the Dockerfile only copies root node_modules to the
+      // production image, so non-hoisted packages would be missing at runtime.
+      noExternal: isBuild
+        ? ['use-sound', /@trigger\.dev\//, /@mantine\//, /@tabler\//, 'lucide-react', 'zustand']
+        : ['use-sound'],
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- Follows up on #26 with the proper long-term fix
- Uses Vite's `ssr.noExternal` to bundle non-hoisted workspace packages into the server build at production build time
- Eliminates runtime dependency on npm hoisting behavior — prevents future "Cannot find package" crashes if npm decides not to hoist a workspace dependency
- The root `package.json` workaround from #26 can be removed once this is merged

## Test plan
- [x] `npm run web:build` passes, server bundle size ~2.8 MB (unchanged)
- [x] Deployed to Fly.io and confirmed webapp starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)