### PR TITLE
fix(tasks): resolve nodemailer createTransport on dynamic import

### DIFF
--- a/packages/tasks/src/workflows/email.ts
+++ b/packages/tasks/src/workflows/email.ts
@@ -23,7 +23,7 @@ export const sendEmailTask = task({
       throw new Error('sendEmailTask must run on the server');
     }
 
-    const nodemailer = await import('nodemailer');
+    const { default: nodemailer } = await import('nodemailer');
     const payload = extractPayload(input);
 
     const transporter = nodemailer.createTransport({


### PR DESCRIPTION
## Summary
- Fix `nodemailer.createTransport is not a function` in the `send_email` Trigger.dev task by destructuring `default` from the dynamic import (CJS interop).