### PR TITLE
fix(tasks): minor trigger.config warning message fix

### DIFF
--- a/packages/tasks/trigger.config.js
+++ b/packages/tasks/trigger.config.js
@@ -35,7 +35,7 @@ export default defineConfig({
 
         // Skip sync if credentials not available (allows local dev without Infisical)
         if (!process.env.INFISICAL_CLIENT_ID || !process.env.INFISICAL_CLIENT_SECRET) {
-          console.warn('[Infisical] Credentials not found, skipping secret sync');
+          console.warn('[Infisical] Credentials not found, skipping secret sync.');
           return {};
         }
 


### PR DESCRIPTION
## Summary

- Adds trailing period to the Infisical credentials warning log in `trigger.config.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)