### PR TITLE
feat(webapp): GitHub repo analytics + admin/TA dashboard expansions

### DIFF
--- a/apps/webapp/app/components/features/analytics/Anomalies.tsx
+++ b/apps/webapp/app/components/features/analytics/Anomalies.tsx
@@ -1,0 +1,121 @@
+import { Tag } from 'antd';
+import {
+  lateCommitRatio,
+  isMegaCommit,
+  averageCommitQuality,
+  busFactor,
+  dumpAndRun,
+} from '@classmoji/services/flags';
+import type { CommitRecord } from './CommitTimeline';
+import type { ContributorRecord } from './GitHubStatsPanel';
+
+export interface AnomaliesProps {
+  snapshot: {
+    commits: CommitRecord[];
+    contributors: ContributorRecord[];
+    total_additions: number;
+    total_deletions: number;
+  };
+  deadline: string | null;
+}
+
+/**
+ * Compact anomaly chips computed from a repo analytics snapshot.
+ * Pure client-side — all heuristics are imported from @classmoji/services
+ * (which only depends on types). Returns null when no flags fire.
+ */
+const Anomalies = ({ snapshot, deadline }: AnomaliesProps) => {
+  const { commits, contributors, total_additions, total_deletions } = snapshot;
+  const deadlineDate = deadline ? new Date(deadline) : null;
+
+  const chips: React.ReactNode[] = [];
+
+  // Late commits
+  const lateRatio = lateCommitRatio(commits, deadlineDate);
+  if (lateRatio > 0.3) {
+    chips.push(
+      <Tag
+        key="late"
+        color="red"
+        data-testid="anomaly-late"
+        className="dark:border-red-800"
+      >
+        Late commits {(lateRatio * 100).toFixed(0)}%
+      </Tag>
+    );
+  }
+
+  // Mega commit (first one we find)
+  const mega = commits.find(c => isMegaCommit(c, total_additions, total_deletions));
+  if (mega) {
+    chips.push(
+      <Tag
+        key="mega"
+        color="orange"
+        data-testid="anomaly-mega"
+        className="dark:border-orange-800"
+      >
+        Mega commit {mega.sha.slice(0, 7)}
+      </Tag>
+    );
+  }
+
+  // Dump and run
+  if (dumpAndRun(commits, deadlineDate)) {
+    chips.push(
+      <Tag
+        key="dump"
+        color="red"
+        data-testid="anomaly-dump"
+        className="dark:border-red-800"
+      >
+        Dump-and-run
+      </Tag>
+    );
+  }
+
+  // Bus factor
+  const bus = busFactor(contributors);
+  if (bus && bus.share > 0.7) {
+    chips.push(
+      <Tag
+        key="bus"
+        color="gold"
+        data-testid="anomaly-bus"
+        className="dark:border-yellow-800"
+      >
+        Bus factor · {bus.login} {(bus.share * 100).toFixed(0)}%
+      </Tag>
+    );
+  }
+
+  // Weak messages
+  if (commits.length > 3) {
+    const quality = averageCommitQuality(commits);
+    if (quality < 0.3) {
+      chips.push(
+        <Tag
+          key="weak"
+          color="default"
+          data-testid="anomaly-weak"
+          className="dark:border-gray-700"
+        >
+          Weak messages
+        </Tag>
+      );
+    }
+  }
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      className="flex flex-wrap gap-2 mb-6"
+      data-testid="anomaly-chips"
+    >
+      {chips}
+    </div>
+  );
+};
+
+export default Anomalies;

--- a/apps/webapp/app/components/features/analytics/CommitTimeline.tsx
+++ b/apps/webapp/app/components/features/analytics/CommitTimeline.tsx
@@ -1,0 +1,121 @@
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ReferenceLine,
+} from 'recharts';
+import { useDarkMode } from '~/hooks';
+import theme from '~/config/theme';
+
+export type CommitRecord = {
+  sha: string;
+  author_login: string | null;
+  author_email: string | null;
+  author_user_id: string | null;
+  ts: string;
+  message: string;
+  additions: number;
+  deletions: number;
+  parents: string[];
+};
+
+export interface CommitTimelineProps {
+  commits: CommitRecord[];
+  deadline: string | null;
+}
+
+/**
+ * Buckets commits by UTC day and returns sorted `{day, count}` rows.
+ * Exported for testing / reuse by summary widgets.
+ */
+export function bucketCommitsByDay(commits: CommitRecord[]): { day: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const c of commits) {
+    if (!c.ts) continue;
+    // Bucket in UTC by manipulating the ISO string directly to avoid
+    // timezone drift (dayjs.utc requires the utc plugin).
+    const day = c.ts.slice(0, 10);
+    counts.set(day, (counts.get(day) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([day, count]) => ({ day, count }))
+    .sort((a, b) => a.day.localeCompare(b.day));
+}
+
+const CommitTimeline = ({ commits, deadline }: CommitTimelineProps) => {
+  const { isDarkMode } = useDarkMode();
+
+  if (!commits || commits.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-500 dark:text-gray-400 text-sm"
+        style={{ height: 180 }}
+        data-testid="commit-timeline-empty"
+      >
+        No commits
+      </div>
+    );
+  }
+
+  const data = bucketCommitsByDay(commits);
+  const deadlineDay = deadline ? deadline.slice(0, 10) : null;
+
+  const axisTick = { fontSize: 12, fill: isDarkMode ? '#9ca3af' : '#666' };
+  const axisLine = { stroke: isDarkMode ? '#4b5563' : '#e0e0e0' };
+
+  return (
+    <div style={{ width: '100%', height: 220 }} data-testid="commit-timeline">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={data}
+          margin={{ top: 12, right: 24, left: 0, bottom: 8 }}
+        >
+          <defs>
+            <linearGradient id="commitTimelineFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={theme.PRIMARY} stopOpacity={0.45} />
+              <stop offset="100%" stopColor={theme.PRIMARY} stopOpacity={0.05} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke={isDarkMode ? '#374151' : '#f0f0f0'} />
+          <XAxis dataKey="day" tick={axisTick} axisLine={axisLine} />
+          <YAxis allowDecimals={false} tick={axisTick} axisLine={axisLine} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: isDarkMode ? '#111827' : '#ffffff',
+              border: `1px solid ${isDarkMode ? '#374151' : '#e5e7eb'}`,
+              borderRadius: 8,
+              color: isDarkMode ? '#f3f4f6' : '#111827',
+            }}
+            labelStyle={{ color: isDarkMode ? '#f3f4f6' : '#111827' }}
+          />
+          <Area
+            type="monotone"
+            dataKey="count"
+            stroke={theme.PRIMARY}
+            strokeWidth={2}
+            fill="url(#commitTimelineFill)"
+          />
+          {deadlineDay && (
+            <ReferenceLine
+              x={deadlineDay}
+              stroke="#dc2626"
+              strokeDasharray="4 4"
+              label={{
+                value: 'Deadline',
+                position: 'top',
+                fill: '#dc2626',
+                fontSize: 12,
+              }}
+            />
+          )}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default CommitTimeline;

--- a/apps/webapp/app/components/features/analytics/ContributorBreakdown.tsx
+++ b/apps/webapp/app/components/features/analytics/ContributorBreakdown.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useFetcher, useRevalidator } from 'react-router';
+import { Button, Input, Modal } from 'antd';
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from 'recharts';
+import {
+  aggregateByContributor,
+  commitsPerDayByContributor,
+} from '@classmoji/services/flags';
+import { useDarkMode } from '~/hooks';
+import type { CommitRecord } from './CommitTimeline';
+import type { ContributorRecord } from './GitHubStatsPanel';
+
+export interface EligibleStudent {
+  id: string;
+  login: string | null;
+  name: string | null;
+}
+
+export interface ContributorBreakdownProps {
+  commits: CommitRecord[];
+  contributors: ContributorRecord[];
+  unmatched: Array<{ login: string; commits: number }>;
+  /** Repository.id — used to POST to /api/repos/:id/contributor-link. */
+  repositoryId: string;
+  /** Classroom members eligible to be linked. */
+  students: EligibleStudent[];
+  /** Called after a successful link upsert (in addition to revalidator). */
+  onLinkSuccess?: () => void;
+}
+
+/**
+ * Deterministic login → HSL color. Simple FNV-1a-ish string hash mod 360
+ * so the same login always gets the same hue across renders.
+ */
+export function loginToColor(login: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < login.length; i++) {
+    hash ^= login.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 65%, 55%)`;
+}
+
+const ContributorBreakdown = ({
+  commits,
+  contributors,
+  unmatched,
+  repositoryId,
+  students,
+  onLinkSuccess,
+}: ContributorBreakdownProps) => {
+  const { isDarkMode } = useDarkMode();
+  const fetcher = useFetcher<{ linked?: boolean; error?: string }>();
+  const { revalidate } = useRevalidator();
+
+  const [linkTarget, setLinkTarget] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const filteredStudents = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return students;
+    return students.filter(s => {
+      const haystack = `${s.name ?? ''} ${s.login ?? ''}`.toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [search, students]);
+
+  const submitting = fetcher.state !== 'idle';
+
+  // Close modal and revalidate when link fetcher succeeds.
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data?.linked) {
+      setLinkTarget(null);
+      setSearch('');
+      revalidate();
+      onLinkSuccess?.();
+    }
+  }, [fetcher.state, fetcher.data, revalidate, onLinkSuccess]);
+
+  const handleLink = (studentId: string) => {
+    if (!linkTarget) return;
+    fetcher.submit(
+      { github_login: linkTarget, user_id: studentId },
+      {
+        method: 'POST',
+        action: `/api/repos/${repositoryId}/contributor-link`,
+        encType: 'application/json',
+      }
+    );
+  };
+
+  if (!commits || commits.length === 0) return null;
+  if (!contributors || contributors.length <= 1) return null;
+
+  const byContrib = aggregateByContributor(commits);
+  const perDay = commitsPerDayByContributor(commits);
+
+  const logins = byContrib.map(c => c.login);
+  const colorMap: Record<string, string> = Object.fromEntries(
+    logins.map(l => [l, loginToColor(l)]),
+  );
+
+  const commitsPieData = byContrib.map(c => ({
+    name: c.login,
+    value: c.commits,
+  }));
+  const linesPieData = byContrib
+    .map(c => ({
+      name: c.login,
+      value: c.additions + c.deletions,
+    }))
+    .filter(d => d.value > 0);
+
+  const axisTick = { fontSize: 12, fill: isDarkMode ? '#9ca3af' : '#666' };
+  const axisLine = { stroke: isDarkMode ? '#4b5563' : '#e0e0e0' };
+  const tooltipStyle = {
+    backgroundColor: isDarkMode ? '#111827' : '#ffffff',
+    border: `1px solid ${isDarkMode ? '#374151' : '#e5e7eb'}`,
+    borderRadius: 8,
+    color: isDarkMode ? '#f3f4f6' : '#111827',
+  };
+  const tooltipLabel = { color: isDarkMode ? '#f3f4f6' : '#111827' };
+
+  return (
+    <div className="mb-6 space-y-6" data-testid="contributor-breakdown">
+      {/* Pies */}
+      <div>
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+          Contribution Share
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div data-testid="commits-pie">
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1 text-center">
+              Commits
+            </div>
+            <div style={{ width: '100%', height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={commitsPieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={70}
+                    label={entry =>
+                      `${entry.name} ${((entry.percent ?? 0) * 100).toFixed(0)}%`
+                    }
+                  >
+                    {commitsPieData.map(d => (
+                      <Cell key={d.name} fill={colorMap[d.name]} />
+                    ))}
+                  </Pie>
+                  <Tooltip contentStyle={tooltipStyle} labelStyle={tooltipLabel} />
+                  <Legend
+                    wrapperStyle={{
+                      fontSize: 12,
+                      color: isDarkMode ? '#d1d5db' : '#374151',
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+          <div data-testid="lines-pie">
+            <div className="text-xs text-gray-500 dark:text-gray-400 mb-1 text-center">
+              Lines changed (added + deleted)
+            </div>
+            <div style={{ width: '100%', height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={linesPieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={70}
+                    label={entry =>
+                      `${entry.name} ${((entry.percent ?? 0) * 100).toFixed(0)}%`
+                    }
+                  >
+                    {linesPieData.map(d => (
+                      <Cell key={d.name} fill={colorMap[d.name]} />
+                    ))}
+                  </Pie>
+                  <Tooltip contentStyle={tooltipStyle} labelStyle={tooltipLabel} />
+                  <Legend
+                    wrapperStyle={{
+                      fontSize: 12,
+                      color: isDarkMode ? '#d1d5db' : '#374151',
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stacked bar of commits per day by contributor */}
+      <div>
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+          Commits per Day by Contributor
+        </div>
+        <div style={{ width: '100%', height: 220 }} data-testid="contributor-stacked-bar">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={perDay}
+              margin={{ top: 12, right: 24, left: 0, bottom: 8 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={isDarkMode ? '#374151' : '#f0f0f0'}
+              />
+              <XAxis dataKey="day" tick={axisTick} axisLine={axisLine} />
+              <YAxis allowDecimals={false} tick={axisTick} axisLine={axisLine} />
+              <Tooltip contentStyle={tooltipStyle} labelStyle={tooltipLabel} />
+              <Legend
+                wrapperStyle={{
+                  fontSize: 12,
+                  color: isDarkMode ? '#d1d5db' : '#374151',
+                }}
+              />
+              {logins.map(login => (
+                <Bar
+                  key={login}
+                  dataKey={login}
+                  stackId="commits"
+                  fill={colorMap[login]}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Link-to-student modal */}
+      <Modal
+        open={linkTarget !== null}
+        onCancel={() => {
+          if (!submitting) {
+            setLinkTarget(null);
+            setSearch('');
+          }
+        }}
+        footer={null}
+        title={
+          linkTarget ? `Link GitHub user ${linkTarget} to a student` : undefined
+        }
+        destroyOnClose
+        data-testid="link-contributor-modal"
+      >
+        <div className="space-y-3">
+          <Input
+            placeholder="Search by name or GitHub login"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            allowClear
+            data-testid="link-contributor-search"
+          />
+          {fetcher.data?.error && (
+            <div
+              className="text-xs text-red-600 dark:text-red-400"
+              data-testid="link-contributor-error"
+            >
+              {fetcher.data.error}
+            </div>
+          )}
+          <div
+            className="max-h-72 overflow-y-auto rounded-lg border border-gray-100 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700"
+            data-testid="link-contributor-student-list"
+          >
+            {filteredStudents.length === 0 ? (
+              <div className="px-3 py-4 text-sm text-gray-500 dark:text-gray-400 text-center">
+                No students match.
+              </div>
+            ) : (
+              filteredStudents.map(s => (
+                <div
+                  key={s.id}
+                  className="flex items-center justify-between px-3 py-2 text-sm"
+                  data-testid={`link-student-row-${s.id}`}
+                >
+                  <div className="min-w-0">
+                    <div className="font-medium text-gray-800 dark:text-gray-100 truncate">
+                      {s.name ?? s.login ?? 'Unknown student'}
+                    </div>
+                    {s.login && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                        @{s.login}
+                      </div>
+                    )}
+                  </div>
+                  <Button
+                    size="small"
+                    type="primary"
+                    loading={submitting}
+                    onClick={() => handleLink(s.id)}
+                  >
+                    Link
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </Modal>
+
+      {/* Unmatched contributors */}
+      {unmatched.length > 0 && (
+        <div data-testid="unmatched-contributors">
+          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+            Unmatched GitHub logins
+          </div>
+          <div className="rounded-lg border border-gray-100 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700">
+            {unmatched.map(u => (
+              <div
+                key={u.login}
+                className="flex items-center justify-between px-3 py-2 text-sm"
+                data-testid={`unmatched-row-${u.login}`}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className="inline-block h-2.5 w-2.5 rounded-full"
+                    style={{ backgroundColor: loginToColor(u.login) }}
+                  />
+                  <span className="font-medium text-gray-800 dark:text-gray-100">
+                    {u.login}
+                  </span>
+                  <span className="text-gray-500 dark:text-gray-400">
+                    · {u.commits} commit{u.commits === 1 ? '' : 's'}
+                  </span>
+                </div>
+                <Button
+                  size="small"
+                  onClick={() => setLinkTarget(u.login)}
+                  data-testid={`link-student-${u.login}`}
+                >
+                  Link to student
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ContributorBreakdown;

--- a/apps/webapp/app/components/features/analytics/GitHubStatsPanel.tsx
+++ b/apps/webapp/app/components/features/analytics/GitHubStatsPanel.tsx
@@ -1,0 +1,280 @@
+import { Card, Button, Alert, Tag } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import dayjs from 'dayjs';
+import StatsCard from '~/components/shared/stats/StatsCard';
+import CommitTimeline, { type CommitRecord } from './CommitTimeline';
+import Anomalies from './Anomalies';
+import ContributorBreakdown, {
+  type EligibleStudent,
+} from './ContributorBreakdown';
+import HeuristicsChips from './HeuristicsChips';
+import PullRequestPills from './PullRequestPills';
+
+export type ContributorRecord = {
+  login: string;
+  user_id: string | null;
+  commits: number;
+  additions: number;
+  deletions: number;
+};
+
+export type PRSummary = { open: number; merged: number; closed: number };
+
+export type GitHubStatsSnapshot = {
+  total_commits: number;
+  total_additions: number;
+  total_deletions: number;
+  first_commit_at: string | null;
+  last_commit_at: string | null;
+  fetched_at: string;
+  stale: boolean;
+  error: string | null;
+  commits: CommitRecord[];
+  contributors: ContributorRecord[];
+  languages: Record<string, number>;
+  pr_summary: PRSummary;
+};
+
+export interface GitHubStatsPanelProps {
+  snapshot: GitHubStatsSnapshot | null;
+  deadline: string | null;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+  /** Repository.id — forwarded to ContributorBreakdown for link-to-student. */
+  repositoryId?: string;
+  /** Classroom members eligible to be linked. */
+  students?: EligibleStudent[];
+  /** Focus percentage (0-100) from quiz focus tracking. Optional. */
+  focusPct?: number | null;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function LanguageBar({ languages }: { languages: Record<string, number> }) {
+  const entries = Object.entries(languages);
+  if (entries.length === 0) return null;
+
+  const total = entries.reduce((sum, [, v]) => sum + v, 0);
+  if (total <= 0) return null;
+
+  const palette = [
+    '#6d5efc',
+    '#8a7afd',
+    '#a89cff',
+    '#c8c0ff',
+    '#dedaff',
+    '#5a4cf0',
+    '#4a3fbb',
+    '#3a3197',
+  ];
+
+  const withPct = entries
+    .map(([name, bytes], i) => ({
+      name,
+      bytes,
+      pct: (bytes / total) * 100,
+      color: palette[i % palette.length],
+    }))
+    .sort((a, b) => b.bytes - a.bytes);
+
+  return (
+    <div className="space-y-2" data-testid="language-breakdown">
+      <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold">
+        Languages
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        {withPct.map(l => (
+          <div
+            key={l.name}
+            title={`${l.name} · ${l.pct.toFixed(1)}%`}
+            style={{ width: `${l.pct}%`, backgroundColor: l.color }}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-600 dark:text-gray-300">
+        {withPct.map(l => (
+          <span key={l.name} className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: l.color }}
+            />
+            <span className="font-medium">{l.name}</span>
+            <span className="text-gray-400 dark:text-gray-500">{l.pct.toFixed(1)}%</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const GitHubStatsPanel = ({
+  snapshot,
+  deadline,
+  onRefresh,
+  refreshing = false,
+  repositoryId,
+  students,
+  focusPct,
+}: GitHubStatsPanelProps) => {
+  if (!snapshot) {
+    return (
+      <Card
+        className="border border-gray-100 dark:border-gray-700"
+        data-testid="github-stats-panel-empty"
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              GitHub Activity
+            </div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              No snapshot yet for this submission.
+            </div>
+          </div>
+          <Button
+            type="primary"
+            icon={<ReloadOutlined />}
+            onClick={onRefresh}
+            disabled={!onRefresh}
+            loading={refreshing}
+          >
+            Refresh
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  const {
+    total_commits,
+    total_additions,
+    total_deletions,
+    fetched_at,
+    stale,
+    error,
+    commits,
+    contributors,
+    languages,
+    pr_summary,
+  } = snapshot;
+
+  return (
+    <Card
+      className="border border-gray-100 dark:border-gray-700"
+      data-testid="github-stats-panel"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 mb-4">
+        <div>
+          <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            GitHub Activity
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <span data-testid="fetched-at">Updated {dayjs(fetched_at).fromNow()}</span>
+            {stale && (
+              <Tag color="warning" data-testid="stale-badge">
+                Stale
+              </Tag>
+            )}
+          </div>
+        </div>
+        <Button
+          icon={<ReloadOutlined />}
+          onClick={onRefresh}
+          disabled={!onRefresh}
+          loading={refreshing}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <Alert
+          type="error"
+          showIcon
+          className="mb-4"
+          message="Failed to refresh analytics"
+          description={error}
+          data-testid="snapshot-error"
+        />
+      )}
+
+      {/* Summary row */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6" data-testid="summary-row">
+        <StatsCard title="Commits">
+          <span data-testid="stat-commits">{formatNumber(total_commits)}</span>
+        </StatsCard>
+        <StatsCard title="Lines Added">
+          <span data-testid="stat-additions" className="text-green-600 dark:text-green-400">
+            +{formatNumber(total_additions)}
+          </span>
+        </StatsCard>
+        <StatsCard title="Lines Deleted">
+          <span data-testid="stat-deletions" className="text-red-600 dark:text-red-400">
+            -{formatNumber(total_deletions)}
+          </span>
+        </StatsCard>
+        <StatsCard title="Contributors">
+          <span data-testid="stat-contributors">{formatNumber(contributors.length)}</span>
+        </StatsCard>
+      </div>
+
+      {/* Commit timeline */}
+      <div className="mb-6">
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+          Commit Timeline
+        </div>
+        <CommitTimeline commits={commits} deadline={deadline} />
+      </div>
+
+      <HeuristicsChips
+        snapshot={{
+          commits,
+          contributors,
+          total_additions,
+          total_deletions,
+        }}
+        focusPct={focusPct ?? null}
+      />
+
+      <Anomalies
+        snapshot={{
+          commits,
+          contributors,
+          total_additions,
+          total_deletions,
+        }}
+        deadline={deadline}
+      />
+
+      {/* Contributor breakdown (only when >1 contributor) */}
+      {contributors.length > 1 && repositoryId && (
+        <ContributorBreakdown
+          commits={commits}
+          contributors={contributors}
+          unmatched={contributors
+            .filter(c => !c.user_id)
+            .map(c => ({ login: c.login, commits: c.commits }))}
+          repositoryId={repositoryId}
+          students={students ?? []}
+        />
+      )}
+
+      {/* Language breakdown */}
+      {Object.keys(languages).length > 0 && (
+        <div className="mb-4">
+          <LanguageBar languages={languages} />
+        </div>
+      )}
+
+      {/* PR summary */}
+      <div data-testid="pr-summary">
+        <PullRequestPills pr_summary={pr_summary} />
+      </div>
+    </Card>
+  );
+};
+
+export default GitHubStatsPanel;

--- a/apps/webapp/app/components/features/analytics/HeuristicsChips.tsx
+++ b/apps/webapp/app/components/features/analytics/HeuristicsChips.tsx
@@ -1,0 +1,108 @@
+import type { CommitRecord } from './CommitTimeline';
+import type { ContributorRecord } from './GitHubStatsPanel';
+
+export interface HeuristicsChipsProps {
+  snapshot: {
+    commits: CommitRecord[];
+    contributors: ContributorRecord[];
+    total_additions: number;
+    total_deletions: number;
+  };
+  /** Percent focused, 0-100. When null/undefined the focus chip is hidden. */
+  focusPct?: number | null;
+}
+
+type ChipTone = 'ok' | 'warn';
+
+interface ChipProps {
+  label: string;
+  value: string;
+  sub: string;
+  tone: ChipTone;
+  testId: string;
+}
+
+function Chip({ label, value, sub, tone, testId }: ChipProps) {
+  const toneClasses =
+    tone === 'warn'
+      ? 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800/60 dark:bg-amber-900/20 dark:text-amber-200'
+      : 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-800/60 dark:bg-emerald-900/20 dark:text-emerald-200';
+
+  return (
+    <div
+      className={`rounded-md border px-3 py-2 ${toneClasses}`}
+      data-testid={testId}
+      data-tone={tone}
+    >
+      <div className="text-[11px] uppercase tracking-wide font-semibold opacity-75">
+        {label}
+      </div>
+      <div className="text-lg font-semibold leading-tight mt-0.5">{value}</div>
+      <div className="text-xs opacity-80 mt-0.5">{sub}</div>
+    </div>
+  );
+}
+
+const HeuristicsChips = ({ snapshot, focusPct }: HeuristicsChipsProps) => {
+  const { commits } = snapshot;
+
+  // Spread — unique commit days
+  const dayset = new Set<string>();
+  for (const c of commits) {
+    if (c.ts) dayset.add(c.ts.slice(0, 10));
+  }
+  const uniqueDays = dayset.size;
+  const spreadTone: ChipTone = uniqueDays < 3 ? 'warn' : 'ok';
+
+  // Commit quality — average message length (chars)
+  const totalLen = commits.reduce((sum, c) => sum + (c.message?.length ?? 0), 0);
+  const avgLen = commits.length > 0 ? Math.round(totalLen / commits.length) : 0;
+  const qualityTone: ChipTone = avgLen < 15 ? 'warn' : 'ok';
+
+  const showFocus = focusPct != null && Number.isFinite(focusPct);
+  const focusTone: ChipTone = showFocus && (focusPct as number) < 70 ? 'warn' : 'ok';
+
+  const chipCount = showFocus ? 3 : 2;
+  const gridClass =
+    chipCount === 3
+      ? 'grid grid-cols-1 md:grid-cols-3 gap-3'
+      : 'grid grid-cols-1 md:grid-cols-2 gap-3';
+
+  return (
+    <div className={`${gridClass} mb-6`} data-testid="heuristics-chips">
+      <Chip
+        label="Spread"
+        value={`${uniqueDays} day${uniqueDays === 1 ? '' : 's'}`}
+        sub={
+          spreadTone === 'warn'
+            ? 'Concentrated in few days'
+            : 'Steady across the week'
+        }
+        tone={spreadTone}
+        testId="heuristic-spread"
+      />
+      <Chip
+        label="Commit quality"
+        value={`avg ${avgLen} chars/msg`}
+        sub={
+          qualityTone === 'warn'
+            ? "Short messages — 'wip', 'fix', etc."
+            : 'Descriptive messages'
+        }
+        tone={qualityTone}
+        testId="heuristic-quality"
+      />
+      {showFocus && (
+        <Chip
+          label="Focus"
+          value={`${Math.round(focusPct as number)}%`}
+          sub={focusTone === 'warn' ? 'Tab switched often' : 'Engaged throughout'}
+          tone={focusTone}
+          testId="heuristic-focus"
+        />
+      )}
+    </div>
+  );
+};
+
+export default HeuristicsChips;

--- a/apps/webapp/app/components/features/analytics/PullRequestPills.tsx
+++ b/apps/webapp/app/components/features/analytics/PullRequestPills.tsx
@@ -1,0 +1,64 @@
+import type { PRSummary } from './GitHubStatsPanel';
+
+export interface PullRequestPillsProps {
+  pr_summary: PRSummary;
+}
+
+type Tone = 'green' | 'violet' | 'gray';
+
+function pillClasses(tone: Tone): string {
+  switch (tone) {
+    case 'green':
+      return 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-200 dark:border-green-800/60';
+    case 'violet':
+      return 'bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-900/30 dark:text-violet-200 dark:border-violet-800/60';
+    case 'gray':
+    default:
+      return 'bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-700';
+  }
+}
+
+/**
+ * Three capsule pills for PR summary. Counts of 0 are hidden.
+ */
+const PullRequestPills = ({ pr_summary }: PullRequestPillsProps) => {
+  const items: Array<{ key: string; count: number; label: string; tone: Tone }> = [
+    { key: 'open', count: pr_summary.open, label: 'open', tone: 'green' },
+    { key: 'merged', count: pr_summary.merged, label: 'merged', tone: 'violet' },
+    { key: 'closed', count: pr_summary.closed, label: 'closed', tone: 'gray' },
+  ];
+
+  const visible = items.filter((i) => i.count > 0);
+  if (visible.length === 0) {
+    return (
+      <div
+        className="text-xs text-gray-500 dark:text-gray-400"
+        data-testid="pr-pills-empty"
+      >
+        No pull requests.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2" data-testid="pr-pills">
+      <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 self-center mr-1">
+        PRs
+      </span>
+      {visible.map((i) => (
+        <span
+          key={i.key}
+          className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium ${pillClasses(
+            i.tone,
+          )}`}
+          data-testid={`pr-pill-${i.key}`}
+        >
+          <span className="tabular-nums">{i.count}</span>
+          <span>{i.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default PullRequestPills;

--- a/apps/webapp/app/components/features/analytics/index.ts
+++ b/apps/webapp/app/components/features/analytics/index.ts
@@ -1,0 +1,20 @@
+export { default as GitHubStatsPanel } from './GitHubStatsPanel';
+export type {
+  GitHubStatsPanelProps,
+  GitHubStatsSnapshot,
+  ContributorRecord,
+  PRSummary,
+} from './GitHubStatsPanel';
+export { default as CommitTimeline, bucketCommitsByDay } from './CommitTimeline';
+export type { CommitTimelineProps, CommitRecord } from './CommitTimeline';
+export { default as Anomalies } from './Anomalies';
+export type { AnomaliesProps } from './Anomalies';
+export { default as ContributorBreakdown, loginToColor } from './ContributorBreakdown';
+export type {
+  ContributorBreakdownProps,
+  EligibleStudent,
+} from './ContributorBreakdown';
+export { default as HeuristicsChips } from './HeuristicsChips';
+export type { HeuristicsChipsProps } from './HeuristicsChips';
+export { default as PullRequestPills } from './PullRequestPills';
+export type { PullRequestPillsProps } from './PullRequestPills';

--- a/apps/webapp/app/components/features/dashboard/AssignmentHeatmap.tsx
+++ b/apps/webapp/app/components/features/dashboard/AssignmentHeatmap.tsx
@@ -1,0 +1,123 @@
+import { Card } from 'antd';
+import { CardHeader } from '~/components';
+
+export interface AssignmentHealthRow {
+  assignmentId: string;
+  title: string;
+  submissionRate: number;
+  medianGrade: number | null;
+  medianTimeToGradeHours: number | null;
+  regradeRate: number;
+}
+
+interface AssignmentHeatmapProps {
+  rows: AssignmentHealthRow[];
+}
+
+/**
+ * Four metrics per assignment, each cell colored from red (bad) to green (good).
+ * Keeping this intentionally simple — a table, not a ScatterChart.
+ */
+
+// Returns a Tailwind class pair for a normalized "goodness" value in [0, 1].
+const bandForGoodness = (g: number): string => {
+  if (g >= 0.8) return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+  if (g >= 0.6) return 'bg-lime-100 text-lime-800 dark:bg-lime-900/30 dark:text-lime-300';
+  if (g >= 0.4) return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+  if (g >= 0.2) return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300';
+  return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+};
+
+const emptyCell = 'bg-gray-50 text-gray-400 dark:bg-gray-800 dark:text-gray-500';
+
+// Higher = better: submissionRate, medianGrade/100 — use as-is.
+// Lower = better: regradeRate, medianTimeToGradeHours — invert.
+const goodnessSubmissionRate = (v: number) => Math.max(0, Math.min(1, v));
+const goodnessMedianGrade = (v: number | null) =>
+  v === null ? null : Math.max(0, Math.min(1, v / 100));
+const goodnessRegradeRate = (v: number) => Math.max(0, Math.min(1, 1 - v));
+// Treat 0-4h as great, 48h+ as terrible.
+const goodnessTTG = (h: number | null) => {
+  if (h === null) return null;
+  const clamped = Math.max(0, Math.min(48, h));
+  return 1 - clamped / 48;
+};
+
+const Cell = ({
+  value,
+  goodness,
+}: {
+  value: string;
+  goodness: number | null;
+}) => (
+  <div
+    className={`flex items-center justify-center text-xs font-medium rounded-md px-2 py-2 tabular-nums ${
+      goodness === null ? emptyCell : bandForGoodness(goodness)
+    }`}
+  >
+    {value}
+  </div>
+);
+
+const AssignmentHeatmap = ({ rows }: AssignmentHeatmapProps) => {
+  return (
+    <Card className="h-full" data-testid="assignment-heatmap">
+      <CardHeader>Assignment Health</CardHeader>
+      <div className="overflow-auto max-h-[420px]">
+        <div className="min-w-[520px]">
+          <div className="grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr] gap-2 text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 pb-2 border-b border-gray-100 dark:border-gray-700 mb-2">
+            <div>Assignment</div>
+            <div className="text-center">Sub Rate</div>
+            <div className="text-center">Median</div>
+            <div className="text-center">TTG</div>
+            <div className="text-center">Regrade</div>
+          </div>
+
+          {rows.length === 0 ? (
+            <div className="text-sm text-gray-500 dark:text-gray-400 py-6 text-center">
+              No assignments yet.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {rows.map((r) => (
+                <div
+                  key={r.assignmentId}
+                  className="grid grid-cols-[1.5fr_1fr_1fr_1fr_1fr] gap-2 items-center"
+                >
+                  <div
+                    className="text-sm text-gray-800 dark:text-gray-200 truncate"
+                    title={r.title}
+                  >
+                    {r.title}
+                  </div>
+                  <Cell
+                    value={`${Math.round(r.submissionRate * 100)}%`}
+                    goodness={goodnessSubmissionRate(r.submissionRate)}
+                  />
+                  <Cell
+                    value={r.medianGrade === null ? '—' : r.medianGrade.toFixed(0)}
+                    goodness={goodnessMedianGrade(r.medianGrade)}
+                  />
+                  <Cell
+                    value={
+                      r.medianTimeToGradeHours === null
+                        ? '—'
+                        : `${r.medianTimeToGradeHours.toFixed(1)}h`
+                    }
+                    goodness={goodnessTTG(r.medianTimeToGradeHours)}
+                  />
+                  <Cell
+                    value={`${Math.round(r.regradeRate * 100)}%`}
+                    goodness={goodnessRegradeRate(r.regradeRate)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default AssignmentHeatmap;

--- a/apps/webapp/app/components/features/dashboard/AtRiskStudents.tsx
+++ b/apps/webapp/app/components/features/dashboard/AtRiskStudents.tsx
@@ -1,0 +1,64 @@
+import { Card, Tag } from 'antd';
+import { CardHeader } from '~/components';
+import UserAvatar from '~/components/shared/UserAvatar';
+
+export interface AtRiskStudent {
+  userId: string;
+  name: string | null;
+  login: string;
+  missedDeadlines: number;
+}
+
+interface AtRiskStudentsProps {
+  atRiskCount: number;
+  students: AtRiskStudent[];
+}
+
+const AtRiskStudents = ({ atRiskCount, students }: AtRiskStudentsProps) => {
+  return (
+    <Card className="h-full" data-testid="at-risk-students">
+      <div className="flex items-center justify-between">
+        <CardHeader>At-Risk Students</CardHeader>
+        <Tag
+          className="border-0 bg-rose-bg dark:bg-red-900/30 text-rose-ink dark:text-red-300 font-semibold"
+          data-testid="at-risk-count"
+        >
+          {atRiskCount} total
+        </Tag>
+      </div>
+      {students.length === 0 ? (
+        <div className="text-sm text-gray-500 dark:text-gray-400 py-6 text-center">
+          No at-risk students. Nice work!
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 max-h-[360px] overflow-y-auto">
+          {students.map((s) => (
+            <div
+              key={s.userId}
+              className="flex items-center justify-between p-2 rounded-lg hover:bg-paper dark:hover:bg-gray-800 transition-colors"
+            >
+              <div className="flex items-center gap-3 min-w-0 flex-1">
+                <UserAvatar login={s.login} name={s.name} seed={s.userId} size={32} />
+                <div className="min-w-0">
+                  <div className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                    {s.name || s.login || 'Unknown'}
+                  </div>
+                  {s.login && (
+                    <div className="text-[11px] text-gray-500 dark:text-gray-400 truncate">
+                      @{s.login}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <Tag className="border-0 bg-amber-bg dark:bg-yellow-900/30 text-amber-ink dark:text-yellow-300 font-medium">
+                {s.missedDeadlines} missed
+              </Tag>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default AtRiskStudents;

--- a/apps/webapp/app/components/features/dashboard/DeadlinePressure.tsx
+++ b/apps/webapp/app/components/features/dashboard/DeadlinePressure.tsx
@@ -1,0 +1,91 @@
+import { Card, Tooltip } from 'antd';
+import dayjs from 'dayjs';
+import { CardHeader } from '~/components';
+
+export interface DeadlineBucket {
+  date: string; // YYYY-MM-DD
+  assignments: Array<{ id: string; title: string; dueAt: string }>;
+}
+
+interface DeadlinePressureProps {
+  buckets: DeadlineBucket[];
+}
+
+/**
+ * Horizontal timeline covering the next 7 days. For each day we render a dot
+ * whose size scales with assignment count. Hover reveals the titles.
+ */
+const DeadlinePressure = ({ buckets }: DeadlinePressureProps) => {
+  const today = dayjs().startOf('day');
+  const days: Array<{ date: string; label: string; dayLabel: string }> = [];
+  for (let i = 0; i < 7; i++) {
+    const d = today.add(i, 'day');
+    days.push({
+      date: d.format('YYYY-MM-DD'),
+      label: d.format('MMM D'),
+      dayLabel: d.format('ddd'),
+    });
+  }
+  const byDate = new Map(buckets.map((b) => [b.date, b]));
+  const maxCount = Math.max(1, ...buckets.map((b) => b.assignments.length));
+
+  return (
+    <Card className="h-full" data-testid="deadline-pressure">
+      <CardHeader>Deadline Pressure (next 7 days)</CardHeader>
+
+      <div className="flex items-end justify-between gap-2 py-6 min-h-[180px]">
+        {days.map((d) => {
+          const bucket = byDate.get(d.date);
+          const count = bucket?.assignments.length ?? 0;
+          // size: 12px (empty) -> 56px (max)
+          const size = count === 0 ? 12 : 16 + Math.round((count / maxCount) * 40);
+          const assignments = bucket?.assignments ?? [];
+          const tooltipContent =
+            count === 0 ? (
+              <span>No deadlines</span>
+            ) : (
+              <div className="text-xs">
+                {assignments.map((a) => (
+                  <div key={a.id} className="truncate">
+                    • {a.title}
+                  </div>
+                ))}
+              </div>
+            );
+
+          return (
+            <div key={d.date} className="flex flex-col items-center gap-2 flex-1 min-w-0">
+              <div className="flex-1 flex items-end justify-center w-full">
+                <Tooltip title={tooltipContent}>
+                  <div
+                    data-testid="deadline-dot"
+                    className={`rounded-full transition-transform hover:scale-110 cursor-pointer flex items-center justify-center text-[10px] font-bold ${
+                      count === 0
+                        ? 'bg-gray-200 dark:bg-gray-700'
+                        : count >= 3
+                          ? 'bg-rose-ink dark:bg-red-500 text-white'
+                          : count === 2
+                            ? 'bg-amber-ink dark:bg-yellow-500 text-white'
+                            : 'bg-primary-500 dark:bg-primary-400 text-white'
+                    }`}
+                    style={{ width: size, height: size }}
+                  >
+                    {count > 0 ? count : ''}
+                  </div>
+                </Tooltip>
+              </div>
+              <div className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold">
+                {d.dayLabel}
+              </div>
+              <div className="text-[11px] text-gray-400 dark:text-gray-500 tabular-nums">
+                {d.label}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+};
+
+export default DeadlinePressure;

--- a/apps/webapp/app/components/features/dashboard/MyDayQueue.tsx
+++ b/apps/webapp/app/components/features/dashboard/MyDayQueue.tsx
@@ -1,0 +1,71 @@
+import { Card, Empty, Tag } from 'antd';
+import { CardHeader } from '~/components';
+import UserAvatar from '~/components/shared/UserAvatar';
+
+export interface MyDayQueueRow {
+  repositoryAssignmentId: string;
+  studentName: string | null;
+  studentLogin: string | null;
+  assignmentTitle: string;
+  ageDays: number;
+}
+
+interface MyDayQueueProps {
+  queue: MyDayQueueRow[];
+}
+
+function slaColor(ageDays: number): { color: string; label: string } {
+  if (ageDays > 7) return { color: 'red', label: `${ageDays}d` };
+  if (ageDays > 3) return { color: 'orange', label: `${ageDays}d` };
+  return { color: 'default', label: `${ageDays}d` };
+}
+
+const MyDayQueue = ({ queue }: MyDayQueueProps) => {
+  return (
+    <Card className="h-full" data-testid="my-day-queue">
+      <CardHeader>My Day</CardHeader>
+      {queue.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <span className="text-gray-500 dark:text-gray-400">Inbox zero — nice.</span>
+          }
+        />
+      ) : (
+        <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+          {queue.map((row) => {
+            const sla = slaColor(row.ageDays);
+            const displayName = row.studentName || row.studentLogin || 'Unknown';
+            return (
+              <li
+                key={row.repositoryAssignmentId}
+                className="flex items-center gap-3 py-2 min-w-0"
+                data-testid="my-day-row"
+              >
+                <UserAvatar
+                  login={row.studentLogin}
+                  name={row.studentName}
+                  seed={row.repositoryAssignmentId}
+                  size={32}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-gray-900 dark:text-gray-100 truncate">
+                    {displayName}
+                  </div>
+                  <div className="text-[11px] text-gray-500 dark:text-gray-400 truncate">
+                    {row.assignmentTitle}
+                  </div>
+                </div>
+                <Tag color={sla.color} className="flex-shrink-0 tabular-nums">
+                  {sla.label}
+                </Tag>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card>
+  );
+};
+
+export default MyDayQueue;

--- a/apps/webapp/app/components/features/dashboard/OwnVsClassHistogram.tsx
+++ b/apps/webapp/app/components/features/dashboard/OwnVsClassHistogram.tsx
@@ -1,0 +1,103 @@
+import { Card, Empty } from 'antd';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { CardHeader } from '~/components';
+import { useDarkMode } from '~/hooks';
+
+export interface GradeBucket {
+  bucket: string;
+  count: number;
+}
+
+interface OwnVsClassHistogramProps {
+  yours: GradeBucket[];
+  classroom: GradeBucket[];
+}
+
+// Class distribution stays a neutral gray so the two bar series never collide
+// visually regardless of the user's accent choice. "Yours" is resolved at
+// render time from the live accent (Recharts doesn't reliably resolve
+// `var(--accent)` in SVG fill attributes).
+const CLASS_COLOR = '#94a3b8';
+
+function normalize(rows: GradeBucket[]): Map<string, number> {
+  const total = rows.reduce((sum, r) => sum + r.count, 0);
+  const out = new Map<string, number>();
+  for (const r of rows) {
+    out.set(r.bucket, total > 0 ? r.count / total : 0);
+  }
+  return out;
+}
+
+const OwnVsClassHistogram = ({ yours, classroom }: OwnVsClassHistogramProps) => {
+  const { accent } = useDarkMode();
+  const yoursMap = normalize(yours);
+  const classMap = normalize(classroom);
+  // Preserve order from `classroom` buckets (canonical), fall back to yours.
+  const source = classroom.length > 0 ? classroom : yours;
+  const data = source.map((r) => ({
+    bucket: r.bucket,
+    yours: Math.round((yoursMap.get(r.bucket) ?? 0) * 1000) / 10,
+    classroom: Math.round((classMap.get(r.bucket) ?? 0) * 1000) / 10,
+  }));
+  const totalYours = yours.reduce((s, r) => s + r.count, 0);
+  const totalClass = classroom.reduce((s, r) => s + r.count, 0);
+  const isEmpty = totalYours === 0 && totalClass === 0;
+
+  return (
+    <Card className="h-full" data-testid="own-vs-class-histogram">
+      <CardHeader>My Grades vs. Class</CardHeader>
+      {isEmpty ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <span className="text-gray-500 dark:text-gray-400">No grades yet.</span>
+          }
+        />
+      ) : (
+        <div style={{ height: 260 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} margin={{ top: 12, right: 12, bottom: 4, left: 0 }}>
+              <CartesianGrid stroke="#e5e7eb" strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="bucket"
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                axisLine={{ stroke: '#e5e7eb' }}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: '#6b7280' }}
+                axisLine={{ stroke: '#e5e7eb' }}
+                tickLine={false}
+                tickFormatter={(v: number) => `${v}%`}
+              />
+              <Tooltip
+                formatter={(v: number, name: string) => [
+                  `${v.toFixed(1)}%`,
+                  name === 'yours' ? 'Yours' : 'Classroom',
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Legend
+                wrapperStyle={{ fontSize: 12 }}
+                formatter={(v: string) => (v === 'yours' ? 'Yours' : 'Classroom')}
+              />
+              <Bar dataKey="yours" fill={accent} radius={[2, 2, 0, 0]} />
+              <Bar dataKey="classroom" fill={CLASS_COLOR} radius={[2, 2, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default OwnVsClassHistogram;

--- a/apps/webapp/app/components/features/dashboard/QuizAnalytics.tsx
+++ b/apps/webapp/app/components/features/dashboard/QuizAnalytics.tsx
@@ -1,0 +1,65 @@
+import { Card } from 'antd';
+import { CardHeader } from '~/components';
+
+export interface QuizAnalyticsData {
+  hardestQuestions: Array<{ questionId: string; prompt: string; correctRate: number }>;
+  avgFocusPct: number | null;
+}
+
+interface QuizAnalyticsProps {
+  data: QuizAnalyticsData;
+}
+
+const QuizAnalytics = ({ data }: QuizAnalyticsProps) => {
+  const pct = data.avgFocusPct;
+  const display = pct === null ? '—' : `${Math.round(pct * 100)}%`;
+
+  return (
+    <Card className="h-full" data-testid="quiz-analytics">
+      <CardHeader>Quiz Analytics</CardHeader>
+      <div className="flex flex-col items-center justify-center py-8">
+        <div className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+          Avg Focus
+        </div>
+        <div
+          className="text-6xl font-bold text-primary-600 dark:text-primary-400 tabular-nums"
+          data-testid="avg-focus-pct"
+        >
+          {display}
+        </div>
+        <div className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          Across all quiz attempts in this class
+        </div>
+      </div>
+
+      <div className="border-t border-gray-100 dark:border-gray-700 pt-4">
+        <div className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+          Hardest Questions
+        </div>
+        {data.hardestQuestions.length === 0 ? (
+          <div className="text-sm text-gray-500 dark:text-gray-400 italic">
+            Hardest questions analytics coming soon
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {data.hardestQuestions.map((q) => (
+              <li
+                key={q.questionId}
+                className="flex items-start justify-between gap-3 text-sm"
+              >
+                <span className="text-gray-800 dark:text-gray-200 flex-1 truncate">
+                  {q.prompt}
+                </span>
+                <span className="text-rose-ink dark:text-red-300 font-semibold tabular-nums">
+                  {Math.round(q.correctRate * 100)}%
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export default QuizAnalytics;

--- a/apps/webapp/app/components/features/dashboard/StreakBadge.tsx
+++ b/apps/webapp/app/components/features/dashboard/StreakBadge.tsx
@@ -1,0 +1,43 @@
+import { Card } from 'antd';
+import dayjs from 'dayjs';
+import { CardHeader } from '~/components';
+
+interface StreakBadgeProps {
+  days: number;
+  lastGradedAt: string | null;
+}
+
+const StreakBadge = ({ days, lastGradedAt }: StreakBadgeProps) => {
+  const hasStreak = days > 0;
+  return (
+    <Card className="h-full" data-testid="streak-badge">
+      <CardHeader>Grading Streak</CardHeader>
+      {hasStreak ? (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-semibold tabular-nums text-gray-900 dark:text-gray-100">
+              {days}
+            </span>
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              day{days === 1 ? '' : 's'}
+            </span>
+            <span aria-hidden className="text-xl">
+              🔥
+            </span>
+          </div>
+          {lastGradedAt && (
+            <div className="text-[11px] text-gray-500 dark:text-gray-400">
+              Last graded {dayjs(lastGradedAt).fromNow()}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="text-sm text-gray-600 dark:text-gray-400 leading-snug">
+          Start a streak — grade 1 assignment today
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default StreakBadge;

--- a/apps/webapp/app/components/features/dashboard/TAOpsTable.tsx
+++ b/apps/webapp/app/components/features/dashboard/TAOpsTable.tsx
@@ -1,0 +1,102 @@
+import { Card, Table } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { CardHeader } from '~/components';
+import UserAvatar from '~/components/shared/UserAvatar';
+
+export interface TaOpsRow {
+  taId: string;
+  login: string;
+  name: string | null;
+  throughput7d: number;
+  avgTimeToGradeHours: number | null;
+  overturnRate: number | null;
+  gradeDistributionMean: number | null;
+}
+
+interface TAOpsTableProps {
+  rows: TaOpsRow[];
+}
+
+const TAOpsTable = ({ rows }: TAOpsTableProps) => {
+  const columns: ColumnsType<TaOpsRow> = [
+    {
+      title: 'TA',
+      key: 'ta',
+      render: (_, r) => (
+        <div className="flex items-center gap-2 min-w-0">
+          <UserAvatar login={r.login} name={r.name} seed={r.taId} size={28} />
+          <div className="min-w-0">
+            <div className="text-sm text-gray-900 dark:text-gray-100 truncate">
+              {r.name || r.login || 'Unknown'}
+            </div>
+            {r.login && (
+              <div className="text-[11px] text-gray-500 dark:text-gray-400 truncate">
+                @{r.login}
+              </div>
+            )}
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: 'Throughput (7d)',
+      key: 'throughput7d',
+      dataIndex: 'throughput7d',
+      align: 'right',
+      sorter: (a, b) => a.throughput7d - b.throughput7d,
+      render: (v: number) => <span className="tabular-nums">{v}</span>,
+    },
+    {
+      title: 'Avg TTG',
+      key: 'avgTimeToGradeHours',
+      align: 'right',
+      sorter: (a, b) =>
+        (a.avgTimeToGradeHours ?? Number.POSITIVE_INFINITY) -
+        (b.avgTimeToGradeHours ?? Number.POSITIVE_INFINITY),
+      render: (_, r) => (
+        <span className="tabular-nums">
+          {r.avgTimeToGradeHours === null ? '—' : `${r.avgTimeToGradeHours.toFixed(1)}h`}
+        </span>
+      ),
+    },
+    {
+      title: 'Overturn %',
+      key: 'overturnRate',
+      align: 'right',
+      sorter: (a, b) => (a.overturnRate ?? -1) - (b.overturnRate ?? -1),
+      render: (_, r) => (
+        <span className="tabular-nums">
+          {r.overturnRate === null ? '—' : `${Math.round(r.overturnRate * 100)}%`}
+        </span>
+      ),
+    },
+    {
+      title: 'Avg Grade Given',
+      key: 'gradeDistributionMean',
+      align: 'right',
+      sorter: (a, b) => (a.gradeDistributionMean ?? -1) - (b.gradeDistributionMean ?? -1),
+      render: (_, r) => (
+        <span className="tabular-nums">
+          {r.gradeDistributionMean === null ? '—' : r.gradeDistributionMean.toFixed(1)}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <Card className="h-full" data-testid="ta-ops-table">
+      <CardHeader>TA Operations</CardHeader>
+      <Table<TaOpsRow>
+        rowKey="taId"
+        size="small"
+        pagination={false}
+        dataSource={rows}
+        columns={columns}
+        scroll={{ x: true, y: 340 }}
+        locale={{ emptyText: 'No TAs yet.' }}
+      />
+    </Card>
+  );
+};
+
+export default TAOpsTable;

--- a/apps/webapp/app/components/features/dashboard/ThroughputSparkline.tsx
+++ b/apps/webapp/app/components/features/dashboard/ThroughputSparkline.tsx
@@ -1,0 +1,74 @@
+import { useId } from 'react';
+import { Card } from 'antd';
+import dayjs from 'dayjs';
+import { ResponsiveContainer, AreaChart, Area, Tooltip } from 'recharts';
+import { CardHeader } from '~/components';
+import { useDarkMode } from '~/hooks';
+
+export interface ThroughputPoint {
+  date: string; // YYYY-MM-DD
+  count: number;
+}
+
+interface ThroughputSparklineProps {
+  data: ThroughputPoint[];
+}
+
+interface TooltipPayloadItem {
+  payload?: ThroughputPoint;
+}
+
+const SparkTooltip = ({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0].payload;
+  if (!point) return null;
+  return (
+    <div className="rounded-md bg-gray-900/90 dark:bg-gray-100/90 px-2 py-1 text-[11px] text-white dark:text-gray-900 shadow">
+      <div className="font-semibold tabular-nums">{point.count} graded</div>
+      <div className="opacity-80">{dayjs(point.date).format('ddd MMM D')}</div>
+    </div>
+  );
+};
+
+const ThroughputSparkline = ({ data }: ThroughputSparklineProps) => {
+  const total = data.reduce((sum, d) => sum + d.count, 0);
+  const { accent } = useDarkMode();
+  const gradientId = useId();
+  return (
+    <Card className="h-full" data-testid="throughput-sparkline">
+      <CardHeader>Throughput (7d)</CardHeader>
+      <div className="text-2xl font-semibold tabular-nums text-gray-900 dark:text-gray-100">
+        {total}
+      </div>
+      <div style={{ height: 60 }} className="mt-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={accent} stopOpacity={0.35} />
+                <stop offset="100%" stopColor={accent} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <Tooltip content={<SparkTooltip />} cursor={{ stroke: accent, strokeOpacity: 0.3 }} />
+            <Area
+              type="monotone"
+              dataKey="count"
+              stroke={accent}
+              strokeWidth={2}
+              fill={`url(#${gradientId})`}
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  );
+};
+
+export default ThroughputSparkline;

--- a/apps/webapp/app/components/features/dashboard/index.ts
+++ b/apps/webapp/app/components/features/dashboard/index.ts
@@ -1,0 +1,17 @@
+export { default as AssignmentHeatmap } from './AssignmentHeatmap';
+export type { AssignmentHealthRow } from './AssignmentHeatmap';
+export { default as TAOpsTable } from './TAOpsTable';
+export type { TaOpsRow } from './TAOpsTable';
+export { default as AtRiskStudents } from './AtRiskStudents';
+export type { AtRiskStudent } from './AtRiskStudents';
+export { default as QuizAnalytics } from './QuizAnalytics';
+export type { QuizAnalyticsData } from './QuizAnalytics';
+export { default as DeadlinePressure } from './DeadlinePressure';
+export type { DeadlineBucket } from './DeadlinePressure';
+export { default as MyDayQueue } from './MyDayQueue';
+export type { MyDayQueueRow } from './MyDayQueue';
+export { default as ThroughputSparkline } from './ThroughputSparkline';
+export type { ThroughputPoint } from './ThroughputSparkline';
+export { default as StreakBadge } from './StreakBadge';
+export { default as OwnVsClassHistogram } from './OwnVsClassHistogram';
+export type { GradeBucket } from './OwnVsClassHistogram';

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -415,7 +415,7 @@ const CommonLayout = ({
 
       {/* Main Content Area */}
       <div
-        className="flex-1 flex flex-col transition-all duration-300 ease-in-out min-w-0 lg:ml-[calc(var(--sider-width)+0.5rem)]"
+        className="flex-1 flex flex-col transition-all duration-300 ease-in-out min-w-0 lg:ml-[calc(var(--sider-width)+1.5rem)]"
         style={{ '--sider-width': `${siderWidth}px` } as React.CSSProperties}
       >
         {/* Mobile-only hamburger (when sidebar is closed) */}
@@ -441,6 +441,8 @@ const CommonLayout = ({
             pathname.includes('/settings') ||
             pathname.includes('/students') ||
             pathname.includes('/grading') ||
+            pathname.includes('/repo-health') ||
+            pathname.includes('/submissions/') ||
             pathname.match(/\/pages(\/|$)/) ||
             pathname.match(/\/grades(\/|$)/) ||
             pathname.match(/\/repositories(\/|$)/)

--- a/apps/webapp/app/components/shared/UserAvatar.tsx
+++ b/apps/webapp/app/components/shared/UserAvatar.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+const GRADIENTS = [
+  'from-rose-400 to-pink-500',
+  'from-amber-400 to-orange-500',
+  'from-emerald-400 to-teal-500',
+  'from-sky-400 to-indigo-500',
+  'from-violet-400 to-fuchsia-500',
+  'from-lime-400 to-green-500',
+  'from-cyan-400 to-blue-500',
+  'from-fuchsia-400 to-rose-500',
+];
+
+const pickGradient = (seed: string) => {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  return GRADIENTS[Math.abs(hash) % GRADIENTS.length];
+};
+
+const getInitials = (name?: string | null, login?: string | null) => {
+  const source = (name || login || '').trim();
+  if (!source) return '?';
+  const parts = source.split(/\s+/).filter(Boolean);
+  const initials = parts
+    .map((p) => p[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+  return initials || source.slice(0, 1).toUpperCase();
+};
+
+interface UserAvatarProps {
+  login?: string | null;
+  name?: string | null;
+  seed?: string | null;
+  size?: number;
+  className?: string;
+  ringClassName?: string;
+}
+
+const UserAvatar = ({
+  login,
+  name,
+  seed,
+  size = 32,
+  className = '',
+  ringClassName = 'ring-1 ring-gray-200 dark:ring-gray-700',
+}: UserAvatarProps) => {
+  const [errored, setErrored] = useState(false);
+  const initials = getInitials(name, login);
+  const gradient = pickGradient(seed || login || name || 'x');
+  const style = { width: size, height: size };
+  const fontSize = Math.max(10, Math.round(size * 0.38));
+
+  if (!login || errored) {
+    return (
+      <div
+        style={{ ...style, fontSize }}
+        className={`rounded-full bg-gradient-to-br ${gradient} text-white flex items-center justify-center font-bold flex-shrink-0 ring-1 ring-black/5 dark:ring-white/10 ${className}`}
+      >
+        {initials}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={`https://github.com/${login}.png?size=${size * 2}`}
+      alt={name || login}
+      onError={() => setErrored(true)}
+      style={style}
+      className={`rounded-full ${ringClassName} flex-shrink-0 object-cover ${className}`}
+    />
+  );
+};
+
+export default UserAvatar;

--- a/apps/webapp/app/constants/routes.ts
+++ b/apps/webapp/app/constants/routes.ts
@@ -20,6 +20,7 @@ import {
   IconLink,
   IconChecklist,
   IconClipboardList,
+  IconHeartRateMonitor,
 } from '@tabler/icons-react';
 
 /**
@@ -40,7 +41,7 @@ export const routeCategories = {
   },
   integrations: {
     label: 'Integrations',
-    items: ['repositories'],
+    items: ['repositories', 'repo-health'],
   },
   settings: {
     label: 'Settings',
@@ -166,6 +167,13 @@ export const routes = {
     link: '/repositories',
     label: 'Repositories',
     icon: IconBrandGithub,
+    roles: ['OWNER'],
+    category: 'integrations',
+  },
+  'repo-health': {
+    link: '/repo-health',
+    label: 'Repo Health',
+    icon: IconHeartRateMonitor,
     roles: ['OWNER'],
     category: 'integrations',
   },

--- a/apps/webapp/app/routes/admin.$class.dashboard/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.dashboard/route.tsx
@@ -281,44 +281,19 @@ const AdminDashboard = ({ loaderData }: Route.ComponentProps) => {
             const [assignments, taOps, cohort, quiz, deadlines] = result;
             return (
               <>
-                <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
-                  <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                    Assignment health
-                  </h3>
-                  <AssignmentHeatmap rows={assignments} />
-                </section>
+                <AssignmentHeatmap rows={assignments} />
 
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                      TA operations
-                    </h3>
-                    <TAOpsTable rows={taOps} />
-                  </section>
-                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                      At-risk students
-                    </h3>
-                    <AtRiskStudents
-                      atRiskCount={cohort.atRiskCount}
-                      students={cohort.atRiskStudents}
-                    />
-                  </section>
+                  <TAOpsTable rows={taOps} />
+                  <AtRiskStudents
+                    atRiskCount={cohort.atRiskCount}
+                    students={cohort.atRiskStudents}
+                  />
                 </div>
 
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                      Quiz analytics
-                    </h3>
-                    <QuizAnalytics data={quiz} />
-                  </section>
-                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                      Deadline pressure
-                    </h3>
-                    <DeadlinePressure buckets={deadlines} />
-                  </section>
+                  <QuizAnalytics data={quiz} />
+                  <DeadlinePressure buckets={deadlines} />
                 </div>
               </>
             );

--- a/apps/webapp/app/routes/admin.$class.dashboard/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.dashboard/route.tsx
@@ -10,6 +10,13 @@ import { requireClassroomAdmin } from '~/utils/routeAuth.server';
 import SubmissionChart from './SubmissionChart';
 import Leaderboard from './Leaderboard';
 import GradingTabsCard from './GradingTabsCard';
+import {
+  AssignmentHeatmap,
+  TAOpsTable,
+  AtRiskStudents,
+  QuizAnalytics,
+  DeadlinePressure,
+} from '~/components/features/dashboard';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -76,8 +83,17 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     lateRepoAssignments: lateRepoAssignmentsPromise,
   };
 
+  const analyticsPromise = Promise.all([
+    ClassmojiService.dashboard.assignmentHealth(classroom.id),
+    ClassmojiService.dashboard.taOps(classroom.id),
+    ClassmojiService.dashboard.cohortOverview(classroom.id),
+    ClassmojiService.dashboard.quizAnalytics(classroom.id),
+    ClassmojiService.dashboard.deadlinePressure(classroom.id),
+  ]).catch(() => null);
+
   return {
     data: Promise.all(Object.values(promises)),
+    analytics: analyticsPromise,
     githubOrganization,
   };
 };
@@ -143,7 +159,7 @@ const RingChart = ({ pct, color }: { pct: number; color: string }) => {
 };
 
 const AdminDashboard = ({ loaderData }: Route.ComponentProps) => {
-  const { data, githubOrganization } = loaderData;
+  const { data, analytics, githubOrganization } = loaderData;
   const { class: classSlug } = useParams();
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
@@ -252,6 +268,58 @@ const AdminDashboard = ({ loaderData }: Route.ComponentProps) => {
                   gradingProgress={gradingProgressPerAssignment}
                   assistantsProgress={assistantsProgress}
                 />
+              </>
+            );
+          }}
+        </Await>
+      </Suspense>
+
+      <Suspense fallback={<Skeleton active paragraph={{ rows: 6 }} />}>
+        <Await resolve={analytics} errorElement={null}>
+          {(result) => {
+            if (!result) return null;
+            const [assignments, taOps, cohort, quiz, deadlines] = result;
+            return (
+              <>
+                <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
+                  <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                    Assignment health
+                  </h3>
+                  <AssignmentHeatmap rows={assignments} />
+                </section>
+
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                      TA operations
+                    </h3>
+                    <TAOpsTable rows={taOps} />
+                  </section>
+                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                      At-risk students
+                    </h3>
+                    <AtRiskStudents
+                      atRiskCount={cohort.atRiskCount}
+                      students={cohort.atRiskStudents}
+                    />
+                  </section>
+                </div>
+
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                      Quiz analytics
+                    </h3>
+                    <QuizAnalytics data={quiz} />
+                  </section>
+                  <section className="rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 p-4 sm:p-5">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                      Deadline pressure
+                    </h3>
+                    <DeadlinePressure buckets={deadlines} />
+                  </section>
+                </div>
               </>
             );
           }}

--- a/apps/webapp/app/routes/admin.$class.repo-health/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.repo-health/route.tsx
@@ -1,0 +1,229 @@
+import { Button, Card, Empty, Tag } from 'antd';
+import dayjs from 'dayjs';
+
+import { ClassmojiService } from '@classmoji/services';
+import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import type { Route } from './+types/route';
+
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
+  const classSlug = params.class!;
+  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+    resourceType: 'REPOSITORIES',
+    action: 'view_repo_health',
+  });
+
+  const health = await ClassmojiService.repoAnalytics.classroomRepoHealth(
+    classroom.id,
+  );
+
+  return { classSlug, health };
+};
+
+const PALETTE = [
+  '#6d5efc',
+  '#8a7afd',
+  '#a89cff',
+  '#5a4cf0',
+  '#f59e0b',
+  '#16a34a',
+  '#06b6d4',
+  '#ec4899',
+];
+
+function LanguageBar({ langs }: { langs: Record<string, number> }) {
+  const entries = Object.entries(langs);
+  const total = entries.reduce((s, [, v]) => s + v, 0);
+  if (total <= 0) {
+    return <span className="text-xs text-gray-400 dark:text-gray-500">—</span>;
+  }
+  const items = entries
+    .map(([name, bytes], i) => ({
+      name,
+      pct: (bytes / total) * 100,
+      color: PALETTE[i % PALETTE.length],
+    }))
+    .sort((a, b) => b.pct - a.pct);
+  return (
+    <div className="flex flex-col gap-1 min-w-[160px]">
+      <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+        {items.map((l) => (
+          <div
+            key={l.name}
+            title={`${l.name} · ${l.pct.toFixed(1)}%`}
+            style={{ width: `${l.pct}%`, backgroundColor: l.color }}
+          />
+        ))}
+      </div>
+      <div className="text-[10px] text-gray-500 dark:text-gray-400 truncate">
+        {items
+          .slice(0, 3)
+          .map((l) => `${l.name} ${l.pct.toFixed(0)}%`)
+          .join(' · ')}
+      </div>
+    </div>
+  );
+}
+
+const RepoHealth = ({ loaderData }: Route.ComponentProps) => {
+  const { health } = loaderData;
+  const { repos, unmatched, nextScheduledAt, autoRefreshEvery } = health;
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="repo-health">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Repo Health
+        </h1>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Schedule card */}
+        <Card
+          className="lg:col-span-1 border border-gray-100 dark:border-gray-700"
+          data-testid="schedule-card"
+        >
+          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+            Snapshot schedule
+          </div>
+          <dl className="space-y-2 text-sm">
+            <div className="flex items-center justify-between">
+              <dt className="text-gray-500 dark:text-gray-400">Auto refresh</dt>
+              <dd className="font-medium text-gray-900 dark:text-gray-100">
+                every {autoRefreshEvery}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-gray-500 dark:text-gray-400">Next run</dt>
+              <dd
+                className="font-medium text-gray-900 dark:text-gray-100"
+                title={new Date(nextScheduledAt).toLocaleString()}
+              >
+                {dayjs(nextScheduledAt).fromNow()}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-gray-500 dark:text-gray-400">
+                Refresh on deadline
+              </dt>
+              <dd>
+                <Tag color="success" className="dark:border-green-800">
+                  enabled
+                </Tag>
+              </dd>
+            </div>
+          </dl>
+        </Card>
+
+        {/* Unmatched contributors */}
+        <Card
+          className="lg:col-span-2 border border-gray-100 dark:border-gray-700"
+          data-testid="unmatched-card"
+        >
+          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-2">
+            Unmatched contributors
+          </div>
+          {unmatched.length === 0 ? (
+            <div className="text-sm text-gray-500 dark:text-gray-400 py-3">
+              Everyone is linked.
+            </div>
+          ) : (
+            <div className="rounded-lg border border-gray-100 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-700 max-h-80 overflow-y-auto">
+              {unmatched.map((u) => (
+                <div
+                  key={`${u.repo}-${u.login}`}
+                  className="flex items-center justify-between px-3 py-2 text-sm"
+                  data-testid={`unmatched-${u.login}-${u.repo}`}
+                >
+                  <div className="min-w-0">
+                    <div className="font-mono text-xs font-semibold text-gray-800 dark:text-gray-100 truncate">
+                      @{u.login}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                      {u.repo} · {u.commits} commit
+                      {u.commits === 1 ? '' : 's'} · first seen{' '}
+                      {dayjs(u.firstSeen).fromNow()}
+                    </div>
+                  </div>
+                  <Button size="small" disabled title="Coming soon">
+                    Match…
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      </div>
+
+      {/* Repos table */}
+      <Card
+        className="border border-gray-100 dark:border-gray-700"
+        data-testid="repos-card"
+      >
+        <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold mb-3">
+          Repositories ({repos.length})
+        </div>
+        {repos.length === 0 ? (
+          <Empty
+            description={
+              <span className="text-gray-500 dark:text-gray-400">
+                No repository snapshots yet.
+              </span>
+            }
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                  <th className="py-2 pr-4 font-semibold">Repo</th>
+                  <th className="py-2 pr-4 font-semibold">Languages</th>
+                  <th className="py-2 pr-4 font-semibold text-right">Commits</th>
+                  <th className="py-2 pr-4 font-semibold">Fetched</th>
+                  <th className="py-2 pr-4 font-semibold">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {repos.map((r) => (
+                  <tr
+                    key={r.name}
+                    className="border-b border-gray-50 dark:border-gray-800 last:border-0"
+                    data-testid={`repo-row-${r.name}`}
+                  >
+                    <td className="py-3 pr-4 font-mono text-xs text-gray-800 dark:text-gray-100">
+                      {r.name}
+                    </td>
+                    <td className="py-3 pr-4">
+                      <LanguageBar langs={r.langs} />
+                    </td>
+                    <td className="py-3 pr-4 text-right tabular-nums text-gray-700 dark:text-gray-200">
+                      {r.commits.toLocaleString()}
+                    </td>
+                    <td
+                      className="py-3 pr-4 text-gray-600 dark:text-gray-300"
+                      title={new Date(r.fetchedAt).toLocaleString()}
+                    >
+                      {dayjs(r.fetchedAt).fromNow()}
+                    </td>
+                    <td className="py-3 pr-4">
+                      {r.status === 'fresh' ? (
+                        <Tag color="success" className="dark:border-green-800">
+                          fresh
+                        </Tag>
+                      ) : (
+                        <Tag color="warning" className="dark:border-amber-800">
+                          stale
+                        </Tag>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default RepoHealth;

--- a/apps/webapp/app/routes/admin.$class.submissions.$id/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.submissions.$id/route.tsx
@@ -1,0 +1,138 @@
+import { Link } from 'react-router';
+import { useState } from 'react';
+import { Alert, Button } from 'antd';
+import { IconChevronLeft } from '@tabler/icons-react';
+
+import { ClassmojiService } from '@classmoji/services';
+import getPrisma from '@classmoji/database';
+import { requireClassroomTeachingTeam } from '~/utils/routeAuth.server';
+import {
+  GitHubStatsPanel,
+  type GitHubStatsSnapshot,
+  type EligibleStudent,
+} from '~/components/features/analytics';
+import type { Route } from './+types/route';
+
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
+  const classSlug = params.class!;
+  const repoAssignmentId = params.id!;
+
+  const { classroom } = await requireClassroomTeachingTeam(request, classSlug, {
+    resourceType: 'REPOSITORY_ASSIGNMENT',
+    action: 'view_submission_analytics',
+  });
+
+  const repoAssignment = await getPrisma().repositoryAssignment.findUnique({
+    where: { id: repoAssignmentId },
+    include: {
+      assignment: true,
+      repository: {
+        include: {
+          student: true,
+          team: true,
+          module: true,
+        },
+      },
+      analytics_snapshot: true,
+    },
+  });
+
+  if (!repoAssignment || repoAssignment.repository.classroom_id !== classroom.id) {
+    throw new Response('Submission not found', { status: 404 });
+  }
+
+  const studentMemberships = await ClassmojiService.classroomMembership.findStudents(
+    classroom.id,
+  );
+  const students: EligibleStudent[] = studentMemberships.map((m) => ({
+    id: m.user.id,
+    name: m.user.name ?? m.user.login ?? 'Unknown',
+    login: m.user.login ?? null,
+  }));
+
+  const snapshot = repoAssignment.analytics_snapshot as unknown as
+    | GitHubStatsSnapshot
+    | null;
+
+  return {
+    classSlug,
+    repoAssignmentId,
+    repoName: repoAssignment.repository.name,
+    assignmentTitle: repoAssignment.assignment.title,
+    deadline: repoAssignment.assignment.student_deadline?.toISOString() ?? null,
+    repositoryId: repoAssignment.repository.id,
+    snapshot,
+    students,
+  };
+};
+
+const SubmissionAnalytics = ({ loaderData }: Route.ComponentProps) => {
+  const {
+    classSlug,
+    repoAssignmentId,
+    repoName,
+    assignmentTitle,
+    deadline,
+    repositoryId,
+    snapshot,
+    students,
+  } = loaderData;
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const res = await fetch(`/api/repos/${repoAssignmentId}/refresh`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Refresh failed (${res.status})`);
+      }
+    } catch (err) {
+      setRefreshError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="submission-analytics">
+      <div className="flex items-center gap-2">
+        <Link to={`/admin/${classSlug}/grading`}>
+          <Button
+            size="small"
+            icon={<IconChevronLeft size={14} />}
+            className="flex items-center"
+          >
+            Back
+          </Button>
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          {assignmentTitle}{' '}
+          <span className="font-mono text-base text-gray-500 dark:text-gray-400">
+            · {repoName}
+          </span>
+        </h1>
+      </div>
+
+      {refreshError ? (
+        <Alert type="error" message={refreshError} closable />
+      ) : null}
+
+      <GitHubStatsPanel
+        snapshot={snapshot}
+        deadline={deadline}
+        onRefresh={onRefresh}
+        refreshing={refreshing}
+        repositoryId={repositoryId}
+        students={students}
+      />
+    </div>
+  );
+};
+
+export default SubmissionAnalytics;

--- a/apps/webapp/app/routes/admin.$class.submissions.$id/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.submissions.$id/route.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { useState } from 'react';
 import { Alert, Button } from 'antd';
 import { IconChevronLeft } from '@tabler/icons-react';
@@ -78,6 +78,12 @@ const SubmissionAnalytics = ({ loaderData }: Route.ComponentProps) => {
     students,
   } = loaderData;
 
+  const { pathname } = useLocation();
+  const isAssistant = pathname.startsWith('/assistant/');
+  const backHref = isAssistant
+    ? `/assistant/${classSlug}/grading`
+    : `/admin/${classSlug}/grades`;
+
   const [refreshing, setRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
 
@@ -102,7 +108,7 @@ const SubmissionAnalytics = ({ loaderData }: Route.ComponentProps) => {
   return (
     <div className="flex flex-col gap-4" data-testid="submission-analytics">
       <div className="flex items-center gap-2">
-        <Link to={`/admin/${classSlug}/grading`}>
+        <Link to={backHref}>
           <Button
             size="small"
             icon={<IconChevronLeft size={14} />}

--- a/apps/webapp/app/routes/api.repos.$id.analytics/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.analytics/route.ts
@@ -1,0 +1,59 @@
+import getPrisma from '@classmoji/database';
+import { ClassmojiService } from '@classmoji/services';
+import { assertClassroomAccess } from '~/utils/routeAuth.server';
+import type { Route } from './+types/route';
+
+/**
+ * GET /api/repos/:id/analytics
+ *
+ * `:id` is the RepositoryAssignment.id. Returns:
+ * `{ snapshot, deadline, repositoryId, students }` where `snapshot` is the
+ * persisted `RepoAnalyticsSnapshot` (or `null` if none yet), `students`
+ * is the classroom's STUDENT roster formatted for `ContributorBreakdown`.
+ */
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
+  const repoAssignmentId = params.id!;
+
+  const repoAssignment = await getPrisma().repositoryAssignment.findUnique({
+    where: { id: repoAssignmentId },
+    include: {
+      assignment: true,
+      repository: {
+        select: { id: true, classroom_id: true, classroom: { select: { slug: true } } },
+      },
+      analytics_snapshot: true,
+    },
+  });
+
+  if (!repoAssignment) {
+    return new Response('Repository assignment not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  await assertClassroomAccess({
+    request,
+    classroomSlug: repoAssignment.repository.classroom.slug,
+    allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
+    resourceType: 'REPOSITORY_ASSIGNMENT',
+    attemptedAction: 'view_submission_analytics',
+    metadata: { repository_assignment_id: repoAssignmentId },
+  });
+
+  const studentMemberships = await ClassmojiService.classroomMembership.findStudents(
+    repoAssignment.repository.classroom_id,
+  );
+  const students = studentMemberships.map((m) => ({
+    id: m.user.id,
+    name: m.user.name ?? m.user.login ?? 'Unknown',
+    login: m.user.login ?? null,
+  }));
+
+  return Response.json({
+    snapshot: repoAssignment.analytics_snapshot,
+    deadline: repoAssignment.assignment.student_deadline?.toISOString() ?? null,
+    repositoryId: repoAssignment.repository.id,
+    students,
+  });
+};

--- a/apps/webapp/app/routes/api.repos.$id.contributor-link/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.contributor-link/route.ts
@@ -1,0 +1,85 @@
+import { ClassmojiService } from '@classmoji/services';
+import getPrisma from '@classmoji/database';
+import { assertClassroomAccess } from '~/utils/routeAuth.server';
+import type { Route } from './+types/route';
+
+/**
+ * POST /api/repos/:id/contributor-link
+ *
+ * `:id` is the Repository.id (NOT the repository_assignment id — the
+ * `RepositoryContributorLink` table is keyed on `(repository_id, github_login)`).
+ *
+ * Body: `{ github_login: string, user_id: string | null }`.
+ *
+ * Upserts a manual GitHub-login → user mapping for the repo. Passing
+ * `user_id: null` unlinks. Only OWNER/TEACHER/ASSISTANT of the owning
+ * classroom may call this.
+ */
+export const action = async ({ params, request }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { 'Content-Type': 'text/plain', Allow: 'POST' },
+    });
+  }
+
+  const repositoryId = params.id!;
+
+  // Resolve the owning classroom so we can run auth against its slug.
+  const repo = await getPrisma().repository.findUnique({
+    where: { id: repositoryId },
+    select: { id: true, classroom: { select: { id: true, slug: true } } },
+  });
+
+  if (!repo) {
+    return new Response('Repository not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  await assertClassroomAccess({
+    request,
+    classroomSlug: repo.classroom.slug,
+    allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
+    resourceType: 'REPOSITORY',
+    attemptedAction: 'link_contributor',
+    metadata: { repository_id: repositoryId },
+  });
+
+  let body: { github_login?: string; user_id?: string | null };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const githubLogin = body.github_login;
+  const userId = body.user_id === undefined ? null : body.user_id;
+
+  if (!githubLogin || typeof githubLogin !== 'string') {
+    return Response.json(
+      { error: 'github_login is required' },
+      { status: 400 }
+    );
+  }
+  if (userId !== null && typeof userId !== 'string') {
+    return Response.json(
+      { error: 'user_id must be a string or null' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ClassmojiService.repoAnalytics.linkContributor(
+      repositoryId,
+      githubLogin,
+      userId
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return Response.json({ error: message }, { status: 400 });
+  }
+
+  return Response.json({ linked: true });
+};

--- a/apps/webapp/app/routes/api.repos.$id.refresh/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.refresh/route.ts
@@ -1,0 +1,59 @@
+import { tasks } from '@trigger.dev/sdk';
+
+import { ClassmojiService } from '@classmoji/services';
+import { assertClassroomAccess } from '~/utils/routeAuth.server';
+import type { Route } from './+types/route';
+
+/**
+ * POST /api/repos/:id/refresh
+ *
+ * Enqueue a `refresh-repo-analytics` run for the given repository_assignment_id.
+ * Scoped to the owning classroom — only OWNER/TEACHER/ASSISTANT may trigger.
+ */
+export const action = async ({ params, request }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { 'Content-Type': 'text/plain', Allow: 'POST' },
+    });
+  }
+
+  const repositoryAssignmentId = params.id!;
+
+  // Resolve the owning classroom so we can run auth against its slug.
+  const repoAssignment =
+    await ClassmojiService.repositoryAssignment.findById(repositoryAssignmentId);
+
+  if (!repoAssignment) {
+    return new Response('Repository assignment not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  const classroom = await ClassmojiService.classroom.findById(
+    repoAssignment.repository.classroom_id
+  );
+
+  if (!classroom) {
+    return new Response('Classroom not found', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  await assertClassroomAccess({
+    request,
+    classroomSlug: classroom.slug,
+    allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
+    resourceType: 'REPOSITORY_ASSIGNMENT',
+    attemptedAction: 'refresh_repo_analytics',
+    metadata: { repository_assignment_id: repositoryAssignmentId },
+  });
+
+  const handle = await tasks.trigger('refresh-repo-analytics', {
+    repositoryAssignmentId,
+  });
+
+  return Response.json({ enqueued: true, job_id: handle.id });
+};

--- a/apps/webapp/app/routes/assistant.$class_.dashboard/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.dashboard/route.tsx
@@ -6,10 +6,23 @@ import type { Route } from './+types/route';
 import { ClassmojiService } from '@classmoji/services';
 import { requireClassroomTeachingTeam } from '~/utils/routeAuth.server';
 import GradingTabsCard from '../admin.$class.dashboard/GradingTabsCard';
+import {
+  MyDayQueue,
+  ThroughputSparkline,
+  StreakBadge,
+  OwnVsClassHistogram,
+} from '~/components/features/dashboard';
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const { class: classSlug } = params;
   const { userId, classroom } = await requireClassroomTeachingTeam(request, classSlug!);
+
+  const cockpitPromise = Promise.all([
+    ClassmojiService.taDashboard.overdueQueue(userId, classroom.id),
+    ClassmojiService.taDashboard.personalThroughput(userId, classroom.id),
+    ClassmojiService.taDashboard.gradingStreak(userId, classroom.id),
+    ClassmojiService.taDashboard.personalGradeDistribution(userId, classroom.id),
+  ]).catch(() => null);
 
   return {
     data: Promise.all([
@@ -18,6 +31,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
       ClassmojiService.helper.findClassroomGradingProgressPerAssignment(classroom.id),
       ClassmojiService.repositoryAssignmentGrader.findGradersProgress(classroom.id),
     ]),
+    cockpit: cockpitPromise,
   };
 };
 
@@ -48,7 +62,7 @@ const StatItem = ({ label, value, subtitle, valueColor }: StatItemProps) => (
 );
 
 const AssistantDashboard = ({ loaderData }: Route.ComponentProps) => {
-  const { data } = loaderData;
+  const { data, cockpit } = loaderData;
 
   return (
     <div className="min-h-full flex flex-col gap-4">
@@ -110,6 +124,36 @@ const AssistantDashboard = ({ loaderData }: Route.ComponentProps) => {
                   gradingProgress={gradingProgress}
                   assistantsProgress={assistantsProgress}
                 />
+              </>
+            );
+          }}
+        </Await>
+      </Suspense>
+
+      <Suspense fallback={<Skeleton active paragraph={{ rows: 4 }} />}>
+        <Await resolve={cockpit} errorElement={null}>
+          {(result) => {
+            if (!result) return null;
+            const [queue, throughput, streak, distribution] = result;
+            return (
+              <>
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                  <div className="lg:col-span-2">
+                    <MyDayQueue queue={queue} />
+                  </div>
+                  <StreakBadge
+                    days={streak.days}
+                    lastGradedAt={streak.lastGradedAt}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                  <ThroughputSparkline data={throughput} />
+                  <OwnVsClassHistogram
+                    yours={distribution.yours}
+                    classroom={distribution.classroom}
+                  />
+                </div>
               </>
             );
           }}

--- a/apps/webapp/app/routes/assistant.$class_.grading/RepositoryAssignmentsTable.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.grading/RepositoryAssignmentsTable.tsx
@@ -1,6 +1,6 @@
-import { Switch, Table, Tooltip } from 'antd';
-import { Link, useParams } from 'react-router';
-import { useEffect, useMemo, useState } from 'react';
+import { Switch, Table, Tooltip, Skeleton, Alert } from 'antd';
+import { useParams } from 'react-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   IconCircleCheck,
   IconFileCheck,
@@ -10,7 +10,13 @@ import {
   IconClockExclamation,
   IconListDetails,
   IconChartBar,
+  IconChevronDown,
 } from '@tabler/icons-react';
+import {
+  GitHubStatsPanel,
+  type GitHubStatsSnapshot,
+  type EligibleStudent,
+} from '~/components/features/analytics';
 import { openRepositoryAssignmentInGithub } from '~/utils/helpers.client';
 import { emojis } from '@classmoji/utils';
 import dayjs from 'dayjs';
@@ -149,6 +155,92 @@ const RepositoryAssignmentsTable = ({
   const { classroom } = useStore();
   const params = useParams();
   const classSlug = params.class as string | undefined;
+
+  // Inline GitHub-analytics drawer — row-level lazy load + cache.
+  type AnalyticsData = {
+    snapshot: GitHubStatsSnapshot | null;
+    deadline: string | null;
+    repositoryId: string;
+    students: EligibleStudent[];
+  };
+  type CacheEntry =
+    | { status: 'loading' }
+    | { status: 'error'; message: string }
+    | { status: 'ready'; data: AnalyticsData; refreshing?: boolean };
+
+  const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
+  const [analyticsCache, setAnalyticsCache] = useState<Record<string, CacheEntry>>({});
+
+  const loadAnalytics = useCallback(async (repoAssignmentId: string) => {
+    setAnalyticsCache(prev => {
+      if (prev[repoAssignmentId]?.status === 'ready') return prev;
+      return { ...prev, [repoAssignmentId]: { status: 'loading' } };
+    });
+    try {
+      const res = await fetch(`/api/repos/${repoAssignmentId}/analytics`);
+      if (!res.ok) {
+        throw new Error((await res.text()) || `Failed (${res.status})`);
+      }
+      const data = (await res.json()) as AnalyticsData;
+      setAnalyticsCache(prev => ({
+        ...prev,
+        [repoAssignmentId]: { status: 'ready', data },
+      }));
+    } catch (err) {
+      setAnalyticsCache(prev => ({
+        ...prev,
+        [repoAssignmentId]: {
+          status: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      }));
+    }
+  }, []);
+
+  const refreshAnalytics = useCallback(
+    async (repoAssignmentId: string) => {
+      setAnalyticsCache(prev => {
+        const entry = prev[repoAssignmentId];
+        if (!entry || entry.status !== 'ready') return prev;
+        return {
+          ...prev,
+          [repoAssignmentId]: { ...entry, refreshing: true },
+        };
+      });
+      try {
+        const res = await fetch(`/api/repos/${repoAssignmentId}/refresh`, {
+          method: 'POST',
+        });
+        if (!res.ok) throw new Error((await res.text()) || `Failed (${res.status})`);
+        // Give the trigger workflow a moment, then re-read the snapshot.
+        setTimeout(() => {
+          void loadAnalytics(repoAssignmentId);
+        }, 1200);
+      } catch (err) {
+        setAnalyticsCache(prev => ({
+          ...prev,
+          [repoAssignmentId]: {
+            status: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }));
+      }
+    },
+    [loadAnalytics],
+  );
+
+  const toggleAnalytics = useCallback(
+    (repoAssignmentId: string) => {
+      setExpandedKeys(prev => {
+        const isOpen = prev.includes(repoAssignmentId);
+        if (!isOpen) void loadAnalytics(repoAssignmentId);
+        return isOpen
+          ? prev.filter(k => k !== repoAssignmentId)
+          : [...prev, repoAssignmentId];
+      });
+    },
+    [loadAnalytics],
+  );
 
   const base = showMyAssignments ? repositoryAssignments : allRepositoryAssignments;
   const searched = useMemo(() => {
@@ -344,14 +436,41 @@ const RepositoryAssignmentsTable = ({
             emojiMappings={emojiMappings as Record<string, unknown>}
           />
           {classSlug ? (
-            <Tooltip title="Submission analytics">
-              <Link
-                to={`/assistant/${classSlug}/submissions/${repoAssignment.id}`}
-                className="inline-flex items-center justify-center h-7 w-7 rounded text-gray-500 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
-              >
-                <IconChartBar size={16} />
-              </Link>
-            </Tooltip>
+            (() => {
+              const isOpen = expandedKeys.includes(repoAssignment.id);
+              return (
+                <Tooltip title={isOpen ? 'Hide analytics' : 'Show analytics'}>
+                  <button
+                    type="button"
+                    aria-expanded={isOpen}
+                    onClick={event => {
+                      event.stopPropagation();
+                      toggleAnalytics(repoAssignment.id);
+                    }}
+                    className={`inline-flex items-center justify-center h-7 w-7 rounded-md transition-all duration-200 ease-out ${
+                      isOpen
+                        ? 'bg-primary-50 text-primary-600 ring-1 ring-primary-200 dark:bg-primary-900/30 dark:text-primary-300 dark:ring-primary-800/60'
+                        : 'text-gray-500 hover:text-primary-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-primary-300 dark:hover:bg-neutral-800'
+                    }`}
+                  >
+                    <span className="relative inline-block w-4 h-4">
+                      <IconChartBar
+                        size={16}
+                        className={`absolute inset-0 transition-all duration-200 ease-out ${
+                          isOpen ? 'opacity-0 -rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'
+                        }`}
+                      />
+                      <IconChevronDown
+                        size={16}
+                        className={`absolute inset-0 transition-all duration-200 ease-out ${
+                          isOpen ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 rotate-90 scale-75'
+                        }`}
+                      />
+                    </span>
+                  </button>
+                </Tooltip>
+              );
+            })()
           ) : null}
         </TableActionButtons>
       ),
@@ -453,6 +572,40 @@ const RepositoryAssignmentsTable = ({
               showQuickJumper: true,
               pageSizeOptions: ['10', '15', '25', '50'],
               showTotal: (total, range) => `${range[0]}-${range[1]} of ${total}`,
+            }}
+            expandable={{
+              expandedRowKeys: expandedKeys,
+              showExpandColumn: false,
+              expandedRowClassName: () => 'analytics-expanded-row',
+              expandedRowRender: (record: RepoAssignment) => {
+                const entry = analyticsCache[record.id];
+                return (
+                  <div className="px-1 py-2 animate-[fadeSlideIn_240ms_cubic-bezier(0.22,1,0.36,1)_both]">
+                    {!entry || entry.status === 'loading' ? (
+                      <div className="py-4">
+                        <Skeleton active paragraph={{ rows: 4 }} />
+                      </div>
+                    ) : entry.status === 'error' ? (
+                      <Alert
+                        type="error"
+                        showIcon
+                        message="Couldn't load analytics"
+                        description={entry.message}
+                        closable
+                      />
+                    ) : (
+                      <GitHubStatsPanel
+                        snapshot={entry.data.snapshot}
+                        deadline={entry.data.deadline}
+                        repositoryId={entry.data.repositoryId}
+                        students={entry.data.students}
+                        refreshing={Boolean(entry.refreshing)}
+                        onRefresh={() => refreshAnalytics(record.id)}
+                      />
+                    )}
+                  </div>
+                );
+              },
             }}
           />
         )}

--- a/apps/webapp/app/routes/assistant.$class_.grading/RepositoryAssignmentsTable.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.grading/RepositoryAssignmentsTable.tsx
@@ -1,4 +1,5 @@
-import { Switch, Table } from 'antd';
+import { Switch, Table, Tooltip } from 'antd';
+import { Link, useParams } from 'react-router';
 import { useEffect, useMemo, useState } from 'react';
 import {
   IconCircleCheck,
@@ -8,6 +9,7 @@ import {
   IconClipboardList,
   IconClockExclamation,
   IconListDetails,
+  IconChartBar,
 } from '@tabler/icons-react';
 import { openRepositoryAssignmentInGithub } from '~/utils/helpers.client';
 import { emojis } from '@classmoji/utils';
@@ -145,6 +147,8 @@ const RepositoryAssignmentsTable = ({
   const [showMyAssignments, setShowMyAssignments] = useState(true);
   const [active, setActive] = useState<TabKey>('overview');
   const { classroom } = useStore();
+  const params = useParams();
+  const classSlug = params.class as string | undefined;
 
   const base = showMyAssignments ? repositoryAssignments : allRepositoryAssignments;
   const searched = useMemo(() => {
@@ -339,6 +343,16 @@ const RepositoryAssignmentsTable = ({
             }}
             emojiMappings={emojiMappings as Record<string, unknown>}
           />
+          {classSlug ? (
+            <Tooltip title="Submission analytics">
+              <Link
+                to={`/assistant/${classSlug}/submissions/${repoAssignment.id}`}
+                className="inline-flex items-center justify-center h-7 w-7 rounded text-gray-500 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
+              >
+                <IconChartBar size={16} />
+              </Link>
+            </Tooltip>
+          ) : null}
         </TableActionButtons>
       ),
     },

--- a/apps/webapp/app/routes/assistant.$class_.submissions.$id/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.submissions.$id/route.tsx
@@ -1,0 +1,4 @@
+export {
+  loader,
+  default,
+} from '../admin.$class.submissions.$id/route';

--- a/apps/webapp/app/styles/global.css
+++ b/apps/webapp/app/styles/global.css
@@ -715,6 +715,18 @@ html[data-theme="dark"] .bar .fill.done { background: #4fd47d; }
   50%      { opacity: 0.3; transform: scale(0.7); }
 }
 
+/* Inline analytics drawer — smooth reveal for the expanded grading row. */
+@keyframes fadeSlideIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.analytics-expanded-row > td {
+  background-color: transparent !important;
+}
+.analytics-expanded-row > td > .ant-table-expanded-row-fixed {
+  padding: 0 16px 12px 16px;
+}
+
 /* ============================================================
    Tweaks FAB + Panel (accent + theme picker)
    ============================================================ */

--- a/packages/database/migrations/20260424020000_repo_analytics/migration.sql
+++ b/packages/database/migrations/20260424020000_repo_analytics/migration.sql
@@ -1,0 +1,54 @@
+-- CreateTable
+CREATE TABLE "repo_analytics_snapshots" (
+    "id" TEXT NOT NULL,
+    "repository_assignment_id" TEXT NOT NULL,
+    "fetched_at" TIMESTAMP(3) NOT NULL,
+    "default_branch" TEXT,
+    "total_commits" INTEGER NOT NULL DEFAULT 0,
+    "total_additions" INTEGER NOT NULL DEFAULT 0,
+    "total_deletions" INTEGER NOT NULL DEFAULT 0,
+    "first_commit_at" TIMESTAMP(3),
+    "last_commit_at" TIMESTAMP(3),
+    "commits" JSONB NOT NULL DEFAULT '[]',
+    "contributors" JSONB NOT NULL DEFAULT '[]',
+    "languages" JSONB NOT NULL DEFAULT '{}',
+    "pr_summary" JSONB NOT NULL DEFAULT '{}',
+    "stale" BOOLEAN NOT NULL DEFAULT false,
+    "error" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "repo_analytics_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "repository_contributor_links" (
+    "id" TEXT NOT NULL,
+    "repository_id" TEXT NOT NULL,
+    "github_login" TEXT NOT NULL,
+    "user_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "repository_contributor_links_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "repo_analytics_snapshots_repository_assignment_id_key" ON "repo_analytics_snapshots"("repository_assignment_id");
+
+-- CreateIndex
+CREATE INDEX "repo_analytics_snapshots_fetched_at_idx" ON "repo_analytics_snapshots"("fetched_at");
+
+-- CreateIndex
+CREATE INDEX "repository_contributor_links_user_id_idx" ON "repository_contributor_links"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "repository_contributor_links_repository_id_github_login_key" ON "repository_contributor_links"("repository_id", "github_login");
+
+-- AddForeignKey
+ALTER TABLE "repo_analytics_snapshots" ADD CONSTRAINT "repo_analytics_snapshots_repository_assignment_id_fkey" FOREIGN KEY ("repository_assignment_id") REFERENCES "repository_assignments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "repository_contributor_links" ADD CONSTRAINT "repository_contributor_links_repository_id_fkey" FOREIGN KEY ("repository_id") REFERENCES "repositories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "repository_contributor_links" ADD CONSTRAINT "repository_contributor_links_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -7,6 +7,7 @@
     "db:generate": "prisma generate",
     "db:reset": "prisma migrate reset --force",
     "db:seed": "node ./scripts/seed.js",
+    "backfill:repo-analytics": "tsx scripts/backfillRepoAnalytics.ts",
     "db:console": "@prismatools/console@latest",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -212,6 +212,7 @@ model User {
   calendar_events               CalendarEvent[]
   ai_conversations              AIConversation[]
   resource_views                ResourceView[]
+  contributor_links             RepositoryContributorLink[]
 
   @@unique([provider, provider_id])
   @@index([provider, login])
@@ -431,6 +432,7 @@ model Repository {
   student     User?                  @relation("StudentRepositories", fields: [student_id], references: [id], onDelete: Cascade)
   team        Team?                  @relation(fields: [team_id], references: [id], onDelete: Cascade)
   assignments RepositoryAssignment[]
+  contributor_links RepositoryContributorLink[]
 
   @@unique([provider, provider_id])
   @@index([classroom_id])
@@ -458,11 +460,50 @@ model RepositoryAssignment {
   graders            RepositoryAssignmentGrader[]
   regrade_requests   RegradeRequest[]
   token_transactions TokenTransaction[]
+  analytics_snapshot RepoAnalyticsSnapshot?
 
   @@unique([provider, provider_id])
   @@index([repository_id])
   @@index([assignment_id])
   @@map("repository_assignments")
+}
+
+model RepoAnalyticsSnapshot {
+  id                       String   @id @default(uuid())
+  repository_assignment_id String   @unique
+  repository_assignment    RepositoryAssignment @relation(fields: [repository_assignment_id], references: [id], onDelete: Cascade)
+  fetched_at               DateTime
+  default_branch           String?
+  total_commits            Int      @default(0)
+  total_additions          Int      @default(0)
+  total_deletions          Int      @default(0)
+  first_commit_at          DateTime?
+  last_commit_at           DateTime?
+  commits                  Json     @default("[]")
+  contributors             Json     @default("[]")
+  languages                Json     @default("{}")
+  pr_summary               Json     @default("{}")
+  stale                    Boolean  @default(false)
+  error                    String?
+  created_at               DateTime @default(now())
+  updated_at               DateTime @default(now()) @updatedAt
+
+  @@index([fetched_at])
+  @@map("repo_analytics_snapshots")
+}
+
+model RepositoryContributorLink {
+  id            String   @id @default(uuid())
+  repository_id String
+  repository    Repository @relation(fields: [repository_id], references: [id], onDelete: Cascade)
+  github_login  String
+  user_id       String?
+  user          User?    @relation(fields: [user_id], references: [id], onDelete: SetNull)
+  created_at    DateTime @default(now())
+
+  @@unique([repository_id, github_login])
+  @@index([user_id])
+  @@map("repository_contributor_links")
 }
 
 // ============================================================================

--- a/packages/database/scripts/backfillRepoAnalytics.ts
+++ b/packages/database/scripts/backfillRepoAnalytics.ts
@@ -1,0 +1,74 @@
+/**
+ * Backfill repo analytics snapshots for every active repository assignment.
+ *
+ * Usage:
+ *   npx tsx packages/database/scripts/backfillRepoAnalytics.ts           # enqueue via Trigger.dev
+ *   npx tsx packages/database/scripts/backfillRepoAnalytics.ts --inline  # run in-process (local dev)
+ *
+ * The default mode mirrors the production refresh flow in
+ * `apps/webapp/app/routes/api.repos.$id.refresh/route.ts` — it enqueues the
+ * `refresh-repo-analytics` Trigger.dev task for each active assignment id.
+ * The `--inline` mode bypasses Trigger.dev and calls
+ * `ClassmojiService.repoAnalytics.refreshOne` directly; useful when the
+ * Trigger.dev runtime isn't available (e.g. a fresh local checkout).
+ */
+
+import { ClassmojiService } from '@classmoji/services';
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[backfill] Unhandled rejection:', reason);
+  process.exit(1);
+});
+
+const INLINE = process.argv.includes('--inline');
+
+async function enqueueAll(ids: string[]): Promise<void> {
+  // Lazy import so `--inline` users don't need Trigger.dev installed.
+  const { tasks } = await import('@trigger.dev/sdk');
+
+  for (const id of ids) {
+    const handle = await tasks.trigger('refresh-repo-analytics', {
+      repositoryAssignmentId: id,
+    });
+    console.log(`[backfill] enqueued repo ${id} → job ${handle.id}`);
+  }
+}
+
+async function runInline(ids: string[]): Promise<void> {
+  for (const id of ids) {
+    try {
+      await ClassmojiService.repoAnalytics.refreshOne(id);
+      console.log(`[backfill] refreshed repo ${id} inline`);
+    } catch (err) {
+      console.error(`[backfill] failed repo ${id}:`, err);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const ids = await ClassmojiService.repoAnalytics.listActiveAssignmentIds();
+
+  if (ids.length === 0) {
+    console.log('[backfill] no active repository assignments found');
+    return;
+  }
+
+  const first = ids[0];
+  const last = ids[ids.length - 1];
+
+  if (INLINE) {
+    console.log(`[backfill] running inline for ${ids.length} assignments (first=${first} last=${last})`);
+    await runInline(ids);
+    console.log(`[backfill] completed ${ids.length} inline refreshes`);
+    return;
+  }
+
+  console.log(`[backfill] enqueueing ${ids.length} Trigger.dev jobs (first=${first} last=${last})`);
+  await enqueueAll(ids);
+  console.log(`[backfill] enqueued ${ids.length} jobs (first=${first} last=${last})`);
+}
+
+main().catch((err) => {
+  console.error('[backfill] fatal:', err);
+  process.exit(1);
+});

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["index.js", "index.ts"]
+  "include": ["index.js", "index.ts", "scripts/**/*.ts"]
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -3,13 +3,15 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\""
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./flags": "./src/classmoji/repoAnalytics.flags.ts"
   },
   "dependencies": {
     "@classmoji/database": "*",
@@ -21,5 +23,8 @@
     "octokit": "^3.1.2",
     "prettier": "^3.6.2",
     "simple-git": "^3.27.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/services/src/classmoji/__tests__/dashboard.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/dashboard.service.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeGradeMedian,
+  computeMedianTimeToGradeHours,
+  emojiToGrade,
+} from '../dashboard.service.ts';
+
+describe('computeGradeMedian', () => {
+  it('returns null on empty', () => {
+    expect(computeGradeMedian([])).toBeNull();
+  });
+
+  it('filters null/undefined/NaN', () => {
+    expect(computeGradeMedian([null, undefined, NaN, 50])).toBe(50);
+  });
+
+  it('computes odd-length median', () => {
+    expect(computeGradeMedian([1, 9, 5])).toBe(5);
+  });
+
+  it('computes even-length median', () => {
+    expect(computeGradeMedian([1, 2, 3, 4])).toBe(2.5);
+  });
+});
+
+describe('emojiToGrade', () => {
+  it('prefers classroom mapping over default', () => {
+    const map = new Map([['heart', 95]]);
+    expect(emojiToGrade('heart', map)).toBe(95);
+  });
+
+  it('falls back to default mapping', () => {
+    expect(emojiToGrade('heart', new Map())).toBe(100);
+  });
+
+  it('returns null for unknown emoji', () => {
+    expect(emojiToGrade('unknown-emoji-xyz', new Map())).toBeNull();
+  });
+});
+
+describe('computeMedianTimeToGradeHours', () => {
+  it('returns null on empty', () => {
+    expect(computeMedianTimeToGradeHours([])).toBeNull();
+  });
+
+  it('ignores rows missing either timestamp', () => {
+    const graded = new Date('2026-01-01T10:00:00Z');
+    expect(
+      computeMedianTimeToGradeHours([
+        { submittedAt: null, gradedAt: graded },
+        { submittedAt: graded, gradedAt: null },
+      ]),
+    ).toBeNull();
+  });
+
+  it('computes hour diff median', () => {
+    const submit = new Date('2026-01-01T00:00:00Z');
+    const g1 = new Date('2026-01-01T02:00:00Z'); // 2h
+    const g2 = new Date('2026-01-01T04:00:00Z'); // 4h
+    const g3 = new Date('2026-01-01T06:00:00Z'); // 6h
+    expect(
+      computeMedianTimeToGradeHours([
+        { submittedAt: submit, gradedAt: g1 },
+        { submittedAt: submit, gradedAt: g2 },
+        { submittedAt: submit, gradedAt: g3 },
+      ]),
+    ).toBe(4);
+  });
+
+  it('skips negative diffs', () => {
+    const submit = new Date('2026-01-02T00:00:00Z');
+    const graded = new Date('2026-01-01T00:00:00Z');
+    expect(
+      computeMedianTimeToGradeHours([{ submittedAt: submit, gradedAt: graded }]),
+    ).toBeNull();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/repoAnalytics.flags.test.ts
+++ b/packages/services/src/classmoji/__tests__/repoAnalytics.flags.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  lateCommitRatio,
+  isMegaCommit,
+  commitMessageQuality,
+  averageCommitQuality,
+  busFactor,
+  dumpAndRun,
+  aggregateByContributor,
+  commitsPerDayByContributor,
+} from '../repoAnalytics.flags.ts';
+import type {
+  CommitRecord,
+  ContributorRecord,
+} from '../repoAnalytics.types.ts';
+
+function commit(partial: Partial<CommitRecord>): CommitRecord {
+  return {
+    sha: 'sha',
+    author_login: 'alice',
+    author_email: null,
+    author_user_id: null,
+    ts: '2026-01-01T00:00:00Z',
+    message: 'msg',
+    additions: 0,
+    deletions: 0,
+    parents: [],
+    ...partial,
+  };
+}
+
+describe('lateCommitRatio', () => {
+  it('returns 0 when empty or no deadline', () => {
+    expect(lateCommitRatio([], new Date('2026-01-01T00:00:00Z'))).toBe(0);
+    expect(lateCommitRatio([commit({})], null)).toBe(0);
+  });
+  it('computes fraction of commits strictly after deadline', () => {
+    const c = [
+      commit({ sha: '1', ts: '2026-01-01T00:00:00Z' }),
+      commit({ sha: '2', ts: '2026-01-11T00:00:00Z' }),
+    ];
+    expect(lateCommitRatio(c, new Date('2026-01-10T00:00:00Z'))).toBe(0.5);
+  });
+});
+
+describe('isMegaCommit', () => {
+  it('is true only when commit exceeds 40% of total additions+deletions', () => {
+    expect(isMegaCommit(commit({ additions: 500 }), 1000, 0)).toBe(true);
+    expect(isMegaCommit(commit({ additions: 400 }), 1000, 0)).toBe(false);
+    expect(isMegaCommit(commit({}), 0, 0)).toBe(false);
+  });
+});
+
+describe('commitMessageQuality', () => {
+  it('scores empty/filler low and descriptive messages high, clamped to [0,1]', () => {
+    expect(commitMessageQuality('')).toBe(0);
+    expect(commitMessageQuality('update')).toBeLessThan(0.3);
+    expect(
+      commitMessageQuality('Refactor auth guard to handle expired tokens'),
+    ).toBeGreaterThanOrEqual(0.7);
+    const q = commitMessageQuality('a'.repeat(100));
+    expect(q).toBeGreaterThanOrEqual(0);
+    expect(q).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('averageCommitQuality', () => {
+  it('returns 0 for empty and averages across commits', () => {
+    expect(averageCommitQuality([])).toBe(0);
+    const c = [
+      commit({ message: 'update' }),
+      commit({ message: 'Refactor auth guard to handle expired tokens' }),
+    ];
+    const avg = averageCommitQuality(c);
+    expect(avg).toBeGreaterThan(0);
+    expect(avg).toBeLessThan(1);
+  });
+});
+
+describe('busFactor', () => {
+  it('is null with <=1 contributors, otherwise the max share', () => {
+    expect(busFactor([])).toBeNull();
+    const one: ContributorRecord[] = [
+      { login: 'alice', user_id: null, commits: 10, additions: 0, deletions: 0 },
+    ];
+    expect(busFactor(one)).toBeNull();
+    const many: ContributorRecord[] = [
+      { login: 'alice', user_id: null, commits: 8, additions: 0, deletions: 0 },
+      { login: 'bob', user_id: null, commits: 1, additions: 0, deletions: 0 },
+      { login: 'carol', user_id: null, commits: 1, additions: 0, deletions: 0 },
+    ];
+    expect(busFactor(many)).toEqual({ login: 'alice', share: 0.8 });
+  });
+});
+
+describe('dumpAndRun', () => {
+  it('true only when the earliest commit is <24h before deadline', () => {
+    const deadline = new Date('2026-01-10T00:00:00Z');
+    expect(dumpAndRun([], deadline)).toBe(false);
+    expect(dumpAndRun([commit({ ts: '2026-01-09T20:00:00Z' })], null)).toBe(false);
+    expect(dumpAndRun([commit({ ts: '2026-01-09T04:00:00Z' })], deadline)).toBe(true);
+    expect(
+      dumpAndRun(
+        [
+          commit({ sha: 'early', ts: '2025-12-01T00:00:00Z' }),
+          commit({ sha: 'late', ts: '2026-01-09T23:00:00Z' }),
+        ],
+        deadline,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('aggregateByContributor', () => {
+  it('aggregates by login (null → "unknown") with sums and desc order', () => {
+    expect(aggregateByContributor([])).toEqual([]);
+    const cs = [
+      commit({ sha: '1', author_login: 'alice', additions: 10, deletions: 1 }),
+      commit({ sha: '2', author_login: 'alice', additions: 5, deletions: 2 }),
+      commit({ sha: '3', author_login: 'bob', additions: 3, deletions: 4 }),
+      commit({ sha: '4', author_login: null }),
+    ];
+    const rows = aggregateByContributor(cs);
+    expect(rows[0]!.login).toBe('alice');
+    expect(rows[0]!.commits).toBe(2);
+    expect(rows[0]!.additions).toBe(15);
+    expect(rows[0]!.deletions).toBe(3);
+    expect(rows.find((r) => r.login === 'unknown')!.commits).toBe(1);
+  });
+});
+
+describe('commitsPerDayByContributor', () => {
+  it('buckets by UTC day, stacks by login, fills intermediate days', () => {
+    expect(commitsPerDayByContributor([])).toEqual([]);
+    const cs = [
+      commit({ sha: '1', author_login: 'alice', ts: '2026-04-15T23:59:00Z' }),
+      commit({ sha: '2', author_login: 'bob', ts: '2026-04-18T00:00:00Z' }),
+      commit({ sha: '3', author_login: null, ts: '2026-04-15T10:00:00Z' }),
+    ];
+    const rows = commitsPerDayByContributor(cs);
+    expect(rows.map((r) => r.day)).toEqual([
+      '2026-04-15',
+      '2026-04-16',
+      '2026-04-17',
+      '2026-04-18',
+    ]);
+    expect(rows[0]).toEqual({ day: '2026-04-15', alice: 1, bob: 0, unknown: 1 });
+    expect(rows[3]).toEqual({ day: '2026-04-18', alice: 0, bob: 1, unknown: 0 });
+  });
+});

--- a/packages/services/src/classmoji/__tests__/repoAnalytics.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/repoAnalytics.service.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  linkAuthorsToUsers,
+  linkContributorsToUsers,
+} from '../repoAnalytics.service.ts';
+import type {
+  CommitRecord,
+  ContributorRecord,
+} from '../repoAnalytics.types.ts';
+
+function commit(partial: Partial<CommitRecord>): CommitRecord {
+  return {
+    sha: 'a',
+    author_login: 'alice',
+    author_email: null,
+    author_user_id: null,
+    ts: '2026-01-01T00:00:00Z',
+    message: 'm',
+    additions: 0,
+    deletions: 0,
+    parents: [],
+    ...partial,
+  };
+}
+
+describe('linkAuthorsToUsers', () => {
+  it('maps by login, leaves null for misses or null login', () => {
+    const commits = [
+      commit({ sha: '1', author_login: 'alice' }),
+      commit({ sha: '2', author_login: 'stranger' }),
+      commit({ sha: '3', author_login: null }),
+    ];
+    const out = linkAuthorsToUsers(commits, new Map([['alice', 'user-1']]));
+    expect(out[0].author_user_id).toBe('user-1');
+    expect(out[1].author_user_id).toBeNull();
+    expect(out[2].author_user_id).toBeNull();
+  });
+});
+
+describe('linkContributorsToUsers', () => {
+  it('sets user_id on login match, null otherwise', () => {
+    const contributors: ContributorRecord[] = [
+      { login: 'alice', user_id: null, commits: 5, additions: 100, deletions: 10 },
+      { login: 'stranger', user_id: null, commits: 2, additions: 20, deletions: 3 },
+    ];
+    const out = linkContributorsToUsers(contributors, new Map([['alice', 'user-1']]));
+    expect(out[0].user_id).toBe('user-1');
+    expect(out[1].user_id).toBeNull();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/taDashboard.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/taDashboard.service.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bucketGrades,
+  computeStreakDays,
+  padDailyBuckets,
+  toDayKey,
+} from '../taDashboard.service.ts';
+
+describe('toDayKey', () => {
+  it('formats UTC YYYY-MM-DD', () => {
+    expect(toDayKey(new Date('2026-04-19T23:59:59.000Z'))).toBe('2026-04-19');
+  });
+});
+
+describe('padDailyBuckets', () => {
+  it('zero-fills 7 days ending on endDay', () => {
+    const counts = new Map<string, number>([
+      ['2026-04-19', 3],
+      ['2026-04-17', 1],
+    ]);
+    const out = padDailyBuckets(counts, '2026-04-19', 7);
+    expect(out).toHaveLength(7);
+    expect(out[0].date).toBe('2026-04-13');
+    expect(out[6]).toEqual({ date: '2026-04-19', count: 3 });
+    expect(out[4]).toEqual({ date: '2026-04-17', count: 1 });
+    expect(out[5]).toEqual({ date: '2026-04-18', count: 0 });
+  });
+
+  it('handles empty counts map', () => {
+    const out = padDailyBuckets(new Map(), '2026-04-19', 7);
+    expect(out).toHaveLength(7);
+    expect(out.every((b) => b.count === 0)).toBe(true);
+  });
+});
+
+describe('computeStreakDays', () => {
+  it('returns 0 on empty', () => {
+    expect(computeStreakDays([])).toEqual({ days: 0, lastDay: null });
+  });
+
+  it('counts consecutive days ending at most recent', () => {
+    expect(
+      computeStreakDays(['2026-04-17', '2026-04-18', '2026-04-19']),
+    ).toEqual({ days: 3, lastDay: '2026-04-19' });
+  });
+
+  it('stops at first gap', () => {
+    expect(
+      computeStreakDays([
+        '2026-04-10',
+        '2026-04-17',
+        '2026-04-18',
+        '2026-04-19',
+      ]),
+    ).toEqual({ days: 3, lastDay: '2026-04-19' });
+  });
+
+  it('deduplicates repeats on the same day', () => {
+    expect(
+      computeStreakDays(['2026-04-19', '2026-04-19', '2026-04-18']),
+    ).toEqual({ days: 2, lastDay: '2026-04-19' });
+  });
+
+  it('single-day streak', () => {
+    expect(computeStreakDays(['2026-04-19'])).toEqual({
+      days: 1,
+      lastDay: '2026-04-19',
+    });
+  });
+});
+
+describe('bucketGrades', () => {
+  it('produces 10 buckets', () => {
+    const out = bucketGrades([]);
+    expect(out).toHaveLength(10);
+    expect(out[0].bucket).toBe('0-10');
+    expect(out[9].bucket).toBe('90-100');
+    expect(out.every((b) => b.count === 0)).toBe(true);
+  });
+
+  it('bins by floor(grade/10)', () => {
+    const out = bucketGrades([0, 9.9, 10, 55, 89.9, 90]);
+    expect(out[0].count).toBe(2); // 0, 9.9
+    expect(out[1].count).toBe(1); // 10
+    expect(out[5].count).toBe(1); // 55
+    expect(out[8].count).toBe(1); // 89.9
+    expect(out[9].count).toBe(1); // 90
+  });
+
+  it('puts exactly 100 in the last bucket', () => {
+    const out = bucketGrades([100, 100]);
+    expect(out[9].count).toBe(2);
+  });
+
+  it('clamps out-of-range values', () => {
+    const out = bucketGrades([-5, 150]);
+    expect(out[0].count).toBe(1);
+    expect(out[9].count).toBe(1);
+  });
+
+  it('ignores non-finite values', () => {
+    const out = bucketGrades([NaN, Infinity, -Infinity, 50]);
+    expect(out[5].count).toBe(1);
+    const total = out.reduce((a, b) => a + b.count, 0);
+    expect(total).toBe(1);
+  });
+});

--- a/packages/services/src/classmoji/dashboard.service.ts
+++ b/packages/services/src/classmoji/dashboard.service.ts
@@ -1,0 +1,646 @@
+/**
+ * Dashboard Service
+ *
+ * Aggregate queries powering the owner dashboard (Task 18 of the TA & Owner
+ * Analytics plan). All functions are classroom-scoped and perform no auth —
+ * the route layer gates access.
+ *
+ * Implementation notes:
+ * - Grades are stored as emoji strings on AssignmentGrade. To convert to a
+ *   numeric 0-100 score we join against the per-classroom EmojiMapping table
+ *   (falling back to DEFAULT_EMOJI_GRADE_MAPPINGS in memory when no mapping
+ *   exists).
+ * - "Submission" proxy: RepositoryAssignment.closed_at being non-null (plus
+ *   status = CLOSED) represents a submission. There is no separate submission
+ *   timestamp in the schema.
+ * - "Active" student: has a QuizAttempt in the last 14 days OR a repository
+ *   whose RepoAnalyticsSnapshot.last_commit_at is in the last 14 days.
+ * - "Hardest question" drilling requires parsing QuizAttempt.question_results_json
+ *   which does not have a stable cross-quiz question identifier today. We
+ *   return an empty array and flag this in the task report. avgFocusPct is
+ *   computable from the existing columns.
+ */
+
+import getPrisma from '@classmoji/database';
+import { DEFAULT_EMOJI_GRADE_MAPPINGS } from '@classmoji/utils';
+
+// Pure helpers (unit-tested)
+
+/**
+ * Median of a numeric array. Returns null for empty input. Ignores NaN/null.
+ */
+export function computeGradeMedian(values: Array<number | null | undefined>): number | null {
+  const nums = values.filter(
+    (v): v is number => typeof v === 'number' && Number.isFinite(v),
+  );
+  if (nums.length === 0) return null;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Resolve a numeric grade (0-100) for a given emoji, using the classroom's
+ * EmojiMapping when present, then DEFAULT_EMOJI_GRADE_MAPPINGS, else null.
+ */
+export function emojiToGrade(
+  emoji: string,
+  classroomMap: Map<string, number>,
+): number | null {
+  const fromClassroom = classroomMap.get(emoji);
+  if (typeof fromClassroom === 'number') return fromClassroom;
+  const fromDefault = DEFAULT_EMOJI_GRADE_MAPPINGS[emoji];
+  return typeof fromDefault === 'number' ? fromDefault : null;
+}
+
+/**
+ * Given a list of grade timestamps per AssignmentGrade and their submission
+ * (closed_at) timestamps, compute median time-to-grade in hours.
+ */
+export function computeMedianTimeToGradeHours(
+  pairs: Array<{ submittedAt: Date | null; gradedAt: Date | null }>,
+): number | null {
+  const diffs: number[] = [];
+  for (const p of pairs) {
+    if (!p.submittedAt || !p.gradedAt) continue;
+    const ms = p.gradedAt.getTime() - p.submittedAt.getTime();
+    if (ms >= 0) diffs.push(ms / 3_600_000);
+  }
+  return computeGradeMedian(diffs);
+}
+
+// Internal helpers
+
+async function loadClassroomEmojiMap(classroomId: string): Promise<Map<string, number>> {
+  const rows = await getPrisma().emojiMapping.findMany({
+    where: { classroom_id: classroomId },
+    select: { emoji: true, grade: true },
+  });
+  return new Map(rows.map((r) => [r.emoji, r.grade]));
+}
+
+// 1. Cohort overview
+
+export interface AtRiskStudent {
+  userId: string;
+  name: string | null;
+  login: string;
+  missedDeadlines: number;
+}
+
+export interface CohortOverview {
+  activeStudents: number;
+  inactiveStudents: number;
+  medianGrade: number | null;
+  atRiskCount: number;
+  atRiskStudents: AtRiskStudent[];
+  activeStudentsSeries: number[];
+  submissionRateSeries: number[];
+  slaSeriesHours: number[];
+  atRiskSeries: number[];
+}
+
+/**
+ * Build N weekly bin cutoffs [start, end) ending at `now`, oldest→newest.
+ */
+function buildWeeklyBins(
+  now: Date,
+  weeks: number,
+): Array<{ start: Date; end: Date }> {
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+  const bins: Array<{ start: Date; end: Date }> = [];
+  const endAnchor = now.getTime();
+  for (let i = weeks - 1; i >= 0; i--) {
+    const end = new Date(endAnchor - i * weekMs);
+    const start = new Date(end.getTime() - weekMs);
+    bins.push({ start, end });
+  }
+  return bins;
+}
+
+function bucketIndex(
+  ts: Date,
+  bins: Array<{ start: Date; end: Date }>,
+): number {
+  const t = ts.getTime();
+  for (let i = 0; i < bins.length; i++) {
+    if (t >= bins[i].start.getTime() && t < bins[i].end.getTime()) return i;
+  }
+  return -1;
+}
+
+export async function cohortOverview(classroomId: string): Promise<CohortOverview> {
+  const prisma = getPrisma();
+  const cutoff = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+  const now = new Date();
+
+  const memberships = await prisma.classroomMembership.findMany({
+    where: { classroom_id: classroomId, role: 'STUDENT' },
+    select: { user_id: true },
+  });
+  const studentIds = memberships.map((m) => m.user_id);
+  const totalStudents = studentIds.length;
+
+  if (totalStudents === 0) {
+    const empty = new Array<number>(12).fill(0);
+    return {
+      activeStudents: 0,
+      inactiveStudents: 0,
+      medianGrade: null,
+      atRiskCount: 0,
+      atRiskStudents: [],
+      activeStudentsSeries: empty,
+      submissionRateSeries: empty,
+      slaSeriesHours: empty,
+      atRiskSeries: empty,
+    };
+  }
+
+  // Active = has quiz attempt in 14d OR repo with last_commit_at in 14d
+  const [recentQuizUsers, recentCommitRepos] = await Promise.all([
+    prisma.quizAttempt.findMany({
+      where: {
+        user_id: { in: studentIds },
+        quiz: { classroom_id: classroomId },
+        started_at: { gte: cutoff },
+      },
+      select: { user_id: true },
+      distinct: ['user_id'],
+    }),
+    prisma.repository.findMany({
+      where: {
+        classroom_id: classroomId,
+        student_id: { in: studentIds },
+        assignments: {
+          some: {
+            analytics_snapshot: { last_commit_at: { gte: cutoff } },
+          },
+        },
+      },
+      select: { student_id: true },
+    }),
+  ]);
+
+  const activeSet = new Set<string>();
+  recentQuizUsers.forEach((r) => activeSet.add(r.user_id));
+  recentCommitRepos.forEach((r) => {
+    if (r.student_id) activeSet.add(r.student_id);
+  });
+  const activeStudents = activeSet.size;
+  const inactiveStudents = totalStudents - activeStudents;
+
+  // Median grade across all student grades
+  const emojiMap = await loadClassroomEmojiMap(classroomId);
+  const grades = await prisma.assignmentGrade.findMany({
+    where: {
+      repository_assignment: {
+        repository: { classroom_id: classroomId, student_id: { in: studentIds } },
+      },
+    },
+    select: { emoji: true },
+  });
+  const numeric = grades
+    .map((g) => emojiToGrade(g.emoji, emojiMap))
+    .filter((v): v is number => v !== null);
+  const medianGrade = computeGradeMedian(numeric);
+
+  // At-risk: students with >= 2 past-due RepositoryAssignments with no grades.
+  const missed = await prisma.repositoryAssignment.findMany({
+    where: {
+      repository: { classroom_id: classroomId, student_id: { in: studentIds } },
+      assignment: { student_deadline: { lt: now } },
+      status: 'OPEN',
+      grades: { none: {} },
+    },
+    select: { repository: { select: { student_id: true } } },
+  });
+  const missedCountByStudent = new Map<string, number>();
+  for (const m of missed) {
+    const sid = m.repository.student_id;
+    if (!sid) continue;
+    missedCountByStudent.set(sid, (missedCountByStudent.get(sid) ?? 0) + 1);
+  }
+  let atRiskCount = 0;
+  const atRiskIds: string[] = [];
+  for (const [sid, count] of missedCountByStudent.entries()) {
+    if (count >= 2) {
+      atRiskCount += 1;
+      atRiskIds.push(sid);
+    }
+  }
+
+  // Load top-10 at-risk student profiles, ordered by missed-deadline count desc.
+  const topAtRiskIds = atRiskIds
+    .map((id) => ({ id, count: missedCountByStudent.get(id) ?? 0 }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+  const atRiskProfiles =
+    topAtRiskIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: topAtRiskIds.map((x) => x.id) } },
+          select: { id: true, name: true, login: true },
+        })
+      : [];
+  const profileById = new Map(atRiskProfiles.map((p) => [p.id, p]));
+  const atRiskStudents: AtRiskStudent[] = topAtRiskIds
+    .map(({ id, count }) => {
+      const p = profileById.get(id);
+      if (!p) return null;
+      return {
+        userId: p.id,
+        name: p.name,
+        login: p.login ?? '',
+        missedDeadlines: count,
+      };
+    })
+    .filter((v): v is AtRiskStudent => v !== null);
+
+  // -------- Weekly series (last 12 weeks, oldest→newest) ----------------
+  const WEEKS = 12;
+  const bins = buildWeeklyBins(now, WEEKS);
+  const earliest = bins[0].start;
+
+  const [weeklyQuizAttempts, weeklySnapshots, weeklyClosed, weeklyGrades, pastDueOpen] =
+    await Promise.all([
+      prisma.quizAttempt.findMany({
+        where: {
+          user_id: { in: studentIds },
+          quiz: { classroom_id: classroomId },
+          started_at: { gte: earliest, lte: now },
+        },
+        select: { user_id: true, started_at: true },
+      }),
+      prisma.repoAnalyticsSnapshot.findMany({
+        where: {
+          repository_assignment: {
+            repository: { classroom_id: classroomId, student_id: { in: studentIds } },
+          },
+          last_commit_at: { gte: earliest, lte: now },
+        },
+        select: {
+          last_commit_at: true,
+          repository_assignment: { select: { repository: { select: { student_id: true } } } },
+        },
+      }),
+      prisma.repositoryAssignment.findMany({
+        where: {
+          repository: { classroom_id: classroomId, student_id: { in: studentIds } },
+          closed_at: { gte: earliest, lte: now },
+        },
+        select: { closed_at: true },
+      }),
+      prisma.assignmentGrade.findMany({
+        where: {
+          repository_assignment: {
+            repository: { classroom_id: classroomId, student_id: { in: studentIds } },
+          },
+          created_at: { gte: earliest, lte: now },
+        },
+        select: {
+          created_at: true,
+          repository_assignment: { select: { closed_at: true } },
+        },
+      }),
+      prisma.repositoryAssignment.findMany({
+        where: {
+          repository: { classroom_id: classroomId, student_id: { in: studentIds } },
+          assignment: { student_deadline: { lt: now, gte: earliest } },
+          status: 'OPEN',
+          grades: { none: {} },
+        },
+        select: {
+          repository: { select: { student_id: true } },
+          assignment: { select: { student_deadline: true } },
+        },
+      }),
+    ]);
+
+  const activeSetsPerBin: Array<Set<string>> = Array.from({ length: WEEKS }, () => new Set());
+  for (const qa of weeklyQuizAttempts) {
+    if (!qa.started_at) continue;
+    const idx = bucketIndex(qa.started_at, bins);
+    if (idx >= 0) activeSetsPerBin[idx].add(qa.user_id);
+  }
+  for (const s of weeklySnapshots) {
+    if (!s.last_commit_at) continue;
+    const sid = s.repository_assignment.repository.student_id;
+    if (!sid) continue;
+    const idx = bucketIndex(s.last_commit_at, bins);
+    if (idx >= 0) activeSetsPerBin[idx].add(sid);
+  }
+  const activeStudentsSeries = activeSetsPerBin.map((s) => s.size);
+
+  const closedCountPerBin = new Array<number>(WEEKS).fill(0);
+  for (const c of weeklyClosed) {
+    if (!c.closed_at) continue;
+    const idx = bucketIndex(c.closed_at, bins);
+    if (idx >= 0) closedCountPerBin[idx] += 1;
+  }
+  const submissionRateSeries = closedCountPerBin.map((n) =>
+    totalStudents > 0 ? Math.min(1, n / totalStudents) : 0,
+  );
+
+  const ttgPerBin: Array<number[]> = Array.from({ length: WEEKS }, () => []);
+  for (const g of weeklyGrades) {
+    const closed = g.repository_assignment.closed_at;
+    if (!closed) continue;
+    const idx = bucketIndex(g.created_at, bins);
+    if (idx < 0) continue;
+    const hours = (g.created_at.getTime() - closed.getTime()) / 3_600_000;
+    if (hours >= 0) ttgPerBin[idx].push(hours);
+  }
+  const slaSeriesHours = ttgPerBin.map((arr) => {
+    const m = computeGradeMedian(arr);
+    return m ?? 0;
+  });
+
+  // At-risk series approximation: for each week-end, count students with >=2
+  // past-due assignments (deadline <= weekEnd) that remain OPEN/ungraded today.
+  const atRiskSeries = bins.map((bin) => {
+    const byStudent = new Map<string, number>();
+    for (const r of pastDueOpen) {
+      const sid = r.repository.student_id;
+      const dl = r.assignment.student_deadline;
+      if (!sid || !dl) continue;
+      if (dl.getTime() <= bin.end.getTime()) {
+        byStudent.set(sid, (byStudent.get(sid) ?? 0) + 1);
+      }
+    }
+    let count = 0;
+    for (const c of byStudent.values()) if (c >= 2) count += 1;
+    return count;
+  });
+
+  return {
+    activeStudents,
+    inactiveStudents,
+    medianGrade,
+    atRiskCount,
+    atRiskStudents,
+    activeStudentsSeries,
+    submissionRateSeries,
+    slaSeriesHours,
+    atRiskSeries,
+  };
+}
+
+// 2. Assignment health
+
+export interface AssignmentHealthRow {
+  assignmentId: string;
+  title: string;
+  submissionRate: number;
+  medianGrade: number | null;
+  medianTimeToGradeHours: number | null;
+  regradeRate: number;
+}
+
+export async function assignmentHealth(
+  classroomId: string,
+): Promise<AssignmentHealthRow[]> {
+  const prisma = getPrisma();
+
+  const [assignments, studentCountRow, emojiMap] = await Promise.all([
+    prisma.assignment.findMany({
+      where: { module: { classroom_id: classroomId } },
+      select: {
+        id: true,
+        title: true,
+        repository_assignments: {
+          select: {
+            id: true,
+            closed_at: true,
+            status: true,
+            repository: { select: { student_id: true } },
+            grades: {
+              select: { emoji: true, created_at: true },
+              orderBy: { created_at: 'asc' },
+            },
+            regrade_requests: { select: { id: true } },
+          },
+        },
+      },
+    }),
+    prisma.classroomMembership.count({
+      where: { classroom_id: classroomId, role: 'STUDENT' },
+    }),
+    loadClassroomEmojiMap(classroomId),
+  ]);
+
+  const enrolled = studentCountRow || 0;
+
+  return assignments.map((a) => {
+    const ras = a.repository_assignments;
+    const submitted = ras.filter((r) => r.closed_at !== null).length;
+    const submissionRate = enrolled > 0 ? submitted / enrolled : 0;
+
+    const gradeValues: number[] = [];
+    const ttgPairs: Array<{ submittedAt: Date | null; gradedAt: Date | null }> = [];
+    let regradeHavers = 0;
+    for (const r of ras) {
+      if (r.grades.length > 0) {
+        const first = r.grades[0];
+        const g = emojiToGrade(first.emoji, emojiMap);
+        if (g !== null) gradeValues.push(g);
+        ttgPairs.push({ submittedAt: r.closed_at, gradedAt: first.created_at });
+      }
+      if (r.regrade_requests.length > 0) regradeHavers += 1;
+    }
+
+    const medianGrade = computeGradeMedian(gradeValues);
+    const medianTimeToGradeHours = computeMedianTimeToGradeHours(ttgPairs);
+    const regradeRate = ras.length > 0 ? regradeHavers / ras.length : 0;
+
+    return {
+      assignmentId: a.id,
+      title: a.title,
+      submissionRate,
+      medianGrade,
+      medianTimeToGradeHours,
+      regradeRate,
+    };
+  });
+}
+
+// 3. TA operations
+
+export interface TaOpsRow {
+  taId: string;
+  login: string;
+  name: string | null;
+  throughput7d: number;
+  avgTimeToGradeHours: number | null;
+  overturnRate: number | null;
+  gradeDistributionMean: number | null;
+}
+
+export async function taOps(classroomId: string): Promise<TaOpsRow[]> {
+  const prisma = getPrisma();
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const taMemberships = await prisma.classroomMembership.findMany({
+    where: {
+      classroom_id: classroomId,
+      role: { in: ['ASSISTANT', 'TEACHER', 'OWNER'] },
+    },
+    select: {
+      user: { select: { id: true, login: true, name: true } },
+    },
+  });
+  if (taMemberships.length === 0) return [];
+  const taIds = taMemberships.map((m) => m.user.id);
+
+  const [allGrades, emojiMap] = await Promise.all([
+    prisma.assignmentGrade.findMany({
+      where: {
+        grader_id: { in: taIds },
+        repository_assignment: {
+          repository: { classroom_id: classroomId },
+        },
+      },
+      select: {
+        grader_id: true,
+        emoji: true,
+        created_at: true,
+        repository_assignment: {
+          select: {
+            closed_at: true,
+            regrade_requests: { select: { status: true } },
+          },
+        },
+      },
+    }),
+    loadClassroomEmojiMap(classroomId),
+  ]);
+
+  const byTa = new Map<string, typeof allGrades>();
+  for (const g of allGrades) {
+    if (!g.grader_id) continue;
+    const bucket = byTa.get(g.grader_id) ?? [];
+    bucket.push(g);
+    byTa.set(g.grader_id, bucket);
+  }
+
+  return taMemberships.map((m) => {
+    const u = m.user;
+    const grades = byTa.get(u.id) ?? [];
+    const throughput7d = grades.filter((g) => g.created_at >= sevenDaysAgo).length;
+
+    const ttg = grades
+      .map((g) =>
+        g.repository_assignment.closed_at
+          ? (g.created_at.getTime() - g.repository_assignment.closed_at.getTime()) /
+            3_600_000
+          : null,
+      )
+      .filter((v): v is number => v !== null && v >= 0);
+    const avgTimeToGradeHours =
+      ttg.length > 0 ? ttg.reduce((a, b) => a + b, 0) / ttg.length : null;
+
+    let overturned = 0;
+    let withRegrade = 0;
+    for (const g of grades) {
+      const reqs = g.repository_assignment.regrade_requests;
+      if (reqs.length > 0) {
+        withRegrade += 1;
+        if (reqs.some((r) => r.status === 'APPROVED')) overturned += 1;
+      }
+    }
+    const overturnRate = withRegrade > 0 ? overturned / withRegrade : null;
+
+    const numericGrades = grades
+      .map((g) => emojiToGrade(g.emoji, emojiMap))
+      .filter((v): v is number => v !== null);
+    const gradeDistributionMean =
+      numericGrades.length > 0
+        ? numericGrades.reduce((a, b) => a + b, 0) / numericGrades.length
+        : null;
+
+    return {
+      taId: u.id,
+      login: u.login ?? '',
+      name: u.name,
+      throughput7d,
+      avgTimeToGradeHours,
+      overturnRate,
+      gradeDistributionMean,
+    };
+  });
+}
+
+// 4. Quiz analytics
+
+export interface QuizAnalytics {
+  hardestQuestions: Array<{ questionId: string; prompt: string; correctRate: number }>;
+  avgFocusPct: number | null;
+}
+
+export async function quizAnalytics(classroomId: string): Promise<QuizAnalytics> {
+  const prisma = getPrisma();
+
+  const attempts = await prisma.quizAttempt.findMany({
+    where: { quiz: { classroom_id: classroomId } },
+    select: {
+      total_duration_ms: true,
+      unfocused_duration_ms: true,
+    },
+  });
+
+  const focusValues: number[] = [];
+  for (const a of attempts) {
+    const total = a.total_duration_ms ?? 0;
+    const unfocused = a.unfocused_duration_ms ?? 0;
+    if (total > 0) {
+      const pct = 1 - unfocused / total;
+      if (pct >= 0 && pct <= 1) focusValues.push(pct);
+    }
+  }
+  const avgFocusPct =
+    focusValues.length > 0
+      ? focusValues.reduce((a, b) => a + b, 0) / focusValues.length
+      : null;
+
+  // "Hardest question" requires a stable per-question identifier across
+  // attempts; QuizAttempt.question_results_json does not guarantee that today.
+  // Return empty array for now (documented limitation).
+  return { hardestQuestions: [], avgFocusPct };
+}
+
+// 5. Deadline pressure
+
+export interface DeadlinePressureBucket {
+  date: string;
+  assignments: Array<{ id: string; title: string; dueAt: string }>;
+}
+
+export async function deadlinePressure(
+  classroomId: string,
+): Promise<DeadlinePressureBucket[]> {
+  const prisma = getPrisma();
+  const now = new Date();
+  const in7 = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const assignments = await prisma.assignment.findMany({
+    where: {
+      module: { classroom_id: classroomId },
+      student_deadline: { gte: now, lte: in7 },
+    },
+    select: { id: true, title: true, student_deadline: true },
+    orderBy: { student_deadline: 'asc' },
+  });
+
+  const buckets = new Map<string, DeadlinePressureBucket>();
+  for (const a of assignments) {
+    if (!a.student_deadline) continue;
+    const date = a.student_deadline.toISOString().slice(0, 10);
+    const bucket = buckets.get(date) ?? { date, assignments: [] };
+    bucket.assignments.push({
+      id: a.id,
+      title: a.title,
+      dueAt: a.student_deadline.toISOString(),
+    });
+    buckets.set(date, bucket);
+  }
+
+  return Array.from(buckets.values()).sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -31,6 +31,9 @@ import * as moduleImportService from './moduleImport.service.ts';
 import * as classroomInviteService from './classroomInvite.service.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import * as resourceViewService from './resourceView.service.ts';
+import * as repoAnalyticsService from './repoAnalytics.service.ts';
+import * as dashboardService from './dashboard.service.ts';
+import * as taDashboardService from './taDashboard.service.ts';
 
 const ClassmojiService = {
   // All services namespaced for consistency
@@ -64,6 +67,9 @@ const ClassmojiService = {
   classroomInvite: classroomInviteService,
   contentManifest: contentManifestService,
   resourceView: resourceViewService,
+  repoAnalytics: repoAnalyticsService,
+  dashboard: dashboardService,
+  taDashboard: taDashboardService,
   // Alias for AI conversation functions (delegates to quizAttempt)
   aiConversation: {
     addMessage: quizAttemptService.addMessage,
@@ -104,4 +110,7 @@ export {
   classroomInviteService,
   contentManifestService,
   resourceViewService,
+  repoAnalyticsService,
+  dashboardService,
+  taDashboardService,
 };

--- a/packages/services/src/classmoji/repoAnalytics.flags.ts
+++ b/packages/services/src/classmoji/repoAnalytics.flags.ts
@@ -1,0 +1,197 @@
+import type {
+  CommitRecord,
+  ContributorRecord,
+} from './repoAnalytics.types.ts';
+
+/**
+ * Ratio of commits after deadline over total commits.
+ * Returns 0 when there are no commits or no deadline.
+ */
+export function lateCommitRatio(
+  commits: CommitRecord[],
+  deadline: Date | null,
+): number {
+  if (!commits.length || !deadline) return 0;
+  const cutoff = deadline.getTime();
+  const late = commits.filter((c) => new Date(c.ts).getTime() > cutoff).length;
+  return late / commits.length;
+}
+
+/**
+ * True when a single commit's (additions + deletions) is more than 40%
+ * of the total (additions + deletions) across all commits.
+ */
+export function isMegaCommit(
+  commit: CommitRecord,
+  totalAdditions: number,
+  totalDeletions: number,
+): boolean {
+  const total = totalAdditions + totalDeletions;
+  if (total <= 0) return false;
+  const size = commit.additions + commit.deletions;
+  return size / total > 0.4;
+}
+
+const FILLER = /^(update|fix|wip|stuff|changes?|tweak|small\s*fix)\.?$/i;
+
+/**
+ * Heuristic quality score in [0, 1] for a commit message.
+ * - base 0.5
+ * - penalize common filler verbs alone
+ * - penalize length < 10 chars
+ * - reward length >= 20 chars
+ */
+export function commitMessageQuality(message: string): number {
+  const m = message.trim();
+  if (!m) return 0;
+  let score = 0.5;
+  if (FILLER.test(m)) score -= 0.3;
+  if (m.length < 10) score -= 0.2;
+  if (m.length >= 20) score += 0.2;
+  return Math.max(0, Math.min(1, score));
+}
+
+/**
+ * Average commitMessageQuality across the given commits.
+ * Returns 0 when there are no commits.
+ */
+export function averageCommitQuality(commits: CommitRecord[]): number {
+  if (!commits.length) return 0;
+  const sum = commits.reduce(
+    (acc, c) => acc + commitMessageQuality(c.message),
+    0,
+  );
+  return sum / commits.length;
+}
+
+/**
+ * Returns null when there is one or zero contributors.
+ * Otherwise returns the contributor with the largest commit share.
+ */
+export function busFactor(
+  contributors: ContributorRecord[],
+): { login: string; share: number } | null {
+  if (contributors.length <= 1) return null;
+  const total = contributors.reduce((acc, c) => acc + c.commits, 0);
+  if (total <= 0) return null;
+  let top = contributors[0]!;
+  for (const c of contributors) {
+    if (c.commits > top.commits) top = c;
+  }
+  return { login: top.login, share: top.commits / total };
+}
+
+/**
+ * True when the first (earliest) commit is less than 24h before the deadline
+ * AND at least 1 commit exists. Signals last-minute "dump and run" behavior.
+ */
+export function dumpAndRun(
+  commits: CommitRecord[],
+  deadline: Date | null,
+): boolean {
+  if (!commits.length || !deadline) return false;
+  const earliest = commits.reduce((min, c) => {
+    const t = new Date(c.ts).getTime();
+    return t < min ? t : min;
+  }, Number.POSITIVE_INFINITY);
+  if (!Number.isFinite(earliest)) return false;
+  const msBefore = deadline.getTime() - earliest;
+  const TWENTY_FOUR_H = 24 * 60 * 60 * 1000;
+  return msBefore < TWENTY_FOUR_H;
+}
+
+/**
+ * Aggregate commits by contributor login.
+ * Returns rows sorted descending by commit count.
+ * Commits with null author_login are bucketed under 'unknown'.
+ */
+export function aggregateByContributor(commits: CommitRecord[]): Array<{
+  login: string;
+  commits: number;
+  additions: number;
+  deletions: number;
+}> {
+  const acc = new Map<
+    string,
+    { login: string; commits: number; additions: number; deletions: number }
+  >();
+  for (const c of commits) {
+    const login = c.author_login ?? 'unknown';
+    const existing = acc.get(login);
+    if (existing) {
+      existing.commits += 1;
+      existing.additions += c.additions;
+      existing.deletions += c.deletions;
+    } else {
+      acc.set(login, {
+        login,
+        commits: 1,
+        additions: c.additions,
+        deletions: c.deletions,
+      });
+    }
+  }
+  return Array.from(acc.values()).sort((a, b) => b.commits - a.commits);
+}
+
+/**
+ * Per-day buckets stacked by contributor. Returns rows suitable for a
+ * Recharts stacked BarChart: `{ day: '2026-04-15', alice: 2, bob: 1, ... }`.
+ * - One row per UTC day between first and last commit (inclusive).
+ * - Missing authors in a day are filled with 0.
+ * - Day bucketing uses the ISO date slice (0,10) of `ts`.
+ * - Returns [] when no commits.
+ */
+export function commitsPerDayByContributor(
+  commits: CommitRecord[],
+): Array<{ day: string } & Record<string, number>> {
+  if (!commits.length) return [];
+
+  const logins = new Set<string>();
+  const counts = new Map<string, Map<string, number>>(); // day -> login -> count
+  let minDay = '9999-99-99';
+  let maxDay = '0000-00-00';
+
+  for (const c of commits) {
+    const day = c.ts.slice(0, 10);
+    const login = c.author_login ?? 'unknown';
+    logins.add(login);
+    if (day < minDay) minDay = day;
+    if (day > maxDay) maxDay = day;
+    let dayMap = counts.get(day);
+    if (!dayMap) {
+      dayMap = new Map<string, number>();
+      counts.set(day, dayMap);
+    }
+    dayMap.set(login, (dayMap.get(login) ?? 0) + 1);
+  }
+
+  // Iterate UTC days between minDay and maxDay.
+  const toMs = (d: string): number => {
+    const [y, m, dd] = d.split('-').map(Number) as [number, number, number];
+    return Date.UTC(y, m - 1, dd);
+  };
+  const fromMs = (ms: number): string => {
+    const d = new Date(ms);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${dd}`;
+  };
+
+  const startMs = toMs(minDay);
+  const endMs = toMs(maxDay);
+  const DAY_MS = 86400000;
+
+  const rows: Array<{ day: string } & Record<string, number>> = [];
+  for (let ms = startMs; ms <= endMs; ms += DAY_MS) {
+    const day = fromMs(ms);
+    const dayMap = counts.get(day);
+    const row: Record<string, string | number> = { day };
+    for (const login of logins) {
+      row[login] = dayMap?.get(login) ?? 0;
+    }
+    rows.push(row as { day: string } & Record<string, number>);
+  }
+  return rows;
+}

--- a/packages/services/src/classmoji/repoAnalytics.service.ts
+++ b/packages/services/src/classmoji/repoAnalytics.service.ts
@@ -1,0 +1,612 @@
+/**
+ * RepoAnalytics Service
+ *
+ * Builds, links, and persists `RepoAnalyticsSnapshot` rows for a
+ * `RepositoryAssignment`. A snapshot is a cached, authored summary of the
+ * underlying repo's commits, contributors, languages, and PR counts — used by
+ * the TA cockpit and owner dashboards.
+ *
+ * High-level flow (see `refreshOne`):
+ *   1. Load the RepositoryAssignment → Repository → Classroom → GitOrganization.
+ *   2. Build a GitProvider from the org's installation/credentials.
+ *   3. Call `buildSnapshot` to fetch commits / contributors / languages / PR summary.
+ *      GitHub's contributor-stats endpoint returns 202 while warming its cache; we
+ *      surface that as `pending: true` and still write the row but mark it `stale`
+ *      so the Trigger.dev task retries.
+ *   4. Resolve GitHub logins → classroom User ids via ClassroomMembership.user.login,
+ *      with `RepositoryContributorLink` rows taking precedence as manual overrides.
+ *   5. Upsert the snapshot row (JSON columns + aggregate totals + stale/error flags).
+ */
+import getPrisma from '@classmoji/database';
+import type { GitProvider } from '../git/GitProvider.ts';
+import { getGitProvider } from '../git/index.ts';
+import type {
+  CommitRecord,
+  ContributorRecord,
+  LanguagesMap,
+  PRSummary,
+  SnapshotPayload,
+} from './repoAnalytics.types.ts';
+
+// Consider a classroom "active" if any of its assignments have a student_deadline
+// within this window (past or future). Used by the cron to limit refresh scope.
+const ACTIVE_WINDOW_DAYS = 30;
+
+function pickLatestSnapshot<T, S extends { fetched_at: Date | string }>(
+  items: T[],
+  getSnap: (t: T) => S | null | undefined,
+  decorate: (snap: S, item: T) => S = (s) => s,
+): S | null {
+  let best: S | null = null;
+  for (const item of items) {
+    const s = getSnap(item);
+    if (!s) continue;
+    const t = new Date(s.fetched_at).getTime();
+    if (!best || t > new Date(best.fetched_at).getTime()) best = decorate(s, item);
+  }
+  return best;
+}
+
+// Pure helpers (unit-tested)
+
+/**
+ * Re-map `author_login` → `author_user_id` on a list of commit records using
+ * the provided lookup map. Pure; returns a new array, does not mutate input.
+ */
+export function linkAuthorsToUsers(
+  commits: CommitRecord[],
+  loginToUserId: Map<string, string>
+): CommitRecord[] {
+  return commits.map((c) => ({
+    ...c,
+    author_user_id:
+      c.author_login && loginToUserId.has(c.author_login)
+        ? (loginToUserId.get(c.author_login) ?? null)
+        : null,
+  }));
+}
+
+/**
+ * Re-map `login` → `user_id` on a list of contributor records. Pure.
+ */
+export function linkContributorsToUsers(
+  contributors: ContributorRecord[],
+  loginToUserId: Map<string, string>
+): ContributorRecord[] {
+  return contributors.map((c) => ({
+    ...c,
+    user_id: loginToUserId.has(c.login) ? (loginToUserId.get(c.login) ?? null) : null,
+  }));
+}
+
+// Snapshot building
+
+/**
+ * Fetch the four provider endpoints that compose a snapshot and normalize them
+ * into `SnapshotPayload`. Returns `pending: true` when GitHub's
+ * contributor-stats cache is still warming; callers should mark the row stale.
+ */
+export async function buildSnapshot(
+  provider: GitProvider,
+  orgLogin: string,
+  repoName: string
+): Promise<{ payload: SnapshotPayload; pending: boolean }> {
+  const [commits, contributorsRes, languages, prSummary] = await Promise.all([
+    provider.listCommits(orgLogin, repoName),
+    provider.getContributorStats(orgLogin, repoName),
+    provider.getLanguages(orgLogin, repoName),
+    provider.listPulls(orgLogin, repoName),
+  ]);
+
+  let contributors: ContributorRecord[] = [];
+  let pending = false;
+  if (Array.isArray(contributorsRes)) {
+    contributors = contributorsRes;
+  } else if ((contributorsRes as { pending?: boolean })?.pending) {
+    pending = true;
+  }
+
+  const payload: SnapshotPayload = {
+    commits,
+    contributors,
+    languages: (languages ?? {}) as LanguagesMap,
+    pr_summary: (prSummary ?? { open: 0, merged: 0, closed: 0 }) as PRSummary,
+  };
+
+  return { payload, pending };
+}
+
+// Upsert
+
+/**
+ * Upsert a snapshot row for a `RepositoryAssignment`. Safe to call with
+ * `payload: null` when recording a hard error — in that case the JSON columns
+ * are reset to their empty defaults, `stale: true` is forced, and the error
+ * message is persisted.
+ */
+export async function upsertSnapshot(
+  repositoryAssignmentId: string,
+  payload: SnapshotPayload | null,
+  opts: { stale?: boolean; error?: string } = {}
+): Promise<void> {
+  const prisma = getPrisma();
+  const now = new Date();
+
+  const commits = payload?.commits ?? [];
+  const contributors = payload?.contributors ?? [];
+  const languages = payload?.languages ?? {};
+  const prSummary = payload?.pr_summary ?? { open: 0, merged: 0, closed: 0 };
+
+  // Aggregate totals derived from commits list.
+  let totalAdditions = 0;
+  let totalDeletions = 0;
+  let firstCommitAt: Date | null = null;
+  let lastCommitAt: Date | null = null;
+  for (const c of commits) {
+    totalAdditions += c.additions ?? 0;
+    totalDeletions += c.deletions ?? 0;
+    const ts = new Date(c.ts);
+    if (!Number.isNaN(ts.getTime())) {
+      if (!firstCommitAt || ts < firstCommitAt) firstCommitAt = ts;
+      if (!lastCommitAt || ts > lastCommitAt) lastCommitAt = ts;
+    }
+  }
+
+  const stale = opts.stale ?? false;
+  const error = opts.error ?? null;
+
+  const data = {
+    fetched_at: now,
+    default_branch: null as string | null,
+    total_commits: commits.length,
+    total_additions: totalAdditions,
+    total_deletions: totalDeletions,
+    first_commit_at: firstCommitAt,
+    last_commit_at: lastCommitAt,
+    commits: commits as unknown as object,
+    contributors: contributors as unknown as object,
+    languages: languages as unknown as object,
+    pr_summary: prSummary as unknown as object,
+    stale,
+    error,
+  };
+
+  await prisma.repoAnalyticsSnapshot.upsert({
+    where: { repository_assignment_id: repositoryAssignmentId },
+    create: {
+      repository_assignment_id: repositoryAssignmentId,
+      ...data,
+    },
+    update: data,
+  });
+}
+
+// Link map builder
+
+/**
+ * Build a `githubLogin → userId` map for a repository. Starts with every
+ * `ClassroomMembership.user.login` in the classroom, then overlays any
+ * `RepositoryContributorLink` rows for this repo (manual overrides win).
+ */
+async function buildLoginToUserIdMap(
+  classroomId: string,
+  repositoryId: string
+): Promise<Map<string, string>> {
+  const prisma = getPrisma();
+  const [memberships, links] = await Promise.all([
+    prisma.classroomMembership.findMany({
+      where: { classroom_id: classroomId },
+      include: { user: { select: { id: true, login: true } } },
+    }),
+    prisma.repositoryContributorLink.findMany({
+      where: { repository_id: repositoryId, user_id: { not: null } },
+    }),
+  ]);
+
+  const map = new Map<string, string>();
+  for (const m of memberships) {
+    const login = m.user?.login;
+    if (login && !map.has(login)) {
+      map.set(login, m.user.id);
+    }
+  }
+  // Overrides take precedence.
+  for (const l of links) {
+    if (l.user_id) map.set(l.github_login, l.user_id);
+  }
+  return map;
+}
+
+// Orchestrator
+
+/**
+ * End-to-end refresh for a single RepositoryAssignment. Intended to be called
+ * by the Trigger.dev workflow (Task 7). Never throws — errors are persisted on
+ * the snapshot row and returned via `{ stale: true, error }` so the task can
+ * decide whether to retry.
+ */
+export async function refreshOne(
+  repositoryAssignmentId: string
+): Promise<{ stale: boolean; error?: string }> {
+  const prisma = getPrisma();
+  try {
+    const ra = await prisma.repositoryAssignment.findUnique({
+      where: { id: repositoryAssignmentId },
+      include: {
+        repository: {
+          include: {
+            classroom: {
+              include: { git_organization: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!ra) throw new Error(`RepositoryAssignment ${repositoryAssignmentId} not found`);
+    const repo = ra.repository;
+    if (!repo) throw new Error('Repository not attached to RepositoryAssignment');
+    const classroom = repo.classroom;
+    if (!classroom) throw new Error('Classroom not attached to Repository');
+    const gitOrg = classroom.git_organization;
+    if (!gitOrg) throw new Error('GitOrganization not attached to Classroom');
+    if (!gitOrg.login) throw new Error('GitOrganization.login is required');
+
+    const provider = getGitProvider(gitOrg);
+
+    const { payload, pending } = await buildSnapshot(provider, gitOrg.login, repo.name);
+
+    const loginToUserId = await buildLoginToUserIdMap(classroom.id, repo.id);
+
+    const linkedPayload: SnapshotPayload = {
+      ...payload,
+      commits: linkAuthorsToUsers(payload.commits, loginToUserId),
+      contributors: linkContributorsToUsers(payload.contributors, loginToUserId),
+    };
+
+    await upsertSnapshot(repositoryAssignmentId, linkedPayload, { stale: pending });
+
+    return { stale: pending };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      await upsertSnapshot(repositoryAssignmentId, null, { stale: true, error: message });
+    } catch (upsertErr) {
+      console.error('[repoAnalytics] failed to persist error snapshot', upsertErr);
+    }
+    return { stale: true, error: message };
+  }
+}
+
+// Manual contributor → user linking
+
+/**
+ * Upsert a `RepositoryContributorLink` for the given `(repository_id, github_login)`.
+ * Passing `userId: null` unlinks (records the mapping with no user). When a
+ * `userId` is supplied, the user MUST be a member of the classroom that owns
+ * the repo — otherwise this throws.
+ *
+ * Callers: the API route backing ContributorBreakdown's "Link to student"
+ * modal. The stored link is consumed by `buildLoginToUserIdMap` on the next
+ * refresh, so newly-linked contributors are attributed correctly.
+ */
+export async function linkContributor(
+  repositoryId: string,
+  githubLogin: string,
+  userId: string | null
+): Promise<void> {
+  const prisma = getPrisma();
+
+  const repo = await prisma.repository.findUnique({
+    where: { id: repositoryId },
+    select: { id: true, classroom_id: true },
+  });
+  if (!repo) throw new Error(`Repository ${repositoryId} not found`);
+
+  if (userId) {
+    const membership = await prisma.classroomMembership.findFirst({
+      where: { classroom_id: repo.classroom_id, user_id: userId },
+      select: { id: true },
+    });
+    if (!membership) {
+      throw new Error(
+        `User ${userId} is not a member of the classroom that owns this repository`
+      );
+    }
+  }
+
+  await prisma.repositoryContributorLink.upsert({
+    where: {
+      repository_id_github_login: {
+        repository_id: repositoryId,
+        github_login: githubLogin,
+      },
+    },
+    create: {
+      repository_id: repositoryId,
+      github_login: githubLogin,
+      user_id: userId,
+    },
+    update: { user_id: userId },
+  });
+}
+
+// Cron helper
+
+// Team aggregation
+
+/**
+ * Shape of a stored snapshot row plus its associated repository name/id — the
+ * subset we expose to the Team Contributions view. Keeps `repoAnalytics.types`
+ * Prisma-free; we redeclare here rather than importing Prisma types.
+ */
+export type TeamRepoSnapshot = {
+  repository_id: string;
+  repository_name: string;
+  repository_assignment_id: string;
+  fetched_at: string;
+  stale: boolean;
+  error: string | null;
+  total_commits: number;
+  total_additions: number;
+  total_deletions: number;
+  first_commit_at: string | null;
+  last_commit_at: string | null;
+  commits: CommitRecord[];
+  contributors: ContributorRecord[];
+  languages: LanguagesMap;
+  pr_summary: PRSummary;
+};
+
+export type TeamAggregate = {
+  commits: CommitRecord[];
+  contributors: ContributorRecord[];
+  total_additions: number;
+  total_deletions: number;
+  snapshotsByRepoId: Record<string, TeamRepoSnapshot>;
+};
+
+/**
+ * Aggregate the latest analytics snapshot across every repository owned by a
+ * team. For each repo we pick its most recent `RepoAnalyticsSnapshot` (ordered
+ * by `fetched_at`) and merge:
+ *   - `commits` via simple concatenation
+ *   - `contributors` summed by `login` (commits/additions/deletions); `user_id`
+ *     preserved from the first snapshot that had one.
+ *
+ * Returns `null` when the team owns no repositories with any snapshots.
+ */
+export async function aggregateForTeam(teamId: string): Promise<TeamAggregate | null> {
+  const prisma = getPrisma();
+
+  const repos = await prisma.repository.findMany({
+    where: { team_id: teamId },
+    select: {
+      id: true,
+      name: true,
+      assignments: {
+        select: {
+          id: true,
+          analytics_snapshot: true,
+        },
+      },
+    },
+  });
+
+  if (repos.length === 0) return null;
+
+  const snapshotsByRepoId: Record<string, TeamRepoSnapshot> = {};
+  const commits: CommitRecord[] = [];
+  const contributorMap = new Map<string, ContributorRecord>();
+  let totalAdditions = 0;
+  let totalDeletions = 0;
+
+  for (const repo of repos) {
+    const latestSnapshot = pickLatestSnapshot(
+      repo.assignments,
+      (ra) => ra.analytics_snapshot,
+      (snap, ra) => ({ ...snap, repository_assignment_id: ra.id }),
+    );
+
+    if (!latestSnapshot) continue;
+
+    const repoCommits = (latestSnapshot.commits ?? []) as unknown as CommitRecord[];
+    const repoContribs = (latestSnapshot.contributors ?? []) as unknown as ContributorRecord[];
+    const repoLangs = (latestSnapshot.languages ?? {}) as unknown as LanguagesMap;
+    const repoPr = (latestSnapshot.pr_summary ?? {
+      open: 0,
+      merged: 0,
+      closed: 0,
+    }) as unknown as PRSummary;
+
+    snapshotsByRepoId[repo.id] = {
+      repository_id: repo.id,
+      repository_name: repo.name,
+      repository_assignment_id: latestSnapshot.repository_assignment_id,
+      fetched_at: latestSnapshot.fetched_at.toISOString(),
+      stale: latestSnapshot.stale,
+      error: latestSnapshot.error,
+      total_commits: latestSnapshot.total_commits,
+      total_additions: latestSnapshot.total_additions,
+      total_deletions: latestSnapshot.total_deletions,
+      first_commit_at: latestSnapshot.first_commit_at
+        ? latestSnapshot.first_commit_at.toISOString()
+        : null,
+      last_commit_at: latestSnapshot.last_commit_at
+        ? latestSnapshot.last_commit_at.toISOString()
+        : null,
+      commits: repoCommits,
+      contributors: repoContribs,
+      languages: repoLangs,
+      pr_summary: repoPr,
+    };
+
+    commits.push(...repoCommits);
+    totalAdditions += latestSnapshot.total_additions;
+    totalDeletions += latestSnapshot.total_deletions;
+
+    for (const c of repoContribs) {
+      const existing = contributorMap.get(c.login);
+      if (existing) {
+        existing.commits += c.commits;
+        existing.additions += c.additions;
+        existing.deletions += c.deletions;
+        if (!existing.user_id && c.user_id) existing.user_id = c.user_id;
+      } else {
+        contributorMap.set(c.login, { ...c });
+      }
+    }
+  }
+
+  if (Object.keys(snapshotsByRepoId).length === 0) return null;
+
+  const contributors = Array.from(contributorMap.values()).sort(
+    (a, b) => b.commits - a.commits
+  );
+
+  return {
+    commits,
+    contributors,
+    total_additions: totalAdditions,
+    total_deletions: totalDeletions,
+    snapshotsByRepoId,
+  };
+}
+
+// Classroom-wide repo health
+
+export interface ClassroomRepoHealthRepo {
+  name: string;
+  langs: Record<string, number>;
+  commits: number;
+  fetchedAt: string;
+  status: 'fresh' | 'stale';
+}
+
+export interface ClassroomRepoUnmatchedContributor {
+  login: string;
+  repo: string;
+  commits: number;
+  firstSeen: string;
+}
+
+export interface ClassroomRepoHealth {
+  repos: ClassroomRepoHealthRepo[];
+  unmatched: ClassroomRepoUnmatchedContributor[];
+  /** ISO timestamp of the next 4h boundary from "now" (UTC). */
+  nextScheduledAt: string;
+  autoRefreshEvery: '4h';
+}
+
+/**
+ * Classroom-wide repo analytics overview for the admin Repo Health page.
+ * Returns all latest snapshots, a list of GitHub logins that appear in
+ * contributor payloads but are not linked to a classroom user, and a
+ * human-readable "next scheduled refresh" timestamp anchored to 4h boundaries.
+ */
+export async function classroomRepoHealth(
+  classroomId: string,
+): Promise<ClassroomRepoHealth> {
+  const prisma = getPrisma();
+
+  const reposRaw = await prisma.repository.findMany({
+    where: { classroom_id: classroomId },
+    select: {
+      id: true,
+      name: true,
+      assignments: {
+        select: {
+          id: true,
+          analytics_snapshot: {
+            select: {
+              fetched_at: true,
+              stale: true,
+              total_commits: true,
+              languages: true,
+              contributors: true,
+            },
+          },
+        },
+      },
+      contributor_links: { select: { github_login: true, user_id: true } },
+    },
+  });
+
+  const repos: ClassroomRepoHealthRepo[] = [];
+  const unmatched: ClassroomRepoUnmatchedContributor[] = [];
+
+  for (const r of reposRaw) {
+    // Latest snapshot across this repo's assignments.
+    const latest = pickLatestSnapshot(r.assignments, (a) => a.analytics_snapshot);
+    if (!latest) continue;
+
+    const langs = (latest.languages ?? {}) as Record<string, number>;
+    repos.push({
+      name: r.name,
+      langs,
+      commits: latest.total_commits,
+      fetchedAt: latest.fetched_at.toISOString(),
+      status: latest.stale ? 'stale' : 'fresh',
+    });
+
+    // Unmatched contributors: appear in payload, are not linked (by membership
+    // login match already baked into user_id), and have no manual link row.
+    const linkedLogins = new Set(
+      r.contributor_links
+        .filter((l) => l.user_id !== null)
+        .map((l) => l.github_login),
+    );
+    const rawContribs = (latest.contributors ?? []) as Array<{
+      login: string;
+      user_id: string | null;
+      commits: number;
+    }>;
+    for (const c of rawContribs) {
+      if (!c || !c.login) continue;
+      if (c.user_id) continue;
+      if (linkedLogins.has(c.login)) continue;
+      unmatched.push({
+        login: c.login,
+        repo: r.name,
+        commits: c.commits,
+        firstSeen: latest.fetched_at.toISOString(),
+      });
+    }
+  }
+
+  repos.sort((a, b) => a.name.localeCompare(b.name));
+  unmatched.sort((a, b) => b.commits - a.commits);
+
+  // Next scheduled at = next 4h boundary in UTC.
+  const now = new Date();
+  const FOUR_H = 4 * 60 * 60 * 1000;
+  const nextMs = Math.ceil(now.getTime() / FOUR_H) * FOUR_H;
+  const nextScheduledAt = new Date(nextMs).toISOString();
+
+  return {
+    repos,
+    unmatched,
+    nextScheduledAt,
+    autoRefreshEvery: '4h',
+  };
+}
+
+/**
+ * Return RepositoryAssignment IDs for assignments whose `student_deadline` is
+ * within the last {@link ACTIVE_WINDOW_DAYS} days or in the future. Used by
+ * the 6-hour refresh cron to bound its work.
+ */
+export async function listActiveAssignmentIds(): Promise<string[]> {
+  const prisma = getPrisma();
+  const cutoff = new Date(Date.now() - ACTIVE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  const rows = await prisma.repositoryAssignment.findMany({
+    where: {
+      assignment: {
+        OR: [{ student_deadline: null }, { student_deadline: { gte: cutoff } }],
+      },
+    },
+    select: { id: true },
+  });
+  return rows.map((r) => r.id);
+}

--- a/packages/services/src/classmoji/repoAnalytics.types.ts
+++ b/packages/services/src/classmoji/repoAnalytics.types.ts
@@ -1,0 +1,30 @@
+export type CommitRecord = {
+  sha: string;
+  author_login: string | null;
+  author_email: string | null;
+  author_user_id: string | null;
+  ts: string; // ISO
+  message: string;
+  additions: number;
+  deletions: number;
+  parents: string[];
+};
+
+export type ContributorRecord = {
+  login: string;
+  user_id: string | null;
+  commits: number;
+  additions: number;
+  deletions: number;
+};
+
+export type LanguagesMap = Record<string, number>;
+
+export type PRSummary = { open: number; merged: number; closed: number };
+
+export type SnapshotPayload = {
+  commits: CommitRecord[];
+  contributors: ContributorRecord[];
+  languages: LanguagesMap;
+  pr_summary: PRSummary;
+};

--- a/packages/services/src/classmoji/taDashboard.service.ts
+++ b/packages/services/src/classmoji/taDashboard.service.ts
@@ -1,0 +1,360 @@
+/**
+ * TA Dashboard Service
+ *
+ * Personal aggregates for an individual TA / grader in a classroom (Task 19 of
+ * the TA & Owner Analytics plan). All functions are scoped by `(userId,
+ * classroomId)` and perform no auth — the route layer gates access. "Active
+ * TA" is implicit: if the user has no grades in the classroom the results are
+ * zero/empty but still well-formed.
+ *
+ * Reuses `emojiToGrade` + `loadClassroomEmojiMap`-style resolution from
+ * `dashboard.service.ts`.
+ */
+
+import getPrisma from '@classmoji/database';
+import { emojiToGrade, computeGradeMedian } from './dashboard.service.ts';
+
+// Pure helpers (unit-tested)
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Format a Date as a UTC YYYY-MM-DD day key. */
+export function toDayKey(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Given an array of counts keyed by day, return a length-`days` array ending
+ * on `endDay` (inclusive, UTC) with zero-fill for missing days. `endDay` is a
+ * YYYY-MM-DD string.
+ */
+export function padDailyBuckets(
+  countsByDay: Map<string, number>,
+  endDay: string,
+  days: number,
+): Array<{ date: string; count: number }> {
+  const out: Array<{ date: string; count: number }> = [];
+  const end = new Date(`${endDay}T00:00:00.000Z`);
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(end.getTime() - i * MS_PER_DAY);
+    const key = toDayKey(d);
+    out.push({ date: key, count: countsByDay.get(key) ?? 0 });
+  }
+  return out;
+}
+
+/**
+ * Given a set of day keys (YYYY-MM-DD) on which a user has graded, compute
+ * the most recent consecutive streak ending on the most recent day. Returns
+ * `{ days: 0, lastGradedAt: null }` for empty input.
+ */
+export function computeStreakDays(dayKeys: Iterable<string>): {
+  days: number;
+  lastDay: string | null;
+} {
+  const set = new Set<string>();
+  for (const k of dayKeys) set.add(k);
+  if (set.size === 0) return { days: 0, lastDay: null };
+  const sorted = [...set].sort();
+  const last = sorted[sorted.length - 1];
+  let cursor = new Date(`${last}T00:00:00.000Z`);
+  let days = 0;
+  while (set.has(toDayKey(cursor))) {
+    days += 1;
+    cursor = new Date(cursor.getTime() - MS_PER_DAY);
+  }
+  return { days, lastDay: last };
+}
+
+/**
+ * Bucket numeric grades (0-100) into 10 equal bins: [0,10), [10,20), ...,
+ * [90,100]. Grade of exactly 100 goes into the last bucket. Values outside
+ * 0-100 are clamped.
+ */
+export function bucketGrades(
+  grades: Array<number>,
+): Array<{ bucket: string; count: number }> {
+  const counts = new Array<number>(10).fill(0);
+  for (const g of grades) {
+    if (!Number.isFinite(g)) continue;
+    const clamped = Math.max(0, Math.min(100, g));
+    let idx = Math.floor(clamped / 10);
+    if (idx >= 10) idx = 9;
+    counts[idx] += 1;
+  }
+  return counts.map((count, i) => ({
+    bucket: i === 9 ? '90-100' : `${i * 10}-${(i + 1) * 10}`,
+    count,
+  }));
+}
+
+// Internal helpers
+
+async function loadClassroomEmojiMap(
+  classroomId: string,
+): Promise<Map<string, number>> {
+  const rows = await getPrisma().emojiMapping.findMany({
+    where: { classroom_id: classroomId },
+    select: { emoji: true, grade: true },
+  });
+  return new Map(rows.map((r) => [r.emoji, r.grade]));
+}
+
+// 1. Personal throughput — 7-day rolling grade counts
+
+export async function personalThroughput(
+  userId: string,
+  classroomId: string,
+): Promise<Array<{ date: string; count: number }>> {
+  const prisma = getPrisma();
+  const since = new Date(Date.now() - 7 * MS_PER_DAY);
+  const grades = await prisma.assignmentGrade.findMany({
+    where: {
+      grader_id: userId,
+      created_at: { gte: since },
+      repository_assignment: {
+        repository: { classroom_id: classroomId },
+      },
+    },
+    select: { created_at: true },
+  });
+  const byDay = new Map<string, number>();
+  for (const g of grades) {
+    const key = toDayKey(g.created_at);
+    byDay.set(key, (byDay.get(key) ?? 0) + 1);
+  }
+  return padDailyBuckets(byDay, toDayKey(new Date()), 7);
+}
+
+// 2. Grading streak
+
+export async function gradingStreak(
+  userId: string,
+  classroomId: string,
+): Promise<{ days: number; lastGradedAt: string | null }> {
+  const prisma = getPrisma();
+  const grades = await prisma.assignmentGrade.findMany({
+    where: {
+      grader_id: userId,
+      repository_assignment: {
+        repository: { classroom_id: classroomId },
+      },
+    },
+    select: { created_at: true },
+    orderBy: { created_at: 'desc' },
+  });
+  if (grades.length === 0) return { days: 0, lastGradedAt: null };
+
+  const dayKeys = grades.map((g) => toDayKey(g.created_at));
+  const { days } = computeStreakDays(dayKeys);
+  return { days, lastGradedAt: grades[0].created_at.toISOString() };
+}
+
+// 3. Overdue queue — rows the TA is assigned to but hasn't touched in >3 days
+
+export interface OverdueQueueRow {
+  repositoryAssignmentId: string;
+  studentName: string | null;
+  studentLogin: string | null;
+  assignmentTitle: string;
+  ageDays: number;
+}
+
+export async function overdueQueue(
+  userId: string,
+  classroomId: string,
+): Promise<OverdueQueueRow[]> {
+  const prisma = getPrisma();
+  const now = Date.now();
+  const cutoff = new Date(now - 3 * MS_PER_DAY);
+
+  // Queue = RepositoryAssignments this user is a grader on, that are still
+  // OPEN (i.e. not yet fully graded/closed) in this classroom. "Opened" =
+  // any grade interaction by anyone; we read the latest grade timestamp and
+  // fall back to the RA created_at.
+  const rows = await prisma.repositoryAssignmentGrader.findMany({
+    where: {
+      grader_id: userId,
+      repository_assignment: {
+        repository: { classroom_id: classroomId },
+        status: 'OPEN',
+      },
+    },
+    select: {
+      repository_assignment: {
+        select: {
+          id: true,
+          created_at: true,
+          grades: {
+            select: { created_at: true },
+            orderBy: { created_at: 'desc' },
+            take: 1,
+          },
+          assignment: { select: { title: true } },
+          repository: {
+            select: {
+              student: { select: { name: true, login: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const enriched = rows
+    .map((r) => {
+      const ra = r.repository_assignment;
+      const lastTouch =
+        ra.grades.length > 0 ? ra.grades[0].created_at : ra.created_at;
+      return {
+        ra,
+        lastTouch,
+        ageMs: now - lastTouch.getTime(),
+      };
+    })
+    .filter((x) => x.lastTouch < cutoff);
+
+  enriched.sort((a, b) => b.ageMs - a.ageMs); // oldest first
+
+  return enriched.slice(0, 10).map((x) => ({
+    repositoryAssignmentId: x.ra.id,
+    studentName: x.ra.repository.student?.name ?? null,
+    studentLogin: x.ra.repository.student?.login ?? null,
+    assignmentTitle: x.ra.assignment.title,
+    ageDays: Math.floor(x.ageMs / MS_PER_DAY),
+  }));
+}
+
+// 4. Personal daily totals — today / week / median-SLA / backlog
+
+export interface PersonalDailyTotals {
+  todayGraded: number;
+  weekGraded: number;
+  /** Median hours between RA.closed_at and grade.created_at over last 30d. */
+  medianSlaHours: number | null;
+  /** Count of OPEN RAs this TA is assigned on that have no grades yet. */
+  backlogCount: number;
+}
+
+export async function personalDailyTotals(
+  userId: string,
+  classroomId: string,
+): Promise<PersonalDailyTotals> {
+  const prisma = getPrisma();
+  const now = new Date();
+  const startOfTodayUtc = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      0,
+      0,
+      0,
+      0,
+    ),
+  );
+  const weekAgo = new Date(now.getTime() - 7 * MS_PER_DAY);
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * MS_PER_DAY);
+
+  const classroomScopedRA = {
+    repository_assignment: {
+      repository: { classroom_id: classroomId },
+    },
+  } as const;
+
+  const [todayGraded, weekGraded, slaGrades, backlogCount] = await Promise.all([
+    prisma.assignmentGrade.count({
+      where: {
+        grader_id: userId,
+        created_at: { gte: startOfTodayUtc },
+        ...classroomScopedRA,
+      },
+    }),
+    prisma.assignmentGrade.count({
+      where: {
+        grader_id: userId,
+        created_at: { gte: weekAgo },
+        ...classroomScopedRA,
+      },
+    }),
+    prisma.assignmentGrade.findMany({
+      where: {
+        grader_id: userId,
+        created_at: { gte: thirtyDaysAgo },
+        repository_assignment: {
+          repository: { classroom_id: classroomId },
+          closed_at: { not: null },
+        },
+      },
+      select: {
+        created_at: true,
+        repository_assignment: { select: { closed_at: true } },
+      },
+    }),
+    prisma.repositoryAssignmentGrader.count({
+      where: {
+        grader_id: userId,
+        repository_assignment: {
+          repository: { classroom_id: classroomId },
+          grades: { none: {} },
+        },
+      },
+    }),
+  ]);
+
+  const slaHours: number[] = [];
+  for (const g of slaGrades) {
+    const closedAt = g.repository_assignment.closed_at;
+    if (!closedAt) continue;
+    const diffMs = g.created_at.getTime() - closedAt.getTime();
+    if (diffMs < 0) continue;
+    slaHours.push(diffMs / (60 * 60 * 1000));
+  }
+  const medianHours = computeGradeMedian(slaHours);
+
+  return {
+    todayGraded,
+    weekGraded,
+    medianSlaHours: medianHours === null ? null : Math.round(medianHours),
+    backlogCount,
+  };
+}
+
+// 5. Personal grade distribution
+
+export interface PersonalGradeDistribution {
+  yours: Array<{ bucket: string; count: number }>;
+  classroom: Array<{ bucket: string; count: number }>;
+}
+
+export async function personalGradeDistribution(
+  userId: string,
+  classroomId: string,
+): Promise<PersonalGradeDistribution> {
+  const prisma = getPrisma();
+  const [allGrades, emojiMap] = await Promise.all([
+    prisma.assignmentGrade.findMany({
+      where: {
+        repository_assignment: {
+          repository: { classroom_id: classroomId },
+        },
+      },
+      select: { emoji: true, grader_id: true },
+    }),
+    loadClassroomEmojiMap(classroomId),
+  ]);
+
+  const yourValues: number[] = [];
+  const classroomValues: number[] = [];
+  for (const g of allGrades) {
+    const val = emojiToGrade(g.emoji, emojiMap);
+    if (val === null) continue;
+    classroomValues.push(val);
+    if (g.grader_id === userId) yourValues.push(val);
+  }
+
+  return {
+    yours: bucketGrades(yourValues),
+    classroom: bucketGrades(classroomValues),
+  };
+}

--- a/packages/services/src/git/GitHubProvider.ts
+++ b/packages/services/src/git/GitHubProvider.ts
@@ -3,6 +3,12 @@ import { createAppAuth } from '@octokit/auth-app';
 import { createHmac, timingSafeEqual } from 'crypto';
 import jwt from 'jsonwebtoken';
 import { GitProvider } from './GitProvider.ts';
+import type {
+  CommitRecord,
+  ContributorRecord,
+  LanguagesMap,
+  PRSummary,
+} from '../classmoji/repoAnalytics.types.ts';
 
 import dotenv from 'dotenv';
 dotenv.config();
@@ -55,6 +61,11 @@ export class GitHubProvider extends GitProvider {
    * @returns {Promise<Octokit>}
    */
   async #getOctokit(): Promise<Octokit> {
+    // Dependency injection hook (used by tests).
+    if (this._octokit) {
+      return this._octokit;
+    }
+
     const cacheKey = this.installationId;
     const cached = GitHubProvider.#installationCache.get(cacheKey);
 
@@ -297,6 +308,90 @@ export class GitHubProvider extends GitProvider {
       branch,
     });
     return data.commit.sha;
+  }
+
+  async listCommits(
+    org: string,
+    repo: string,
+    opts: { since?: string; branch?: string } = {}
+  ): Promise<CommitRecord[]> {
+    const octokit = await this.#getOctokit();
+    const commits: CommitRecord[] = [];
+    for await (const { data } of octokit.paginate.iterator(octokit.rest.repos.listCommits, {
+      owner: org,
+      repo,
+      sha: opts.branch,
+      since: opts.since,
+      per_page: 100,
+    })) {
+      for (const c of data) {
+        const { data: full } = await octokit.rest.repos.getCommit({
+          owner: org,
+          repo,
+          ref: c.sha,
+        });
+        commits.push({
+          sha: c.sha,
+          author_login: c.author?.login ?? null,
+          author_email: c.commit.author?.email ?? null,
+          author_user_id: null,
+          ts: c.commit.author?.date ?? new Date().toISOString(),
+          message: c.commit.message ?? '',
+          additions: full.stats?.additions ?? 0,
+          deletions: full.stats?.deletions ?? 0,
+          parents: (c.parents ?? []).map((p: { sha: string }) => p.sha),
+        });
+      }
+    }
+    return commits;
+  }
+
+  async getContributorStats(
+    org: string,
+    repo: string
+  ): Promise<{ pending: true } | ContributorRecord[]> {
+    const octokit = await this.#getOctokit();
+    const res = await octokit.request('GET /repos/{owner}/{repo}/stats/contributors', {
+      owner: org,
+      repo,
+    });
+    if (res.status === 202) return { pending: true };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return ((res.data as any[]) ?? []).map((row: any) => ({
+      login: row.author?.login ?? 'unknown',
+      user_id: null,
+      commits: row.total,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      additions: (row.weeks ?? []).reduce((s: number, w: any) => s + (w.a ?? 0), 0),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      deletions: (row.weeks ?? []).reduce((s: number, w: any) => s + (w.d ?? 0), 0),
+    }));
+  }
+
+  async getLanguages(org: string, repo: string): Promise<LanguagesMap> {
+    const octokit = await this.#getOctokit();
+    const { data } = await octokit.rest.repos.listLanguages({ owner: org, repo });
+    return data ?? {};
+  }
+
+  async listPulls(org: string, repo: string): Promise<PRSummary> {
+    const octokit = await this.#getOctokit();
+    const { data } = await octokit.rest.pulls.list({
+      owner: org,
+      repo,
+      state: 'all',
+      per_page: 100,
+    });
+    return data.reduce<PRSummary>(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (acc, pr: any) => {
+        if (pr.state === 'open') acc.open += 1;
+        else if (pr.merged_at) acc.merged += 1;
+        else acc.closed += 1;
+        return acc;
+      },
+      { open: 0, merged: 0, closed: 0 }
+    );
   }
 
   /**

--- a/packages/services/src/git/GitLabProvider.ts
+++ b/packages/services/src/git/GitLabProvider.ts
@@ -1,4 +1,10 @@
 import { GitProvider } from './GitProvider.ts';
+import type {
+  CommitRecord,
+  ContributorRecord,
+  LanguagesMap,
+  PRSummary,
+} from '../classmoji/repoAnalytics.types.ts';
 
 /**
  * GitLab adapter - implements GitProvider interface.
@@ -137,6 +143,29 @@ export class GitLabProvider extends GitProvider {
   ): Promise<never> {
     // TODO: GET /api/v4/projects/:id/repository/branches/:branch
     throw new Error('GitLabProvider.getLatestCommitSHA() not implemented');
+  }
+
+  async listCommits(
+    _group: string,
+    _project: string,
+    _opts?: { since?: string; branch?: string }
+  ): Promise<CommitRecord[]> {
+    throw new Error('GitLabProvider.listCommits() not implemented');
+  }
+
+  async getContributorStats(
+    _group: string,
+    _project: string
+  ): Promise<{ pending: true } | ContributorRecord[]> {
+    throw new Error('GitLabProvider.getContributorStats() not implemented');
+  }
+
+  async getLanguages(_group: string, _project: string): Promise<LanguagesMap> {
+    throw new Error('GitLabProvider.getLanguages() not implemented');
+  }
+
+  async listPulls(_group: string, _project: string): Promise<PRSummary> {
+    throw new Error('GitLabProvider.listPulls() not implemented');
   }
 
   /**

--- a/packages/services/src/git/GitProvider.ts
+++ b/packages/services/src/git/GitProvider.ts
@@ -80,6 +80,37 @@ export class GitProvider {
     throw new Error('getLatestCommitSHA() must be implemented by subclass');
   }
 
+  async listCommits(
+    _org: string,
+    _repo: string,
+    _opts?: { since?: string; branch?: string }
+  ): Promise<import('../classmoji/repoAnalytics.types.ts').CommitRecord[]> {
+    throw new Error('listCommits() must be implemented by subclass');
+  }
+
+  async getContributorStats(
+    _org: string,
+    _repo: string
+  ): Promise<
+    { pending: true } | import('../classmoji/repoAnalytics.types.ts').ContributorRecord[]
+  > {
+    throw new Error('getContributorStats() must be implemented by subclass');
+  }
+
+  async getLanguages(
+    _org: string,
+    _repo: string
+  ): Promise<import('../classmoji/repoAnalytics.types.ts').LanguagesMap> {
+    throw new Error('getLanguages() must be implemented by subclass');
+  }
+
+  async listPulls(
+    _org: string,
+    _repo: string
+  ): Promise<import('../classmoji/repoAnalytics.types.ts').PRSummary> {
+    throw new Error('listPulls() must be implemented by subclass');
+  }
+
   async createBranch(org: string, repo: string, branch: string, sha: string): Promise<void> {
     throw new Error('createBranch() must be implemented by subclass');
   }

--- a/packages/services/src/git/__tests__/GitHubProvider.getContributorStats.test.ts
+++ b/packages/services/src/git/__tests__/GitHubProvider.getContributorStats.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GitHubProvider } from '../GitHubProvider.ts';
+import type { ContributorRecord } from '../../classmoji/repoAnalytics.types.ts';
+
+function makeFakeOctokit(response: { status: number; data: unknown }) {
+  const fakeOctokit = {
+    request: vi.fn(async (_route: string, _params: unknown) => response),
+    paginate: {
+      iterator() {
+        return {
+          // eslint-disable-next-line require-yield
+          async *[Symbol.asyncIterator]() {
+            return;
+          },
+        };
+      },
+    },
+  };
+  return fakeOctokit;
+}
+
+describe('GitHubProvider.getContributorStats', () => {
+  it('returns { pending: true } when GitHub responds 202 (cache warming)', async () => {
+    const fakeOctokit = makeFakeOctokit({ status: 202, data: null });
+
+    const provider = new GitHubProvider('1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider as unknown as { _octokit: unknown })._octokit = fakeOctokit as any;
+
+    const result = await provider.getContributorStats('org', 'repo');
+    expect(result).toEqual({ pending: true });
+  });
+
+  it('maps contributor rows into ContributorRecord[] when GitHub responds 200', async () => {
+    const fakeOctokit = makeFakeOctokit({
+      status: 200,
+      data: [
+        {
+          author: { login: 'ada' },
+          total: 3,
+          weeks: [
+            { a: 10, d: 2 },
+            { a: 5, d: 0 },
+          ],
+        },
+      ],
+    });
+
+    const provider = new GitHubProvider('1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider as unknown as { _octokit: unknown })._octokit = fakeOctokit as any;
+
+    const result = (await provider.getContributorStats('org', 'repo')) as ContributorRecord[];
+    expect(result).toEqual([
+      {
+        login: 'ada',
+        user_id: null,
+        commits: 3,
+        additions: 15,
+        deletions: 2,
+      },
+    ]);
+  });
+});

--- a/packages/services/src/git/__tests__/GitHubProvider.getLanguages.test.ts
+++ b/packages/services/src/git/__tests__/GitHubProvider.getLanguages.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GitHubProvider } from '../GitHubProvider.ts';
+
+describe('GitHubProvider.getLanguages', () => {
+  it('returns the languages map from GitHub unchanged', async () => {
+    const fakeOctokit = {
+      rest: {
+        repos: {
+          listLanguages: vi.fn(async (_params: unknown) => ({
+            data: { TypeScript: 1234, CSS: 56 },
+          })),
+        },
+      },
+      paginate: {
+        iterator() {
+          return {
+            // eslint-disable-next-line require-yield
+            async *[Symbol.asyncIterator]() {
+              return;
+            },
+          };
+        },
+      },
+    };
+
+    const provider = new GitHubProvider('1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider as unknown as { _octokit: unknown })._octokit = fakeOctokit as any;
+
+    const result = await provider.getLanguages('org', 'repo');
+    expect(result).toEqual({ TypeScript: 1234, CSS: 56 });
+    expect(fakeOctokit.rest.repos.listLanguages).toHaveBeenCalledWith({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+});

--- a/packages/services/src/git/__tests__/GitHubProvider.listCommits.test.ts
+++ b/packages/services/src/git/__tests__/GitHubProvider.listCommits.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { GitHubProvider } from '../GitHubProvider.ts';
+import type { CommitRecord } from '../../classmoji/repoAnalytics.types.ts';
+
+type FakeCommitSummary = {
+  sha: string;
+  author: { login: string } | null;
+  commit: {
+    author: { email: string; date: string } | null;
+    message: string;
+  };
+  parents: { sha: string }[];
+};
+
+function makeFakeOctokit(pages: FakeCommitSummary[][], fullMap: Record<string, { stats: { additions: number; deletions: number } }>) {
+  const calls: { listArgs: unknown; getCommitRefs: string[] } = {
+    listArgs: null,
+    getCommitRefs: [],
+  };
+
+  const listCommitsMethod = Object.assign(
+    (() => {
+      throw new Error('listCommits should be called via paginate.iterator in listCommits()');
+    }) as unknown as (...args: unknown[]) => unknown,
+    {},
+  );
+
+  const fakeOctokit = {
+    paginate: {
+      iterator(method: unknown, args: unknown) {
+        calls.listArgs = args;
+        // Ensure we received the expected endpoint reference
+        if (method !== listCommitsMethod) {
+          throw new Error('unexpected list method passed to paginate.iterator');
+        }
+        let i = 0;
+        return {
+          async *[Symbol.asyncIterator]() {
+            for (; i < pages.length; i++) {
+              yield { data: pages[i] };
+            }
+          },
+        };
+      },
+    },
+    rest: {
+      repos: {
+        listCommits: listCommitsMethod,
+        async getCommit({ ref }: { owner: string; repo: string; ref: string }) {
+          calls.getCommitRefs.push(ref);
+          const full = fullMap[ref];
+          if (!full) throw new Error(`no fake full commit for ${ref}`);
+          return { data: full };
+        },
+      },
+    },
+    _calls: calls,
+  };
+
+  return fakeOctokit;
+}
+
+describe('GitHubProvider.listCommits', () => {
+  it('maps commit summaries + per-commit stats into CommitRecord[]', async () => {
+    const fakeOctokit = makeFakeOctokit(
+      [
+        [
+          {
+            sha: 'aaa111',
+            author: { login: 'alice' },
+            commit: {
+              author: { email: 'alice@example.com', date: '2026-01-01T12:00:00Z' },
+              message: 'first commit',
+            },
+            parents: [],
+          },
+          {
+            sha: 'bbb222',
+            author: { login: 'bob' },
+            commit: {
+              author: { email: 'bob@example.com', date: '2026-01-02T12:00:00Z' },
+              message: 'second commit',
+            },
+            parents: [{ sha: 'aaa111' }],
+          },
+        ],
+      ],
+      {
+        aaa111: { stats: { additions: 10, deletions: 2 } },
+        bbb222: { stats: { additions: 5, deletions: 1 } },
+      },
+    );
+
+    const provider = new GitHubProvider('1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider as unknown as { _octokit: unknown })._octokit = fakeOctokit as any;
+
+    const commits: CommitRecord[] = await provider.listCommits('org', 'repo');
+
+    expect(commits).toHaveLength(2);
+    expect(commits[0]).toEqual({
+      sha: 'aaa111',
+      author_login: 'alice',
+      author_email: 'alice@example.com',
+      author_user_id: null,
+      ts: '2026-01-01T12:00:00Z',
+      message: 'first commit',
+      additions: 10,
+      deletions: 2,
+      parents: [],
+    });
+    expect(commits[1]).toEqual({
+      sha: 'bbb222',
+      author_login: 'bob',
+      author_email: 'bob@example.com',
+      author_user_id: null,
+      ts: '2026-01-02T12:00:00Z',
+      message: 'second commit',
+      additions: 5,
+      deletions: 1,
+      parents: ['aaa111'],
+    });
+  });
+
+  it('returns author_login: null when GitHub author is null (non-linked email)', async () => {
+    const fakeOctokit = makeFakeOctokit(
+      [
+        [
+          {
+            sha: 'ccc333',
+            author: null,
+            commit: {
+              author: { email: 'stranger@example.com', date: '2026-01-03T12:00:00Z' },
+              message: 'orphan commit',
+            },
+            parents: [{ sha: 'bbb222' }],
+          },
+        ],
+      ],
+      {
+        ccc333: { stats: { additions: 1, deletions: 1 } },
+      },
+    );
+
+    const provider = new GitHubProvider('1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider as unknown as { _octokit: unknown })._octokit = fakeOctokit as any;
+
+    const commits = await provider.listCommits('org', 'repo');
+    expect(commits).toHaveLength(1);
+    expect(commits[0].author_login).toBeNull();
+    expect(commits[0].author_email).toBe('stranger@example.com');
+    expect(commits[0].parents).toEqual(['bbb222']);
+  });
+});

--- a/packages/services/src/git/__tests__/GitHubProvider.listPulls.test.ts
+++ b/packages/services/src/git/__tests__/GitHubProvider.listPulls.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GitHubProvider } from '../GitHubProvider.ts';
+
+describe('GitHubProvider.listPulls', () => {
+  it('counts open, merged, and closed-unmerged PRs into PRSummary', async () => {
+    const fakeOctokit = {
+      rest: {
+        pulls: {
+          list: vi.fn(async (_params: unknown) => ({
+            data: [
+              { state: 'open', merged_at: null },
+              { state: 'closed', merged_at: '2026-01-02T00:00:00Z' },
+              { state: 'closed', merged_at: null },
+            ],
+          })),
+        },
+      },
+      paginate: {
+        iterator() {
+          return {
+            // eslint-disable-next-line require-yield
+            async *[Symbol.asyncIterator]() {
+              return;
+            },
+          };
+        },
+      },
+    };
+
+    const provider = new GitHubProvider('1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (provider as unknown as { _octokit: unknown })._octokit = fakeOctokit as any;
+
+    const result = await provider.listPulls('org', 'repo');
+    expect(result).toEqual({ open: 1, merged: 1, closed: 1 });
+    expect(fakeOctokit.rest.pulls.list).toHaveBeenCalledWith({
+      owner: 'org',
+      repo: 'repo',
+      state: 'all',
+      per_page: 100,
+    });
+  });
+});

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -44,3 +44,33 @@ export {
   assessmentGuidelines,
   getExamplePrompts,
 } from './classmoji/quizPrompts.ts';
+
+// Repo analytics snapshot payload types
+export type {
+  CommitRecord,
+  ContributorRecord,
+  LanguagesMap,
+  PRSummary,
+  SnapshotPayload,
+} from './classmoji/repoAnalytics.types.ts';
+
+// Repo analytics service entry points (server-only; touches Prisma)
+export {
+  aggregateForTeam,
+} from './classmoji/repoAnalytics.service.ts';
+export type {
+  TeamAggregate,
+  TeamRepoSnapshot,
+} from './classmoji/repoAnalytics.service.ts';
+
+// Repo analytics flag heuristics (pure, client-safe)
+export {
+  lateCommitRatio,
+  isMegaCommit,
+  commitMessageQuality,
+  averageCommitQuality,
+  busFactor,
+  dumpAndRun,
+  aggregateByContributor,
+  commitsPerDayByContributor,
+} from './classmoji/repoAnalytics.flags.ts';

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -6,6 +6,7 @@ import * as extensionTasks from './workflows/extension.ts';
 import * as installationTasks from './workflows/installation.ts';
 import * as tokenTasks from './workflows/token.ts';
 import * as contributionTasks from './workflows/contribution.ts';
+import * as repoAnalyticsTasks from './workflows/repoAnalytics.ts';
 
 // comment to trigger a build
 
@@ -18,6 +19,7 @@ const Tasks = {
   ...installationTasks,
   ...tokenTasks,
   ...contributionTasks,
+  ...repoAnalyticsTasks,
 };
 
 export default Tasks;

--- a/packages/tasks/src/workflows/repoAnalytics.ts
+++ b/packages/tasks/src/workflows/repoAnalytics.ts
@@ -1,0 +1,62 @@
+import { task, schedules, logger } from '@trigger.dev/sdk';
+import { ClassmojiService } from '@classmoji/services';
+
+interface RefreshRepoAnalyticsPayload {
+  repositoryAssignmentId: string;
+}
+
+/**
+ * Refresh analytics for a single repository assignment.
+ *
+ * If the snapshot comes back stale (e.g. GitHub contributor-stats cache is
+ * still warming and returned 202), self-reschedule in 60s so the row
+ * eventually fills in without manual intervention.
+ */
+export const refreshRepoAnalytics = task({
+  id: 'refresh-repo-analytics',
+  retry: {
+    maxAttempts: 3,
+  },
+  run: async (payload: RefreshRepoAnalyticsPayload) => {
+    const { repositoryAssignmentId } = payload;
+
+    const result = await ClassmojiService.repoAnalytics.refreshOne(repositoryAssignmentId);
+
+    if (result.stale) {
+      logger.info('Repo analytics still stale, rescheduling in 60s', {
+        repositoryAssignmentId,
+        error: result.error,
+      });
+
+      await refreshRepoAnalytics.trigger(
+        { repositoryAssignmentId },
+        { delay: '60s' }
+      );
+    }
+
+    return result;
+  },
+});
+
+/**
+ * Cron: refresh analytics for every active repository assignment every 6h.
+ */
+export const refreshAllActiveRepoAnalytics = schedules.task({
+  id: 'refresh-repo-analytics-all',
+  cron: '0 */6 * * *',
+  run: async () => {
+    const ids = await ClassmojiService.repoAnalytics.listActiveAssignmentIds();
+
+    logger.info('Refreshing active repo analytics', {
+      count: ids.length,
+      first: ids[0] ?? null,
+      last: ids[ids.length - 1] ?? null,
+    });
+
+    for (const id of ids) {
+      await refreshRepoAnalytics.trigger({ repositoryAssignmentId: id });
+    }
+
+    return { count: ids.length };
+  },
+});


### PR DESCRIPTION
## Summary
- Adds GitHub repo analytics foundation: Prisma models (`RepoAnalyticsSnapshot`, `RepositoryContributorLink`) + migration, GitHub/GitLab provider methods, `repoAnalytics` service, Trigger.dev `refreshRepoAnalytics` workflow + cron, and `/api/repos/:id/refresh` + `/contributor-link` routes.
- New **Repo Health** admin route and per-submission GitHub analytics deep-dive, plus an inline analytics drawer in the grading table (lazy-loaded via `GET /api/repos/:id/analytics`, client-cached, smooth fade/slide expand).
- Expands admin dashboard (assignment health, TA ops, at-risk students, quiz analytics, deadline pressure) and TA dashboard (my-day queue, throughput sparkline, streak badge, grade distribution).
- Layout fixes: resolves 4px sidebar/main overlap, adds new self-styled routes to the bare-canvas list, removes double-card wrappers around dashboard panels.

## Test plan
- [ ] `npm run web:build` passes
- [ ] `npm run db:deploy` applies the new migration cleanly
- [ ] Repo Health route renders for an admin with a GitHub-linked classroom
- [ ] Grading table: chart icon expands inline drawer, refresh enqueues a trigger and re-reads snapshot
- [ ] Admin + TA dashboards render all new panels without double-card wrapping
- [ ] No sidebar/main overlap on `/repo-health`, `/submissions/*`, and standard routes