### PR TITLE
fix: respect late override in student-facing UI

### DIFF
--- a/apps/webapp/app/components/ui/display/RepositoryAssignmentStatus.jsx
+++ b/apps/webapp/app/components/ui/display/RepositoryAssignmentStatus.jsx
@@ -3,6 +3,8 @@ import { Tag } from 'antd';
 const RepositoryAssignmentStatus = ({ repositoryAssignment, isDropped }) => {
   const hasLateHours = repositoryAssignment?.num_late_hours > 0;
   const hasExtension = repositoryAssignment?.extension_hours > 0;
+  const isLateOverride = repositoryAssignment?.is_late_override;
+  const isLate = hasLateHours && !isLateOverride;
 
   return (
     <div className="w-full">
@@ -20,9 +22,15 @@ const RepositoryAssignmentStatus = ({ repositoryAssignment, isDropped }) => {
           </Tag>
         )}
 
-        {hasLateHours && (
+        {isLate && (
           <Tag color="orange" bordered={false}>
             Late
+          </Tag>
+        )}
+
+        {hasLateHours && isLateOverride && (
+          <Tag color="green" bordered={false}>
+            Late Excused
           </Tag>
         )}
 
@@ -33,8 +41,8 @@ const RepositoryAssignmentStatus = ({ repositoryAssignment, isDropped }) => {
         )}
       </div>
 
-      {/* Late Information - only show if there are still late hours remaining */}
-      {hasLateHours && (
+      {/* Late Information - only show if late and not overridden */}
+      {isLate && (
         <div className="flex flex-col gap-1 ml-2 mt-3">
           {hasExtension && (
             <p className="text-sm italic text-blue-500">

--- a/apps/webapp/app/routes/student.$class.dashboard/TokenPopupForm.jsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/TokenPopupForm.jsx
@@ -126,7 +126,7 @@ const TokenPopupForm = ({ repositoryAssignment, balance }) => {
 
   const hasDeadlinePassed = dayjs(repositoryAssignment.assignment.student_deadline).isBefore(dayjs());
 
-  if (hasDeadlinePassed == false || repositoryAssignment.num_late_hours == 0) return null;
+  if (hasDeadlinePassed == false || repositoryAssignment.num_late_hours == 0 || repositoryAssignment.is_late_override) return null;
 
   return (
     <Popover

--- a/apps/webapp/app/routes/student.$class.dashboard/route.jsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/route.jsx
@@ -192,15 +192,23 @@ const StudentDashboard = ({ loaderData }) => {
           <div>
             <Countdown deadline={deadline} />
             <div className="mt-2">
-              {record.extension_hours > 0 && record.num_late_hours > 0 && (
-                <p className="pt-2 text-sm font-semibold text-green-600 ">
-                  ➖ {record.extension_hours} extension hour(s).
+              {record.num_late_hours > 0 && record.is_late_override ? (
+                <p className="pt-2 text-sm font-semibold text-green-600">
+                  ✓ Late penalty waived by instructor.
                 </p>
-              )}
-              {record.num_late_hours > 0 && (
-                <p className="pt-2 text-sm font-semibold text-red-600 ">
-                  ⚠️ {record.num_late_hours} hour(s) late.
-                </p>
+              ) : (
+                <>
+                  {record.extension_hours > 0 && record.num_late_hours > 0 && (
+                    <p className="pt-2 text-sm font-semibold text-green-600">
+                      ➖ {record.extension_hours} extension hour(s).
+                    </p>
+                  )}
+                  {record.num_late_hours > 0 && (
+                    <p className="pt-2 text-sm font-semibold text-red-600">
+                      ⚠️ {record.num_late_hours} hour(s) late.
+                    </p>
+                  )}
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Student views were using `num_late_hours` (raw calculation) instead of checking `is_late_override`, so assignments with an instructor-applied late override still appeared as "Late" to students
- Now shows a green **"Late Excused"** tag and **"✓ Late penalty waived by instructor"** message when override is active
- Hides the token extension purchase button when override is active (no need to buy extensions if penalty is already waived)

## Files changed
- `RepositoryAssignmentStatus.jsx` — gates "Late" tag on override, adds "Late Excused" tag
- `student.$class.dashboard/route.jsx` — shows waived message instead of late warning
- `student.$class.dashboard/TokenPopupForm.jsx` — hides purchase button when overridden

## Test plan
- [ ] Apply a late override to a student's assignment as an instructor
- [ ] Verify student sees "Late Excused" green tag instead of "Late" orange tag
- [ ] Verify student dashboard shows "✓ Late penalty waived by instructor" instead of late hours warning
- [ ] Verify token purchase extension button is hidden for overridden assignments
- [ ] Verify non-overridden late assignments still show "Late" tag and hours as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)