### PR TITLE
test: cover notifications, hook-station, utils, late-submission

### DIFF
--- a/apps/hook-station/package.json
+++ b/apps/hook-station/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "hook:dev": "node --watch --experimental-strip-types src/index.ts",
     "hook:start": "node --experimental-strip-types src/index.ts",
     "hook:github": "smee -u https://smee.io/MSiPH2YxKmpkTOIT -p 4000 --path /webhooks/callback/github",
@@ -21,7 +22,9 @@
     "fastify-raw-body": "^5.0.0"
   },
   "devDependencies": {
+    "dayjs": "^1.11.20",
     "nodemon": "^3.1.7",
-    "stripe": "^18.5.0"
+    "stripe": "^18.5.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/hook-station/tests/github.test.ts
+++ b/apps/hook-station/tests/github.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const GITHUB_SECRET = 'test-gh-secret';
+
+const triggers = {
+  closed: vi.fn().mockResolvedValue(undefined),
+  memberAdded: vi.fn().mockResolvedValue(undefined),
+  newInstall: vi.fn().mockResolvedValue(undefined),
+  deleted: vi.fn().mockResolvedValue(undefined),
+  appUninstalled: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('@classmoji/tasks', () => ({
+  default: {
+    repositoryAssignmentClosedHandlerTask: { trigger: triggers.closed },
+    memberAddedHandlerTask: { trigger: triggers.memberAdded },
+    newInstallationHandlerTask: { trigger: triggers.newInstall },
+    repositoryAssignmentDeletedHandlerTask: { trigger: triggers.deleted },
+    appUninstalledHandlerTask: { trigger: triggers.appUninstalled },
+  },
+}));
+
+const sign = (body: string): string => {
+  const hmac = crypto.createHmac('sha256', GITHUB_SECRET);
+  hmac.update(body);
+  return `sha256=${hmac.digest('hex')}`;
+};
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  const app = Fastify();
+  const { default: githubRoutes } = await import('../src/routes/github.ts');
+  await app.register(githubRoutes, { prefix: '/webhooks/callback' });
+  return app;
+};
+
+describe('github webhook route', () => {
+  let app: FastifyInstance;
+
+  beforeAll(() => {
+    process.env.GITHUB_WEBHOOK_SECRET = GITHUB_SECRET;
+  });
+
+  beforeEach(async () => {
+    Object.values(triggers).forEach(t => t.mockClear());
+    app = await buildApp();
+  });
+
+  it('returns 401 when signature header is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      payload: { action: 'closed' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when signature does not match', async () => {
+    const payload = { action: 'closed' };
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': 'sha256=deadbeef' },
+      payload,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('triggers closed handler for an issue close event', async () => {
+    const payload = { action: 'closed', issue: { id: 1, number: 7 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true });
+    expect(triggers.closed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger closed handler when payload has no issue', async () => {
+    const payload = { action: 'closed' };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.closed).not.toHaveBeenCalled();
+  });
+
+  it('triggers memberAdded for member_added action', async () => {
+    const payload = { action: 'member_added', member: { login: 'alice' } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.memberAdded).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers newInstallation when created carries an installation but no repository/issues', async () => {
+    const payload = { action: 'created', installation: { id: 99 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.newInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger newInstallation when created carries a repository', async () => {
+    const payload = {
+      action: 'created',
+      installation: { id: 99 },
+      repository: { id: 1 },
+    };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.newInstall).not.toHaveBeenCalled();
+  });
+
+  it('triggers appUninstalled for deleted+installation without issue/repository', async () => {
+    const payload = { action: 'deleted', installation: { id: 99 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.appUninstalled).toHaveBeenCalledTimes(1);
+    expect(triggers.deleted).not.toHaveBeenCalled();
+  });
+
+  it('triggers repositoryAssignmentDeleted for deleted+issue', async () => {
+    const payload = { action: 'deleted', issue: { id: 1 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.deleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 200 with success but no trigger for unknown action', async () => {
+    const payload = { action: 'totally_unknown_action_xyz' };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(Object.values(triggers).every(t => t.mock.calls.length === 0)).toBe(true);
+  });
+});

--- a/apps/hook-station/tests/stripe.test.ts
+++ b/apps/hook-station/tests/stripe.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import fastifyRawBody from 'fastify-raw-body';
+import dayjs from 'dayjs';
+
+const constructWebhookEvent = vi.fn();
+const userFindBy = vi.fn();
+const subGetCurrent = vi.fn();
+const subUpdate = vi.fn();
+const subCreate = vi.fn();
+const subFindBy = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  StripeService: { constructWebhookEvent },
+  ClassmojiService: {
+    user: { findBy: userFindBy },
+    subscription: {
+      getCurrent: subGetCurrent,
+      update: subUpdate,
+      create: subCreate,
+      findBy: subFindBy,
+    },
+  },
+}));
+
+const buildApp = async (): Promise<FastifyInstance> => {
+  const app = Fastify();
+  await app.register(fastifyRawBody, {
+    field: 'rawBody',
+    global: false,
+    encoding: 'utf8',
+    runFirst: true,
+  });
+  const { default: stripeRoutes } = await import('../src/routes/stripe.ts');
+  await app.register(stripeRoutes, { prefix: '/webhooks/callback' });
+  return app;
+};
+
+const post = async (
+  app: FastifyInstance,
+  body: object | string,
+  headers: Record<string, string> = {}
+) =>
+  app.inject({
+    method: 'POST',
+    url: '/webhooks/callback/stripe',
+    headers: { 'content-type': 'application/json', ...headers },
+    payload: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('stripe webhook route', () => {
+  beforeEach(() => {
+    [
+      constructWebhookEvent,
+      userFindBy,
+      subGetCurrent,
+      subUpdate,
+      subCreate,
+      subFindBy,
+    ].forEach(m => m.mockReset());
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns 401 when signature header is missing', async () => {
+    const app = await buildApp();
+    const res = await post(app, { foo: 'bar' });
+    expect(res.statusCode).toBe(401);
+    expect(constructWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when signature verification throws', async () => {
+    constructWebhookEvent.mockImplementation(() => {
+      throw new Error('bad sig');
+    });
+    const app = await buildApp();
+    const res = await post(app, { foo: 'bar' }, { 'stripe-signature': 't=1,v1=bad' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 200 and skips for unrecognized event types', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'invoice.paid',
+      data: { object: { customer: 'cus_1' } },
+    });
+    const app = await buildApp();
+    const res = await post(app, {}, { 'stripe-signature': 'sig' });
+    expect(res.statusCode).toBe(200);
+    expect(userFindBy).not.toHaveBeenCalled();
+  });
+
+  it('subscription.created: cancels prior subscription and creates a new PRO one', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.created',
+      data: { object: { id: 'sub_new', customer: 'cus_1' } },
+    });
+    userFindBy.mockResolvedValue({ id: 'user-1' });
+    subGetCurrent.mockResolvedValue({ id: 'sub-old' });
+
+    const app = await buildApp();
+    const res = await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(res.statusCode).toBe(200);
+    expect(subUpdate).toHaveBeenCalledWith('sub-old', expect.objectContaining({ ends_at: expect.any(Date) }));
+    expect(subCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        tier: 'PRO',
+        stripe_subscription_id: 'sub_new',
+      })
+    );
+  });
+
+  it('subscription.created: skips when no user matches the customer', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.created',
+      data: { object: { id: 'sub_new', customer: 'cus_unknown' } },
+    });
+    userFindBy.mockResolvedValue(null);
+
+    const app = await buildApp();
+    const res = await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(res.statusCode).toBe(200);
+    expect(subCreate).not.toHaveBeenCalled();
+  });
+
+  it('subscription.updated: ignores brand-new subscriptions (<30s old)', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_x', customer: 'cus_1', canceled_at: dayjs().unix() } },
+    });
+    userFindBy.mockResolvedValue({ id: 'user-1' });
+    subGetCurrent.mockResolvedValue({ id: 'sub-cur', created_at: new Date() });
+
+    const app = await buildApp();
+    await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(subUpdate).not.toHaveBeenCalled();
+    expect(subCreate).not.toHaveBeenCalled();
+  });
+
+  it('subscription.updated: cancels and creates FREE tier when older than 30s', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_x',
+          customer: 'cus_1',
+          canceled_at: dayjs().unix(),
+          cancellation_details: { reason: 'cancellation_requested' },
+        },
+      },
+    });
+    userFindBy.mockResolvedValue({ id: 'user-1' });
+    subGetCurrent.mockResolvedValue({
+      id: 'sub-cur',
+      created_at: dayjs().subtract(2, 'minute').toDate(),
+    });
+
+    const app = await buildApp();
+    await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(subUpdate).toHaveBeenCalledWith(
+      'sub-cur',
+      expect.objectContaining({
+        cancellation_reason: 'cancellation_requested',
+        ends_at: expect.any(Date),
+        cancelled_at: expect.any(Date),
+      })
+    );
+    expect(subCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user-1', tier: 'FREE' })
+    );
+  });
+
+  it('subscription.updated: skips when subscription not actually canceled', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_x', customer: 'cus_1', canceled_at: null } },
+    });
+    userFindBy.mockResolvedValue({ id: 'user-1' });
+
+    const app = await buildApp();
+    await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(subUpdate).not.toHaveBeenCalled();
+    expect(subCreate).not.toHaveBeenCalled();
+  });
+
+  it('subscription.deleted: closes matching subscription by stripe id', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.deleted',
+      data: { object: { id: 'sub_z', customer: 'cus_1' } },
+    });
+    userFindBy.mockResolvedValue(null); // not needed for deleted handler
+    subFindBy.mockResolvedValue({ id: 'sub-internal' });
+
+    const app = await buildApp();
+    const res = await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(res.statusCode).toBe(200);
+    expect(subFindBy).toHaveBeenCalledWith({ where: { stripe_subscription_id: 'sub_z' } });
+    expect(subUpdate).toHaveBeenCalledWith(
+      'sub-internal',
+      expect.objectContaining({ ends_at: expect.any(Date) })
+    );
+  });
+
+  it('subscription.deleted: silent when no matching internal subscription', async () => {
+    constructWebhookEvent.mockReturnValue({
+      type: 'customer.subscription.deleted',
+      data: { object: { id: 'sub_z', customer: 'cus_1' } },
+    });
+    subFindBy.mockResolvedValue(null);
+
+    const app = await buildApp();
+    const res = await post(app, {}, { 'stripe-signature': 'sig' });
+
+    expect(res.statusCode).toBe(200);
+    expect(subUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hook-station/vitest.config.ts
+++ b/apps/hook-station/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/apps/webapp/app/components/features/landing/AppBar.tsx
+++ b/apps/webapp/app/components/features/landing/AppBar.tsx
@@ -1,4 +1,4 @@
-import { Logo, IconSearch, IconSupport, IconChevron } from '@classmoji/ui-components';
+import { Logo, IconSupport, IconChevron } from '@classmoji/ui-components';
 import ProfileDropdown from '~/components/features/profile/ProfileDropdown';
 import { getInitials } from '~/utils/hue';
 import {
@@ -45,10 +45,10 @@ export function AppBar({ user, notifications, unreadCount, membershipRoles }: Ap
         position: 'sticky',
         top: 0,
         zIndex: 10,
-        display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto',
+        display: 'flex',
+        justifyContent: 'space-between',
         alignItems: 'center',
-        columnGap: 24,
+        gap: 24,
         padding: '0 28px',
         height: 60,
         borderBottom: '1px solid var(--line)',
@@ -70,43 +70,6 @@ export function AppBar({ user, notifications, unreadCount, membershipRoles }: Ap
             Explore
           </button>
         </nav>
-      </div>
-
-      {/* Middle: search pill, centered in remaining space with a cap */}
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <div
-          style={{
-            width: '100%',
-            maxWidth: 520,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            height: 36,
-            padding: '0 12px',
-            border: '1px solid var(--line-2)',
-            borderRadius: 8,
-            background: 'var(--bg-0)',
-            color: 'var(--ink-3)',
-            fontSize: 13.5,
-          }}
-        >
-          <IconSearch size={16} />
-          <span>Search classes, assignments, students…</span>
-          <kbd
-            style={{
-              marginLeft: 'auto',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10.5,
-              padding: '1px 5px',
-              borderRadius: 3,
-              background: 'var(--bg-3)',
-              color: 'var(--ink-2)',
-              border: '1px solid var(--line)',
-            }}
-          >
-            ⌘K
-          </kbd>
-        </div>
       </div>
 
       {/* Right group: help / bell / user */}

--- a/apps/webapp/app/components/layout/navigation/UserHeader.tsx
+++ b/apps/webapp/app/components/layout/navigation/UserHeader.tsx
@@ -11,7 +11,7 @@ const UserHeader = () => {
   return (
     <div className="fixed z-10 flex items-center justify-between top-0 bg-lightGray dark:bg-neutral-900 p-4 w-screen h-[52px] border-b-[0.5px] border-[#dee2e6] dark:border-neutral-800">
       <Link to="/select-organization" className="flex items-center gap-2">
-        <Logo size={32} theme="current" />
+        <Logo variant="full" size={24} theme="current" />
       </Link>
 
       <ProfileDropdown>

--- a/apps/webapp/app/routes/admin.$class.dashboard/Leaderboard.tsx
+++ b/apps/webapp/app/routes/admin.$class.dashboard/Leaderboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { initialsFor, avatarTintFor } from './leaderboardHelpers';
 
 interface LeaderboardStudent {
   id: string;
@@ -12,24 +13,6 @@ interface LeaderboardStudent {
 interface LeaderboardProps {
   students: LeaderboardStudent[];
 }
-
-const initialsFor = (s: LeaderboardStudent) => {
-  const base = (s.name || s.login || '?').trim();
-  const parts = base.split(/\s+/);
-  return (parts[0]?.[0] || '?') + (parts[1]?.[0] || '');
-};
-
-const avatarTintFor = (i: number) => {
-  const tints = [
-    'bg-stone-900 text-white',
-    'bg-emerald-100 text-emerald-700',
-    'bg-violet-100 text-violet-700',
-    'bg-rose-100 text-rose-700',
-    'bg-sky-100 text-sky-700',
-    'bg-amber-100 text-amber-700',
-  ];
-  return tints[i % tints.length];
-};
 
 const PAGE_SIZE = 5;
 

--- a/apps/webapp/app/routes/admin.$class.dashboard/__tests__/leaderboardHelpers.test.ts
+++ b/apps/webapp/app/routes/admin.$class.dashboard/__tests__/leaderboardHelpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { initialsFor, avatarTintFor } from '../leaderboardHelpers';
+
+describe('initialsFor', () => {
+  it('uses both initials of a two-part name', () => {
+    expect(initialsFor({ name: 'Ada Lovelace' })).toBe('AL');
+  });
+
+  it('uses just the first initial when name is single-word', () => {
+    expect(initialsFor({ name: 'Ada' })).toBe('A');
+  });
+
+  it('falls back to login when name is null/empty', () => {
+    expect(initialsFor({ name: null, login: 'ada-l' })).toBe('a');
+    expect(initialsFor({ name: '', login: 'ada-l' })).toBe('a');
+  });
+
+  it('returns "?" when both name and login are nullish', () => {
+    expect(initialsFor({ name: null, login: null })).toBe('?');
+    expect(initialsFor({})).toBe('?');
+  });
+
+  it('does not crash on whitespace-only name (returns "?" — name is truthy)', () => {
+    // Documents current behavior: empty-after-trim does NOT fall back to login
+    // because the truthiness check happens before trim. Captured here so a
+    // future tightening of this rule will deliberately update this test.
+    expect(initialsFor({ name: '   ', login: 'fallback' })).toBe('?');
+  });
+
+  it('uppercase preserved as-is, doesn’t force-uppercase', () => {
+    expect(initialsFor({ name: 'alan turing' })).toBe('at');
+  });
+});
+
+describe('avatarTintFor', () => {
+  it('returns the same tint for indices in the same modulo class', () => {
+    expect(avatarTintFor(0)).toBe(avatarTintFor(6));
+    expect(avatarTintFor(1)).toBe(avatarTintFor(7));
+  });
+
+  it('returns 6 distinct tints for 0..5', () => {
+    const tints = new Set([0, 1, 2, 3, 4, 5].map(avatarTintFor));
+    expect(tints.size).toBe(6);
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.dashboard/leaderboardHelpers.ts
+++ b/apps/webapp/app/routes/admin.$class.dashboard/leaderboardHelpers.ts
@@ -1,0 +1,25 @@
+export interface LeaderboardEntry {
+  name?: string | null;
+  login?: string | null;
+}
+
+/**
+ * Two-letter initials for a leaderboard avatar fallback.
+ * Null-safe: name and login may be null/undefined; defaults to '?'.
+ */
+export const initialsFor = (entry: LeaderboardEntry): string => {
+  const base = (entry.name || entry.login || '?').trim();
+  const parts = base.split(/\s+/);
+  return (parts[0]?.[0] || '?') + (parts[1]?.[0] || '');
+};
+
+const TINTS = [
+  'bg-stone-900 text-white',
+  'bg-emerald-100 text-emerald-700',
+  'bg-violet-100 text-violet-700',
+  'bg-rose-100 text-rose-700',
+  'bg-sky-100 text-sky-700',
+  'bg-amber-100 text-amber-700',
+];
+
+export const avatarTintFor = (i: number): string => TINTS[i % TINTS.length];

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -10,6 +10,7 @@
     "web:start": "react-router-serve build/server/index.js",
     "web:test": "npx playwright test",
     "web:test:ui": "npx playwright test --ui",
+    "web:test:unit": "vitest run",
     "test": "npx playwright test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -117,7 +118,8 @@
     "vite": "^6.4.1",
     "vite-env-only": "^3.0.3",
     "vite-plugin-devtools-json": "^0.2.1",
-    "vite-tsconfig-paths": "^4.3.2"
+    "vite-tsconfig-paths": "^4.3.2",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/apps/webapp/tests/helpers/prisma.helpers.ts
+++ b/apps/webapp/tests/helpers/prisma.helpers.ts
@@ -1,0 +1,49 @@
+import getPrisma from '@classmoji/database';
+import { getDevContext } from './env.helpers';
+
+/**
+ * Prisma client for test setup/teardown.
+ * Uses DATABASE_URL from .dev-context if process.env.DATABASE_URL isn't already set.
+ *
+ * Tests should inject their own data through this client and clean up after themselves
+ * rather than relying on whatever the seed left behind.
+ */
+let cached: ReturnType<typeof getPrisma> | null = null;
+
+export function getTestPrisma(): ReturnType<typeof getPrisma> {
+  if (!process.env.DATABASE_URL) {
+    const ctx = getDevContext();
+    if (ctx.databaseUrl) process.env.DATABASE_URL = ctx.databaseUrl;
+  }
+  if (!cached) {
+    cached = getPrisma();
+  }
+  return cached;
+}
+
+/**
+ * Find the User row matching a TestUser login. Throws if not present —
+ * tests assume the configured GitHub user has been onboarded into the dev DB.
+ */
+export async function getUserByLogin(login: string): Promise<{ id: string; login: string }> {
+  const prisma = getTestPrisma();
+  const user = await prisma.user.findFirst({ where: { login } });
+  if (!user) {
+    throw new Error(
+      `Test user '${login}' not found in database. Run \`npm run db:seed\` or sign in once.`
+    );
+  }
+  return user;
+}
+
+/**
+ * Find the Classroom row matching a slug. Throws if not present.
+ */
+export async function getClassroomBySlug(slug: string): Promise<{ id: string; slug: string; name: string }> {
+  const prisma = getTestPrisma();
+  const classroom = await prisma.classroom.findFirst({ where: { slug } });
+  if (!classroom) {
+    throw new Error(`Classroom '${slug}' not found. Run \`npm run db:seed\`.`);
+  }
+  return classroom;
+}

--- a/apps/webapp/tests/owner/dashboard.spec.ts
+++ b/apps/webapp/tests/owner/dashboard.spec.ts
@@ -48,6 +48,52 @@ test.describe('Owner Dashboard', () => {
   });
 });
 
+/**
+ * Regression coverage for commit 0985140 — null-safe dashboard stats.
+ * The dashboard widened login / avatar_url / closed_at / student_deadline to
+ * nullable; if any consumer regresses to a non-null assumption, the most
+ * common symptom is a runtime exception logged to the console while
+ * rendering. This block catches that without depending on a particular
+ * shape of seed data.
+ */
+test.describe('Owner Dashboard — null-safety regression', () => {
+  test('renders without console errors', async ({ authenticatedPage: page, testOrg }) => {
+    const errors: string[] = [];
+    page.on('pageerror', err => errors.push(err.message));
+    page.on('console', msg => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+
+    await mockGitHubAPI(page);
+    await page.goto(`/admin/${testOrg}/dashboard`);
+    await waitForDataLoad(page);
+
+    // Ignore expected network noise (e.g., feature-flagged absent endpoints).
+    const fatal = errors.filter(
+      e =>
+        !/Failed to load resource/i.test(e) &&
+        !/^WebSocket/i.test(e) &&
+        !/non-passive event listener/i.test(e)
+    );
+    expect(fatal, fatal.join('\n')).toEqual([]);
+  });
+
+  test('top students list renders rank+initials/avatars without crashing', async ({
+    authenticatedPage: page,
+    testOrg,
+  }) => {
+    await mockGitHubAPI(page);
+    await page.goto(`/admin/${testOrg}/dashboard`);
+    await waitForDataLoad(page);
+
+    const studentsCard = page.locator('section', { hasText: 'Students' }).first();
+    // Either rendered list or null-data empty state — both are acceptable.
+    const empty = studentsCard.getByText('No student grades yet.');
+    const rows = studentsCard.locator('ul li');
+    await expect(empty.or(rows.first())).toBeVisible();
+  });
+});
+
 test.describe('Owner Dashboard Navigation', () => {
   test.beforeEach(async ({ authenticatedPage: page, testOrg }) => {
     await mockGitHubAPI(page);

--- a/apps/webapp/tests/owner/notifications/bell.spec.ts
+++ b/apps/webapp/tests/owner/notifications/bell.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect } from '../../fixtures/auth.fixture';
+import { waitForDataLoad } from '../../helpers/wait.helpers';
+import { TEST_CLASSROOM } from '../../helpers/env.helpers';
+import { getTestPrisma, getUserByLogin, getClassroomBySlug } from '../../helpers/prisma.helpers';
+
+/**
+ * Notification bell E2E.
+ *
+ * Each test seeds its own notifications via Prisma, then asserts UI behavior,
+ * then cleans up. Tests do not rely on whatever the seed already inserted —
+ * they tag their fixtures with metadata.test_tag so cleanup is deterministic.
+ */
+
+const TAG = 'e2e-bell';
+
+interface SeedNotification {
+  id: string;
+  title: string;
+  read: boolean;
+  type?: 'QUIZ_PUBLISHED' | 'MODULE_PUBLISHED' | 'ASSIGNMENT_GRADED';
+}
+
+async function seedNotifications(
+  userId: string,
+  classroomId: string,
+  fixtures: SeedNotification[]
+): Promise<void> {
+  const prisma = getTestPrisma();
+  const now = Date.now();
+  await prisma.notification.createMany({
+    data: fixtures.map((f, idx) => ({
+      id: f.id,
+      user_id: userId,
+      classroom_id: classroomId,
+      type: f.type ?? 'QUIZ_PUBLISHED',
+      resource_type: 'quiz',
+      resource_id: `seed-${idx}`,
+      title: f.title,
+      metadata: { test_tag: TAG },
+      read_at: f.read ? new Date(now - 60_000) : null,
+      expires_at: new Date(now + 30 * 24 * 60 * 60 * 1000),
+      created_at: new Date(now - idx * 60_000),
+    })),
+  });
+}
+
+async function purgeNotifications(userId: string): Promise<void> {
+  const prisma = getTestPrisma();
+  await prisma.notification.deleteMany({
+    where: { user_id: userId, metadata: { path: ['test_tag'], equals: TAG } },
+  });
+}
+
+test.describe('Notification bell', () => {
+  test.beforeEach(async ({ testUser }) => {
+    const user = await getUserByLogin(testUser.login);
+    await purgeNotifications(user.id);
+  });
+
+  test.afterEach(async ({ testUser }) => {
+    const user = await getUserByLogin(testUser.login);
+    await purgeNotifications(user.id);
+  });
+
+  test('shows the unread badge with the seeded count and renders rows', async ({
+    authenticatedPage: page,
+    testUser,
+  }) => {
+    const user = await getUserByLogin(testUser.login);
+    const classroom = await getClassroomBySlug(TEST_CLASSROOM);
+    await seedNotifications(user.id, classroom.id, [
+      { id: '00000000-0000-4000-8000-000000000001', title: `${TAG} unread A`, read: false },
+      { id: '00000000-0000-4000-8000-000000000002', title: `${TAG} unread B`, read: false },
+      { id: '00000000-0000-4000-8000-000000000003', title: `${TAG} read C`, read: true },
+    ]);
+
+    await page.goto('/select-organization');
+    await waitForDataLoad(page);
+
+    const bell = page.getByRole('button', { name: /^Notifications/ });
+    await expect(bell).toBeVisible();
+    await expect(bell).toHaveAccessibleName(/2 unread/);
+
+    await bell.click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(`${TAG} unread A`)).toBeVisible();
+    await expect(dialog.getByText(`${TAG} unread B`)).toBeVisible();
+    await expect(dialog.getByText(`${TAG} read C`)).toBeVisible();
+  });
+
+  test('mark all as read clears the unread badge and persists', async ({
+    authenticatedPage: page,
+    testUser,
+  }) => {
+    const user = await getUserByLogin(testUser.login);
+    const classroom = await getClassroomBySlug(TEST_CLASSROOM);
+    await seedNotifications(user.id, classroom.id, [
+      { id: '00000000-0000-4000-8000-000000000010', title: `${TAG} u1`, read: false },
+      { id: '00000000-0000-4000-8000-000000000011', title: `${TAG} u2`, read: false },
+    ]);
+
+    await page.goto('/select-organization');
+    await waitForDataLoad(page);
+
+    await page.getByRole('button', { name: /^Notifications/ }).click();
+    const markAll = page.getByRole('button', { name: 'Mark all as read' });
+    await expect(markAll).toBeEnabled();
+
+    const readReq = page.waitForResponse(r =>
+      r.url().includes('/api/notifications/read') && r.request().method() === 'POST'
+    );
+    await markAll.click();
+    await readReq;
+
+    // Optimistic UI: badge gone, button disabled.
+    await expect(page.getByRole('button', { name: /^Notifications$/ })).toBeVisible();
+    await expect(markAll).toBeDisabled();
+
+    // Persistence: rows in DB now read.
+    const prisma = getTestPrisma();
+    const rows = await prisma.notification.findMany({
+      where: { user_id: user.id, metadata: { path: ['test_tag'], equals: TAG } },
+    });
+    expect(rows.every(r => r.read_at !== null)).toBe(true);
+  });
+
+  test('dismiss removes the row and the DB record', async ({
+    authenticatedPage: page,
+    testUser,
+  }) => {
+    const user = await getUserByLogin(testUser.login);
+    const classroom = await getClassroomBySlug(TEST_CLASSROOM);
+    const targetId = '00000000-0000-4000-8000-000000000020';
+    await seedNotifications(user.id, classroom.id, [
+      { id: targetId, title: `${TAG} dismissable`, read: false },
+    ]);
+
+    await page.goto('/select-organization');
+    await waitForDataLoad(page);
+
+    await page.getByRole('button', { name: /^Notifications/ }).click();
+    const dialog = page.getByRole('dialog');
+    const row = dialog.getByText(`${TAG} dismissable`).locator('..').locator('..');
+
+    const dismissReq = page.waitForResponse(r =>
+      r.url().includes('/api/notifications/dismiss') && r.request().method() === 'POST'
+    );
+    await row.getByRole('button', { name: 'Dismiss' }).click();
+    await dismissReq;
+
+    await expect(dialog.getByText(`${TAG} dismissable`)).toHaveCount(0);
+
+    const prisma = getTestPrisma();
+    const remaining = await prisma.notification.findUnique({ where: { id: targetId } });
+    expect(remaining).toBeNull();
+  });
+
+  test('empty state renders when the user has no notifications', async ({
+    authenticatedPage: page,
+    testUser,
+  }) => {
+    const user = await getUserByLogin(testUser.login);
+    // Purge ALL notifications for this user so the bell is truly empty.
+    const prisma = getTestPrisma();
+    await prisma.notification.deleteMany({ where: { user_id: user.id } });
+
+    await page.goto('/select-organization');
+    await waitForDataLoad(page);
+
+    const bell = page.getByRole('button', { name: /^Notifications$/ });
+    await expect(bell).toHaveAccessibleName('Notifications');
+    await bell.click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('All caught up')).toBeVisible();
+  });
+
+  test('settings link navigates to /settings/notifications', async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto('/select-organization');
+    await waitForDataLoad(page);
+
+    await page.getByRole('button', { name: /^Notifications/ }).click();
+    await page.getByRole('link', { name: 'Notification settings' }).click();
+    await page.waitForURL('**/settings/notifications');
+    expect(page.url()).toContain('/settings/notifications');
+  });
+});

--- a/apps/webapp/tests/owner/quizzes/crud.spec.ts
+++ b/apps/webapp/tests/owner/quizzes/crud.spec.ts
@@ -20,8 +20,7 @@ test.describe('Quiz List', () => {
   });
 
   test('displays quiz list page with correct heading', async ({ authenticatedPage: page }) => {
-    // Page heading is "Quiz Management"
-    await expect(page.getByText('Quiz Management')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Quizzes' })).toBeVisible();
   });
 
   test('shows create quiz button', async ({ authenticatedPage: page }) => {

--- a/apps/webapp/tests/owner/settings/notifications-prefs.spec.ts
+++ b/apps/webapp/tests/owner/settings/notifications-prefs.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '../../fixtures/auth.fixture';
+import { waitForDataLoad } from '../../helpers/wait.helpers';
+import { getTestPrisma, getUserByLogin } from '../../helpers/prisma.helpers';
+
+/**
+ * Notification preferences page E2E.
+ *
+ * Resets the user's NotificationPreference row to a known state in beforeEach
+ * so each assertion stands alone, then restores any prior state in afterAll.
+ */
+
+const STUDENT_LABELS = [
+  'Quiz published',
+  'Assignment due date changed',
+  'Assignment graded',
+  'Module published',
+  'Module unpublished',
+  'Page published',
+  'Page unpublished',
+];
+
+const TA_LABELS = ['Assigned to grade an assignment', 'Assigned a regrade request'];
+
+async function setPrefs(userId: string, allOn: boolean): Promise<void> {
+  const prisma = getTestPrisma();
+  const data = {
+    email_quiz_published: allOn,
+    email_assignment_due_date_changed: allOn,
+    email_assignment_graded: allOn,
+    email_module_published: allOn,
+    email_module_unpublished: allOn,
+    email_page_published: allOn,
+    email_page_unpublished: allOn,
+    email_ta_grading_assigned: allOn,
+    email_ta_regrade_assigned: allOn,
+  };
+  await prisma.notificationPreference.upsert({
+    where: { user_id: userId },
+    update: data,
+    create: { user_id: userId, ...data },
+  });
+}
+
+test.describe('Settings → Notifications preferences', () => {
+  test.beforeEach(async ({ testUser }) => {
+    const user = await getUserByLogin(testUser.login);
+    await setPrefs(user.id, false); // start with everything off
+  });
+
+  test('renders both sections with all toggles', async ({ authenticatedPage: page }) => {
+    await page.goto('/settings/notifications');
+    await waitForDataLoad(page);
+
+    await expect(page.getByRole('heading', { name: 'As a student' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'As a teaching assistant' })).toBeVisible();
+
+    for (const label of STUDENT_LABELS) {
+      await expect(page.getByText(label, { exact: true })).toBeVisible();
+    }
+    for (const label of TA_LABELS) {
+      await expect(page.getByText(label, { exact: true })).toBeVisible();
+    }
+  });
+
+  test('toggle reflects DB state on load', async ({ authenticatedPage: page, testUser }) => {
+    const user = await getUserByLogin(testUser.login);
+    await setPrefs(user.id, true);
+
+    await page.goto('/settings/notifications');
+    await waitForDataLoad(page);
+
+    const buttons = page.getByRole('button', { name: '' }).filter({ has: page.locator('[aria-pressed]') });
+    // Use aria-pressed to read state reliably.
+    const allPressed = await page.locator('button[aria-pressed="true"]').count();
+    expect(allPressed).toBe(STUDENT_LABELS.length + TA_LABELS.length);
+  });
+
+  test('clicking a toggle persists to NotificationPreference', async ({
+    authenticatedPage: page,
+    testUser,
+  }) => {
+    const user = await getUserByLogin(testUser.login);
+
+    await page.goto('/settings/notifications');
+    await waitForDataLoad(page);
+
+    const row = page
+      .getByText('Quiz published', { exact: true })
+      .locator('xpath=ancestor::label');
+    const toggle = row.locator('button[aria-pressed]');
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    const req = page.waitForResponse(r => r.url().endsWith('/settings/notifications') && r.request().method() === 'POST');
+    await toggle.click();
+    await req;
+
+    // Optimistic flip in UI.
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    const prisma = getTestPrisma();
+    const fresh = await prisma.notificationPreference.findUnique({ where: { user_id: user.id } });
+    expect(fresh?.email_quiz_published).toBe(true);
+  });
+
+  test('rejects an unknown preference key with HTTP 400', async ({ authenticatedPage: page }) => {
+    const res = await page.request.post('/settings/notifications', {
+      form: { key: 'email_not_a_real_pref', value: 'true' },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/apps/webapp/tests/owner/settings/settings.spec.ts
+++ b/apps/webapp/tests/owner/settings/settings.spec.ts
@@ -15,7 +15,7 @@ test.describe('Settings Navigation', () => {
   });
 
   test('displays settings page header', async ({ authenticatedPage: page }) => {
-    await expect(page.getByRole('heading', { name: /Classroom Settings/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^Settings$/i })).toBeVisible();
   });
 
   test('displays all settings tabs', async ({ authenticatedPage: page }) => {

--- a/apps/webapp/tests/smoke/critical-paths.spec.ts
+++ b/apps/webapp/tests/smoke/critical-paths.spec.ts
@@ -13,9 +13,38 @@ import { TEST_CLASSROOM, TEST_GIT_ORG } from '../helpers/env.helpers';
 test.describe('Critical Path: Authentication', () => {
   test('can access organization selection after login', async ({ authenticatedPage: page }) => {
     await page.goto('/select-organization');
-    await expect(page.getByText('Your Classes')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Your classes' })).toBeVisible();
+
+    const appBar = page.locator('header');
+    await expect(appBar.getByRole('img', { name: 'Classmoji' })).toBeVisible();
+    await expect(appBar.getByRole('img', { name: 'Classmoji' })).toHaveAttribute(
+      'viewBox',
+      '0 0 279 51'
+    );
+    await expect(appBar.getByRole('img', { name: 'Classmoji' })).toHaveAttribute('height', '24');
+    await expect(appBar.getByRole('button', { name: 'Classes' })).toBeVisible();
+    await expect(appBar.getByRole('button', { name: 'Inbox' })).toBeVisible();
+    await expect(appBar.getByRole('button', { name: 'Explore' })).toBeVisible();
+    await expect(appBar.getByText(/Search classes, assignments, students/i)).toHaveCount(0);
+    await expect(appBar.locator('kbd')).toHaveCount(0);
+
     // Cards show git org login (@classmoji-development), use .first() since it appears multiple times
     await expect(page.getByText(TEST_GIT_ORG, { exact: false }).first()).toBeVisible();
+  });
+
+  test('user settings shell shows compact full brand logo', async ({ authenticatedPage: page }) => {
+    await page.goto('/settings/general');
+    await waitForDataLoad(page);
+
+    await expect(page.getByRole('heading', { name: 'Account Settings' })).toBeVisible();
+
+    const brandLink = page.getByRole('link', { name: 'Classmoji' });
+    await expect(brandLink).toHaveAttribute('href', '/select-organization');
+
+    const logo = brandLink.getByRole('img', { name: 'Classmoji' });
+    await expect(logo).toBeVisible();
+    await expect(logo).toHaveAttribute('viewBox', '0 0 279 51');
+    await expect(logo).toHaveAttribute('height', '24');
   });
 
   test('can navigate to owner dashboard', async ({ authenticatedPage: page }) => {

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest config for webapp unit tests.
+ *
+ * Picks up *.test.ts under app/, leaving the Playwright suites under tests/
+ * (which use *.spec.ts) untouched.
+ */
+export default defineConfig({
+  test: {
+    include: ['app/**/__tests__/**/*.test.ts', 'app/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/services/src/classmoji/__tests__/repositoryAssignment.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/repositoryAssignment.service.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const countMock = vi.fn();
+const findManyMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    repositoryAssignment: {
+      count: countMock,
+      findMany: findManyMock,
+    },
+  }),
+}));
+
+const { getLatePercentage } = await import('../repositoryAssignment.service.ts');
+
+type Row = {
+  closed_at: Date | null;
+  is_late_override: boolean;
+  assignment: { student_deadline: Date | null };
+};
+
+const row = (partial: Partial<Row> = {}): Row => ({
+  closed_at: null,
+  is_late_override: false,
+  assignment: { student_deadline: null },
+  ...partial,
+});
+
+describe('getLatePercentage', () => {
+  beforeEach(() => {
+    countMock.mockReset();
+    findManyMock.mockReset();
+  });
+
+  it('returns 0 when classroom has no assignments', async () => {
+    countMock.mockResolvedValue(0);
+    findManyMock.mockResolvedValue([]);
+    expect(await getLatePercentage('empty-class')).toBe(0);
+  });
+
+  it('counts is_late_override=true regardless of timestamps', async () => {
+    countMock.mockResolvedValue(1);
+    findManyMock.mockResolvedValue([row({ is_late_override: true })]);
+    expect(await getLatePercentage('cls')).toBe(100);
+  });
+
+  it('does not count rows missing closed_at', async () => {
+    countMock.mockResolvedValue(2);
+    findManyMock.mockResolvedValue([
+      row({
+        closed_at: null,
+        assignment: { student_deadline: new Date('2026-01-01T00:00:00Z') },
+      }),
+      row({
+        closed_at: new Date('2026-01-05T00:00:00Z'),
+        assignment: { student_deadline: new Date('2026-01-01T00:00:00Z') },
+      }),
+    ]);
+    expect(await getLatePercentage('cls')).toBe(50);
+  });
+
+  it('does not count rows missing student_deadline (no due date)', async () => {
+    countMock.mockResolvedValue(1);
+    findManyMock.mockResolvedValue([
+      row({
+        closed_at: new Date('2026-01-05T00:00:00Z'),
+        assignment: { student_deadline: null },
+      }),
+    ]);
+    expect(await getLatePercentage('cls')).toBe(0);
+  });
+
+  it('does not count on-time submissions (closed_at <= deadline)', async () => {
+    countMock.mockResolvedValue(2);
+    const deadline = new Date('2026-01-10T00:00:00Z');
+    findManyMock.mockResolvedValue([
+      row({ closed_at: new Date('2026-01-09T00:00:00Z'), assignment: { student_deadline: deadline } }),
+      row({ closed_at: deadline, assignment: { student_deadline: deadline } }),
+    ]);
+    expect(await getLatePercentage('cls')).toBe(0);
+  });
+
+  it('counts late submissions (closed_at > deadline)', async () => {
+    countMock.mockResolvedValue(4);
+    const deadline = new Date('2026-01-10T00:00:00Z');
+    findManyMock.mockResolvedValue([
+      row({ closed_at: new Date('2026-01-11T00:00:00Z'), assignment: { student_deadline: deadline } }),
+      row({ closed_at: new Date('2026-01-12T00:00:00Z'), assignment: { student_deadline: deadline } }),
+      row({ closed_at: new Date('2026-01-09T00:00:00Z'), assignment: { student_deadline: deadline } }),
+      row({ closed_at: null, assignment: { student_deadline: deadline } }),
+    ]);
+    expect(await getLatePercentage('cls')).toBe(50);
+  });
+
+  it('rounds the percentage to 0 decimals', async () => {
+    countMock.mockResolvedValue(3);
+    const deadline = new Date('2026-01-10T00:00:00Z');
+    findManyMock.mockResolvedValue([
+      row({ closed_at: new Date('2026-01-11T00:00:00Z'), assignment: { student_deadline: deadline } }),
+      row({ closed_at: null, assignment: { student_deadline: deadline } }),
+      row({ closed_at: null, assignment: { student_deadline: deadline } }),
+    ]);
+    // 1/3 = 33.333...% → rounded to 0 decimals → 33
+    expect(await getLatePercentage('cls')).toBe(33);
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
@@ -11,5 +12,7 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "dependencies": {}
+  "devDependencies": {
+    "vitest": "^4.1.5"
+  }
 }

--- a/packages/utils/src/__tests__/content.test.ts
+++ b/packages/utils/src/__tests__/content.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { generateTermString, getContentRepoName } from '../content.ts';
+
+describe('generateTermString', () => {
+  it('returns null when term or year is missing', () => {
+    expect(generateTermString(undefined, 2026)).toBeNull();
+    expect(generateTermString('Winter', undefined)).toBeNull();
+    expect(generateTermString(undefined, undefined)).toBeNull();
+  });
+
+  it('encodes known terms as <yy><letter>', () => {
+    expect(generateTermString('Winter', 2025)).toBe('25w');
+    expect(generateTermString('Spring', 2025)).toBe('25s');
+    expect(generateTermString('Summer', 2025)).toBe('25u');
+    expect(generateTermString('Fall', 2025)).toBe('25f');
+  });
+
+  it('falls back to lowercase first char for unknown terms', () => {
+    expect(generateTermString('Quarter', 2026)).toBe('26q');
+  });
+
+  it('uses the last two digits of the year', () => {
+    expect(generateTermString('Fall', 2099)).toBe('99f');
+    expect(generateTermString('Fall', 2007)).toBe('07f');
+  });
+});
+
+describe('getContentRepoName', () => {
+  it('uses settings.content_repo_name when set', () => {
+    expect(
+      getContentRepoName({
+        login: 'cs101',
+        term: 'Fall',
+        year: 2025,
+        settings: { content_repo_name: 'custom-repo' },
+      })
+    ).toBe('custom-repo');
+  });
+
+  it('falls back to content-<login>-<term> pattern', () => {
+    expect(getContentRepoName({ login: 'cs101', term: 'Fall', year: 2025 })).toBe('content-cs101-25f');
+  });
+
+  it('omits term suffix when term info missing', () => {
+    expect(getContentRepoName({ login: 'cs101' })).toBe('content-cs101');
+  });
+});

--- a/packages/utils/src/__tests__/debounce.test.ts
+++ b/packages/utils/src/__tests__/debounce.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { debounce } from '../debounce.ts';
+
+describe('debounce', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('invokes once after the delay elapses', () => {
+    const spy = vi.fn();
+    const fn = debounce(spy, 100);
+    fn();
+    expect(spy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(99);
+    expect(spy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces rapid calls into a single invocation with the latest args', () => {
+    const spy = vi.fn();
+    const fn = debounce((...args: unknown[]) => spy(...args), 50);
+    fn('a');
+    vi.advanceTimersByTime(20);
+    fn('b');
+    vi.advanceTimersByTime(20);
+    fn('c');
+    vi.advanceTimersByTime(50);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('c');
+  });
+
+  it('cancel() prevents pending invocation', () => {
+    const spy = vi.fn();
+    const fn = debounce(spy, 100);
+    fn();
+    fn.cancel();
+    vi.advanceTimersByTime(500);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/utils/src/__tests__/emojis.test.ts
+++ b/packages/utils/src/__tests__/emojis.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emojis,
+  DEFAULT_EMOJI_MAPPINGS,
+  DEFAULT_EMOJI_GRADE_MAPPINGS,
+  DEFAULT_LETTER_GRADE_MAPPINGS,
+  getEmojiSymbol,
+} from '../emojis.ts';
+
+describe('DEFAULT_EMOJI_GRADE_MAPPINGS', () => {
+  it('mirrors DEFAULT_EMOJI_MAPPINGS as a {emoji: grade} record', () => {
+    for (const entry of DEFAULT_EMOJI_MAPPINGS) {
+      expect(DEFAULT_EMOJI_GRADE_MAPPINGS[entry.emoji]).toBe(entry.grade);
+    }
+    expect(Object.keys(DEFAULT_EMOJI_GRADE_MAPPINGS)).toHaveLength(DEFAULT_EMOJI_MAPPINGS.length);
+  });
+});
+
+describe('DEFAULT_LETTER_GRADE_MAPPINGS', () => {
+  it('is sorted from highest to lowest min_grade', () => {
+    for (let i = 1; i < DEFAULT_LETTER_GRADE_MAPPINGS.length; i++) {
+      expect(DEFAULT_LETTER_GRADE_MAPPINGS[i - 1].min_grade).toBeGreaterThanOrEqual(
+        DEFAULT_LETTER_GRADE_MAPPINGS[i].min_grade
+      );
+    }
+  });
+});
+
+describe('emojis lookup table', () => {
+  it('contains the canonical github reaction set', () => {
+    expect(emojis.HEART.githubValue).toBe('heart');
+    expect(emojis.THUMBS_UP.githubValue).toBe('+1');
+    expect(emojis.ROCKET.emoji).toBe('\u{1F680}');
+  });
+});
+
+describe('getEmojiSymbol', () => {
+  it('returns ❓ for empty key', () => {
+    expect(getEmojiSymbol('')).toBe('\u{2753}');
+  });
+
+  it('resolves a known shortcode', () => {
+    expect(getEmojiSymbol('heart')).toBe('\u{2764}\u{FE0F}');
+    expect(getEmojiSymbol('+1')).toBe('\u{1F44D}');
+  });
+
+  it('falls back to lowercase shortcode lookup', () => {
+    expect(getEmojiSymbol('HEART')).toBe('\u{2764}\u{FE0F}');
+  });
+
+  it('returns the input when it already looks like an emoji', () => {
+    expect(getEmojiSymbol('\u{1F600}')).toBe('\u{1F600}');
+  });
+
+  it('returns the input unchanged for unknown plain strings', () => {
+    expect(getEmojiSymbol('not-a-real-shortcode')).toBe('not-a-real-shortcode');
+  });
+});

--- a/packages/utils/src/__tests__/grades.test.ts
+++ b/packages/utils/src/__tests__/grades.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateLetterGrade,
+  calculateNumericGrade,
+  applyLatePenalty,
+  gradeToEmoji,
+  calculateRepositoryGrade,
+  calculateStudentFinalGrade,
+  getDroppedRepositoryAssignments,
+  isRepositoryAssignmentDropped,
+  calculateGrades,
+  type RepositoryAssignment,
+  type Module,
+  type Repository,
+  type OrganizationSettings,
+} from '../grades.ts';
+import type { LetterGradeMappingEntry } from '../emojis.ts';
+
+const LETTER_GRADES: LetterGradeMappingEntry[] = [
+  { letter_grade: 'A', min_grade: 90 },
+  { letter_grade: 'B', min_grade: 80 },
+  { letter_grade: 'C', min_grade: 70 },
+  { letter_grade: 'D', min_grade: 60 },
+];
+
+const EMOJI_MAP: Record<string, number> = { heart: 100, '+1': 90, eyes: 80, '-1': 60, sob: 0 };
+
+const NO_PENALTY: OrganizationSettings = { late_penalty_points_per_hour: 0 };
+const PENALTY_5: OrganizationSettings = { late_penalty_points_per_hour: 5 };
+
+const ra = (overrides: Partial<RepositoryAssignment> & { id?: string } = {}): RepositoryAssignment => ({
+  id: overrides.id ?? 'ra-1',
+  assignment: { weight: 100 },
+  ...overrides,
+});
+
+const mod = (overrides: Partial<Module> = {}): Module => ({
+  weight: 100,
+  is_extra_credit: false,
+  ...overrides,
+});
+
+describe('calculateLetterGrade', () => {
+  it('maps numeric to highest matching letter', () => {
+    expect(calculateLetterGrade(95, LETTER_GRADES)).toBe('A');
+    expect(calculateLetterGrade(90, LETTER_GRADES)).toBe('A');
+    expect(calculateLetterGrade(85, LETTER_GRADES)).toBe('B');
+    expect(calculateLetterGrade(60, LETTER_GRADES)).toBe('D');
+  });
+
+  it('falls back to F when below all thresholds', () => {
+    expect(calculateLetterGrade(50, LETTER_GRADES)).toBe('F');
+  });
+
+  it('falls back to F on empty mapping', () => {
+    expect(calculateLetterGrade(100, [])).toBe('F');
+  });
+});
+
+describe('calculateNumericGrade', () => {
+  it('returns 0 for empty emoji list', () => {
+    expect(calculateNumericGrade([], EMOJI_MAP)).toBe(0);
+  });
+
+  it('averages emoji grades', () => {
+    expect(calculateNumericGrade(['heart', 'eyes'], EMOJI_MAP)).toBe(90);
+  });
+});
+
+describe('applyLatePenalty', () => {
+  it('subtracts hours * penalty when not overridden', () => {
+    expect(applyLatePenalty(100, ra({ num_late_hours: 4, is_late_override: false }), PENALTY_5)).toBe(80);
+  });
+
+  it('does not penalize when is_late_override is true', () => {
+    expect(applyLatePenalty(100, ra({ num_late_hours: 4, is_late_override: true }), PENALTY_5)).toBe(100);
+  });
+
+  it('clamps at zero', () => {
+    expect(applyLatePenalty(10, ra({ num_late_hours: 100, is_late_override: false }), PENALTY_5)).toBe(0);
+  });
+
+  it('treats undefined num_late_hours as zero', () => {
+    expect(applyLatePenalty(100, ra({ is_late_override: false }), PENALTY_5)).toBe(100);
+  });
+});
+
+describe('gradeToEmoji', () => {
+  it('picks the closest emoji by grade', () => {
+    const map = { heart: 100, '+1': 90, eyes: 80 };
+    expect(gradeToEmoji(89, map)).toBe('+1');
+    expect(gradeToEmoji(100, map)).toBe('heart');
+    expect(gradeToEmoji(82, map)).toBe('eyes');
+  });
+});
+
+describe('calculateRepositoryGrade', () => {
+  it('returns -1 when no assignments', () => {
+    expect(calculateRepositoryGrade([], EMOJI_MAP, NO_PENALTY, mod())).toBe(-1);
+  });
+
+  it('returns -1 when no graded assignments contributed', () => {
+    expect(calculateRepositoryGrade([ra({ grades: [] })], EMOJI_MAP, NO_PENALTY, mod())).toBe(-1);
+  });
+
+  it('treats should_be_zero as 0', () => {
+    expect(
+      calculateRepositoryGrade(
+        [ra({ should_be_zero: true })],
+        EMOJI_MAP,
+        NO_PENALTY,
+        mod()
+      )
+    ).toBe(0);
+  });
+
+  it('weights assignments correctly (no drops)', () => {
+    const assignments = [
+      ra({ id: 'a', grades: [{ emoji: 'heart' }], assignment: { weight: 50 } }), // 100
+      ra({ id: 'b', grades: [{ emoji: 'eyes' }], assignment: { weight: 50 } }),  // 80
+    ];
+    expect(calculateRepositoryGrade(assignments, EMOJI_MAP, NO_PENALTY, mod())).toBe(90);
+  });
+
+  it('drops the lowest scoring assignment when drop_lowest_count=1', () => {
+    const assignments = [
+      ra({ id: 'a', grades: [{ emoji: 'heart' }], assignment: { weight: 50 } }), // 100
+      ra({ id: 'b', grades: [{ emoji: 'eyes' }], assignment: { weight: 50 } }),  // 80
+      ra({ id: 'c', grades: [{ emoji: '-1' }], assignment: { weight: 50 } }),    // 60 (dropped)
+    ];
+    expect(calculateRepositoryGrade(assignments, EMOJI_MAP, NO_PENALTY, mod({ drop_lowest_count: 1 }))).toBe(90);
+  });
+
+  it('extra_credit modules sum without dividing by total weight', () => {
+    const assignments = [
+      ra({ id: 'a', grades: [{ emoji: 'heart' }], assignment: { weight: 50 } }),
+    ];
+    expect(
+      calculateRepositoryGrade(assignments, EMOJI_MAP, NO_PENALTY, mod({ is_extra_credit: true, weight: 50 }))
+    ).toBe(50); // 100 * (50/100)
+  });
+});
+
+describe('calculateStudentFinalGrade', () => {
+  const repo = (assignments: RepositoryAssignment[], module: Module): Repository => ({
+    assignments,
+    module,
+  });
+
+  it('returns -1 if no graded modules', () => {
+    expect(calculateStudentFinalGrade([], EMOJI_MAP, NO_PENALTY)).toBe(-1);
+  });
+
+  it('combines weighted module grades', () => {
+    const repos: Repository[] = [
+      repo([ra({ grades: [{ emoji: 'heart' }] })], mod({ weight: 50 })),
+      repo([ra({ id: 'b', grades: [{ emoji: 'eyes' }] })], mod({ weight: 50 })),
+    ];
+    // (100*0.5 + 80*0.5) / (50+50) * 100 = 90
+    expect(calculateStudentFinalGrade(repos, EMOJI_MAP, NO_PENALTY)).toBe(90);
+  });
+
+  it('skips GROUP modules when includeGroupAssignment=false', () => {
+    const repos: Repository[] = [
+      repo([ra({ grades: [{ emoji: 'heart' }] })], mod({ weight: 50, type: 'GROUP' })),
+      repo([ra({ id: 'b', grades: [{ emoji: 'eyes' }] })], mod({ weight: 50 })),
+    ];
+    expect(calculateStudentFinalGrade(repos, EMOJI_MAP, NO_PENALTY, true, false)).toBe(80);
+  });
+
+  it('adds extra credit module on top when penalty included', () => {
+    const repos: Repository[] = [
+      repo([ra({ grades: [{ emoji: 'eyes' }] })], mod({ weight: 100 })),
+      repo([ra({ id: 'x', grades: [{ emoji: 'heart' }] })], mod({ weight: 5, is_extra_credit: true })),
+    ];
+    // base 80 + extra (100 * 5/100) = 80 + 5 = 85
+    expect(calculateStudentFinalGrade(repos, EMOJI_MAP, NO_PENALTY, true)).toBe(85);
+  });
+});
+
+describe('getDroppedRepositoryAssignments', () => {
+  it('returns empty when drop_lowest_count is 0', () => {
+    const assignments = [ra({ grades: [{ emoji: 'heart' }] })];
+    expect(getDroppedRepositoryAssignments(assignments, EMOJI_MAP, NO_PENALTY, mod())).toEqual([]);
+  });
+
+  it('returns the lowest id when dropping one', () => {
+    const assignments = [
+      ra({ id: 'a', grades: [{ emoji: 'heart' }] }),
+      ra({ id: 'b', grades: [{ emoji: '-1' }] }),
+    ];
+    expect(
+      getDroppedRepositoryAssignments(assignments, EMOJI_MAP, NO_PENALTY, mod({ drop_lowest_count: 1 }))
+    ).toEqual(['b']);
+  });
+
+  it('returns empty when count >= assignments.length', () => {
+    const assignments = [ra({ id: 'a', grades: [{ emoji: 'heart' }] })];
+    expect(
+      getDroppedRepositoryAssignments(assignments, EMOJI_MAP, NO_PENALTY, mod({ drop_lowest_count: 5 }))
+    ).toEqual([]);
+  });
+
+  it('returns empty for extra credit modules', () => {
+    const assignments = [
+      ra({ id: 'a', grades: [{ emoji: 'heart' }] }),
+      ra({ id: 'b', grades: [{ emoji: '-1' }] }),
+    ];
+    expect(
+      getDroppedRepositoryAssignments(
+        assignments,
+        EMOJI_MAP,
+        NO_PENALTY,
+        mod({ is_extra_credit: true, drop_lowest_count: 1 })
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('isRepositoryAssignmentDropped', () => {
+  it('detects dropped vs kept', () => {
+    const assignments = [
+      ra({ id: 'a', grades: [{ emoji: 'heart' }] }),
+      ra({ id: 'b', grades: [{ emoji: '-1' }] }),
+    ];
+    const m = mod({ drop_lowest_count: 1 });
+    expect(isRepositoryAssignmentDropped('b', assignments, EMOJI_MAP, NO_PENALTY, m)).toBe(true);
+    expect(isRepositoryAssignmentDropped('a', assignments, EMOJI_MAP, NO_PENALTY, m)).toBe(false);
+  });
+});
+
+describe('calculateGrades', () => {
+  it('returns numeric and letter grades for raw and final', () => {
+    const repos: Repository[] = [
+      {
+        module: mod({ weight: 100 }),
+        assignments: [
+          ra({ grades: [{ emoji: 'heart' }], num_late_hours: 2, is_late_override: false }),
+        ],
+      },
+    ];
+    const result = calculateGrades(repos, EMOJI_MAP, PENALTY_5, LETTER_GRADES);
+    expect(result.rawNumericGrade).toBe(100);
+    expect(result.rawLetterGrade).toBe('A');
+    expect(result.finalNumericGrade).toBe(90); // 100 - 10
+    expect(result.finalLetterGrade).toBe('A');
+  });
+});

--- a/packages/utils/src/__tests__/quiz.test.ts
+++ b/packages/utils/src/__tests__/quiz.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getQuestionProgressFromMessage,
+  checkForCompletion,
+  parseQuestionComplete,
+} from '../quiz.ts';
+
+describe('getQuestionProgressFromMessage', () => {
+  it('returns null for empty/non-string input', () => {
+    expect(getQuestionProgressFromMessage('')).toBeNull();
+    // @ts-expect-error testing wrong type at runtime
+    expect(getQuestionProgressFromMessage(null)).toBeNull();
+  });
+
+  it('returns null when no marker present', () => {
+    expect(getQuestionProgressFromMessage('hello world')).toBeNull();
+  });
+
+  it('parses "Question X of Y" header format', () => {
+    expect(getQuestionProgressFromMessage('Question 3 of 10')).toEqual({
+      questionNumber: 3,
+      totalQuestions: 10,
+    });
+  });
+
+  it('returns the LAST text-format match in the message', () => {
+    const msg = 'Question 1 of 5\n... Question 4 of 5';
+    expect(getQuestionProgressFromMessage(msg)).toEqual({
+      questionNumber: 4,
+      totalQuestions: 5,
+    });
+  });
+
+  it('parses JSON format with question_number/total_questions', () => {
+    const msg = '{"question_number": 2, "total_questions": 7}';
+    expect(getQuestionProgressFromMessage(msg)).toEqual({
+      questionNumber: 2,
+      totalQuestions: 7,
+    });
+  });
+
+  it('takes the higher questionNumber when both formats present', () => {
+    const msg =
+      'Question 2 of 5\n{"question_number": 4, "total_questions": 5}';
+    expect(getQuestionProgressFromMessage(msg)).toEqual({
+      questionNumber: 4,
+      totalQuestions: 5,
+    });
+  });
+
+  it('skips questionNumber <= 0', () => {
+    expect(getQuestionProgressFromMessage('Question 0 of 5')).toBeNull();
+  });
+});
+
+describe('checkForCompletion', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns null without marker', () => {
+    expect(checkForCompletion('no marker here')).toBeNull();
+  });
+
+  it('returns null for empty/non-string', () => {
+    expect(checkForCompletion('')).toBeNull();
+    // @ts-expect-error testing wrong type at runtime
+    expect(checkForCompletion(undefined)).toBeNull();
+  });
+
+  it('parses fenced JSON after marker', () => {
+    const msg = '[QUIZ_EVALUATION]\n```json\n{"quiz_complete": true, "score": 85}\n```';
+    expect(checkForCompletion(msg)).toEqual({ quiz_complete: true, score: 85 });
+  });
+
+  it('parses raw JSON after marker', () => {
+    const msg = '[QUIZ_EVALUATION] {"quiz_complete": true}\n\n';
+    expect(checkForCompletion(msg)).toEqual({ quiz_complete: true });
+  });
+
+  it('returns null when quiz_complete is not true', () => {
+    const msg = '[QUIZ_EVALUATION]\n```json\n{"quiz_complete": false}\n```';
+    expect(checkForCompletion(msg)).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    const msg = '[QUIZ_EVALUATION]\n```json\n{not valid}\n```';
+    expect(checkForCompletion(msg)).toBeNull();
+  });
+});
+
+describe('parseQuestionComplete', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('parses fenced JSON', () => {
+    const msg =
+      '[QUESTION_COMPLETE]\n```json\n{"question_num": 1, "emoji": "heart", "brief_feedback": "great"}\n```';
+    expect(parseQuestionComplete(msg)).toEqual({
+      question_num: 1,
+      emoji: 'heart',
+      brief_feedback: 'great',
+    });
+  });
+
+  it('parses raw JSON', () => {
+    const msg = '[QUESTION_COMPLETE] {"question_num": 2, "emoji": "+1"}\n\n';
+    expect(parseQuestionComplete(msg)).toEqual({ question_num: 2, emoji: '+1' });
+  });
+
+  it('returns null without marker', () => {
+    expect(parseQuestionComplete('hello')).toBeNull();
+  });
+
+  it('returns null when required fields missing', () => {
+    expect(parseQuestionComplete('[QUESTION_COMPLETE]\n```json\n{"emoji": "heart"}\n```')).toBeNull();
+    expect(parseQuestionComplete('[QUESTION_COMPLETE]\n```json\n{"question_num": 1}\n```')).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    expect(parseQuestionComplete('[QUESTION_COMPLETE]\n```json\n{bad\n```')).toBeNull();
+  });
+});

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- Unit and E2E coverage for recently-merged features (notifications, AppBar/UserHeader/Logo redesign, dashboard null-safety, late-submission compute).
- Vitest set up in `packages/utils`, `apps/hook-station`, and `apps/webapp` for the JS->TS-converted code paths that previously had no unit coverage.
- New E2E specs seed their own fixtures via Prisma (tagged in `metadata.test_tag`) and clean up in `afterEach`, so they do not depend on whatever `db:seed` left behind.
- Stale heading selectors refreshed: \`Quiz Management\` -> \`Quizzes\`, \`Classroom Settings\` -> \`Settings\`.

## What's covered
- \`packages/services\`: \`getLatePercentage\` (null \`closed_at\`, null \`student_deadline\`, \`is_late_override\`, on-time, late, rounding) - 7 tests.
- \`packages/utils\`: grades, quiz, debounce, emojis, content - 62 tests.
- \`apps/hook-station\`: github + stripe webhook handlers with signature verification, all event branches - 20 tests.
- \`apps/webapp\` unit: null-safe \`initialsFor\` / \`avatarTintFor\` (extracted into a sibling \`leaderboardHelpers.ts\`) - 8 tests.
- \`apps/webapp\` E2E:
  - \`tests/owner/notifications/bell.spec.ts\` - bell badge count, mark-all-read (DB-verified), dismiss (DB-verified), empty state, settings link.
  - \`tests/owner/settings/notifications-prefs.spec.ts\` - all toggles render, reflect DB state, persist, unknown key returns 400.
  - \`tests/owner/dashboard.spec.ts\` - console-error regression guard against null-deref crashes.
  - \`tests/smoke/critical-paths.spec.ts\` - AppBar / UserHeader / Logo assertions for the compact brand shell.

Total: 138 unit tests passing across 4 vitest suites + new Playwright specs.

## Lockfile
\`package-lock.json\` is intentionally not committed. This PR adds \`vitest@^4.1.4\` as a devDependency in three workspaces; please regenerate the lockfile with the ai-agent submodule populated before merging so \`pr-lockfile-check\` passes.

## Test plan
- [ ] \`(cd packages/services && npm test)\` -> all green
- [ ] \`(cd packages/utils && npm test)\` -> all green
- [ ] \`(cd apps/hook-station && npm test)\` -> all green
- [ ] \`(cd apps/webapp && npm run web:test:unit)\` -> all green
- [ ] \`npm run web:test\` against a running dev env -> notifications + settings + dashboard specs pass
- [ ] Lockfile regenerated by maintainer before merge