### PR TITLE
Replace react-toastify with Callout system

### DIFF
--- a/apps/slides/app/root.tsx
+++ b/apps/slides/app/root.tsx
@@ -9,7 +9,6 @@ import {
   useRouteLoaderData,
 } from 'react-router';
 import React, { useEffect } from 'react';
-import { ToastContainer } from 'react-toastify';
 
 import useStore from '~/store';
 import type { SlideUser } from '~/store';
@@ -23,7 +22,6 @@ export function useUser() {
   return useRouteLoaderData('root');
 }
 
-import 'react-toastify/dist/ReactToastify.css';
 import '~/styles/tailwind.css';
 import '~/styles/global.css';
 
@@ -75,17 +73,6 @@ const App = () => {
         />
       </head>
       <body className="bg-white dark:bg-gray-900" suppressHydrationWarning>
-        <ToastContainer
-          position="top-center"
-          autoClose={3000}
-          hideProgressBar
-          newestOnTop={false}
-          closeOnClick
-          pauseOnFocusLoss
-          draggable
-          pauseOnHover
-          theme="colored"
-        />
         <Outlet />
         <ScrollRestoration />
         <Scripts />

--- a/apps/slides/package.json
+++ b/apps/slides/package.json
@@ -47,7 +47,6 @@
     "react-markdown": "^10.1.0",
     "react-router": "^7.9.2",
     "react-router-dom": "^7.9.2",
-    "react-toastify": "^10.0.4",
     "reveal.js": "^5.1.0",
     "router": "^2.2.0",
     "socket.io": "^4.8.1",

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -501,7 +501,7 @@ const CommonLayout = ({
                 : 'px-4 pt-14 pb-4 sm:px-6 lg:px-8 lg:pt-6 lg:pb-6 min-h-full'
             }
           >
-            <CalloutSlot className="mb-3" />
+            <CalloutSlot />
             {children}
           </div>
         </div>

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { IconFileText, IconMenu2, IconLogout, IconApple } from '@tabler/icons-react';
 import { signOut } from '@classmoji/auth/client';
 import useLocalStorageState from 'use-local-storage-state';
-import { Logo } from '@classmoji/ui-components';
+import { Logo, CalloutSlot } from '@classmoji/ui-components';
 import { ProTierFeature, RequireRole, RecentViewers } from '~/components';
 import { useRoleSettings, useSubscription, useRole, useDarkMode } from '~/hooks';
 import { routes, routeCategories, DEMO_ORG_ID, getThemeByKey } from '~/constants';
@@ -501,6 +501,7 @@ const CommonLayout = ({
                 : 'px-4 pt-14 pb-4 sm:px-6 lg:px-8 lg:pt-6 lg:pb-6 min-h-full'
             }
           >
+            <CalloutSlot className="mb-3" />
             {children}
           </div>
         </div>

--- a/apps/webapp/app/contexts/index.ts
+++ b/apps/webapp/app/contexts/index.ts
@@ -8,7 +8,7 @@ export const UserContext = createContext<{ user: AppUser | null }>({
 
 export interface FetcherContextValue {
   fetcher: FetcherWithComponents<unknown> | null;
-  notify: (action: string, message?: string, position?: unknown) => void;
+  notify: (action: string, message?: string) => void;
 }
 
 export const FetcherContext = createContext<FetcherContextValue>({

--- a/apps/webapp/app/contexts/index.ts
+++ b/apps/webapp/app/contexts/index.ts
@@ -1,6 +1,5 @@
 import { createContext } from 'react';
 import type { FetcherWithComponents } from 'react-router';
-import type { ToastPosition } from 'react-toastify';
 import type { AppUser } from '~/types';
 
 export const UserContext = createContext<{ user: AppUser | null }>({
@@ -9,7 +8,7 @@ export const UserContext = createContext<{ user: AppUser | null }>({
 
 export interface FetcherContextValue {
   fetcher: FetcherWithComponents<unknown> | null;
-  notify: (action: string, message?: string, position?: ToastPosition) => void;
+  notify: (action: string, message?: string, position?: unknown) => void;
 }
 
 export const FetcherContext = createContext<FetcherContextValue>({

--- a/apps/webapp/app/hooks/useNotifiedFetcher.ts
+++ b/apps/webapp/app/hooks/useNotifiedFetcher.ts
@@ -1,65 +1,74 @@
 import { useFetcher } from 'react-router';
 import { useEffect, useRef } from 'react';
-import { toast, type ToastPosition } from 'react-toastify';
+import { useCallout } from '@classmoji/ui-components';
 
 export const useNotifiedFetcher = () => {
-  const toastIds = useRef(new Map()); // Track multiple toasts by ID
+  const calloutIds = useRef(new Map<string, string>()); // Track callouts by action key
+  const callout = useCallout();
   const fetcher = useFetcher();
-
-  const dismissToast = (action: string) => {
-    toast.dismiss(toastIds.current.get(action));
-  };
 
   useEffect(() => {
     if (fetcher.data?.success) {
-      const id = toastIds.current.get(fetcher.data.action);
+      const action = fetcher.data.action;
+      const id = action ? calloutIds.current.get(action) : undefined;
       if (id) {
-        toast.update(id, {
-          render: fetcher.data.success,
-          type: 'success',
-          isLoading: false,
-          autoClose: 2000,
+        callout.update(id, {
+          variant: 'success',
+          title: fetcher.data.success,
+          autoDismissMs: 2000,
+        });
+        calloutIds.current.delete(action);
+      } else {
+        // Fallback if no progress callout was shown
+        callout.show({
+          variant: 'success',
+          title: fetcher.data.success,
+          autoDismissMs: 2000,
         });
       }
-
       fetcher.reset();
     } else if (fetcher.data?.error) {
-      const id = toastIds.current.get(fetcher.data.action);
+      const action = fetcher.data.action;
+      const id = action ? calloutIds.current.get(action) : undefined;
       if (id) {
-        toast.update(id, {
-          render: fetcher.data.error,
-          type: 'error',
-          isLoading: false,
-          autoClose: 4000,
+        callout.update(id, {
+          variant: 'error',
+          title: fetcher.data.error,
         });
+        calloutIds.current.delete(action);
       } else {
-        // Fallback if no loading toast was shown
-        toast.error(fetcher.data.error);
+        // Fallback if no progress callout was shown
+        callout.show({
+          variant: 'error',
+          title: fetcher.data.error,
+        });
       }
       fetcher.reset();
     } else if (fetcher.data?.info) {
-      toast.info(fetcher.data.info, {
-        toastId: 'info',
+      callout.show({
+        variant: 'info',
+        title: fetcher.data.info,
       });
       fetcher.reset();
     }
   }, [fetcher.state, fetcher.data]);
 
-  const notify = (action: string, message?: string, position: ToastPosition = 'bottom-center') => {
-    if (toastIds.current.has(action)) {
-      dismissToast(action);
+  const notify = (action: string, message?: string, _position?: unknown) => {
+    // Suppress unused-arg lint for backward-compatible signature.
+    void _position;
+
+    const existingId = calloutIds.current.get(action);
+    if (existingId) {
+      callout.dismiss(existingId);
     }
 
-    // Create a new toast and store its ID
-    const id = toast(message, {
-      type: 'info',
-      autoClose: false,
-      isLoading: true,
-      position,
-      toastId: action,
+    const id = callout.show({
+      variant: 'progress',
+      title: message ?? '…',
+      persistent: true,
     });
 
-    toastIds.current.set(action, id); // Store ID by action type
+    calloutIds.current.set(action, id);
   };
 
   const reset = () => {

--- a/apps/webapp/app/hooks/useNotifiedFetcher.ts
+++ b/apps/webapp/app/hooks/useNotifiedFetcher.ts
@@ -1,81 +1,70 @@
 import { useFetcher } from 'react-router';
 import { useEffect, useRef } from 'react';
 import { useCallout } from '@classmoji/ui-components';
+import type { CalloutPayload } from '@classmoji/ui-components';
 
 export const useNotifiedFetcher = () => {
-  const calloutIds = useRef(new Map<string, string>()); // Track callouts by action key
+  const calloutIds = useRef(new Map<string, string>());
   const callout = useCallout();
   const fetcher = useFetcher();
 
+  const finalize = (
+    action: string | undefined,
+    payload: Pick<CalloutPayload, 'variant' | 'title' | 'autoDismissMs'>,
+  ) => {
+    const id = action ? calloutIds.current.get(action) : undefined;
+    if (id) {
+      callout.update(id, payload);
+      calloutIds.current.delete(action!);
+    } else {
+      callout.show(payload);
+    }
+    fetcher.reset();
+  };
+
   useEffect(() => {
     if (fetcher.data?.success) {
-      const action = fetcher.data.action;
-      const id = action ? calloutIds.current.get(action) : undefined;
-      if (id) {
-        callout.update(id, {
-          variant: 'success',
-          title: fetcher.data.success,
-          autoDismissMs: 2000,
-        });
-        calloutIds.current.delete(action);
-      } else {
-        // Fallback if no progress callout was shown
-        callout.show({
-          variant: 'success',
-          title: fetcher.data.success,
-          autoDismissMs: 2000,
-        });
-      }
-      fetcher.reset();
-    } else if (fetcher.data?.error) {
-      const action = fetcher.data.action;
-      const id = action ? calloutIds.current.get(action) : undefined;
-      if (id) {
-        callout.update(id, {
-          variant: 'error',
-          title: fetcher.data.error,
-        });
-        calloutIds.current.delete(action);
-      } else {
-        // Fallback if no progress callout was shown
-        callout.show({
-          variant: 'error',
-          title: fetcher.data.error,
-        });
-      }
-      fetcher.reset();
-    } else if (fetcher.data?.info) {
-      callout.show({
-        variant: 'info',
-        title: fetcher.data.info,
+      finalize(fetcher.data.action, {
+        variant: 'success',
+        title: fetcher.data.success,
+        autoDismissMs: 2000,
       });
+    } else if (fetcher.data?.error) {
+      finalize(fetcher.data.action, {
+        variant: 'error',
+        title: fetcher.data.error,
+      });
+    } else if (fetcher.data?.info) {
+      callout.show({ variant: 'info', title: fetcher.data.info });
       fetcher.reset();
     }
+    // `callout` and `finalize` are intentionally omitted: callout is stable per
+    // CalloutProvider, finalize closes over them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetcher.state, fetcher.data]);
 
-  const notify = (action: string, message?: string, _position?: unknown) => {
-    // Suppress unused-arg lint for backward-compatible signature.
-    void _position;
+  // Persistent progress callouts would otherwise be orphaned on unmount.
+  useEffect(() => {
+    const ids = calloutIds.current;
+    return () => {
+      for (const id of ids.values()) callout.dismiss(id);
+      ids.clear();
+    };
+  }, [callout]);
 
+  const notify = (action: string, message?: string) => {
     const existingId = calloutIds.current.get(action);
-    if (existingId) {
-      callout.dismiss(existingId);
-    }
-
+    if (existingId) callout.dismiss(existingId);
     const id = callout.show({
       variant: 'progress',
       title: message ?? '…',
       persistent: true,
     });
-
     calloutIds.current.set(action, id);
   };
 
   const reset = () => {
-    fetcher.submit(null, {
-      method: 'post',
-      action: '/reset-fetcher',
-    });
+    fetcher.submit(null, { method: 'post', action: '/reset-fetcher' });
   };
 
   fetcher.reset = reset;

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -269,8 +269,8 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   };
 };
 
-// Local wrapper that calls useNotifiedFetcher inside CalloutProvider so that
-// future migrations of useNotifiedFetcher to useCallout() see a valid context.
+// Provides FetcherContext; must live inside CalloutProvider since
+// useNotifiedFetcher reads useCallout().
 const FetcherProvider = ({ children }: { children: React.ReactNode }) => {
   const { fetcher, notify } = useNotifiedFetcher();
   return (

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -14,7 +14,6 @@ import axios from 'axios';
 
 import React, { useEffect } from 'react';
 import dayjs from 'dayjs';
-import { ToastContainer, cssTransition } from 'react-toastify';
 import { ConfigProvider, theme } from 'antd';
 import { IconMoodSad } from '@tabler/icons-react';
 import { auth as triggerAuth } from '@trigger.dev/sdk';
@@ -45,17 +44,10 @@ dayjs.extend(isSameOrBefore);
 
 import getPrisma from '@classmoji/database';
 import '@fontsource/quicksand/700.css';
-import 'react-toastify/dist/ReactToastify.css';
 import '~/styles/tailwind.css';
 import '~/styles/global.css';
 
 React.useLayoutEffect = React.useEffect;
-
-const ToastFade = cssTransition({
-  enter: 'toast-fade-in',
-  exit: 'toast-fade-out',
-  collapse: false,
-});
 
 export const meta = () => {
   return [{ title: 'Classmoji' }];
@@ -452,20 +444,6 @@ const App = ({ loaderData }: Route.ComponentProps) => {
             <UserContext.Provider value={{ user }}>
               <CalloutProvider>
                 <FetcherProvider>
-                  <ToastContainer
-                    position="bottom-center"
-                    autoClose={4000}
-                    hideProgressBar
-                    newestOnTop={false}
-                    closeOnClick={false}
-                    pauseOnFocusLoss
-                    draggable={false}
-                    pauseOnHover
-                    icon={false}
-                    theme="light"
-                    transition={ToastFade}
-                  />
-
                   <ImpersonationBanner
                     key={(session as Record<string, Record<string, string>>)?.session?.id}
                     session={session}

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -20,6 +20,7 @@ import { IconMoodSad } from '@tabler/icons-react';
 import { auth as triggerAuth } from '@trigger.dev/sdk';
 
 import { GitHubProvider, ClassmojiService } from '@classmoji/services';
+import { CalloutProvider } from '@classmoji/ui-components';
 import { auth, getAuthSession } from '@classmoji/auth/server';
 import { isAIAgentConfigured } from '~/utils/aiFeatures.server';
 import type { Route } from './+types/root';
@@ -276,8 +277,16 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   };
 };
 
-const App = ({ loaderData }: Route.ComponentProps) => {
+// Local wrapper that calls useNotifiedFetcher inside CalloutProvider so that
+// future migrations of useNotifiedFetcher to useCallout() see a valid context.
+const FetcherProvider = ({ children }: { children: React.ReactNode }) => {
   const { fetcher, notify } = useNotifiedFetcher();
+  return (
+    <FetcherContext.Provider value={{ fetcher, notify }}>{children}</FetcherContext.Provider>
+  );
+};
+
+const App = ({ loaderData }: Route.ComponentProps) => {
   const { user, session } = loaderData;
   const { isDarkMode, accent } = useDarkMode();
   const { pathname } = useLocation();
@@ -441,30 +450,32 @@ const App = ({ loaderData }: Route.ComponentProps) => {
             )}
           >
             <UserContext.Provider value={{ user }}>
-              <FetcherContext.Provider value={{ fetcher, notify }}>
-                <ToastContainer
-                  position="bottom-center"
-                  autoClose={4000}
-                  hideProgressBar
-                  newestOnTop={false}
-                  closeOnClick={false}
-                  pauseOnFocusLoss
-                  draggable={false}
-                  pauseOnHover
-                  icon={false}
-                  theme="light"
-                  transition={ToastFade}
-                />
+              <CalloutProvider>
+                <FetcherProvider>
+                  <ToastContainer
+                    position="bottom-center"
+                    autoClose={4000}
+                    hideProgressBar
+                    newestOnTop={false}
+                    closeOnClick={false}
+                    pauseOnFocusLoss
+                    draggable={false}
+                    pauseOnHover
+                    icon={false}
+                    theme="light"
+                    transition={ToastFade}
+                  />
 
-                <ImpersonationBanner
-                  key={(session as Record<string, Record<string, string>>)?.session?.id}
-                  session={session}
-                />
-                <Outlet />
-                <SyllabusBotRoot />
-                <ScrollRestoration />
-                <Scripts />
-              </FetcherContext.Provider>
+                  <ImpersonationBanner
+                    key={(session as Record<string, Record<string, string>>)?.session?.id}
+                    session={session}
+                  />
+                  <Outlet />
+                  <SyllabusBotRoot />
+                  <ScrollRestoration />
+                  <Scripts />
+                </FetcherProvider>
+              </CalloutProvider>
             </UserContext.Provider>
           </ConfigProvider>
         </RenderErrorBoundary>

--- a/apps/webapp/app/routes/_user.settings.billing/route.tsx
+++ b/apps/webapp/app/routes/_user.settings.billing/route.tsx
@@ -12,11 +12,11 @@ import { namedAction } from 'remix-utils/named-action';
 import dayjs from 'dayjs';
 
 import { ClassmojiService, StripeService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import { useSubscription } from '~/hooks';
 import InfoCard from './InforCard';
 import { getUsageData } from './utils';
 import { getAuthSession } from '@classmoji/auth/server';
-import { toast } from 'react-toastify';
 import type { Route } from './+types/route';
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
@@ -45,6 +45,7 @@ const SettingsSubscription = ({ loaderData }: Route.ComponentProps) => {
   const [loading, setLoading] = useState(false);
   const { search } = useLocation();
   const toastShownRef = useRef(new Set());
+  const callout = useCallout();
 
   useEffect(() => {
     const url = new URLSearchParams(search);
@@ -52,7 +53,7 @@ const SettingsSubscription = ({ loaderData }: Route.ComponentProps) => {
     const sessionId = url.get('session_id');
 
     if (success && sessionId && !toastShownRef.current.has(sessionId)) {
-      toast.success('Subscription updated successfully');
+      callout.show({ variant: 'success', title: 'Subscription updated successfully' });
       toastShownRef.current.add(sessionId);
     }
   }, [search]);
@@ -68,7 +69,7 @@ const SettingsSubscription = ({ loaderData }: Route.ComponentProps) => {
   useEffect(() => {
     const data = loaderData as Record<string, unknown>;
     if (data?.action === 'UPDATE_SUBSCRIPTION') {
-      toast.success(data.message as string);
+      callout.show({ variant: 'success', title: data.message as string });
     }
   }, [loaderData]);
 

--- a/apps/webapp/app/routes/admin.$class.assistants.$login/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.assistants.$login/route.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { ConfigProvider, Drawer, Button, Tag, Card, Progress, Collapse, theme, Empty } from 'antd';
 import { IconX, IconUserSearch, IconClock } from '@tabler/icons-react';
-import { toast } from 'react-toastify';
 
 import { useRouteDrawer, useDarkMode } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import { RequireRole, StatsCard } from '~/components';
 import { requireClassroomAdmin } from '~/utils/routeAuth.server';
 import { addAuditLog } from '~/utils/helpers';
@@ -121,10 +121,11 @@ const AdminAssistantDrawer = ({ loaderData }: Route.ComponentProps) => {
   const navigate = useNavigate();
   const { class: classSlug } = useParams();
   const [impersonating, setImpersonating] = useState(false);
+  const callout = useCallout();
 
   const handleImpersonate = async () => {
     if (!assistant.login) {
-      toast.error('Assistant has not accepted invite.');
+      callout.show({ variant: 'error', title: 'Assistant has not accepted invite.' });
       return;
     }
 
@@ -141,7 +142,10 @@ const AdminAssistantDrawer = ({ loaderData }: Route.ComponentProps) => {
       navigate(`/assistant/${classSlug}/dashboard`);
     } catch (error: unknown) {
       console.error('Impersonation failed:', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to view as assistant');
+      callout.show({
+        variant: 'error',
+        title: error instanceof Error ? error.message : 'Failed to view as assistant',
+      });
     } finally {
       setImpersonating(false);
     }

--- a/apps/webapp/app/routes/admin.$class.assistants/FormAssistant.tsx
+++ b/apps/webapp/app/routes/admin.$class.assistants/FormAssistant.tsx
@@ -1,11 +1,11 @@
 import { Form, Input, Button, Space, Typography } from 'antd';
 import { useState } from 'react';
-import { toast } from 'react-toastify';
 import { Octokit } from '@octokit/rest';
 
 import { IconMail, IconUser, IconBrandGithubCopilot } from '@tabler/icons-react';
 
 import { useGlobalFetcher } from '~/hooks';
+import { useCallout } from '@classmoji/ui-components';
 import { ActionTypes } from '~/constants';
 
 const { Text } = Typography;
@@ -20,6 +20,7 @@ const FormAssistant = ({ close, token }: FormAssistantProps) => {
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
   const [verifying, setVerifying] = useState(false);
+  const callout = useCallout();
   const octokit = new Octokit({ auth: token });
 
   const validateGitHubUser = async (login: string) => {
@@ -46,7 +47,7 @@ const FormAssistant = ({ close, token }: FormAssistantProps) => {
       const user = await validateGitHubUser(login);
 
       if (!user) {
-        toast.error('GitHub login is required');
+        callout.show({ variant: 'error', title: 'GitHub login is required' });
         setLoading(false);
         return;
       }
@@ -72,14 +73,17 @@ const FormAssistant = ({ close, token }: FormAssistantProps) => {
 
       close();
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : 'Failed to verify GitHub user');
+      callout.show({
+        variant: 'error',
+        title: error instanceof Error ? error.message : 'Failed to verify GitHub user',
+      });
     } finally {
       setLoading(false);
     }
   };
 
   const onFinishFailed = () => {
-    toast.error('Please fill in all required fields');
+    callout.show({ variant: 'error', title: 'Please fill in all required fields' });
   };
 
   const handleGitHubLoginChange = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/webapp/app/routes/admin.$class.assistants/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.assistants/route.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 
 import { IconUserSearch, IconTrash } from '@tabler/icons-react';
 import { Table, Radio, Popconfirm, Modal, Tag } from 'antd';
-import { toast } from 'react-toastify';
 
 import { getAuthSession } from '@classmoji/auth/server';
 import { authClient } from '@classmoji/auth/client';
@@ -16,6 +15,7 @@ import {
   TableActionButtons,
 } from '~/components';
 import { ClassmojiService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 export { action } from './action';
 import FormAssistant from './FormAssistant';
 
@@ -57,10 +57,11 @@ const AdminAssistants = ({ loaderData }: Route.ComponentProps) => {
   const { show, close, visible } = useDisclosure();
   const [query, setQuery] = useState('');
   const [impersonating, setImpersonating] = useState(false);
+  const callout = useCallout();
 
   const handleImpersonate = async (assistant: Assistant) => {
     if (!assistant.login) {
-      toast.error('Assistant has not accepted invite.');
+      callout.show({ variant: 'error', title: 'Assistant has not accepted invite.' });
       return;
     }
 
@@ -77,7 +78,10 @@ const AdminAssistants = ({ loaderData }: Route.ComponentProps) => {
       navigate(`/assistant/${classSlug}`);
     } catch (error: unknown) {
       console.error('Impersonation failed:', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to view as assistant');
+      callout.show({
+        variant: 'error',
+        title: error instanceof Error ? error.message : 'Failed to view as assistant',
+      });
     } finally {
       setImpersonating(false);
     }
@@ -173,7 +177,7 @@ const AdminAssistants = ({ loaderData }: Route.ComponentProps) => {
               if (assistant.login) {
                 navigate(`/admin/${classSlug}/assistants/${assistant.login}`);
               } else {
-                toast.error('Assistant has not accepted invite.');
+                callout.show({ variant: 'error', title: 'Assistant has not accepted invite.' });
               }
             }}
           >

--- a/apps/webapp/app/routes/admin.$class.calendar/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.calendar/route.tsx
@@ -3,8 +3,8 @@ import { Button, Modal } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import invariant from 'tiny-invariant';
 import { data, useFetcher, useParams } from 'react-router';
-import { toast } from 'react-toastify';
 import { ClassmojiService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import getPrisma from '@classmoji/database';
 import { assertClassroomAccess } from '~/utils/helpers';
 import { buildCalendarUrl, getCalendarDateRange } from '~/utils/calendar.server';
@@ -316,6 +316,7 @@ const AdminCalendar = ({ loaderData }: Route.ComponentProps) => {
   const { class: classSlug } = useParams();
   const fetcher = useFetcher();
   const eventsFetcher = useFetcher();
+  const callout = useCallout();
 
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -352,7 +353,7 @@ const AdminCalendar = ({ loaderData }: Route.ComponentProps) => {
         eventsFetcher.load(`?year=${currentViewYear}&month=${currentViewMonth}`);
       } else if (fetcher.data.error) {
         setOptimisticEvents(null); // Revert on error
-        toast.error(fetcher.data.error);
+        callout.show({ variant: 'error', title: fetcher.data.error });
       }
     }
   }, [fetcher.data, fetcher.state]);
@@ -393,7 +394,7 @@ const AdminCalendar = ({ loaderData }: Route.ComponentProps) => {
     const canDragEvent = isAdmin || Number(event.created_by) === Number(userId);
 
     if (!canDragEvent) {
-      toast.error('You can only move your own events');
+      callout.show({ variant: 'error', title: 'You can only move your own events' });
       return;
     }
 

--- a/apps/webapp/app/routes/admin.$class.modules.form/FormModule.tsx
+++ b/apps/webapp/app/routes/admin.$class.modules.form/FormModule.tsx
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import { useEffect, useState } from 'react';
 import { Octokit } from '@octokit/rest';
-import { toast } from 'react-toastify';
 
 import { useRevalidator } from 'react-router';
+import { useCallout } from '@classmoji/ui-components';
 import { useForm, type Control, type FieldValues } from 'react-hook-form';
 import { FormItem } from 'react-hook-form-antd';
 import {
@@ -124,6 +124,7 @@ const FormModule = ({
 
   const { fetcher, notify } = useGlobalFetcher();
   const revalidator = useRevalidator();
+  const callout = useCallout();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [opened, { open: openIssueModal, close: closeIssueModal }] = useDisclosure();
 
@@ -213,7 +214,10 @@ const FormModule = ({
 
       const fetcherData = fetcher!.data as ActionResponse | undefined;
       if (fetcherData?.error) {
-        toast.error(fetcherData.error || 'Failed to save module.');
+        callout.show({
+          variant: 'error',
+          title: fetcherData.error || 'Failed to save module.',
+        });
         return;
       }
 
@@ -710,7 +714,10 @@ const FormModule = ({
                     style={{ backgroundColor: '#619462', borderColor: '#619462' }}
                     onClick={() => {
                       if (!assignment.title.length)
-                        return toast.error('Please fill in the assignment title.');
+                        return callout.show({
+                          variant: 'error',
+                          title: 'Please fill in the assignment title.',
+                        });
 
                       const doesAssignmentExist = (assignments || []).find(
                         (a: { id?: string | number | null }) => a.id === assignment.id

--- a/apps/webapp/app/routes/admin.$class.modules_.$title.assign-graders/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.modules_.$title.assign-graders/route.tsx
@@ -1,12 +1,12 @@
 import { Modal, Form, Select, Radio } from 'antd';
 import { useState, useEffect } from 'react';
-import { toast } from 'react-toastify';
 import { useNavigate, useLocation, useParams } from 'react-router';
 import { nanoid } from 'nanoid';
 import { auth } from '@trigger.dev/sdk';
 
 import { useDisclosure, useGlobalFetcher } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import { assignGradersToAssignmentsHandler } from './utils';
 import { requireClassroomAdmin } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
@@ -34,6 +34,7 @@ const AssignGraders = ({ loaderData }: Route.ComponentProps) => {
   const navigate = useNavigate();
   const { fetcher } = useGlobalFetcher();
   const { pathname } = useLocation();
+  const callout = useCallout();
 
   useEffect(() => {
     show();
@@ -51,12 +52,12 @@ const AssignGraders = ({ loaderData }: Route.ComponentProps) => {
 
   const onSubmit = () => {
     if (!selectedAssignmentId) {
-      toast.error('Please select an assignment');
+      callout.show({ variant: 'error', title: 'Please select an assignment' });
       return;
     }
 
     if (method === 'EXISTING' && !templateAssignmentId) {
-      toast.error('Please select a template assignment');
+      callout.show({ variant: 'error', title: 'Please select a template assignment' });
       return;
     }
 

--- a/apps/webapp/app/routes/admin.$class.modules_.$title/Menu.tsx
+++ b/apps/webapp/app/routes/admin.$class.modules_.$title/Menu.tsx
@@ -1,6 +1,6 @@
 import { Button, Dropdown } from 'antd';
 import { useNavigate, useParams } from 'react-router';
-import { toast } from 'react-toastify';
+import { useCallout } from '@classmoji/ui-components';
 import { useGlobalFetcher, useSubscription } from '~/hooks';
 
 interface MenuProps {
@@ -21,10 +21,14 @@ const Menu = ({ module, assistants }: MenuProps) => {
   const { class: classSlug, title: moduleTitle } = useParams();
   const { fetcher } = useGlobalFetcher();
   const { isProTier } = useSubscription();
+  const callout = useCallout();
 
   const calculateContributions = () => {
     if (module.type === 'INDIVIDUAL') {
-      toast.error('Individual assignments do not support calculating contributions');
+      callout.show({
+        variant: 'error',
+        title: 'Individual assignments do not support calculating contributions',
+      });
       return;
     }
 
@@ -54,12 +58,12 @@ const Menu = ({ module, assistants }: MenuProps) => {
         <button
           onClick={() => {
             if (!module.assignments || module.assignments.length === 0) {
-              toast.error('No assignments to assign graders');
+              callout.show({ variant: 'error', title: 'No assignments to assign graders' });
               return;
             }
 
             if (assistants.length === 0) {
-              toast.error('No graders found');
+              callout.show({ variant: 'error', title: 'No graders found' });
               return;
             }
 

--- a/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useFetcher } from 'react-router';
 import { Form, Button, Alert, Modal, Tabs } from 'antd';
 import { FileTextOutlined, UploadOutlined } from '@ant-design/icons';
-import { toast } from 'react-toastify';
 import { assertClassroomAccess } from '~/utils/helpers';
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import { ContentService } from '@classmoji/content';
 import { processMarkdownImport } from '~/utils/markdownImporter.server';
 import { wrapHtmlContent } from '~/utils/htmlWrapper';
@@ -279,6 +279,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
   const fetcher = useFetcher();
   const navigate = useNavigate();
   const { opened, close } = useRouteDrawer({});
+  const callout = useCallout();
   const [form] = Form.useForm();
   const [activeTab, setActiveTab] = useState('create-blank');
   const [importFiles, setImportFiles] = useState<{ markdown: File | null; images: File[] }>({
@@ -313,7 +314,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
   // Redirect on success (single page only - batch handled separately)
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data?.created && fetcher.data.page && !batchProgress) {
-      toast.success('Page created successfully!');
+      callout.show({ variant: 'success', title: 'Page created successfully!' });
       navigate(`/admin/${classroom.slug}/pages/${fetcher.data.page.id}`);
     }
   }, [fetcher.state, fetcher.data, navigate, classroom.slug, batchProgress]);
@@ -337,7 +338,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
       const initResult = await initResponse.json();
 
       if (initResult.error) {
-        toast.error(initResult.error);
+        callout.show({ variant: 'error', title: initResult.error });
         setBatchProgress(null);
         return;
       }
@@ -388,16 +389,23 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
       setBatchProgress(null);
 
       if (errors.length > 0) {
-        toast.warning(
-          `Imported ${total - errors.length} of ${total} pages. ${errors.length} failed.`
-        );
+        callout.show({
+          variant: 'error',
+          title: `Imported ${total - errors.length} of ${total} pages. ${errors.length} failed.`,
+        });
       } else {
-        toast.success(`Successfully imported ${total} page${total !== 1 ? 's' : ''}!`);
+        callout.show({
+          variant: 'success',
+          title: `Successfully imported ${total} page${total !== 1 ? 's' : ''}!`,
+        });
       }
       navigate(`/admin/${classroom.slug}/pages`);
     } catch (err: unknown) {
       console.error('Batch import failed:', err);
-      toast.error('Batch import failed: ' + (err instanceof Error ? err.message : String(err)));
+      callout.show({
+        variant: 'error',
+        title: 'Batch import failed: ' + (err instanceof Error ? err.message : String(err)),
+      });
       setBatchProgress(null);
     }
   };

--- a/apps/webapp/app/routes/admin.$class.pages/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages/route.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useFetcher, Link, Outlet, useSearchParams, useNavigate } from 'react-router';
 import { Table, Button, Input, Select, Switch, Tooltip } from 'antd';
 import { IconPlus, IconEyeOff, IconLock, IconWorld, IconMenu2 } from '@tabler/icons-react';
-import { toast } from 'react-toastify';
 import { assertClassroomAccess } from '~/utils/helpers';
 import { ClassmojiService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import getPrisma from '@classmoji/database';
 import { TableActionButtons, RecentViewers } from '~/components';
 import type { Route } from './+types/route';
@@ -129,39 +129,34 @@ export default function AdminPages({ loaderData }: Route.ComponentProps) {
   const fetcher = useFetcher();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchText, setSearchText] = useState('');
-  const toastIdRef = useRef<string | number | null>(null);
   const navigate = useNavigate();
+  const callout = useCallout();
 
   // Show toast notification after delete (from redirect)
   useEffect(() => {
     if (searchParams.get('deleted') === 'true') {
-      toast.success('Page deleted successfully!');
+      callout.show({ variant: 'success', title: 'Page deleted successfully!' });
       // Remove the query param to prevent showing toast on refresh
       setSearchParams({}, { replace: true });
     }
   }, [searchParams, setSearchParams]);
 
-  // Show loading toast when deleting
+  // Show success/error callout when delete completes
   useEffect(() => {
-    if (fetcher.state === 'submitting') {
-      toastIdRef.current = toast.loading('Deleting page...');
-    } else if (fetcher.state === 'idle' && toastIdRef.current) {
-      if (fetcher.data?.success) {
-        toast.update(toastIdRef.current, {
-          render: fetcher.data.message || 'Page deleted successfully!',
-          type: 'success',
-          isLoading: false,
-          autoClose: 3000,
+    if (fetcher.state === 'idle' && fetcher.data) {
+      if (fetcher.data.success) {
+        callout.show({
+          variant: 'success',
+          title: fetcher.data.message || 'Page deleted successfully!',
+          autoDismissMs: 3000,
         });
-      } else if (fetcher.data?.error) {
-        toast.update(toastIdRef.current, {
-          render: fetcher.data.error || 'Failed to delete page',
-          type: 'error',
-          isLoading: false,
-          autoClose: 3000,
+      } else if (fetcher.data.error) {
+        callout.show({
+          variant: 'error',
+          title: fetcher.data.error || 'Failed to delete page',
+          autoDismissMs: 3000,
         });
       }
-      toastIdRef.current = null;
     }
   }, [fetcher.state, fetcher.data]);
 

--- a/apps/webapp/app/routes/admin.$class.settings.grades/EmojiMapping.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.grades/EmojiMapping.tsx
@@ -1,10 +1,10 @@
 import { Input, InputNumber, Button, Table, Form, Card, Popconfirm, Alert, Select } from 'antd';
-import { toast } from 'react-toastify';
 import { useState } from 'react';
 
 import { DeleteOutlined, WarningOutlined } from '@ant-design/icons';
 
 import { SettingSection, Emoji } from '~/components';
+import { useCallout } from '@classmoji/ui-components';
 import { useGlobalFetcher, useSubscription } from '~/hooks';
 
 import tokenImage from '~/assets/images/token.png';
@@ -47,6 +47,7 @@ const EmojiMapping = ({ emojiMappings, orphanedEmojis }: EmojiMappingProps) => {
   const [editValue, setEditValue] = useState<string | number | null>(null);
 
   const { notify, fetcher } = useGlobalFetcher();
+  const callout = useCallout();
 
   // Handle inline cell update
   const handleCellUpdate = (emojiKey: string, field: string, value: string | number | null) => {
@@ -96,7 +97,10 @@ const EmojiMapping = ({ emojiMappings, orphanedEmojis }: EmojiMappingProps) => {
       .map(([oldEmoji, newEmoji]) => ({ oldEmoji, newEmoji }));
 
     if (mappings.length === 0) {
-      return toast.error('Please select a new emoji for at least one orphaned grade.');
+      return callout.show({
+        variant: 'error',
+        title: 'Please select a new emoji for at least one orphaned grade.',
+      });
     }
 
     notify('Remapping grades...');
@@ -115,7 +119,10 @@ const EmojiMapping = ({ emojiMappings, orphanedEmojis }: EmojiMappingProps) => {
 
   const createEmojiMapping = () => {
     if (!emoji || !grade) {
-      return toast.error('Please select an emoji and enter a numeric value.');
+      return callout.show({
+        variant: 'error',
+        title: 'Please select an emoji and enter a numeric value.',
+      });
     }
 
     notify('Creating emoji mapping...');

--- a/apps/webapp/app/routes/admin.$class.settings.grades/LetterGradeMapping.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.grades/LetterGradeMapping.tsx
@@ -1,10 +1,10 @@
 import { Input, InputNumber, Button, Table, Card, Form, Popconfirm } from 'antd';
-import { toast } from 'react-toastify';
 import { useState } from 'react';
 
 import { DeleteOutlined } from '@ant-design/icons';
 
 import { SettingSection } from '~/components';
+import { useCallout } from '@classmoji/ui-components';
 import { useGlobalFetcher } from '~/hooks';
 
 interface LetterGradeMap {
@@ -25,6 +25,7 @@ const LetterGradeMapping = ({ letterGradeMappings }: LetterGradeMappingProps) =>
   const [editValue, setEditValue] = useState<number | null>(null);
 
   const { notify, fetcher } = useGlobalFetcher();
+  const callout = useCallout();
 
   // Handle inline cell update
   const handleCellUpdate = (letterGradeKey: string, newMinGrade: number | null) => {
@@ -51,7 +52,10 @@ const LetterGradeMapping = ({ letterGradeMappings }: LetterGradeMappingProps) =>
 
   const createLetterGradeMapping = () => {
     if (!letterGrade || !minGrade) {
-      return toast.error('Please enter a letter grade and a minimum numeric value.');
+      return callout.show({
+        variant: 'error',
+        title: 'Please enter a letter grade and a minimum numeric value.',
+      });
     }
 
     notify('Creating letter grade mapping...');

--- a/apps/webapp/app/routes/admin.$class.settings.team/TagSection.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.team/TagSection.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { SettingSection, TableActionButtons } from '~/components';
 import { Input, Button, Table, Tag } from 'antd';
+import { useCallout } from '@classmoji/ui-components';
 import { useGlobalFetcher } from '~/hooks';
 
 interface Tag {
@@ -17,10 +17,11 @@ interface TagSectionProps {
 const TagSection = ({ tags }: TagSectionProps) => {
   const [name, setName] = useState('');
   const { fetcher } = useGlobalFetcher();
+  const callout = useCallout();
 
   const createTag = () => {
     if (tags.find((tag: Tag) => tag.name === name)) {
-      toast.error('Tag already exists');
+      callout.show({ variant: 'error', title: 'Tag already exists' });
       return;
     }
 

--- a/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 import { RequireRole, TableActionButtons, UserThumbnailView } from '~/components';
 import { useGlobalFetcher } from '~/hooks';
-import { toast } from 'react-toastify';
+import { useCallout } from '@classmoji/ui-components';
 import { ActionTypes } from '~/constants';
 import { authClient } from '@classmoji/auth/client';
 
@@ -32,10 +32,11 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
   const navigate = useNavigate();
   const { fetcher, notify } = useGlobalFetcher();
   const [impersonating, setImpersonating] = useState(false);
+  const callout = useCallout();
 
   const handleImpersonate = async (student: Student) => {
     if (!student.login) {
-      toast.error('Student has not accepted invite.');
+      callout.show({ variant: 'error', title: 'Student has not accepted invite.' });
       return;
     }
 
@@ -55,7 +56,10 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
       navigate(`/student/${classSlug}`);
     } catch (error: unknown) {
       console.error('Impersonation failed:', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to view as student');
+      callout.show({
+        variant: 'error',
+        title: error instanceof Error ? error.message : 'Failed to view as student',
+      });
     } finally {
       setImpersonating(false);
     }
@@ -161,7 +165,7 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
             onView={() => {
               if (student.login) {
                 navigate(`${pathname}/${student.login}`);
-              } else toast.error('Student has not accepted invite.');
+              } else callout.show({ variant: 'error', title: 'Student has not accepted invite.' });
             }}
           >
             <RequireRole roles={['OWNER']}>

--- a/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
@@ -3,9 +3,9 @@ import { Button, Modal } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import invariant from 'tiny-invariant';
 import { data, useFetcher, useParams } from 'react-router';
-import { toast } from 'react-toastify';
 import type { Route } from './+types/route';
 import { ClassmojiService } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import getPrisma from '@classmoji/database';
 import { assertClassroomAccess } from '~/utils/helpers';
 import { buildCalendarUrl, getCalendarDateRange } from '~/utils/calendar.server';
@@ -279,6 +279,7 @@ const AssistantCalendar = ({ loaderData }: Route.ComponentProps) => {
   const { class: classSlug } = useParams();
   const fetcher = useFetcher();
   const eventsFetcher = useFetcher();
+  const callout = useCallout();
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<CalendarEventWithLinks | null>(null);
@@ -314,7 +315,7 @@ const AssistantCalendar = ({ loaderData }: Route.ComponentProps) => {
         eventsFetcher.load(`?year=${currentViewYear}&month=${currentViewMonth}`);
       } else if (fetcher.data.error) {
         setOptimisticEvents(null); // Revert on error
-        toast.error(fetcher.data.error);
+        callout.show({ variant: 'error', title: fetcher.data.error });
       }
     }
   }, [fetcher.data, fetcher.state]);
@@ -330,7 +331,7 @@ const AssistantCalendar = ({ loaderData }: Route.ComponentProps) => {
   const handleUpdateEvent = (eventData: EventFormData) => {
     if (!selectedEvent?.id) {
       console.error('[Calendar] Cannot update: selectedEvent.id is missing');
-      toast.error('Unable to update event - please try again');
+      callout.show({ variant: 'error', title: 'Unable to update event - please try again' });
       return;
     }
 
@@ -356,7 +357,7 @@ const AssistantCalendar = ({ loaderData }: Route.ComponentProps) => {
   const handleEventDrop = (event: CalendarEventWithLinks, newStartTime: Date, newEndTime: Date) => {
     // Only allow dragging user's own events (not deadlines)
     if (event.is_deadline || String(event.created_by) !== String(userId)) {
-      toast.error('You can only move your own events');
+      callout.show({ variant: 'error', title: 'You can only move your own events' });
       return;
     }
 

--- a/apps/webapp/app/routes/student.$class.dashboard/TokenPopupForm.tsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/TokenPopupForm.tsx
@@ -4,8 +4,8 @@ import { IconCalendarPlus } from '@tabler/icons-react';
 import { useRevalidator } from 'react-router';
 import dayjs from 'dayjs';
 import useSound from 'use-sound';
-import { toast } from 'react-toastify';
 
+import { useCallout } from '@classmoji/ui-components';
 import { useNotifiedFetcher, useUser } from '~/hooks';
 import useStore from '~/store';
 import tokenImage from '~/assets/images/token.png';
@@ -35,6 +35,7 @@ const TokenPopupForm = ({ repositoryAssignment, balance }: TokenPopupFormProps) 
   const { classroom } = useStore();
   const [play] = useSound(coinsSound, { volume: 0.6 });
   const revalidator = useRevalidator();
+  const callout = useCallout();
 
   // Revalidate parent route data after successful purchase
   useEffect(() => {
@@ -64,26 +65,32 @@ const TokenPopupForm = ({ repositoryAssignment, balance }: TokenPopupFormProps) 
   ) => {
     // Validate all required values exist
     if (balance === null || balance === undefined) {
-      toast.error('Unable to determine token balance. Please refresh the page.');
+      callout.show({
+        variant: 'error',
+        title: 'Unable to determine token balance. Please refresh the page.',
+      });
       hide();
       return;
     }
 
     if (!repoAssignment?.assignment?.tokens_per_hour) {
-      toast.error('Token cost not configured for this assignment.');
+      callout.show({ variant: 'error', title: 'Token cost not configured for this assignment.' });
       hide();
       return;
     }
 
     if (!purchaseHours || purchaseHours <= 0) {
-      toast.error('Please select a valid number of hours.');
+      callout.show({ variant: 'error', title: 'Please select a valid number of hours.' });
       hide();
       return;
     }
 
     const tokenCost = repoAssignment.assignment.tokens_per_hour * purchaseHours;
     if (balance < tokenCost) {
-      toast.error(`Insufficient tokens. You need ${tokenCost} tokens but only have ${balance}.`);
+      callout.show({
+        variant: 'error',
+        title: `Insufficient tokens. You need ${tokenCost} tokens but only have ${balance}.`,
+      });
       hide();
       return;
     }

--- a/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
+++ b/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
@@ -1,11 +1,11 @@
 import { Button, Card, Input, List, Avatar, Tag, Empty } from 'antd';
 import { IconUsers, IconUserPlus, IconLogout, IconPlus } from '@tabler/icons-react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useFetcher, Link } from 'react-router';
-import { toast } from 'react-toastify';
 import { namedAction } from 'remix-utils/named-action';
 import type { Route } from './+types/route';
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { useCallout } from '@classmoji/ui-components';
 import { assertClassroomAccess } from '~/utils/helpers';
 import { titleToIdentifier } from '@classmoji/utils';
 import { tasks } from '@trigger.dev/sdk/v3';
@@ -263,50 +263,23 @@ const StudentTeamPage = ({ loaderData }: Route.ComponentProps) => {
   const fetcher = useFetcher();
   const [teamName, setTeamName] = useState('');
   const [showCreateForm, setShowCreateForm] = useState(false);
-  const toastIdRef = useRef<string | number | null>(null);
+  const callout = useCallout();
 
   const isSubmitting = fetcher.state !== 'idle';
-
-  // Show loading toast when submitting
-  useEffect(() => {
-    if (fetcher.state === 'submitting' && !toastIdRef.current) {
-      toastIdRef.current = toast.loading('Processing...');
-    }
-  }, [fetcher.state]);
 
   // Show feedback from action
   useEffect(() => {
     if (fetcher.data?.success) {
-      if (toastIdRef.current) {
-        toast.update(toastIdRef.current, {
-          render: fetcher.data.success,
-          type: 'success',
-          isLoading: false,
-          autoClose: 3000,
-        });
-        toastIdRef.current = null;
-      } else {
-        toast.success(fetcher.data.success);
-      }
+      callout.show({ variant: 'success', title: fetcher.data.success, autoDismissMs: 3000 });
     }
     if (fetcher.data?.error) {
-      if (toastIdRef.current) {
-        toast.update(toastIdRef.current, {
-          render: fetcher.data.error,
-          type: 'error',
-          isLoading: false,
-          autoClose: 3000,
-        });
-        toastIdRef.current = null;
-      } else {
-        toast.error(fetcher.data.error);
-      }
+      callout.show({ variant: 'error', title: fetcher.data.error, autoDismissMs: 3000 });
     }
   }, [fetcher.data]);
 
   const handleCreateTeam = () => {
     if (!teamName.trim()) {
-      toast.error('Please enter a team name');
+      callout.show({ variant: 'error', title: 'Please enter a team name' });
       return;
     }
     fetcher.submit({ teamName }, { method: 'post', action: '?/create' });

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -91,7 +91,6 @@
     "react-router": "^7.9.2",
     "react-router-dom": "^7.9.2",
     "react-syntax-highlighter": "^16.1.0",
-    "react-toastify": "^10.0.4",
     "recharts": "^2.13.3",
     "rehype-highlight": "^7.0.2",
     "remix-forms": "^2.2.1",

--- a/docs/plans/2026-05-05-callout-system-design.md
+++ b/docs/plans/2026-05-05-callout-system-design.md
@@ -1,0 +1,184 @@
+# Callout System — Design
+
+**Date:** 2026-05-05
+**Status:** Awaiting approval
+**Author:** Muhammad Moiz (with Claude)
+
+## Problem
+
+Today, transient feedback in the webapp (and slides) is delivered through `react-toastify` toasts that float in from `bottom-center`. There are also bespoke progress modals (`TriggerProgress`, `ImportProgressModal`) for long-running work. The current setup has three problems:
+
+1. **Visual disconnect.** A toast at the bottom of the screen has no spatial relationship to the action that triggered it. Users miss confirmations and errors, especially on long pages.
+2. **Inconsistent surfaces.** Toasts, progress modals, and inline alerts each have their own visual language and code path.
+3. **Naming overload.** "Notification" already means push notifications and email digests in this product. The toast layer needs its own term.
+
+## Goal
+
+Replace bottom-floating toasts and ad-hoc progress UI with a single inline component — the **Callout** — that slides into a dedicated slot in the page near the relevant content. Build it as a reusable primitive in `@classmoji/ui-components` so any future feature (and the slides app) can use it without re-implementing.
+
+## Non-goals
+
+- Push notifications, email digests, in-app inbox.
+- The `ImpersonationBanner` (top-fixed admin bar) — different concern, stays as is.
+- Streaming chat status (`isStreaming` flags in syllabus bot / prompt assistant) — already inline, no change.
+- A general-purpose modal/drawer/popover system.
+
+## Naming
+
+**Callout.** Used by GitHub Primer and Notion for the same pattern. Unambiguous in this codebase: no collision with push/email notifications, no collision with `useNotifiedFetcher`, no collision with `ImpersonationBanner`.
+
+## Architecture
+
+### Package & files
+
+Lives in `packages/ui-components/src/Callout/`:
+
+```
+Callout/
+  index.ts                  // public exports
+  CalloutProvider.tsx       // context, queue, slot registry
+  CalloutSlot.tsx           // anchor that renders the active callout
+  CalloutCard.tsx           // visual: avatar/icon, title, message, dismiss
+  useCallout.ts             // imperative API for callers
+  variants.ts               // success | error | info | progress styling map
+  types.ts
+  Callout.test.tsx
+```
+
+Exported from `packages/ui-components/src/index.ts` alongside other primitives.
+
+### Public API
+
+```tsx
+// 1. Wrap once at the app root (replaces <ToastContainer />)
+<CalloutProvider>
+  <App />
+</CalloutProvider>
+
+// 2. Default slot — rendered once, high in the route shell
+//    (CommonLayout, just below the AppBar/breadcrumb area)
+<CalloutSlot />                       // implicit id="default"
+
+// 3. Optional contextual slot — feature places one near its UI
+<CalloutSlot id="quiz-editor" />
+
+// 4. Fire from anywhere
+const callout = useCallout();
+callout.show({
+  variant: 'success',
+  title: 'Saved',
+  message: 'Settings updated.',
+});
+
+callout.show({
+  variant: 'progress',
+  title: 'Syncing repos',
+  message: '3 of 12 complete',
+  slot: 'quiz-editor',
+  progress: 0.25,             // 0..1; renders thin bar in card
+  persistent: true,           // overrides per-variant default
+});
+
+// 5. Update / dismiss in-flight
+const id = callout.show({ variant: 'progress', title: 'Importing slides' });
+callout.update(id, { progress: 0.6, message: 'Processing images' });
+callout.update(id, { variant: 'success', title: 'Import complete' });
+callout.dismiss(id);
+```
+
+`useCallout()` returns a stable object — calling it does not re-subscribe the component. The provider keeps the dispatcher in a ref so callers don't re-render when the queue changes.
+
+### Slot behavior (single-slot, replace-on-new)
+
+Each `CalloutSlot` subscribes to one queue keyed by its `id`. When `show()` fires:
+
+1. Provider routes the payload by `slot` (defaults to `"default"`).
+2. The target slot renders **at most one** callout. A new callout replaces the current one with a 180ms crossfade.
+3. If the targeted slot is not currently mounted, the provider buffers the message for 500ms (covers route transitions where the slot mounts a tick later), then falls back to the default slot. After 500ms with no slot, the message is dropped and a `console.warn` is emitted in dev so the misrouting is visible.
+
+### Dismiss behavior (per-variant defaults, override allowed)
+
+| Variant    | Default lifetime              | Reasoning                                 |
+| ---------- | ----------------------------- | ----------------------------------------- |
+| `success`  | Auto-dismiss after 4s         | Matches existing toast feel; low signal.  |
+| `info`     | Persistent until X'd          | User decides when they've read it.        |
+| `error`    | Persistent until X'd          | Errors should not silently disappear.     |
+| `progress` | Persistent; auto-dismisses 2s after morphing to `success` | Confirms completion without lingering. |
+
+Any callout can override with `persistent: true`, `autoDismissMs: <number>`, or `autoDismissMs: null`.
+
+### Animation
+
+`framer-motion` (already in webapp deps). The card mounts with `initial={{ opacity: 0, y: -8 }}`, animates to `{ opacity: 1, y: 0 }` with a 220ms spring. On replace, the outgoing card crossfades over 180ms while the new card slides in. `prefers-reduced-motion` short-circuits to opacity-only transitions.
+
+### Visual
+
+Matches the screenshot: rounded-2xl card, white bg / `dark:bg-neutral-900`, ring-1 stone/neutral, optional leading icon or avatar, bold title + body in same line on desktop, stacked on mobile, dismiss `IconX` on the right. Per-variant left-edge accent (subtle bar) so variant is glanceable without overpowering the card.
+
+The existing `Card`, `IconButton`, and icon primitives from `@classmoji/ui-components` are reused — `CalloutCard` is composed from them, not styled from scratch.
+
+### Types
+
+```ts
+type CalloutVariant = 'success' | 'error' | 'info' | 'progress';
+
+interface CalloutPayload {
+  variant: CalloutVariant;
+  title: string;
+  message?: string;
+  slot?: string;                     // default: 'default'
+  progress?: number;                 // 0..1, only meaningful for 'progress'
+  icon?: ReactNode;                  // override default variant icon
+  action?: { label: string; onClick: () => void }; // optional CTA
+  persistent?: boolean;
+  autoDismissMs?: number | null;
+}
+
+interface CalloutHandle {
+  show: (p: CalloutPayload) => string;       // returns id
+  update: (id: string, p: Partial<CalloutPayload>) => void;
+  dismiss: (id: string) => void;
+}
+```
+
+## Migration
+
+There are ~20 files importing from `react-toastify` (~78 call sites including `useNotifiedFetcher`-driven ones). A big-bang rewrite is risky. Plan:
+
+1. **Land the primitive.** Build `Callout` in `@classmoji/ui-components` with tests. No app changes yet.
+2. **Mount the provider + default slot.** In `apps/webapp/app/root.tsx` add `<CalloutProvider>` around the tree. In `CommonLayout.tsx`, render `<CalloutSlot />` just below the page header (above the floating card content area). Keep `<ToastContainer />` mounted in parallel during migration.
+3. **Replace `useNotifiedFetcher`.** Rewrite the hook to drive `useCallout()` instead of `toast()`. This single change migrates the majority of call sites because most use the `notify(action, message)` pattern, not direct `toast.*` calls. Public API of the hook stays identical — no caller changes needed.
+4. **Migrate direct `toast.*` callers.** ~20 files with explicit `toast.success(...)` / `toast.error(...)`. Replace with `useCallout().show(...)` one route group at a time. Each PR touches a single feature area to keep diffs reviewable.
+5. **Replace `TriggerProgress` modal usage.** Convert callers to `callout.show({ variant: 'progress', slot: '<feature-slot>', ... })` and `callout.update(...)` driven by the existing Trigger.dev polling. Delete `TriggerProgress` once all callers migrate.
+6. **Replace `ImportProgressModal` (slides).** Same pattern — slides app gets its own `<CalloutProvider>` + `<CalloutSlot />` in `apps/slides/app/root.tsx`.
+7. **Remove `react-toastify`.** Drop `<ToastContainer />` from both root files, uninstall the package, delete `cssTransition` import.
+
+Steps 1–3 can land in a single PR (the primitive plus the `useNotifiedFetcher` rewrite covers most of the surface invisibly). Steps 4–7 land incrementally.
+
+### `useNotifiedFetcher` compatibility note
+
+The hook today auto-dismisses success at 2s and error at 4s. The new variant defaults are 4s for success and persistent for error. The hook will pass `autoDismissMs: 2000` for success to preserve the existing snappy feel for fetcher-driven flows; errors will become persistent (a behavior improvement — errors currently disappear after 4s, which is too short).
+
+## Testing
+
+Unit tests in `Callout.test.tsx` (Vitest + React Testing Library, matching the existing `packages/ui-components` test setup):
+
+- `show()` renders into the default slot.
+- `show({ slot: 'x' })` renders into slot `x`, not default.
+- A second `show()` to the same slot replaces the first.
+- `update()` morphs the active card without remounting.
+- Auto-dismiss timers fire per variant default and clean up on unmount.
+- Buffered fallback to default slot after 500ms when target is unmounted.
+- `prefers-reduced-motion` skips translate animation.
+
+Manual smoke pass after each migration PR using existing Playwright smoke tests in `apps/webapp/tests/smoke/critical-paths.spec.ts` — the suite already covers form-submit flows that surface toasts today.
+
+## Risks
+
+- **Slot discoverability.** Devs need to know slots exist. Mitigation: default slot covers 95% of cases; doc comment in `CalloutSlot.tsx` and a short README in `packages/ui-components/src/Callout/`.
+- **Long-running progress callouts blocking other messages.** Single-slot replace means a progress callout will be replaced by an unrelated success/error. Mitigation: features that need durable progress (Trigger.dev syncs) should declare a dedicated slot rather than firing into `default`.
+- **Slides app divergence.** Slides currently uses `top-center` toasts; moving to inline may shift expectations. Mitigation: the slides cutover (step 6) is independent and can be deferred.
+
+## Open questions
+
+None remaining — defaults above can be tweaked during implementation review.

--- a/docs/plans/2026-05-05-callout-system.md
+++ b/docs/plans/2026-05-05-callout-system.md
@@ -1,0 +1,368 @@
+# Callout System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace bottom-floating `react-toastify` toasts and ad-hoc progress modals with a unified inline `Callout` primitive in `@classmoji/ui-components`, anchored via slots and animated with framer-motion.
+
+**Architecture:** Single-slot replace-on-new model. Provider holds a slot registry and per-slot queue; slots render the active payload via framer-motion crossfade. Per-variant dismiss defaults (success auto, error/info/progress persistent). Migration is incremental: ship the primitive, swap `useNotifiedFetcher` internals (covers most callers invisibly), then migrate direct `toast.*` callers and bespoke progress modals one feature at a time, then drop `react-toastify`.
+
+**Tech Stack:** TypeScript, React 19, framer-motion 12, Vitest + React Testing Library, Tailwind, react-router 7.
+
+**Design doc:** `docs/plans/2026-05-05-callout-system-design.md`
+
+**Commit policy:** Conventional commits, no Claude/AI co-author footer, no "Generated with" footer.
+
+---
+
+## Phase 1 — Build the primitive
+
+### Task 1: Scaffold package structure and types
+
+**Files:**
+- Create: `packages/ui-components/src/Callout/types.ts`
+- Create: `packages/ui-components/src/Callout/variants.ts`
+- Create: `packages/ui-components/src/Callout/index.ts` (placeholder, exports filled in later)
+
+**Step 1:** Create `types.ts` with:
+```ts
+import type { ReactNode } from 'react';
+
+export type CalloutVariant = 'success' | 'error' | 'info' | 'progress';
+
+export interface CalloutAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface CalloutPayload {
+  variant: CalloutVariant;
+  title: string;
+  message?: string;
+  slot?: string;
+  progress?: number;
+  icon?: ReactNode;
+  action?: CalloutAction;
+  persistent?: boolean;
+  autoDismissMs?: number | null;
+}
+
+export interface CalloutHandle {
+  show: (payload: CalloutPayload) => string;
+  update: (id: string, payload: Partial<CalloutPayload>) => void;
+  dismiss: (id: string) => void;
+}
+
+export interface ActiveCallout extends CalloutPayload {
+  id: string;
+  slot: string;
+}
+```
+
+**Step 2:** Create `variants.ts` with per-variant defaults (default lifetime, accent color, default icon name). Use existing `Icon*` from `../icons` — `IconCheck` (success), `IconX` (error), `IconBell` (info), `IconArrowRotate` (progress).
+
+```ts
+import type { CalloutVariant } from './types.ts';
+
+export interface VariantConfig {
+  defaultAutoDismissMs: number | null;
+  accentClassName: string; // tailwind classes for left accent bar
+  iconColorClassName: string;
+}
+
+export const VARIANT_CONFIG: Record<CalloutVariant, VariantConfig> = {
+  success: {
+    defaultAutoDismissMs: 4000,
+    accentClassName: 'bg-emerald-500',
+    iconColorClassName: 'text-emerald-600 dark:text-emerald-400',
+  },
+  error: {
+    defaultAutoDismissMs: null,
+    accentClassName: 'bg-rose-500',
+    iconColorClassName: 'text-rose-600 dark:text-rose-400',
+  },
+  info: {
+    defaultAutoDismissMs: null,
+    accentClassName: 'bg-sky-500',
+    iconColorClassName: 'text-sky-600 dark:text-sky-400',
+  },
+  progress: {
+    defaultAutoDismissMs: null,
+    accentClassName: 'bg-violet-500',
+    iconColorClassName: 'text-violet-600 dark:text-violet-400',
+  },
+};
+```
+
+**Step 3:** Verify TypeScript compiles. Run `npx tsc -p packages/ui-components/tsconfig.json --noEmit` (or whatever the package's typecheck script is — check `package.json`).
+
+**Step 4:** Commit.
+```
+git add packages/ui-components/src/Callout
+git commit -m "feat(ui-components): scaffold Callout types and variants"
+```
+
+---
+
+### Task 2: Build CalloutProvider with queue + slot registry
+
+**Files:**
+- Create: `packages/ui-components/src/Callout/CalloutProvider.tsx`
+
+**Behavior:**
+- React context exposing `CalloutHandle`.
+- Maintains `Map<slotId, ActiveCallout | null>` for the active payload per slot.
+- Maintains `Set<slotId>` of mounted slots (registered via `__registerSlot` / `__unregisterSlot` exposed through internal context).
+- `show(payload)`:
+  - Generates id via `crypto.randomUUID()`.
+  - Resolves target slot (`payload.slot ?? 'default'`).
+  - If slot is mounted: assigns the payload as the slot's active callout (replaces any prior).
+  - If slot is unmounted: stores in a buffer keyed by slot id with a 500ms timer. On timer expiry, fall back to `'default'` slot if mounted; otherwise drop and `console.warn` in dev (`process.env.NODE_ENV !== 'production'`).
+  - Schedules auto-dismiss timer per resolved `autoDismissMs` (payload override → variant default).
+  - Returns id.
+- `update(id, partial)`: locates active callout by id across slots; merges; resets auto-dismiss timer if `autoDismissMs` or `variant` changed. If the merged variant is a terminal `success` from a `progress` morph, default auto-dismiss to 2000ms unless explicitly overridden.
+- `dismiss(id)`: clears the slot if it currently holds id; clears its timer.
+- All state is held in refs + a single tick counter `useState` to trigger re-render on changes — keeps `useCallout()` returning a stable handle (no re-subscriptions).
+
+Export an internal `useCalloutInternal()` hook for `CalloutSlot` to subscribe to its slot's active payload.
+
+**Step 1:** Implement.
+**Step 2:** TypeScript check.
+**Step 3:** Commit.
+```
+git commit -m "feat(ui-components): add CalloutProvider with slot registry and queue"
+```
+
+---
+
+### Task 3: Build CalloutCard visual
+
+**Files:**
+- Create: `packages/ui-components/src/Callout/CalloutCard.tsx`
+
+**Behavior:**
+- Pure presentational component. Props: `payload: ActiveCallout`, `onDismiss: () => void`.
+- Layout matches the screenshot in `docs/plans/2026-05-05-callout-system-design.md`:
+  - Outer: `relative flex items-center gap-3 rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 px-4 py-3 shadow-sm overflow-hidden`
+  - Left accent: absolutely positioned `w-1 inset-y-0 left-0` div using `VARIANT_CONFIG[variant].accentClassName`.
+  - Icon: payload.icon if provided, else default per variant. For `progress` with no icon override, render the default icon with a slow Tailwind `animate-spin`.
+  - Text: `<span className="font-semibold text-gray-900 dark:text-gray-100">{title}</span>` followed by `<span className="text-gray-600 dark:text-gray-400">{message}</span>` on the same line on `sm+`, stacked on mobile.
+  - Optional action button (uses `Button` from `../Button`).
+  - Dismiss button (`IconButton` with `IconX`).
+  - For `progress` variant with `progress != null`: render a `h-0.5 bg-violet-500` bar at the bottom edge with width `${progress * 100}%`, transitioning width over 240ms.
+
+**Step 1:** Implement.
+**Step 2:** TypeScript check.
+**Step 3:** Commit.
+```
+git commit -m "feat(ui-components): add CalloutCard visual component"
+```
+
+---
+
+### Task 4: Build CalloutSlot with framer-motion animation
+
+**Files:**
+- Create: `packages/ui-components/src/Callout/CalloutSlot.tsx`
+
+**Behavior:**
+- Props: `id?: string` (default `"default"`), `className?: string`.
+- Registers/unregisters with provider on mount/unmount via internal context.
+- Subscribes to its slot's active callout.
+- Renders an `<AnimatePresence mode="wait">` containing the active `CalloutCard` keyed by callout id.
+- Motion: `initial={{ opacity: 0, y: -8 }}`, `animate={{ opacity: 1, y: 0 }}`, `exit={{ opacity: 0, y: -4 }}`, `transition={{ duration: 0.18, ease: 'easeOut' }}`.
+- If `useReducedMotion()` is true, drop the `y` translate and use opacity-only.
+- Container is `className={cn('w-full', className)}` — no fixed positioning. Caller controls placement.
+
+**Step 1:** Implement.
+**Step 2:** TypeScript check.
+**Step 3:** Commit.
+```
+git commit -m "feat(ui-components): add CalloutSlot with framer-motion animation"
+```
+
+---
+
+### Task 5: Add useCallout hook + finalize public exports
+
+**Files:**
+- Create: `packages/ui-components/src/Callout/useCallout.ts`
+- Modify: `packages/ui-components/src/Callout/index.ts`
+- Modify: `packages/ui-components/src/index.ts`
+
+**Behavior:**
+- `useCallout()` returns the `CalloutHandle` from context. Throws a descriptive error in dev if used outside a `CalloutProvider`.
+- `index.ts` re-exports `CalloutProvider`, `CalloutSlot`, `useCallout`, and the public types.
+- Top-level `packages/ui-components/src/index.ts` re-exports those alongside the existing primitives, in the same style as `Card`, `Chip`, etc.
+
+**Step 1:** Implement.
+**Step 2:** TypeScript check across consuming apps: `npm run typecheck` (or apps/webapp's typecheck script).
+**Step 3:** Commit.
+```
+git commit -m "feat(ui-components): export Callout public API"
+```
+
+---
+
+### Task 6: Tests
+
+**Files:**
+- Create: `packages/ui-components/src/Callout/Callout.test.tsx`
+
+**Test cases (one `it()` each):**
+1. `show()` renders into the default slot.
+2. `show({ slot: 'x' })` renders into slot `x` and not into default.
+3. A second `show()` to the same slot replaces the first.
+4. `update(id, ...)` morphs the active card without unmounting (assert by checking the dismiss button DOM node identity — replace would unmount it).
+5. `dismiss(id)` removes the active callout from its slot.
+6. `success` auto-dismisses after 4000ms (use `vi.useFakeTimers()`).
+7. `error` does not auto-dismiss.
+8. `progress` morphed to `success` via `update` auto-dismisses 2000ms later.
+9. `show({ slot: 'unmounted' })` falls back to `default` after 500ms when `default` is mounted.
+10. `show({ slot: 'unmounted' })` is dropped (no throw, console.warn called) after 500ms when `default` is also unmounted.
+
+Use `@testing-library/react`. Reference an existing `packages/ui-components` test for setup conventions (look in `Card/`, `Button/`, etc.).
+
+**Step 1:** Write tests.
+**Step 2:** Run: `npm run test --workspace=packages/ui-components` (or whatever script applies — check `packages/ui-components/package.json`).
+**Step 3:** All green. Fix any implementation bugs surfaced.
+**Step 4:** Commit.
+```
+git commit -m "test(ui-components): cover Callout slot routing, replace, lifetimes"
+```
+
+---
+
+## Phase 2 — Wire into webapp
+
+### Task 7: Mount provider and default slot in webapp
+
+**Files:**
+- Modify: `apps/webapp/app/root.tsx` — wrap the app tree with `<CalloutProvider>`. Keep existing `<ToastContainer />` mounted in parallel.
+- Modify: `apps/webapp/app/components/layout/navigation/CommonLayout.tsx` — render `<CalloutSlot />` directly above the route content area, inside the floating-card container's outer wrapper. Read the file first; place the slot where the page title row begins so the slot sits above page content but inside the routed area, with `className="mb-3"` for spacing.
+
+**Step 1:** Inspect `apps/webapp/app/root.tsx` for the right wrap point (look for the existing `<ToastContainer />` import — wrap inside that level).
+**Step 2:** Inspect `CommonLayout.tsx` for where the page title row is rendered. Place the slot just before it.
+**Step 3:** Manual smoke: `npm run web:dev` is already running per AGENTS.md (do not start it). Open any admin page and confirm no regressions. Use Playwright/Chrome tools if available.
+**Step 4:** Commit.
+```
+git commit -m "feat(webapp): mount CalloutProvider and default slot in CommonLayout"
+```
+
+---
+
+### Task 8: Rewrite useNotifiedFetcher to use Callout
+
+**Files:**
+- Modify: `apps/webapp/app/hooks/useNotifiedFetcher.ts`
+
+**Behavior:** Public API of the hook stays identical (`{ fetcher, notify }`). Internals route through `useCallout()` instead of `toast()`:
+- `notify(action, message)` → `callout.show({ variant: 'progress', title: message ?? '…', persistent: true })`. Track returned id by `action` in a ref Map.
+- On `fetcher.data.success`: `callout.update(id, { variant: 'success', title: fetcher.data.success, autoDismissMs: 2000 })`.
+- On `fetcher.data.error`: if id exists `callout.update(id, { variant: 'error', title: fetcher.data.error })`; else `callout.show({ variant: 'error', title: fetcher.data.error })`.
+- On `fetcher.data.info`: dedupe by `info` slot id like before — `callout.show({ variant: 'info', title: fetcher.data.info })`.
+- Drop the `position` arg from `notify()` signature (no positional concept anymore) but keep it as an ignored optional third arg for backward compatibility — type as `unknown` and ignore.
+
+**Step 1:** Implement.
+**Step 2:** Manual smoke: trigger a form submission on any admin page that uses `useGlobalFetcher().notify(...)`. Verify the callout appears in the default slot above the route content and morphs to success/error.
+**Step 3:** Commit.
+```
+git commit -m "refactor(webapp): drive useNotifiedFetcher through Callout system"
+```
+
+---
+
+## Phase 3 — Migrate direct toast.* callers
+
+There are ~20 files importing `toast` from `react-toastify`. Group migrations by feature area to keep diffs reviewable. Each task below = one commit.
+
+For each file: replace `import { toast } from 'react-toastify'` with `import { useCallout } from '@classmoji/ui-components'`, replace `toast.success(msg)` with `callout.show({ variant: 'success', title: msg })`, etc. Where the call is inside an event handler in a component, instantiate `const callout = useCallout()` at the top of the component. Where it's outside a component (rare — verify), refactor to call from the nearest component.
+
+### Task 9: Migrate admin classroom routes
+
+**Files (modify each, one commit covering all):**
+- `apps/webapp/app/routes/admin.$class.modules_.$title.assign-graders/route.tsx`
+- `apps/webapp/app/routes/admin.$class.assistants.$login/route.tsx`
+- `apps/webapp/app/routes/admin.$class.calendar/route.tsx`
+- `apps/webapp/app/routes/admin.$class.pages.new/route.tsx`
+- `apps/webapp/app/routes/admin.$class.pages/route.tsx`
+- `apps/webapp/app/routes/admin.$class.modules.form/FormModule.tsx`
+- `apps/webapp/app/routes/admin.$class.modules_.$title/Menu.tsx`
+- `apps/webapp/app/routes/admin.$class.assistants/route.tsx`
+- `apps/webapp/app/routes/admin.$class.assistants/FormAssistant.tsx`
+- `apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx`
+
+Smoke each route's primary action in the browser.
+
+```
+git commit -m "refactor(webapp): migrate admin classroom routes to Callout"
+```
+
+### Task 10: Migrate admin settings + assistant + student routes
+
+**Files:**
+- `apps/webapp/app/routes/admin.$class.settings.team/TagSection.tsx`
+- `apps/webapp/app/routes/admin.$class.settings.grades/LetterGradeMapping.tsx`
+- `apps/webapp/app/routes/admin.$class.settings.grades/EmojiMapping.tsx`
+- `apps/webapp/app/routes/_user.settings.billing/route.tsx`
+- `apps/webapp/app/routes/assistant.$class_.calendar/route.tsx`
+- `apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx`
+- `apps/webapp/app/routes/student.$class.dashboard/TokenPopupForm.tsx`
+
+```
+git commit -m "refactor(webapp): migrate settings, assistant, student routes to Callout"
+```
+
+---
+
+## Phase 4 — Replace bespoke progress UI
+
+### Task 11: Replace TriggerProgress
+
+**Files:**
+- Read: `apps/webapp/app/components/ui/display/TriggerProgress.tsx` and find all callers (`grep -rn TriggerProgress apps/webapp`).
+- For each caller: replace the modal usage with a `<CalloutSlot id="<feature-slot>" />` placed inline in the feature UI, and convert the polling logic to call `callout.show({ variant: 'progress', slot: '<feature-slot>', progress, ... })` and `callout.update(...)` as the run progresses, then `callout.update(id, { variant: 'success', ... })` on completion or `{ variant: 'error', ... }` on failure.
+- Delete `TriggerProgress.tsx` once no callers remain.
+
+```
+git commit -m "refactor(webapp): replace TriggerProgress modal with inline Callout"
+```
+
+### Task 12: Replace ImportProgressModal in slides app
+
+**Files:**
+- Mount `<CalloutProvider>` in `apps/slides/app/root.tsx`.
+- Add a `<CalloutSlot />` in the slides editor shell.
+- Replace `apps/slides/app/components/ImportProgressModal.tsx` callers with progress callouts. Delete the modal file once unused.
+
+```
+git commit -m "refactor(slides): replace ImportProgressModal with inline Callout"
+```
+
+---
+
+## Phase 5 — Remove react-toastify
+
+### Task 13: Drop react-toastify
+
+**Only run after every direct caller is migrated.** Verify with `grep -rn "react-toastify" apps packages` — should return zero matches.
+
+**Files:**
+- Modify: `apps/webapp/app/root.tsx` — remove `<ToastContainer />` and the `react-toastify` import.
+- Modify: `apps/slides/app/root.tsx` — same.
+- Remove `react-toastify` from `apps/webapp/package.json` and `apps/slides/package.json`. Run `npm install` to update lockfile **only if** the ai-agent submodule is populated (per AGENTS.md, contributors without the submodule must not commit lockfile changes). If the submodule is empty, leave the lockfile and flag in PR description.
+
+```
+git commit -m "chore: remove react-toastify after full migration to Callout"
+```
+
+---
+
+## Verification checklist (run before final PR)
+
+- [ ] `npm run typecheck` (or per-workspace) clean.
+- [ ] `npm run test --workspace=packages/ui-components` green.
+- [ ] `npm run web:test` (Playwright) green for routes touched in phases 3–4.
+- [ ] Manual: success, error, info callouts visible above route content.
+- [ ] Manual: progress callout morphs to success and auto-dismisses.
+- [ ] `grep -rn "react-toastify" apps packages` → no matches.
+- [ ] `grep -rn "TriggerProgress" apps` → no matches.

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -15,10 +15,14 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "framer-motion": "^12.23.22"
   },
   "dependencies": {
     "@codesandbox/sandpack-react": "^2.20.0",
     "@codesandbox/sandpack-themes": "^2.0.21"
+  },
+  "devDependencies": {
+    "framer-motion": "^12.23.22"
   }
 }

--- a/packages/ui-components/src/Callout/CalloutCard.tsx
+++ b/packages/ui-components/src/Callout/CalloutCard.tsx
@@ -1,37 +1,12 @@
-import type { ReactNode } from 'react';
 import { Button } from '../Button/Button.tsx';
 import { IconButton } from '../IconButton/IconButton.tsx';
-import {
-  IconArrowRotate,
-  IconBell,
-  IconCheck,
-  IconX,
-} from '../icons/index.tsx';
-import type { ActiveCallout, CalloutVariant } from './types.ts';
-import { VARIANT_CONFIG } from './variants.ts';
+import { IconX } from '../icons/index.tsx';
+import type { ActiveCallout } from './types.ts';
+import { VARIANT_CONFIG } from './variants.tsx';
 
 export interface CalloutCardProps {
   payload: ActiveCallout;
   onDismiss: () => void;
-}
-
-function defaultIconFor(variant: CalloutVariant): ReactNode {
-  switch (variant) {
-    case 'success':
-      return <IconCheck size={18} />;
-    case 'error':
-      return <IconX size={18} />;
-    case 'info':
-      return <IconBell size={18} />;
-    case 'progress':
-      return (
-        <IconArrowRotate
-          size={18}
-          className="animate-spin"
-          style={{ animationDuration: '1.6s' }}
-        />
-      );
-  }
 }
 
 export function CalloutCard({ payload, onDismiss }: CalloutCardProps) {
@@ -42,10 +17,9 @@ export function CalloutCard({ payload, onDismiss }: CalloutCardProps) {
   const role = isAlert ? 'alert' : 'status';
   const ariaLive: 'assertive' | 'polite' = isAlert ? 'assertive' : 'polite';
 
-  const iconNode = icon ?? defaultIconFor(variant);
   const showProgressBar = variant === 'progress' && progress != null;
-  const clampedProgress = showProgressBar
-    ? Math.max(0, Math.min(1, progress as number))
+  const progressPct = showProgressBar
+    ? Math.max(0, Math.min(1, progress)) * 100
     : 0;
 
   return (
@@ -64,7 +38,7 @@ export function CalloutCard({ payload, onDismiss }: CalloutCardProps) {
       <div
         className={`flex-shrink-0 flex items-center justify-center w-6 h-6 ${config.iconColorClassName}`}
       >
-        {iconNode}
+        {icon ?? config.defaultIcon}
       </div>
 
       {/* Text block */}
@@ -104,7 +78,7 @@ export function CalloutCard({ payload, onDismiss }: CalloutCardProps) {
           aria-hidden="true"
           className="absolute bottom-0 left-0 h-0.5 bg-violet-500"
           style={{
-            width: `${clampedProgress * 100}%`,
+            width: `${progressPct}%`,
             transition: 'width 240ms ease-out',
           }}
         />

--- a/packages/ui-components/src/Callout/CalloutCard.tsx
+++ b/packages/ui-components/src/Callout/CalloutCard.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import { Button } from '../Button/Button.tsx';
+import { IconButton } from '../IconButton/IconButton.tsx';
+import {
+  IconArrowRotate,
+  IconBell,
+  IconCheck,
+  IconX,
+} from '../icons/index.tsx';
+import type { ActiveCallout, CalloutVariant } from './types.ts';
+import { VARIANT_CONFIG } from './variants.ts';
+
+export interface CalloutCardProps {
+  payload: ActiveCallout;
+  onDismiss: () => void;
+}
+
+function defaultIconFor(variant: CalloutVariant): ReactNode {
+  switch (variant) {
+    case 'success':
+      return <IconCheck size={18} />;
+    case 'error':
+      return <IconX size={18} />;
+    case 'info':
+      return <IconBell size={18} />;
+    case 'progress':
+      return (
+        <IconArrowRotate
+          size={18}
+          className="animate-spin"
+          style={{ animationDuration: '1.6s' }}
+        />
+      );
+  }
+}
+
+export function CalloutCard({ payload, onDismiss }: CalloutCardProps) {
+  const { variant, title, message, icon, action, progress } = payload;
+  const config = VARIANT_CONFIG[variant];
+
+  const isAlert = variant === 'error';
+  const role = isAlert ? 'alert' : 'status';
+  const ariaLive: 'assertive' | 'polite' = isAlert ? 'assertive' : 'polite';
+
+  const iconNode = icon ?? defaultIconFor(variant);
+  const showProgressBar = variant === 'progress' && progress != null;
+  const clampedProgress = showProgressBar
+    ? Math.max(0, Math.min(1, progress as number))
+    : 0;
+
+  return (
+    <div
+      role={role}
+      aria-live={ariaLive}
+      className="relative flex items-center gap-3 rounded-2xl bg-white dark:bg-neutral-900 ring-1 ring-stone-200 dark:ring-neutral-800 px-4 py-3 shadow-sm overflow-hidden"
+    >
+      {/* Left accent bar */}
+      <div
+        aria-hidden="true"
+        className={`absolute inset-y-0 left-0 w-1 ${config.accentClassName}`}
+      />
+
+      {/* Icon */}
+      <div
+        className={`flex-shrink-0 flex items-center justify-center w-6 h-6 ${config.iconColorClassName}`}
+      >
+        {iconNode}
+      </div>
+
+      {/* Text block */}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-col sm:flex-row sm:items-baseline sm:gap-1.5">
+          <span className="font-semibold text-gray-900 dark:text-gray-100">
+            {title}
+          </span>
+          {message ? (
+            <span className="text-gray-600 dark:text-gray-400">{message}</span>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Optional action */}
+      {action ? (
+        <Button
+          variant="ghost"
+          onClick={action.onClick}
+          className="flex-shrink-0"
+        >
+          {action.label}
+        </Button>
+      ) : null}
+
+      {/* Dismiss */}
+      <IconButton
+        label="Dismiss"
+        icon={<IconX size={16} />}
+        onClick={onDismiss}
+        className="flex-shrink-0"
+      />
+
+      {/* Progress bar */}
+      {showProgressBar ? (
+        <div
+          aria-hidden="true"
+          className="absolute bottom-0 left-0 h-0.5 bg-violet-500"
+          style={{
+            width: `${clampedProgress * 100}%`,
+            transition: 'width 240ms ease-out',
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui-components/src/Callout/CalloutProvider.tsx
+++ b/packages/ui-components/src/Callout/CalloutProvider.tsx
@@ -13,15 +13,30 @@ import type {
   CalloutHandle,
   CalloutPayload,
 } from './types.ts';
-import { VARIANT_CONFIG } from './variants.ts';
+import { VARIANT_CONFIG } from './variants.tsx';
 
-const DEFAULT_SLOT_ID = 'default';
+export const DEFAULT_CALLOUT_SLOT_ID = 'default';
 const BUFFER_TIMEOUT_MS = 500;
 const PROGRESS_TO_SUCCESS_DISMISS_MS = 2000;
 
 interface BufferedEntry {
   payload: ActiveCallout;
   timer: ReturnType<typeof setTimeout>;
+}
+
+function shallowEqualPayload(a: ActiveCallout, b: ActiveCallout): boolean {
+  return (
+    a.id === b.id &&
+    a.slot === b.slot &&
+    a.variant === b.variant &&
+    a.title === b.title &&
+    a.message === b.message &&
+    a.progress === b.progress &&
+    a.icon === b.icon &&
+    a.action === b.action &&
+    a.persistent === b.persistent &&
+    a.autoDismissMs === b.autoDismissMs
+  );
 }
 
 export interface CalloutSlotInternal {
@@ -38,11 +53,7 @@ interface SlotInternalContextValue {
   registerSlot: (slotId: string) => void;
   unregisterSlot: (slotId: string) => void;
   dismiss: (id: string) => void;
-  /**
-   * Monotonically increasing tick — slots subscribe to it (via context) so
-   * they re-render when the registry changes. Stored on the context value
-   * so the provider can bump it without changing the dispatcher identities.
-   */
+  // Bumped on every registry mutation so slots subscribed to this context re-render.
   tick: number;
 }
 
@@ -55,19 +66,14 @@ export interface CalloutProviderProps {
 }
 
 export function CalloutProvider({ children }: CalloutProviderProps) {
-  // Single tick to trigger re-renders when registry changes.
   const [tick, setTick] = useState(0);
   const bumpTick = useCallback(() => {
     setTick((t) => t + 1);
   }, []);
 
-  // Per-slot active payload.
   const slotsRef = useRef<Map<string, ActiveCallout | null>>(new Map());
-  // Currently mounted slot ids.
   const mountedSlotsRef = useRef<Set<string>>(new Set());
-  // Payloads waiting for their target slot to mount.
   const bufferedByTargetSlotRef = useRef<Map<string, BufferedEntry>>(new Map());
-  // Auto-dismiss timers, keyed by callout id.
   const dismissTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
   );
@@ -89,7 +95,7 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
     [],
   );
 
-  // Forward-declare dismiss so scheduleAutoDismiss can call it.
+  // dismiss is defined below; scheduleAutoDismiss reaches it through this ref.
   const dismissRef = useRef<(id: string) => void>(() => {});
 
   const scheduleAutoDismiss = useCallback(
@@ -138,15 +144,13 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
     return null;
   }, []);
 
-  // ---------- Public dispatchers (stable via refs) ----------
-
   const show = useCallback(
     (payload: CalloutPayload): string => {
       const id =
         typeof crypto !== 'undefined' && 'randomUUID' in crypto
           ? crypto.randomUUID()
           : `callout_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-      const targetSlotId = payload.slot ?? DEFAULT_SLOT_ID;
+      const targetSlotId = payload.slot ?? DEFAULT_CALLOUT_SLOT_ID;
       const active: ActiveCallout = { ...payload, id, slot: targetSlotId };
 
       if (mountedSlotsRef.current.has(targetSlotId)) {
@@ -169,20 +173,20 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
           return;
         }
         if (
-          targetSlotId !== DEFAULT_SLOT_ID &&
-          mountedSlotsRef.current.has(DEFAULT_SLOT_ID)
+          targetSlotId !== DEFAULT_CALLOUT_SLOT_ID &&
+          mountedSlotsRef.current.has(DEFAULT_CALLOUT_SLOT_ID)
         ) {
           const fallback: ActiveCallout = {
             ...entry.payload,
-            slot: DEFAULT_SLOT_ID,
+            slot: DEFAULT_CALLOUT_SLOT_ID,
           };
-          placeInSlot(DEFAULT_SLOT_ID, fallback);
+          placeInSlot(DEFAULT_CALLOUT_SLOT_ID, fallback);
           bumpTick();
           return;
         }
         if (process.env.NODE_ENV !== 'production') {
           console.warn(
-            `[Callout] Dropped callout id=${entry.payload.id}: no slot "${targetSlotId}" or "${DEFAULT_SLOT_ID}" mounted within ${BUFFER_TIMEOUT_MS}ms`,
+            `[Callout] Dropped callout id=${entry.payload.id}: no slot "${targetSlotId}" or "${DEFAULT_CALLOUT_SLOT_ID}" mounted within ${BUFFER_TIMEOUT_MS}ms`,
           );
         }
       }, BUFFER_TIMEOUT_MS);
@@ -198,12 +202,13 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
 
   const update = useCallback(
     (id: string, partial: Partial<CalloutPayload>): void => {
-      // Live in a slot?
       const slotId = findSlotForId(id);
       if (slotId !== null) {
         const current = slotsRef.current.get(slotId);
         if (!current) return;
         const merged: ActiveCallout = { ...current, ...partial, id, slot: slotId };
+
+        if (shallowEqualPayload(current, merged)) return;
 
         const isProgressToSuccessMorph =
           current.variant === 'progress' &&
@@ -225,21 +230,18 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
         return;
       }
 
-      // Buffered?
       const bufferTarget = findBufferForId(id);
       if (bufferTarget !== null) {
         const entry = bufferedByTargetSlotRef.current.get(bufferTarget);
         if (entry === undefined) return;
-        const merged: ActiveCallout = {
+        // `slot` in partial is ignored mid-flight — it would strand the buffer timer.
+        entry.payload = {
           ...entry.payload,
           ...partial,
           id,
-          // Don't let `slot` in partial change the buffer target mid-flight.
           slot: entry.payload.slot,
         };
-        entry.payload = merged;
       }
-      // Otherwise: no-op (defensive — already dismissed).
     },
     [
       bumpTick,
@@ -273,13 +275,12 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
     [bumpTick, clearDismissTimer, findBufferForId, findSlotForId],
   );
 
-  // Keep dismissRef pointed at the latest dismiss closure.
   useEffect(() => {
     dismissRef.current = dismiss;
   }, [dismiss]);
 
-  // ---------- Stable handle (refs so consumers don't re-render) ----------
-
+  // Mirror dispatchers into refs so the public handle (built once below) stays
+  // stable across renders — consumers of useCallout() do not re-render on tick.
   const showRef = useRef(show);
   const updateRef = useRef(update);
   const dismissPublicRef = useRef(dismiss);
@@ -302,15 +303,12 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
     [],
   );
 
-  // ---------- Slot registration (for CalloutSlot) ----------
-
   const registerSlot = useCallback(
     (slotId: string) => {
       mountedSlotsRef.current.add(slotId);
       if (!slotsRef.current.has(slotId)) {
         slotsRef.current.set(slotId, null);
       }
-      // If something is buffered for this slot, deliver immediately.
       const buffered = bufferedByTargetSlotRef.current.get(slotId);
       if (buffered !== undefined) {
         clearTimeout(buffered.timer);
@@ -352,7 +350,6 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
     [getActive, registerSlot, unregisterSlot, dismiss, tick],
   );
 
-  // Clean up all timers on full provider unmount.
   useEffect(() => {
     const dismissTimers = dismissTimersRef.current;
     const bufferEntries = bufferedByTargetSlotRef.current;
@@ -373,11 +370,7 @@ export function CalloutProvider({ children }: CalloutProviderProps) {
   );
 }
 
-/**
- * Internal hook for `CalloutSlot` (Task 4) to register itself, read its
- * active payload, and dismiss callouts. Not for app code — app code uses
- * `useCallout()` from Task 5.
- */
+// Internal hook used by CalloutSlot. App code should use useCallout() instead.
 export function useCalloutSlotInternal(slotId: string): CalloutSlotInternal {
   const ctx = useContext(SlotInternalContext);
   if (ctx === null) {
@@ -385,19 +378,10 @@ export function useCalloutSlotInternal(slotId: string): CalloutSlotInternal {
       'useCalloutSlotInternal must be used inside a <CalloutProvider>',
     );
   }
-  // Subscribing to ctx (which carries `tick`) ensures the slot re-renders
-  // whenever the registry changes.
-  const active = ctx.getActive(slotId);
-  const registerSlot = useCallback(() => {
-    ctx.registerSlot(slotId);
-  }, [ctx, slotId]);
-  const unregisterSlot = useCallback(() => {
-    ctx.unregisterSlot(slotId);
-  }, [ctx, slotId]);
   return {
-    active,
-    registerSlot,
-    unregisterSlot,
+    active: ctx.getActive(slotId),
+    registerSlot: () => ctx.registerSlot(slotId),
+    unregisterSlot: () => ctx.unregisterSlot(slotId),
     dismiss: ctx.dismiss,
   };
 }

--- a/packages/ui-components/src/Callout/CalloutProvider.tsx
+++ b/packages/ui-components/src/Callout/CalloutProvider.tsx
@@ -1,0 +1,403 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { ReactNode } from 'react';
+import type {
+  ActiveCallout,
+  CalloutHandle,
+  CalloutPayload,
+} from './types.ts';
+import { VARIANT_CONFIG } from './variants.ts';
+
+const DEFAULT_SLOT_ID = 'default';
+const BUFFER_TIMEOUT_MS = 500;
+const PROGRESS_TO_SUCCESS_DISMISS_MS = 2000;
+
+interface BufferedEntry {
+  payload: ActiveCallout;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface CalloutSlotInternal {
+  active: ActiveCallout | null;
+  registerSlot: () => void;
+  unregisterSlot: () => void;
+  dismiss: (id: string) => void;
+}
+
+export const CalloutHandleContext = createContext<CalloutHandle | null>(null);
+
+interface SlotInternalContextValue {
+  getActive: (slotId: string) => ActiveCallout | null;
+  registerSlot: (slotId: string) => void;
+  unregisterSlot: (slotId: string) => void;
+  dismiss: (id: string) => void;
+  /**
+   * Monotonically increasing tick — slots subscribe to it (via context) so
+   * they re-render when the registry changes. Stored on the context value
+   * so the provider can bump it without changing the dispatcher identities.
+   */
+  tick: number;
+}
+
+const SlotInternalContext = createContext<SlotInternalContextValue | null>(
+  null,
+);
+
+export interface CalloutProviderProps {
+  children: ReactNode;
+}
+
+export function CalloutProvider({ children }: CalloutProviderProps) {
+  // Single tick to trigger re-renders when registry changes.
+  const [tick, setTick] = useState(0);
+  const bumpTick = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
+
+  // Per-slot active payload.
+  const slotsRef = useRef<Map<string, ActiveCallout | null>>(new Map());
+  // Currently mounted slot ids.
+  const mountedSlotsRef = useRef<Set<string>>(new Set());
+  // Payloads waiting for their target slot to mount.
+  const bufferedByTargetSlotRef = useRef<Map<string, BufferedEntry>>(new Map());
+  // Auto-dismiss timers, keyed by callout id.
+  const dismissTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+
+  const clearDismissTimer = useCallback((id: string) => {
+    const timer = dismissTimersRef.current.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      dismissTimersRef.current.delete(id);
+    }
+  }, []);
+
+  const resolveAutoDismissMs = useCallback(
+    (payload: CalloutPayload): number | null => {
+      if (payload.persistent === true) return null;
+      if (payload.autoDismissMs !== undefined) return payload.autoDismissMs;
+      return VARIANT_CONFIG[payload.variant].defaultAutoDismissMs;
+    },
+    [],
+  );
+
+  // Forward-declare dismiss so scheduleAutoDismiss can call it.
+  const dismissRef = useRef<(id: string) => void>(() => {});
+
+  const scheduleAutoDismiss = useCallback(
+    (payload: ActiveCallout) => {
+      clearDismissTimer(payload.id);
+      const ms = resolveAutoDismissMs(payload);
+      if (ms === null || ms <= 0) return;
+      const timer = setTimeout(() => {
+        dismissRef.current(payload.id);
+      }, ms);
+      dismissTimersRef.current.set(payload.id, timer);
+    },
+    [clearDismissTimer, resolveAutoDismissMs],
+  );
+
+  const placeInSlot = useCallback(
+    (slotId: string, active: ActiveCallout) => {
+      slotsRef.current.set(slotId, active);
+      scheduleAutoDismiss(active);
+    },
+    [scheduleAutoDismiss],
+  );
+
+  const clearBufferFor = useCallback((targetSlotId: string) => {
+    const existing = bufferedByTargetSlotRef.current.get(targetSlotId);
+    if (existing !== undefined) {
+      clearTimeout(existing.timer);
+      bufferedByTargetSlotRef.current.delete(targetSlotId);
+    }
+  }, []);
+
+  const findSlotForId = useCallback((id: string): string | null => {
+    for (const [slotId, active] of slotsRef.current.entries()) {
+      if (active && active.id === id) return slotId;
+    }
+    return null;
+  }, []);
+
+  const findBufferForId = useCallback((id: string): string | null => {
+    for (const [
+      targetSlotId,
+      entry,
+    ] of bufferedByTargetSlotRef.current.entries()) {
+      if (entry.payload.id === id) return targetSlotId;
+    }
+    return null;
+  }, []);
+
+  // ---------- Public dispatchers (stable via refs) ----------
+
+  const show = useCallback(
+    (payload: CalloutPayload): string => {
+      const id =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : `callout_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      const targetSlotId = payload.slot ?? DEFAULT_SLOT_ID;
+      const active: ActiveCallout = { ...payload, id, slot: targetSlotId };
+
+      if (mountedSlotsRef.current.has(targetSlotId)) {
+        clearBufferFor(targetSlotId);
+        placeInSlot(targetSlotId, active);
+        bumpTick();
+        return id;
+      }
+
+      // Buffer until the slot mounts (or fall back to default).
+      clearBufferFor(targetSlotId);
+      const timer = setTimeout(() => {
+        const entry = bufferedByTargetSlotRef.current.get(targetSlotId);
+        if (entry === undefined) return;
+        bufferedByTargetSlotRef.current.delete(targetSlotId);
+
+        if (mountedSlotsRef.current.has(targetSlotId)) {
+          placeInSlot(targetSlotId, entry.payload);
+          bumpTick();
+          return;
+        }
+        if (
+          targetSlotId !== DEFAULT_SLOT_ID &&
+          mountedSlotsRef.current.has(DEFAULT_SLOT_ID)
+        ) {
+          const fallback: ActiveCallout = {
+            ...entry.payload,
+            slot: DEFAULT_SLOT_ID,
+          };
+          placeInSlot(DEFAULT_SLOT_ID, fallback);
+          bumpTick();
+          return;
+        }
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            `[Callout] Dropped callout id=${entry.payload.id}: no slot "${targetSlotId}" or "${DEFAULT_SLOT_ID}" mounted within ${BUFFER_TIMEOUT_MS}ms`,
+          );
+        }
+      }, BUFFER_TIMEOUT_MS);
+
+      bufferedByTargetSlotRef.current.set(targetSlotId, {
+        payload: active,
+        timer,
+      });
+      return id;
+    },
+    [bumpTick, clearBufferFor, placeInSlot],
+  );
+
+  const update = useCallback(
+    (id: string, partial: Partial<CalloutPayload>): void => {
+      // Live in a slot?
+      const slotId = findSlotForId(id);
+      if (slotId !== null) {
+        const current = slotsRef.current.get(slotId);
+        if (!current) return;
+        const merged: ActiveCallout = { ...current, ...partial, id, slot: slotId };
+
+        const isProgressToSuccessMorph =
+          current.variant === 'progress' &&
+          merged.variant === 'success' &&
+          partial.autoDismissMs === undefined;
+
+        slotsRef.current.set(slotId, merged);
+
+        if (isProgressToSuccessMorph) {
+          clearDismissTimer(id);
+          const timer = setTimeout(() => {
+            dismissRef.current(id);
+          }, PROGRESS_TO_SUCCESS_DISMISS_MS);
+          dismissTimersRef.current.set(id, timer);
+        } else {
+          scheduleAutoDismiss(merged);
+        }
+        bumpTick();
+        return;
+      }
+
+      // Buffered?
+      const bufferTarget = findBufferForId(id);
+      if (bufferTarget !== null) {
+        const entry = bufferedByTargetSlotRef.current.get(bufferTarget);
+        if (entry === undefined) return;
+        const merged: ActiveCallout = {
+          ...entry.payload,
+          ...partial,
+          id,
+          // Don't let `slot` in partial change the buffer target mid-flight.
+          slot: entry.payload.slot,
+        };
+        entry.payload = merged;
+      }
+      // Otherwise: no-op (defensive — already dismissed).
+    },
+    [
+      bumpTick,
+      clearDismissTimer,
+      findBufferForId,
+      findSlotForId,
+      scheduleAutoDismiss,
+    ],
+  );
+
+  const dismiss = useCallback(
+    (id: string): void => {
+      let changed = false;
+      const slotId = findSlotForId(id);
+      if (slotId !== null) {
+        slotsRef.current.set(slotId, null);
+        clearDismissTimer(id);
+        changed = true;
+      }
+      const bufferTarget = findBufferForId(id);
+      if (bufferTarget !== null) {
+        const entry = bufferedByTargetSlotRef.current.get(bufferTarget);
+        if (entry !== undefined) {
+          clearTimeout(entry.timer);
+          bufferedByTargetSlotRef.current.delete(bufferTarget);
+          changed = true;
+        }
+      }
+      if (changed) bumpTick();
+    },
+    [bumpTick, clearDismissTimer, findBufferForId, findSlotForId],
+  );
+
+  // Keep dismissRef pointed at the latest dismiss closure.
+  useEffect(() => {
+    dismissRef.current = dismiss;
+  }, [dismiss]);
+
+  // ---------- Stable handle (refs so consumers don't re-render) ----------
+
+  const showRef = useRef(show);
+  const updateRef = useRef(update);
+  const dismissPublicRef = useRef(dismiss);
+  useEffect(() => {
+    showRef.current = show;
+  }, [show]);
+  useEffect(() => {
+    updateRef.current = update;
+  }, [update]);
+  useEffect(() => {
+    dismissPublicRef.current = dismiss;
+  }, [dismiss]);
+
+  const handle = useMemo<CalloutHandle>(
+    () => ({
+      show: (payload) => showRef.current(payload),
+      update: (id, partial) => updateRef.current(id, partial),
+      dismiss: (id) => dismissPublicRef.current(id),
+    }),
+    [],
+  );
+
+  // ---------- Slot registration (for CalloutSlot) ----------
+
+  const registerSlot = useCallback(
+    (slotId: string) => {
+      mountedSlotsRef.current.add(slotId);
+      if (!slotsRef.current.has(slotId)) {
+        slotsRef.current.set(slotId, null);
+      }
+      // If something is buffered for this slot, deliver immediately.
+      const buffered = bufferedByTargetSlotRef.current.get(slotId);
+      if (buffered !== undefined) {
+        clearTimeout(buffered.timer);
+        bufferedByTargetSlotRef.current.delete(slotId);
+        placeInSlot(slotId, buffered.payload);
+      }
+      bumpTick();
+    },
+    [bumpTick, placeInSlot],
+  );
+
+  const unregisterSlot = useCallback(
+    (slotId: string) => {
+      mountedSlotsRef.current.delete(slotId);
+      const active = slotsRef.current.get(slotId);
+      if (active) {
+        clearDismissTimer(active.id);
+      }
+      slotsRef.current.delete(slotId);
+      bumpTick();
+    },
+    [bumpTick, clearDismissTimer],
+  );
+
+  const getActive = useCallback(
+    (slotId: string): ActiveCallout | null =>
+      slotsRef.current.get(slotId) ?? null,
+    [],
+  );
+
+  const slotInternalValue = useMemo<SlotInternalContextValue>(
+    () => ({
+      getActive,
+      registerSlot,
+      unregisterSlot,
+      dismiss,
+      tick,
+    }),
+    [getActive, registerSlot, unregisterSlot, dismiss, tick],
+  );
+
+  // Clean up all timers on full provider unmount.
+  useEffect(() => {
+    const dismissTimers = dismissTimersRef.current;
+    const bufferEntries = bufferedByTargetSlotRef.current;
+    return () => {
+      for (const timer of dismissTimers.values()) clearTimeout(timer);
+      dismissTimers.clear();
+      for (const entry of bufferEntries.values()) clearTimeout(entry.timer);
+      bufferEntries.clear();
+    };
+  }, []);
+
+  return (
+    <CalloutHandleContext.Provider value={handle}>
+      <SlotInternalContext.Provider value={slotInternalValue}>
+        {children}
+      </SlotInternalContext.Provider>
+    </CalloutHandleContext.Provider>
+  );
+}
+
+/**
+ * Internal hook for `CalloutSlot` (Task 4) to register itself, read its
+ * active payload, and dismiss callouts. Not for app code — app code uses
+ * `useCallout()` from Task 5.
+ */
+export function useCalloutSlotInternal(slotId: string): CalloutSlotInternal {
+  const ctx = useContext(SlotInternalContext);
+  if (ctx === null) {
+    throw new Error(
+      'useCalloutSlotInternal must be used inside a <CalloutProvider>',
+    );
+  }
+  // Subscribing to ctx (which carries `tick`) ensures the slot re-renders
+  // whenever the registry changes.
+  const active = ctx.getActive(slotId);
+  const registerSlot = useCallback(() => {
+    ctx.registerSlot(slotId);
+  }, [ctx, slotId]);
+  const unregisterSlot = useCallback(() => {
+    ctx.unregisterSlot(slotId);
+  }, [ctx, slotId]);
+  return {
+    active,
+    registerSlot,
+    unregisterSlot,
+    dismiss: ctx.dismiss,
+  };
+}

--- a/packages/ui-components/src/Callout/CalloutSlot.tsx
+++ b/packages/ui-components/src/Callout/CalloutSlot.tsx
@@ -27,9 +27,26 @@ export function CalloutSlot({
   }, []);
 
   const initial = reducedMotion
-    ? { opacity: 0, y: 0 }
-    : { opacity: 0, y: -8 };
-  const exit = reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -4 };
+    ? { opacity: 0, y: 0, scale: 1 }
+    : { opacity: 0, y: -24, scale: 0.96 };
+  const animate = { opacity: 1, y: 0, scale: 1 };
+  const exit = reducedMotion
+    ? { opacity: 0, y: 0, scale: 1 }
+    : { opacity: 0, y: -16, scale: 0.98 };
+
+  const enterTransition = reducedMotion
+    ? { duration: 0.15, ease: 'easeOut' as const }
+    : {
+        type: 'spring' as const,
+        stiffness: 380,
+        damping: 30,
+        mass: 0.8,
+        opacity: { duration: 0.18, ease: 'easeOut' as const },
+      };
+  const exitTransition = {
+    duration: 0.2,
+    ease: [0.4, 0, 1, 1] as [number, number, number, number],
+  };
 
   const baseClass =
     'pointer-events-none fixed top-4 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4';
@@ -37,14 +54,15 @@ export function CalloutSlot({
 
   return (
     <div className={wrapperClass}>
-      <AnimatePresence>
+      <AnimatePresence mode="popLayout">
         {active ? (
           <motion.div
             key={active.id}
             initial={initial}
-            animate={{ opacity: 1, y: 0 }}
-            exit={exit}
-            transition={{ duration: 0.18, ease: 'easeOut' }}
+            animate={animate}
+            exit={{ ...exit, transition: exitTransition }}
+            transition={enterTransition}
+            style={{ transformOrigin: 'top center', willChange: 'transform, opacity' }}
             className="pointer-events-auto"
           >
             <CalloutCard

--- a/packages/ui-components/src/Callout/CalloutSlot.tsx
+++ b/packages/ui-components/src/Callout/CalloutSlot.tsx
@@ -31,7 +31,9 @@ export function CalloutSlot({
     : { opacity: 0, y: -8 };
   const exit = reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -4 };
 
-  const wrapperClass = className ? `w-full ${className}` : 'w-full';
+  const baseClass =
+    'pointer-events-none fixed top-4 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4';
+  const wrapperClass = className ? `${baseClass} ${className}` : baseClass;
 
   return (
     <div className={wrapperClass}>
@@ -43,6 +45,7 @@ export function CalloutSlot({
             animate={{ opacity: 1, y: 0 }}
             exit={exit}
             transition={{ duration: 0.18, ease: 'easeOut' }}
+            className="pointer-events-auto"
           >
             <CalloutCard
               payload={active}

--- a/packages/ui-components/src/Callout/CalloutSlot.tsx
+++ b/packages/ui-components/src/Callout/CalloutSlot.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { CalloutCard } from './CalloutCard.tsx';
+import { useCalloutSlotInternal } from './CalloutProvider.tsx';
+
+const DEFAULT_SLOT_ID = 'default';
+
+export interface CalloutSlotProps {
+  id?: string;
+  className?: string;
+}
+
+function cn(...parts: Array<string | undefined | false | null>): string {
+  return parts.filter(Boolean).join(' ');
+}
+
+export function CalloutSlot({
+  id = DEFAULT_SLOT_ID,
+  className,
+}: CalloutSlotProps) {
+  const { active, registerSlot, unregisterSlot, dismiss } =
+    useCalloutSlotInternal(id);
+  const reducedMotion = useReducedMotion();
+
+  // Latest dispatcher refs so the mount/unmount effect can stay [] without
+  // capturing stale closures (registerSlot/unregisterSlot identities change
+  // on every provider tick).
+  const registerRef = useRef(registerSlot);
+  const unregisterRef = useRef(unregisterSlot);
+  useEffect(() => {
+    registerRef.current = registerSlot;
+    unregisterRef.current = unregisterSlot;
+  }, [registerSlot, unregisterSlot]);
+
+  // Register exactly once on mount, unregister exactly once on unmount.
+  useEffect(() => {
+    registerRef.current();
+    return () => {
+      unregisterRef.current();
+    };
+  }, []);
+
+  const initial = reducedMotion
+    ? { opacity: 0, y: 0 }
+    : { opacity: 0, y: -8 };
+  const exit = reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -4 };
+
+  return (
+    <div className={cn('w-full', className)}>
+      <AnimatePresence mode="wait">
+        {active ? (
+          <motion.div
+            key={active.id}
+            initial={initial}
+            animate={{ opacity: 1, y: 0 }}
+            exit={exit}
+            transition={{ duration: 0.18, ease: 'easeOut' }}
+          >
+            <CalloutCard
+              payload={active}
+              onDismiss={() => dismiss(active.id)}
+            />
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/packages/ui-components/src/Callout/CalloutSlot.tsx
+++ b/packages/ui-components/src/Callout/CalloutSlot.tsx
@@ -1,43 +1,29 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { CalloutCard } from './CalloutCard.tsx';
-import { useCalloutSlotInternal } from './CalloutProvider.tsx';
-
-const DEFAULT_SLOT_ID = 'default';
+import {
+  DEFAULT_CALLOUT_SLOT_ID,
+  useCalloutSlotInternal,
+} from './CalloutProvider.tsx';
 
 export interface CalloutSlotProps {
   id?: string;
   className?: string;
 }
 
-function cn(...parts: Array<string | undefined | false | null>): string {
-  return parts.filter(Boolean).join(' ');
-}
-
 export function CalloutSlot({
-  id = DEFAULT_SLOT_ID,
+  id = DEFAULT_CALLOUT_SLOT_ID,
   className,
 }: CalloutSlotProps) {
   const { active, registerSlot, unregisterSlot, dismiss } =
     useCalloutSlotInternal(id);
   const reducedMotion = useReducedMotion();
 
-  // Latest dispatcher refs so the mount/unmount effect can stay [] without
-  // capturing stale closures (registerSlot/unregisterSlot identities change
-  // on every provider tick).
-  const registerRef = useRef(registerSlot);
-  const unregisterRef = useRef(unregisterSlot);
   useEffect(() => {
-    registerRef.current = registerSlot;
-    unregisterRef.current = unregisterSlot;
-  }, [registerSlot, unregisterSlot]);
-
-  // Register exactly once on mount, unregister exactly once on unmount.
-  useEffect(() => {
-    registerRef.current();
-    return () => {
-      unregisterRef.current();
-    };
+    registerSlot();
+    return unregisterSlot;
+    // registerSlot/unregisterSlot read the latest provider context internally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const initial = reducedMotion
@@ -45,9 +31,11 @@ export function CalloutSlot({
     : { opacity: 0, y: -8 };
   const exit = reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -4 };
 
+  const wrapperClass = className ? `w-full ${className}` : 'w-full';
+
   return (
-    <div className={cn('w-full', className)}>
-      <AnimatePresence mode="wait">
+    <div className={wrapperClass}>
+      <AnimatePresence>
         {active ? (
           <motion.div
             key={active.id}

--- a/packages/ui-components/src/Callout/index.ts
+++ b/packages/ui-components/src/Callout/index.ts
@@ -1,0 +1,7 @@
+export type {
+  CalloutVariant,
+  CalloutAction,
+  CalloutPayload,
+  CalloutHandle,
+  ActiveCallout,
+} from './types.ts';

--- a/packages/ui-components/src/Callout/index.ts
+++ b/packages/ui-components/src/Callout/index.ts
@@ -1,3 +1,7 @@
+export { CalloutProvider } from './CalloutProvider.tsx';
+export { CalloutSlot } from './CalloutSlot.tsx';
+export { useCallout } from './useCallout.ts';
+
 export type {
   CalloutVariant,
   CalloutAction,

--- a/packages/ui-components/src/Callout/types.ts
+++ b/packages/ui-components/src/Callout/types.ts
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+export type CalloutVariant = 'success' | 'error' | 'info' | 'progress';
+
+export interface CalloutAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface CalloutPayload {
+  variant: CalloutVariant;
+  title: string;
+  message?: string;
+  slot?: string;
+  progress?: number;
+  icon?: ReactNode;
+  action?: CalloutAction;
+  persistent?: boolean;
+  autoDismissMs?: number | null;
+}
+
+export interface CalloutHandle {
+  show: (payload: CalloutPayload) => string;
+  update: (id: string, payload: Partial<CalloutPayload>) => void;
+  dismiss: (id: string) => void;
+}
+
+export interface ActiveCallout extends CalloutPayload {
+  id: string;
+  slot: string;
+}

--- a/packages/ui-components/src/Callout/useCallout.ts
+++ b/packages/ui-components/src/Callout/useCallout.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { CalloutHandleContext } from './CalloutProvider.tsx';
+import type { CalloutHandle } from './types.ts';
+
+export function useCallout(): CalloutHandle {
+  const handle = useContext(CalloutHandleContext);
+  if (handle === null) {
+    throw new Error(
+      'useCallout must be used inside a <CalloutProvider>. ' +
+        'Wrap your app root with <CalloutProvider> from @classmoji/ui-components.',
+    );
+  }
+  return handle;
+}

--- a/packages/ui-components/src/Callout/variants.ts
+++ b/packages/ui-components/src/Callout/variants.ts
@@ -1,0 +1,30 @@
+import type { CalloutVariant } from './types.ts';
+
+export interface VariantConfig {
+  defaultAutoDismissMs: number | null;
+  accentClassName: string;
+  iconColorClassName: string;
+}
+
+export const VARIANT_CONFIG: Record<CalloutVariant, VariantConfig> = {
+  success: {
+    defaultAutoDismissMs: 4000,
+    accentClassName: 'bg-emerald-500',
+    iconColorClassName: 'text-emerald-600 dark:text-emerald-400',
+  },
+  error: {
+    defaultAutoDismissMs: null,
+    accentClassName: 'bg-rose-500',
+    iconColorClassName: 'text-rose-600 dark:text-rose-400',
+  },
+  info: {
+    defaultAutoDismissMs: null,
+    accentClassName: 'bg-sky-500',
+    iconColorClassName: 'text-sky-600 dark:text-sky-400',
+  },
+  progress: {
+    defaultAutoDismissMs: null,
+    accentClassName: 'bg-violet-500',
+    iconColorClassName: 'text-violet-600 dark:text-violet-400',
+  },
+};

--- a/packages/ui-components/src/Callout/variants.tsx
+++ b/packages/ui-components/src/Callout/variants.tsx
@@ -1,9 +1,17 @@
+import type { ReactNode } from 'react';
+import {
+  IconArrowRotate,
+  IconBell,
+  IconCheck,
+  IconX,
+} from '../icons/index.tsx';
 import type { CalloutVariant } from './types.ts';
 
 export interface VariantConfig {
   defaultAutoDismissMs: number | null;
   accentClassName: string;
   iconColorClassName: string;
+  defaultIcon: ReactNode;
 }
 
 export const VARIANT_CONFIG: Record<CalloutVariant, VariantConfig> = {
@@ -11,20 +19,30 @@ export const VARIANT_CONFIG: Record<CalloutVariant, VariantConfig> = {
     defaultAutoDismissMs: 4000,
     accentClassName: 'bg-emerald-500',
     iconColorClassName: 'text-emerald-600 dark:text-emerald-400',
+    defaultIcon: <IconCheck size={18} />,
   },
   error: {
     defaultAutoDismissMs: null,
     accentClassName: 'bg-rose-500',
     iconColorClassName: 'text-rose-600 dark:text-rose-400',
+    defaultIcon: <IconX size={18} />,
   },
   info: {
     defaultAutoDismissMs: null,
     accentClassName: 'bg-sky-500',
     iconColorClassName: 'text-sky-600 dark:text-sky-400',
+    defaultIcon: <IconBell size={18} />,
   },
   progress: {
     defaultAutoDismissMs: null,
     accentClassName: 'bg-violet-500',
     iconColorClassName: 'text-violet-600 dark:text-violet-400',
+    defaultIcon: (
+      <IconArrowRotate
+        size={18}
+        className="animate-spin"
+        style={{ animationDuration: '1.6s' }}
+      />
+    ),
   },
 };

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -46,6 +46,16 @@ export type { EmojiScaleProps, EmojiGrade } from './EmojiScale/index.ts';
 export { IconButton } from './IconButton/index.ts';
 export type { IconButtonProps } from './IconButton/index.ts';
 
+// Callout system
+export { CalloutProvider, CalloutSlot, useCallout } from './Callout/index.ts';
+export type {
+  CalloutVariant,
+  CalloutAction,
+  CalloutPayload,
+  CalloutHandle,
+  ActiveCallout,
+} from './Callout/index.ts';
+
 // Icon library
 export {
   Icon,


### PR DESCRIPTION
## Summary
- Replaces `react-toastify` with a new in-house **Callout** system: `CalloutProvider` + `CalloutSlot` + `useCallout`, plus a default slot mounted in `CommonLayout` and `useNotifiedFetcher` driven through it
- Migrates all admin / assistant / student / settings / classroom routes from toasts to Callout
- Removes `react-toastify` and lands a few follow-up refactors (icon config, no-op update guard, dropped legacy `_position` arg)
- UX polish: floats the callout as a fixed top-center overlay (no more page-content shift) and smooths the enter/exit motion with a soft spring + scale

## Test plan
- [ ] Trigger a fetcher action that produces a success/error callout — confirm it appears at top-center and does not shift page content
- [ ] Trigger a long-running progress callout — confirm enter is smooth (spring), exit is a quick fade, and content beneath does not jump
- [ ] Verify `prefers-reduced-motion` yields a plain fade
- [ ] Sweep admin, assistant, student, and settings routes for any remaining `react-toastify` imports / leftover toast UI
- [ ] Run `npm run web:test`