### PR TITLE
chore(staging): deploy trigger to staging environment

### DIFF
--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -82,7 +82,7 @@ jobs:
         working-directory: packages/tasks
         run: npx trigger.dev@4.4.0 deploy --push
         env:
-          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_STAGING_ACCESS_TOKEN }}
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
           INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
           INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           INFISICAL_PROJECT_ID: e9a6487c-350e-41e7-8bba-2d95ca5934a6

--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Deploy to Trigger.dev
         working-directory: packages/tasks
-        run: npx trigger.dev@4.4.0 deploy --push
+        run: npx trigger.dev@4.4.0 deploy --push -e staging
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
           INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}


### PR DESCRIPTION
## Summary

- Adds `-e staging` flag to the Trigger.dev deploy command so it deploys to the staging environment instead of the default