### PR TITLE
feat(webapp): rename team cascades to GitHub team and repos (#81)

### DIFF
--- a/apps/webapp/app/constants/actionTypes.ts
+++ b/apps/webapp/app/constants/actionTypes.ts
@@ -18,6 +18,7 @@ export const ActionTypes = {
 
   SAVE_TEAM: 'save-team',
   DELETE_TEAM: 'delete-team',
+  RENAME_TEAM: 'rename-team',
   ADD_TEAM_MEMBER: 'add-team-member',
   REMOVE_TEAM_MEMBER: 'remove-team-member',
 

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
@@ -8,6 +8,11 @@ import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
+interface RepoRename {
+  id: string;
+  name: string;
+}
+
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
   const slug = params.slug!;
@@ -87,6 +92,95 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       return {
         success: 'Tag removed successfully',
         action: ActionTypes.REMOVE_TEAM_TAG,
+      };
+    },
+
+    async renameTeam() {
+      const { newName } = data as { newName?: string };
+      const trimmed = typeof newName === 'string' ? newName.trim() : '';
+      if (!trimmed) {
+        throw new Response('New team name is required', { status: 400 });
+      }
+
+      const gitOrgLogin = classroom.git_organization?.login;
+      if (!gitOrgLogin) {
+        throw new Response('Git organization not configured', { status: 400 });
+      }
+      if (classroom.git_organization?.provider !== 'GITHUB') {
+        throw new Response('Team rename is only supported for GitHub organizations', {
+          status: 400,
+        });
+      }
+
+      const team = await ClassmojiService.team.findBySlugAndClassroomId(slug, classroom.id);
+      if (!team) {
+        throw new Response('Team not found', { status: 404 });
+      }
+
+      const teamWithRepos = await ClassmojiService.team.findByIdWithRepositories(team.id);
+      const repositories = teamWithRepos?.repositories ?? [];
+
+      const gitProvider = getGitProvider(classroom.git_organization);
+
+      // Rename GitHub team first — it is authoritative for the new slug.
+      const updated = await gitProvider.updateTeam(gitOrgLogin, slug, { name: trimmed });
+      const newSlug = updated.slug;
+
+      // Collision guard: ensure another local team doesn't already occupy the new slug.
+      if (newSlug !== slug) {
+        const existing = await ClassmojiService.team.findBySlugAndClassroomId(
+          newSlug,
+          classroom.id
+        );
+        if (existing && existing.id !== team.id) {
+          throw new Response(
+            `A team with slug "${newSlug}" already exists in this classroom`,
+            { status: 409 }
+          );
+        }
+      }
+
+      const oldSuffix = `-${slug}`;
+      const failed: { name: string; error: string }[] = [];
+      const succeeded: RepoRename[] = [];
+
+      const renameQueue = async.queue<(typeof repositories)[number]>(async repo => {
+        if (!repo.name.includes(oldSuffix)) {
+          return;
+        }
+        const newRepoName = repo.name.split(oldSuffix).join(`-${newSlug}`);
+        try {
+          await gitProvider.updateRepo(gitOrgLogin, repo.name, { name: newRepoName });
+          succeeded.push({ id: repo.id, name: newRepoName });
+        } catch (error: unknown) {
+          failed.push({
+            name: repo.name,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        await sleep(250);
+      }, 1);
+
+      if (repositories.length > 0) {
+        renameQueue.push(repositories);
+        await renameQueue.drain();
+      }
+
+      await ClassmojiService.team.renameAndRepos({
+        teamId: team.id,
+        newName: updated.name,
+        newSlug,
+        repoRenames: succeeded,
+      });
+
+      return {
+        success:
+          failed.length === 0
+            ? `Renamed team to @${newSlug}.`
+            : `Renamed team to @${newSlug}. ${failed.length} repo(s) failed to rename.`,
+        action: ActionTypes.RENAME_TEAM,
+        newSlug,
+        failed,
       };
     },
   });

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/route.tsx
@@ -1,8 +1,8 @@
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import _ from 'lodash';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { Card, Button, Drawer, Table, Select, Tag } from 'antd';
+import { Card, Button, Drawer, Input, Modal, Table, Select, Tag } from 'antd';
 
 import { useRouteDrawer, useGlobalFetcher } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
@@ -30,17 +30,63 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const team = await ClassmojiService.team.findBySlugAndClassroomId(slug, classroom.id);
   const teamMembers = team!.memberships.map(({ user }) => user);
   const tags = await ClassmojiService.organizationTag.findByClassroomId(classroom.id);
+  const teamWithRepos = await ClassmojiService.team.findByIdWithRepositories(team!.id);
+  const repositoryCount = teamWithRepos?.repositories.length ?? 0;
+  const canRenameTeam = classroom.git_organization?.provider === 'GITHUB';
 
-  return { team, students: studentsObjects, teamMembers, tags };
+  return { team, students: studentsObjects, teamMembers, tags, repositoryCount, canRenameTeam };
 };
 
 const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
-  const { students, teamMembers, tags, team } = loaderData;
+  const { students, teamMembers, tags, team, repositoryCount, canRenameTeam } = loaderData;
   const [membersToAdd, setMembersToAdd] = useState<string[]>([]);
   const [tagsToAdd, setTagsToAdd] = useState<string[]>([]);
+  const [renameValue, setRenameValue] = useState(team!.name);
+  const [renameConfirmOpen, setRenameConfirmOpen] = useState(false);
+  const [renameFailures, setRenameFailures] = useState<{ name: string; error: string }[]>([]);
+  const renameSubmitted = useRef(false);
   const { opened: _opened, close, open } = useRouteDrawer({});
-  const { slug } = useParams();
+  const params = useParams();
+  const { slug, class: classSlug } = params;
+  const navigate = useNavigate();
   const { fetcher, notify } = useGlobalFetcher();
+
+  useEffect(() => {
+    if (!renameSubmitted.current) return;
+    const data = fetcher?.data as
+      | { action?: string; newSlug?: string; failed?: { name: string; error: string }[] }
+      | undefined;
+    if (data?.action === ActionTypes.RENAME_TEAM && data.newSlug) {
+      renameSubmitted.current = false;
+      const failures = data.failed ?? [];
+      if (failures.length > 0) {
+        setRenameFailures(failures);
+      }
+      navigate(`/admin/${classSlug}/teams/${data.newSlug}/edit`, { replace: true });
+    }
+  }, [fetcher?.data, classSlug, navigate]);
+
+  const trimmedRenameValue = renameValue.trim();
+  const renameDisabled = !trimmedRenameValue || trimmedRenameValue === team!.name;
+
+  const onRenameSubmit = () => {
+    if (renameDisabled) return;
+    setRenameConfirmOpen(true);
+  };
+
+  const onRenameConfirm = () => {
+    notify(ActionTypes.RENAME_TEAM, 'Renaming team...');
+    renameSubmitted.current = true;
+    fetcher!.submit(
+      { newName: trimmedRenameValue },
+      {
+        method: 'post',
+        encType: 'application/json',
+        action: '?/renameTeam',
+      }
+    );
+    setRenameConfirmOpen(false);
+  };
 
   const onAddStudents = () => {
     notify(ActionTypes.ADD_TEAM_MEMBER, 'Adding student(s) to team...');
@@ -134,6 +180,74 @@ const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
 
   return (
     <Drawer onClose={close} title={`@${slug}`} open={Boolean(open)} width="50%">
+      {canRenameTeam && (
+        <>
+          <p className="pb-2 font-semibold text-xl">Rename team</p>
+
+          <Card className="mb-8">
+            <div className="flex items-center gap-4">
+              <Input
+                value={renameValue}
+                onChange={e => setRenameValue(e.target.value)}
+                placeholder="Team name"
+              />
+              <Button onClick={onRenameSubmit} disabled={renameDisabled}>
+                Rename
+              </Button>
+            </div>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Renames the team on GitHub and every linked repository ({repositoryCount} repo
+              {repositoryCount === 1 ? '' : 's'}). Local clones need to update their git remote.
+            </p>
+          </Card>
+        </>
+      )}
+
+      {renameFailures.length > 0 && (
+        <Card
+          className="mb-8 border-red-300 dark:border-red-700"
+          title={
+            <span className="text-red-700 dark:text-red-400">
+              {renameFailures.length} repo{renameFailures.length === 1 ? '' : 's'} failed to rename
+            </span>
+          }
+          extra={
+            <Button size="small" onClick={() => setRenameFailures([])}>
+              Dismiss
+            </Button>
+          }
+        >
+          <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+            The team was renamed but these repositories still have the old suffix on GitHub.
+            Rename them manually or retry by renaming the team again.
+          </p>
+          <ul className="text-sm">
+            {renameFailures.map(f => (
+              <li key={f.name} className="mb-1">
+                <strong>{f.name}</strong>
+                <span className="ml-2 text-gray-500 dark:text-gray-400">— {f.error}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      <Modal
+        open={renameConfirmOpen}
+        title="Rename this team?"
+        okText="Rename"
+        onOk={onRenameConfirm}
+        onCancel={() => setRenameConfirmOpen(false)}
+      >
+        <p>
+          This will rename the team on GitHub and update{' '}
+          <strong>
+            {repositoryCount} repositor{repositoryCount === 1 ? 'y' : 'ies'}
+          </strong>
+          . Team members and anyone with local clones will need to update their git remote URLs.
+        </p>
+      </Modal>
+
       <p className="pb-2 font-semibold text-xl">Tags</p>
 
       <Card className="mb-8 ">

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@classmoji/services": "*",
         "@classmoji/utils": "*",
         "@fastify/websocket": "^11.0.1",
-        "@trigger.dev/sdk": "4.3.3",
+        "@trigger.dev/sdk": "4.4.0",
         "fastify": "^5.2.0",
         "jsonwebtoken": "^9.0.2",
         "pino-pretty": "^13.0.0",
@@ -17236,30 +17236,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -17271,19 +17247,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esniff": {

--- a/packages/services/src/classmoji/team.service.ts
+++ b/packages/services/src/classmoji/team.service.ts
@@ -111,6 +111,42 @@ export const findById = async (teamId: string) => {
   });
 };
 
+export const findByIdWithRepositories = async (teamId: string) => {
+  return getPrisma().team.findUnique({
+    where: { id: teamId },
+    include: {
+      repositories: true,
+    },
+  });
+};
+
+interface RepoRename {
+  id: string;
+  name: string;
+}
+
+export const renameAndRepos = async (payload: {
+  teamId: string;
+  newName: string;
+  newSlug: string;
+  repoRenames: RepoRename[];
+}) => {
+  const { teamId, newName, newSlug, repoRenames } = payload;
+  const prisma = getPrisma();
+  return prisma.$transaction([
+    prisma.team.update({
+      where: { id: teamId },
+      data: { name: newName, slug: newSlug },
+    }),
+    ...repoRenames.map(r =>
+      prisma.repository.update({
+        where: { id: r.id },
+        data: { name: r.name },
+      })
+    ),
+  ]);
+};
+
 export const findByTagId = async (classroomId: string, tagId: string) => {
   return getPrisma().team.findMany({
     where: {

--- a/packages/services/src/git/GitHubProvider.ts
+++ b/packages/services/src/git/GitHubProvider.ts
@@ -258,6 +258,28 @@ export class GitHubProvider extends GitProvider {
     });
   }
 
+  /**
+   * Rename a repository. GitHub auto-redirects the old URL for a grace period,
+   * but users with local clones should update their remotes.
+   * @param {string} org - Organization login
+   * @param {string} currentName - Current repository name
+   * @param {{ name: string }} patch - New name
+   * @returns {Promise<{ name: string }>}
+   */
+  async updateRepo(
+    org: string,
+    currentName: string,
+    patch: { name: string }
+  ): Promise<{ name: string }> {
+    const octokit = await this.#getOctokit();
+    const { data } = await octokit.request('PATCH /repos/{owner}/{repo}', {
+      owner: org,
+      repo: currentName,
+      name: patch.name,
+    });
+    return { name: data.name };
+  }
+
   // ─── Branches & PRs ────────────────────────────────────────────────────────
 
   /**
@@ -628,6 +650,28 @@ export class GitHubProvider extends GitProvider {
     const octokit = await this.#getOctokit();
     const { data } = await octokit.request('GET /orgs/{org}/teams', { org });
     return data;
+  }
+
+  /**
+   * Update a team. GitHub regenerates the slug from the new name server-side,
+   * and the response contains the authoritative new slug.
+   * @param {string} org - Organization login
+   * @param {string} currentSlug - Current team slug
+   * @param {{ name: string }} patch - New name
+   * @returns {Promise<{ id: number; slug: string; name: string; node_id: string }>}
+   */
+  async updateTeam(
+    org: string,
+    currentSlug: string,
+    patch: { name: string }
+  ): Promise<{ id: number; slug: string; name: string; node_id: string }> {
+    const octokit = await this.#getOctokit();
+    const { data } = await octokit.request('PATCH /orgs/{org}/teams/{team_slug}', {
+      org,
+      team_slug: currentSlug,
+      name: patch.name,
+    });
+    return { id: data.id, slug: data.slug, name: data.name, node_id: data.node_id };
   }
 
   /**

--- a/packages/services/src/git/GitProvider.ts
+++ b/packages/services/src/git/GitProvider.ts
@@ -67,6 +67,14 @@ export class GitProvider {
     throw new Error('deleteRepository() must be implemented by subclass');
   }
 
+  async updateRepo(
+    org: string,
+    currentName: string,
+    patch: { name: string }
+  ): Promise<{ name: string }> {
+    throw new Error('updateRepo() must be implemented by subclass');
+  }
+
   // ─── Branches & PRs ────────────────────────────────────────────────────────
   async getLatestCommitSHA(org: string, repo: string, branch?: string): Promise<string> {
     throw new Error('getLatestCommitSHA() must be implemented by subclass');
@@ -149,6 +157,14 @@ export class GitProvider {
     teamSlug: string
   ): Promise<{ id: number; slug: string; name: string }> {
     throw new Error('getTeam() must be implemented by subclass');
+  }
+
+  async updateTeam(
+    org: string,
+    currentSlug: string,
+    patch: { name: string }
+  ): Promise<{ id: number; slug: string; name: string }> {
+    throw new Error('updateTeam() must be implemented by subclass');
   }
 
   async addTeamMember(org: string, teamSlug: string, username: string): Promise<void> {


### PR DESCRIPTION
* update lock file

* feat(webapp): rename team cascades to Github team and linked repos

Admins can rename a team from the team-edit drawer; the rename is applied on Github first (authoritative new slug) and then cascaded to every linked repository by rewriting the -{oldSlug} suffix. Per- repo failures are collected and surfaced in the UI so admins know which repos need manual follow-up. Rename card is hidden for class- rooms without a Github org.



---------

## What changed?

<!-- A brief description of what this PR does -->

## Why?

<!-- Why is this change needed? What problem does it solve? -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Screenshots (if UI changes)

<!-- 📸 Drag & drop screenshots here - include both light and dark mode! -->

**Light mode:**

**Dark mode:**

## How to test

<!-- Steps for reviewers to test your changes -->

1.
2.
3.

## Checklist

- [ ] Tests added/updated (if applicable)
- [ ] Dark mode support added (if UI changes)
- [ ] Documentation updated (if needed)
- [ ] Ready for review

---

💡 **First-time contributor?** Welcome! Don't worry if you're not sure about something - we're here to help. Feel free to ask questions in the comments!
