### PR TITLE
chore: add staging deploy workflow and rename prod workflow

### DIFF
--- a/.github/workflows/deploy-fly-prod.yml
+++ b/.github/workflows/deploy-fly-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Fly.io
+name: Deploy to Fly.io (Production)
 
 on:
   push:

--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -1,0 +1,121 @@
+name: Deploy to Fly.io (Staging)
+
+on:
+  push:
+    branches:
+      - staging
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Detect which apps have changes
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      webapp: ${{ steps.filter.outputs.webapp }}
+      ai-agent: ${{ steps.filter.outputs.ai-agent }}
+      hook-station: ${{ steps.filter.outputs.hook-station }}
+      site: ${{ steps.filter.outputs.site }}
+      slides: ${{ steps.filter.outputs.slides }}
+      pages: ${{ steps.filter.outputs.pages }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            webapp:
+              - 'apps/webapp/**'
+              - 'packages/**'
+            ai-agent:
+              - 'apps/ai-agent/**'
+              - 'packages/**'
+            hook-station:
+              - 'apps/hook-station/**'
+              - 'packages/**'
+            site:
+              - 'apps/site/**'
+            slides:
+              - 'apps/slides/**'
+              - 'packages/**'
+            pages:
+              - 'apps/pages/**'
+              - 'packages/**'
+
+  deploy-webapp:
+    needs: changes
+    if: needs.changes.outputs.webapp == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy webapp
+        run: flyctl deploy --config apps/webapp/fly.toml --dockerfile apps/webapp/Dockerfile --remote-only --app classmoji-webapp-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-ai-agent:
+    needs: changes
+    if: needs.changes.outputs.ai-agent == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy ai-agent
+        run: flyctl deploy --config apps/ai-agent/fly.toml --dockerfile apps/ai-agent/Dockerfile --remote-only --app classmoji-ai-agent-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-hook-station:
+    needs: changes
+    if: needs.changes.outputs.hook-station == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy hook-station
+        run: flyctl deploy --config apps/hook-station/fly.toml --dockerfile apps/hook-station/Dockerfile --remote-only --app classmoji-hook-station-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-site:
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy site
+        working-directory: apps/site
+        run: flyctl deploy --remote-only --app classmoji-site-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-slides:
+    needs: changes
+    if: needs.changes.outputs.slides == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy slides
+        run: flyctl deploy --config apps/slides/fly.toml --dockerfile apps/slides/Dockerfile --remote-only --app classmoji-slides-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-pages:
+    needs: changes
+    if: needs.changes.outputs.pages == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy pages
+        run: flyctl deploy --config apps/pages/fly.toml --dockerfile apps/pages/Dockerfile --remote-only --app classmoji-pages-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Renames `deploy-fly.yml` to `deploy-fly-prod.yml` (name updated to "Deploy to Fly.io (Production)")
- Adds `deploy-fly-staging.yml` that triggers on push to `staging` and deploys each service to its `*-staging` Fly app via the `--app` flag

## How it works

The `fly.toml` files are reused as-is. The `--app classmoji-<service>-staging` flag in each deploy command overrides the hardcoded prod app name in `fly.toml`, so no duplicate config files are needed.