### PR TITLE
chore(tasks): map trigger.dev env to correct infisical environment

### DIFF
--- a/packages/tasks/trigger.config.js
+++ b/packages/tasks/trigger.config.js
@@ -51,9 +51,9 @@ export default defineConfig({
             clientSecret: process.env.INFISICAL_CLIENT_SECRET,
           });
 
-          // Use prod environment for all Trigger.dev environments
-          // TODO: Create dev and sta environments in Infisical for environment-specific secrets
-          const infisicalEnv = 'prod';
+          // Map Trigger.dev environment to Infisical environment
+          const envMap = { prod: 'prod', staging: 'sta' };
+          const infisicalEnv = envMap[ctx.environment] ?? 'prod';
 
           console.log(`[Infisical] Syncing secrets from environment: ${infisicalEnv} (Trigger.dev env: ${ctx.environment})`);
 


### PR DESCRIPTION
## Summary

- Resolves the TODO in `trigger.config.js` — Trigger.dev deployments now pull secrets from the matching Infisical environment (`prod` → `prod`, `staging` → `sta`) instead of always using `prod`
- Falls back to `prod` for any unknown environment

## Test plan

- [ ] Deploy to Trigger.dev staging and confirm secrets are pulled from the `sta` Infisical environment