### PR TITLE
fix(auth): include selfAccessRoles in membership lookup query

### DIFF
--- a/packages/auth/src/server.js
+++ b/packages/auth/src/server.js
@@ -540,7 +540,12 @@ export const assertClassroomAccess = async ({
     });
   }
 
-  const rolesForLookup = Array.isArray(allowedRoles) ? allowedRoles : allowedRoles ? [allowedRoles] : [];
+  // Include selfAccessRoles in the lookup so members with those roles are found
+  // (e.g., a STUDENT with selfAccessRoles can still be found as a classroom member)
+  const rolesForLookup = [...new Set([
+    ...(Array.isArray(allowedRoles) ? allowedRoles : allowedRoles ? [allowedRoles] : []),
+    ...selfAccessRoles,
+  ])];
   const membership = await ClassmojiService.classroomMembership.findByClassroomAndUser(
     classroom.id,
     authData.userId,


### PR DESCRIPTION
The membership DB query in assertClassroomAccess only filtered by allowedRoles, causing students using selfAccessRoles (token purchase, token cancel) to get "Not a member of this classroom" errors. The query now includes both allowedRoles and selfAccessRoles so all potentially-granting roles are found.

Introduced in fbca5ed when the membership lookup was updated to filter by role for the new @@unique([classroom_id, user_id, role]) constraint.