### PR TITLE
ci(staging): auto-deploy ai-agent, site, slides, and pages

### DIFF
--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       webapp: ${{ steps.filter.outputs.webapp }}
+      ai-agent: ${{ steps.filter.outputs.ai-agent }}
       hook-station: ${{ steps.filter.outputs.hook-station }}
       tasks: ${{ steps.filter.outputs.tasks }}
     steps:
@@ -25,6 +26,10 @@ jobs:
           filters: |
             webapp:
               - 'apps/webapp/**'
+              - 'packages/**'
+            ai-agent:
+              - 'apps/ai-agent'
+              - 'apps/ai-agent/**'
               - 'packages/**'
             hook-station:
               - 'apps/hook-station/**'
@@ -44,6 +49,21 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy webapp
         run: flyctl deploy --config apps/webapp/fly.toml --dockerfile apps/webapp/Dockerfile --remote-only --app classmoji-webapp-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-ai-agent:
+    needs: changes
+    if: needs.changes.outputs.ai-agent == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy ai-agent
+        run: flyctl deploy --config apps/ai-agent/fly.toml --dockerfile apps/ai-agent/Dockerfile --remote-only --app classmoji-ai-agent-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -17,6 +17,9 @@ jobs:
       webapp: ${{ steps.filter.outputs.webapp }}
       ai-agent: ${{ steps.filter.outputs.ai-agent }}
       hook-station: ${{ steps.filter.outputs.hook-station }}
+      site: ${{ steps.filter.outputs.site }}
+      slides: ${{ steps.filter.outputs.slides }}
+      pages: ${{ steps.filter.outputs.pages }}
       tasks: ${{ steps.filter.outputs.tasks }}
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +36,14 @@ jobs:
               - 'packages/**'
             hook-station:
               - 'apps/hook-station/**'
+              - 'packages/**'
+            site:
+              - 'apps/site/**'
+            slides:
+              - 'apps/slides/**'
+              - 'packages/**'
+            pages:
+              - 'apps/pages/**'
               - 'packages/**'
             tasks:
               - 'packages/tasks/**'
@@ -76,6 +87,43 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy hook-station
         run: flyctl deploy --config apps/hook-station/fly.toml --dockerfile apps/hook-station/Dockerfile --remote-only --app classmoji-hook-station-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-site:
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy site
+        working-directory: apps/site
+        run: flyctl deploy --remote-only --app classmoji-site-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-slides:
+    needs: changes
+    if: needs.changes.outputs.slides == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy slides
+        run: flyctl deploy --config apps/slides/fly.toml --dockerfile apps/slides/Dockerfile --remote-only --app classmoji-slides-staging
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-pages:
+    needs: changes
+    if: needs.changes.outputs.pages == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy pages
+        run: flyctl deploy --config apps/pages/fly.toml --dockerfile apps/pages/Dockerfile --remote-only --app classmoji-pages-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## Summary
Fully mirrors `deploy-fly-prod.yml` into staging. Previously only **webapp**, **hook-station**, and **Trigger.dev tasks** auto-deployed on `staging` merges; **ai-agent**, **site**, **slides**, and **pages** all required manual `flyctl deploy`.

New auto-deploy jobs (all target `classmoji-<app>-staging`):
- **ai-agent** — `submodules: true` checkout; filter watches the submodule pointer (`apps/ai-agent`), in-tree files (`apps/ai-agent/**`), and `packages/**`.
- **site** — `apps/site/**` filter; `--app` overrides the fly.toml default.
- **slides** — `apps/slides/**` + `packages/**`.
- **pages** — `apps/pages/**` + `packages/**`.

No changes to existing webapp / hook-station / trigger jobs.

## Follow-up
After merging, PR #79 (ai-agent submodule bump) will auto-deploy staging's ai-agent once it's merged next.