### PR TITLE
docs: improve local development setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Monorepo via npm workspaces + Turbo; Node 22+ required.
 > ```
 
 - Install: `npm install`; Init: `npm run init`
-- Start DB (Docker): `npm run db:start`
+- Start DB (Docker): `npm run db:start` (postgres only; works without the ai-agent submodule)
+- Start ai-agent container (requires submodule): `npm run ai-agent:docker`
 - **Prisma schema** lives in `packages/database/schema.prisma` (not the default location). Migrations are in `packages/database/migrations/`. **Never use `prisma db push`** — always create proper migrations. Workflow: edit schema → `npm run db:generate` (regenerate client) → create migration → `npm run db:deploy` (apply migrations).
 - Query DB: `psql "$DATABASE_URL" -c "SELECT ..."`
 - All apps (concurrent dev): `npm run dev` (check `.dev-context` for ports/database after starting)

--- a/apps/site/src/content/docs/docs/open-source/local-development/index.mdx
+++ b/apps/site/src/content/docs/docs/open-source/local-development/index.mdx
@@ -82,8 +82,8 @@ Neon is a serverless PostgreSQL platform with a generous free tier. It's a great
 Regardless of which option you chose:
 
 ```bash
-npm run db:deploy   # applies migrations
 npm run db:generate # generates the Prisma client
+npm run db:deploy   # applies migrations
 npm run db:seed     # seeds dev classroom and fake users
 ```
 

--- a/apps/site/src/content/docs/docs/open-source/local-development/index.mdx
+++ b/apps/site/src/content/docs/docs/open-source/local-development/index.mdx
@@ -141,7 +141,7 @@ Trigger.dev is the background job runner Classmoji uses for tasks like repositor
 ```env
 TRIGGER_SECRET_KEY="tr_dev_your-key-here"
 ```
-5. In the trigger sidebard, click on the **General** tab and copy the **Project ref** value (e.g. `proj_abccrutouxchmrddss`).
+5. In the trigger sidebar, click on the **General** tab and copy the **Project ref** value (e.g. `proj_abccrutouxchmrddss`).
 6. Add it to your `/packages/tasks/trigger.config.js` file as the `project` value.
 
 ```js

--- a/apps/site/src/content/docs/docs/open-source/local-development/index.mdx
+++ b/apps/site/src/content/docs/docs/open-source/local-development/index.mdx
@@ -83,6 +83,7 @@ Regardless of which option you chose:
 
 ```bash
 npm run db:deploy   # applies migrations
+npm run db:generate # generates the Prisma client
 npm run db:seed     # seeds dev classroom and fake users
 ```
 
@@ -140,7 +141,15 @@ Trigger.dev is the background job runner Classmoji uses for tasks like repositor
 ```env
 TRIGGER_SECRET_KEY="tr_dev_your-key-here"
 ```
+5. In the trigger sidebard, click on the **General** tab and copy the **Project ref** value (e.g. `proj_abccrutouxchmrddss`).
+6. Add it to your `/packages/tasks/trigger.config.js` file as the `project` value.
 
+```js
+export default defineConfig({
+  project: 'proj_abccrutouxchmrddss',
+  ...rest,
+});
+```
 ### Set up the webhook tunnel
 
 GitHub needs a public URL to send webhook events to. But your local server isn't reachable from the internet — that's where [Smee](https://smee.io) comes in.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - classmoji-network
 
   ai-agent:
+    profiles:
+      - ai-agent
     container_name: classmoji-ai-agent
     build:
       context: .

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hook:stripe": "dotenv -e .env -- turbo run hook:stripe --log-prefix=none",
     "hook:dev": "dotenv -e .env -- turbo run hook:dev --log-prefix=none",
     "hook:start": "dotenv -e .env -- turbo run hook:start",
+    "ai-agent:docker": "docker compose --profile ai-agent up -d",
     "ai-agent:dev": "dotenv -e .env -- turbo run dev --filter=@classmoji/ai-agent --log-prefix=none",
     "ai-agent:start": "dotenv -e .env -- turbo run start --filter=@classmoji/ai-agent",
     "db:generate": "dotenv -e .env -- turbo run db:generate",


### PR DESCRIPTION
Fixes #40

## Summary

- Make `ai-agent` Docker service opt-in via Compose profile — `npm run db:start` now only starts postgres, fixing failures for contributors without the private ai-agent submodule
- Add `npm run ai-agent:docker` script for contributors who have the submodule and want the containerized version
- Add missing `npm run db:generate` step (before `db:deploy`) to the local dev docs — fixes seed failures reported by contributors
- Fix typo: "sidebard" → "sidebar" in Trigger.dev setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)