### PR TITLE
feat(webapp): add health check endpoint

### DIFF
--- a/apps/webapp/app/routes/health/route.jsx
+++ b/apps/webapp/app/routes/health/route.jsx
@@ -1,0 +1,13 @@
+// Health check endpoint for the webapp service
+export const loader = async () => {
+  return new Response(
+    JSON.stringify({
+      status: 'ok',
+      service: 'webapp',
+      timestamp: new Date().toISOString(),
+    }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+};

--- a/apps/webapp/fly.toml
+++ b/apps/webapp/fly.toml
@@ -18,6 +18,13 @@ primary_region = 'iad'
   auto_start_machines = true
   min_machines_running = 1
 
+  [[http_service.checks]]
+    interval = '15s'
+    timeout = '5s'
+    grace_period = '30s'
+    method = 'GET'
+    path = '/health'
+
 [env]
   HOST = "0.0.0.0"
   PORT = "8080"

--- a/apps/webapp/fly.toml
+++ b/apps/webapp/fly.toml
@@ -19,7 +19,7 @@ primary_region = 'iad'
   min_machines_running = 1
 
   [[http_service.checks]]
-    interval = '15s'
+    interval = '30s'
     timeout = '5s'
     grace_period = '30s'
     method = 'GET'


### PR DESCRIPTION
## Summary

- Adds `/health` route to webapp returning `{ status, service, timestamp }`
- Configures Fly.io health check in `fly.toml` (GET `/health` every 30s, 5s timeout, 30s grace period)