### PR TITLE
fix: bump trigger.dev CLI to 4.4.0

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Deploy to Trigger.dev
         working-directory: packages/tasks
-        run: npx trigger.dev@4.3.3 deploy --push
+        run: npx trigger.dev@4.4.0 deploy --push
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
           INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- Bump `npx trigger.dev` CLI version in deploy workflow from 4.3.3 to 4.4.0 to match installed `@trigger.dev/*` packages

## Test plan
- [ ] Trigger.dev deploy CI step passes without version mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)