### PR TITLE
Fixed the search on grading page

### DIFF
--- a/apps/webapp/app/routes/admin.$class.grades/GradesTable.jsx
+++ b/apps/webapp/app/routes/admin.$class.grades/GradesTable.jsx
@@ -39,7 +39,8 @@ const GradesTable = props => {
       const name = student.name?.toLowerCase() || '';
       const login = student.login?.toLowerCase() || '';
       const email = student.email?.toLowerCase() || '';
-      return name.includes(query) || login.includes(query) || email.includes(query);
+      const providerEmail = student.provider_email?.toLowerCase() || '';
+      return name.includes(query) || login.includes(query) || email.includes(query) || providerEmail.includes(query);
     });
   }, [students, searchQuery]);
 

--- a/apps/webapp/app/routes/admin.$class.students/route.jsx
+++ b/apps/webapp/app/routes/admin.$class.students/route.jsx
@@ -54,11 +54,15 @@ const StudentsScreen = ({ loaderData }) => {
 
   const filteredStudents = !query
     ? allStudents
-    : allStudents.filter(
-        student =>
-          student.name?.toLowerCase().includes(query.toLowerCase()) ||
-          student?.login?.toLowerCase().includes(query.toLowerCase())
-      );
+    : allStudents.filter(student => {
+        const q = query.toLowerCase();
+        return (
+          student.name?.toLowerCase().includes(q) ||
+          student.login?.toLowerCase().includes(q) ||
+          student.email?.toLowerCase().includes(q) ||
+          student.provider_email?.toLowerCase().includes(q)
+        );
+      });
 
   return (
     <>

--- a/apps/webapp/app/routes/assistant.$class_.grading/RepositoryAssignmentsTable.jsx
+++ b/apps/webapp/app/routes/assistant.$class_.grading/RepositoryAssignmentsTable.jsx
@@ -26,12 +26,25 @@ const RepositoryAssignmentsTable = ({
   const { classroom } = useStore(state => state);
 
   useEffect(() => {
-    if (showMyAssignments) {
-      setAssignmentsList(repositoryAssignments);
-    } else {
-      setAssignmentsList(allRepositoryAssignments);
+    const base = showMyAssignments ? repositoryAssignments : allRepositoryAssignments;
+    if (!userQuery.trim()) {
+      setAssignmentsList(base);
+      return;
     }
-  }, [showMyAssignments, repositoryAssignments, allRepositoryAssignments]);
+    const q = userQuery.toLowerCase();
+    setAssignmentsList(
+      base.filter(a => {
+        const student = a.repository?.student;
+        const team = a.repository?.team;
+        return (
+          student?.name?.toLowerCase().includes(q) ||
+          student?.login?.toLowerCase().includes(q) ||
+          team?.name?.toLowerCase().includes(q) ||
+          team?.slug?.toLowerCase().includes(q)
+        );
+      })
+    );
+  }, [showMyAssignments, repositoryAssignments, allRepositoryAssignments, userQuery]);
 
   // Filter functions for different tabs
   const filterAssignments = (assignments, tab) => {


### PR DESCRIPTION
Previously, the search bar in the Students, Grades, and Grading tables only matched on student name and GitHub login. This meant searching by email address returned no results.

## Changes
- **admin.class.students** — filter now includes `email` and `provider_email`
- **admin.class.grades / GradesTable** — filter now includes `provider_email`
- **assistant.class.grading / RepositoryAssignmentsTable** — wired up `userQuery` to actually filter the table (it had no effect before); filters on student name, login, team name, and team slug