### PR TITLE
Remove terms concept; add content_namespace, pin/archive landing

### DIFF
--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -93,19 +93,9 @@ export const loader = async ({
     login?: string;
     avatar_url?: string;
   } | null;
-  const term = page.classroom.term;
-  const year = page.classroom.year;
-
-  // Generate term string (format: 25w for Winter 2025)
-  const generateTermString = (term: string | null, year: number | null): string | null => {
-    if (!term || !year) return null;
-    const termMap: Record<string, string> = { Winter: 'w', Spring: 's', Summer: 'u', Fall: 'f' };
-    const yearShort = String(year).slice(-2);
-    return `${yearShort}${termMap[term] || term.charAt(0).toLowerCase()}`;
-  };
-
-  const termString = generateTermString(term, year);
-  const repoName = termString ? `content-${gitOrg?.login}-${termString}` : null;
+  const contentNamespace = page.classroom.content_namespace;
+  const repoName =
+    contentNamespace && gitOrg?.login ? `content-${gitOrg.login}-${contentNamespace}` : null;
 
   return {
     page: {

--- a/apps/pages/app/routes/_index/route.tsx
+++ b/apps/pages/app/routes/_index/route.tsx
@@ -1,6 +1,5 @@
 import { useLoaderData } from 'react-router';
 import { ClassmojiService, getAuthSession } from '~/utils/db.server.ts';
-import { generateTermString } from '@classmoji/utils';
 
 /**
  * Root index route.
@@ -25,8 +24,7 @@ export const loader = async ({ request }: { request: Request }) => {
     classrooms: sortedMemberships.map(m => ({
       slug: m.classroom.slug,
       name: m.classroom.name,
-      term: m.classroom.term,
-      year: m.classroom.year,
+      content_namespace: m.classroom.content_namespace,
       role: m.role,
     })),
   };
@@ -46,13 +44,7 @@ const Index = () => {
         {classrooms.length > 0 ? (
           <div className="space-y-2">
             {classrooms.map(
-              (c: {
-                slug: string;
-                name: string;
-                term: string | null;
-                year: number | null;
-                role: string;
-              }) => (
+              (c: { slug: string; name: string; content_namespace: string; role: string }) => (
                 <a
                   key={c.slug}
                   href={`/${c.slug}`}
@@ -61,7 +53,7 @@ const Index = () => {
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <span className="px-2 py-0.5 text-xs bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded uppercase">
-                        {generateTermString(c.term ?? undefined, c.year ?? undefined)}
+                        {c.content_namespace}
                       </span>
                       <span className="font-medium text-gray-900 dark:text-white">{c.name}</span>
                     </div>

--- a/apps/pages/app/types/pages.ts
+++ b/apps/pages/app/types/pages.ts
@@ -41,8 +41,7 @@ export interface PageForContent {
     id: string;
     slug: string;
     name: string;
-    term: string | null;
-    year: number | null;
+    content_namespace: string;
     avatar_url?: string | null;
     git_organization?: {
       login: string;
@@ -69,8 +68,7 @@ export interface PagesUser {
 export interface ClassroomListItem {
   slug: string;
   name: string;
-  term: string | null;
-  year: number | null;
+  content_namespace: string;
   role: string;
 }
 

--- a/apps/pages/app/utils/content.server.ts
+++ b/apps/pages/app/utils/content.server.ts
@@ -1,5 +1,4 @@
 import { ContentService } from '@classmoji/content';
-import { generateTermString } from '@classmoji/utils';
 import type { PageForContent } from '~/types/pages.ts';
 
 interface CoverImage {
@@ -18,11 +17,7 @@ interface PageContentResult {
  */
 function getRepoName(page: PageForContent): string {
   const gitOrg = page.classroom.git_organization!;
-  const term = generateTermString(
-    page.classroom.term ?? undefined,
-    page.classroom.year ?? undefined
-  );
-  return `content-${gitOrg.login}-${term}`;
+  return `content-${gitOrg.login}-${page.classroom.content_namespace}`;
 }
 
 /**

--- a/apps/slides/app/routes/$classroomSlug.$slideId.delete/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.$slideId.delete/route.tsx
@@ -47,7 +47,9 @@ export const loader = async ({
 
   // Build the GitHub paths that will be deleted
   const gitOrgLogin = slideInfo.slide.classroom?.git_organization?.login;
-  const repoName = gitOrgLogin ? `content-${gitOrgLogin}-${slideInfo.slide.term}` : null;
+  const contentNamespace = slideInfo.slide.classroom?.content_namespace;
+  const repoName =
+    gitOrgLogin && contentNamespace ? `content-${gitOrgLogin}-${contentNamespace}` : null;
   const contentPath = slideInfo.slide.content_path;
 
   return {
@@ -56,7 +58,6 @@ export const loader = async ({
     slide: {
       id: slideInfo.slide.id,
       title: slideInfo.slide.title,
-      term: slideInfo.slide.term,
       contentPath,
     },
     github: repoName

--- a/apps/slides/app/routes/$classroomSlug.new/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.new/route.tsx
@@ -30,7 +30,7 @@ export const loader = async ({
   });
 
   // Get classroom with git_organization
-  const classroom = await getPrisma().classroom.findUnique({
+  const classroom = await getPrisma().classroom.findFirst({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });
@@ -83,7 +83,7 @@ export const action = async ({
   });
 
   // Get classroom with git_organization for GitHub API calls
-  const classroom = await getPrisma().classroom.findUnique({
+  const classroom = await getPrisma().classroom.findFirst({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });

--- a/apps/slides/app/routes/$classroomSlug.new/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.new/route.tsx
@@ -159,10 +159,6 @@ export const action = async ({
       data: {
         title,
         slug,
-        // Slide.term column is dropped in a later migration; populate with
-        // the classroom's content_namespace until then so the NOT NULL
-        // constraint is satisfied.
-        term: contentNamespace,
         content_path: contentPath,
         classroom_id: classroom.id,
         created_by: userId,

--- a/apps/slides/app/routes/$classroomSlug.new/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.new/route.tsx
@@ -12,7 +12,6 @@ import { getGitProvider, ClassmojiService } from '@classmoji/services';
 import { ContentService } from '@classmoji/content';
 import { requireClassroomTeachingTeam } from '@classmoji/auth/server';
 import { useUser } from '~/root';
-import { generateTermString } from '@classmoji/utils';
 import { generateSlideTemplate } from '~/utils/slideHelpers.server';
 
 export const loader = async ({
@@ -46,15 +45,14 @@ export const loader = async ({
     throw new Response('Git organization not configured for this classroom', { status: 400 });
   }
 
-  // Generate term string from classroom settings
-  const term = generateTermString(classroom.term ?? undefined, classroom.year ?? undefined);
-  if (!term) {
-    throw new Response('Classroom term/year not configured', { status: 400 });
+  const contentNamespace = classroom.content_namespace;
+  if (!contentNamespace) {
+    throw new Response('Classroom content namespace not configured', { status: 400 });
   }
 
   return {
     classroomSlug,
-    term,
+    contentNamespace,
     gitOrgLogin,
     classroom,
     webappUrl: process.env.WEBAPP_URL || 'http://localhost:3000',
@@ -73,7 +71,6 @@ export const action = async ({
   const formData = await request.formData();
 
   const title = (formData.get('title') as string | null)?.trim();
-  const term = formData.get('term') as string;
 
   // Validate required fields
   if (!title) {
@@ -100,14 +97,19 @@ export const action = async ({
     return { error: 'Git organization not configured for this classroom' };
   }
 
+  const contentNamespace = classroom.content_namespace;
+  if (!contentNamespace) {
+    return { error: 'Classroom content namespace not configured' };
+  }
+
   // Generate slug from title
   const slug = title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 
-  // Content repo name: content-{gitOrgLogin}-{term}
-  const repoName = `content-${gitOrgLogin}-${term}`;
+  // Content repo name: content-{gitOrgLogin}-{contentNamespace}
+  const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
 
   // Flat content path: slides/{slug}
   const contentPath = `slides/${slug}`;
@@ -121,7 +123,7 @@ export const action = async ({
       await gitProvider.createPublicRepository(
         gitOrgLogin,
         repoName,
-        `Course content for ${classroom.name || gitOrgLogin} - ${term}`
+        `Course content for ${classroom.name || gitOrgLogin} - ${contentNamespace}`
       );
 
       // Give GitHub a moment to initialize the repo
@@ -157,7 +159,10 @@ export const action = async ({
       data: {
         title,
         slug,
-        term,
+        // Slide.term column is dropped in a later migration; populate with
+        // the classroom's content_namespace until then so the NOT NULL
+        // constraint is satisfied.
+        term: contentNamespace,
         content_path: contentPath,
         classroom_id: classroom.id,
         created_by: userId,
@@ -177,7 +182,7 @@ export const action = async ({
 };
 
 export default function CreateSlidePage() {
-  const { classroomSlug, term, classroom, webappUrl } = useLoaderData<typeof loader>();
+  const { classroomSlug, contentNamespace, classroom, webappUrl } = useLoaderData<typeof loader>();
   const userContext = useUser();
   const user = userContext?.user;
   const navigation = useNavigation();
@@ -196,16 +201,7 @@ export default function CreateSlidePage() {
     membership?.role === 'TEACHER' ||
     membership?.role === 'ASSISTANT';
 
-  // Format term for display (e.g., "25w" -> "Winter 2025")
-  const termDisplayMap: Record<string, string> = {
-    w: 'Winter',
-    s: 'Spring',
-    u: 'Summer',
-    f: 'Fall',
-  };
-  const termYear = term ? `20${term.slice(0, 2)}` : '';
-  const termSeason = term ? termDisplayMap[term.slice(2)] : '';
-  const termDisplay = term ? `${termSeason} ${termYear}` : '';
+  const namespaceDisplay = contentNamespace ?? '';
 
   if (!canCreate) {
     return (
@@ -250,9 +246,6 @@ export default function CreateSlidePage() {
         {/* Create Form */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xs border border-gray-200 dark:border-gray-700 p-6">
           <Form method="post">
-            {/* Hidden field for term */}
-            <input type="hidden" name="term" value={term} />
-
             {/* Error message */}
             {error && (
               <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md">
@@ -274,19 +267,19 @@ export default function CreateSlidePage() {
               />
             </div>
 
-            {/* Term (read-only) */}
+            {/* Content namespace (read-only) */}
             <div className="mb-6">
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Term
+                Content namespace
               </label>
               <input
                 type="text"
-                value={termDisplay}
+                value={namespaceDisplay}
                 disabled
                 className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 cursor-not-allowed"
               />
               <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
-                Term is determined by your classroom settings
+                Determined by your classroom settings
               </p>
             </div>
 

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -77,7 +77,7 @@ export const loader = async ({
   }
 
   // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.term}`;
+  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const filePath = `${slide.content_path}/index.html`;
 
   // Build the content URL using content proxy (CDN-first + API fallback)
@@ -244,7 +244,7 @@ export const action = async ({
 
   // Used for content URLs and fallback orgLogin param
   const gitOrgLogin = gitOrganization.login;
-  const repo = `content-${gitOrgLogin}-${slide.term}`;
+  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const filePath = `${slide.content_path}/index.html`;
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -61,7 +61,7 @@ export const loader = async ({
   }
 
   // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.term}`;
+  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const filePath = `${slide.content_path}/index.html`;
 
   // Build the content URL using content proxy (CDN-first + API fallback)

--- a/apps/slides/app/routes/$slideId_.present/route.tsx
+++ b/apps/slides/app/routes/$slideId_.present/route.tsx
@@ -46,7 +46,7 @@ export const loader = async ({
   }
 
   // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.term}`;
+  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const filePath = `${slide.content_path}/index.html`;
 
   // Build the content URL using content proxy (CDN-first + API fallback)

--- a/apps/slides/app/routes/$slideId_.speaker/route.tsx
+++ b/apps/slides/app/routes/$slideId_.speaker/route.tsx
@@ -53,7 +53,7 @@ export const loader = async ({
   }
 
   // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.term}`;
+  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const filePath = `${slide.content_path}/index.html`;
 
   // Fetch content using shared utility (CDN first, API fallback)

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -61,6 +61,7 @@ export const loader = async ({ request }: { request: Request }) => {
         select: {
           slug: true,
           name: true,
+          content_namespace: true,
         },
       },
       links: {
@@ -417,7 +418,7 @@ export default function SlidesIndex() {
                       {slide.links?.[0]?.module?.title || '—'}
                     </p>
                     <div className="mt-2 text-xs text-gray-400 dark:text-gray-500">
-                      {slide.term}
+                      {slide.classroom?.content_namespace}
                     </div>
                   </Link>
                 </div>

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -241,9 +241,6 @@ export const action = async ({ request }: { request: Request }) => {
         data: {
           title: `${slide.title} (Copy)`,
           slug: newSlug,
-          // Slide.term column is dropped in a later migration; populate
-          // with the classroom's content_namespace until then.
-          term: slide.classroom?.content_namespace ?? '',
           content_path: newContentPath,
           classroom_id: slide.classroom_id,
           created_by: authData?.userId || slide.created_by,

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -197,7 +197,7 @@ export const action = async ({ request }: { request: Request }) => {
         return { error: 'Git organization not configured for this classroom' };
       }
 
-      const repo = `content-${gitOrganization.login}-${slide.term}`;
+      const repo = `content-${gitOrganization.login}-${slide.classroom?.content_namespace}`;
       const newSlug = `${slide.slug}-copy-${Date.now()}`;
       const newContentPath = `slides/${newSlug}`;
 
@@ -240,7 +240,9 @@ export const action = async ({ request }: { request: Request }) => {
         data: {
           title: `${slide.title} (Copy)`,
           slug: newSlug,
-          term: slide.term,
+          // Slide.term column is dropped in a later migration; populate
+          // with the classroom's content_namespace until then.
+          term: slide.classroom?.content_namespace ?? '',
           content_path: newContentPath,
           classroom_id: slide.classroom_id,
           created_by: authData?.userId || slide.created_by,

--- a/apps/slides/app/routes/api.slides.import.start/route.ts
+++ b/apps/slides/app/routes/api.slides.import.start/route.ts
@@ -16,7 +16,6 @@
 import { randomUUID } from 'crypto';
 import getPrisma from '@classmoji/database';
 import { requireClassroomStaff } from '@classmoji/auth/server';
-import { generateTermString } from '@classmoji/utils';
 import { processZipImport } from '~/utils/slidesComImporter.server';
 import { importStreamManager } from '~/utils/importStreamManager';
 
@@ -98,7 +97,13 @@ export const action = async ({ request }: { request: Request }) => {
     );
   }
 
-  const term = generateTermString(classroom.term ?? undefined, classroom.year ?? undefined);
+  const contentNamespace = classroom.content_namespace;
+  if (!contentNamespace) {
+    return Response.json(
+      { error: 'Classroom content namespace not configured' },
+      { status: 400 }
+    );
+  }
 
   // Generate unique import ID for SSE routing
   // This is returned immediately while the actual slideId is created during import
@@ -128,7 +133,7 @@ export const action = async ({ request }: { request: Request }) => {
     org: gitOrgLogin,
     classroomSlug,
     classroomId: classroom.id,
-    term: term!,
+    contentNamespace,
     userId,
     cloudinaryVideoPaths,
     onProgress,

--- a/apps/slides/app/routes/api.slides.import.start/route.ts
+++ b/apps/slides/app/routes/api.slides.import.start/route.ts
@@ -80,7 +80,7 @@ export const action = async ({ request }: { request: Request }) => {
   }
 
   // Get classroom with git_organization
-  const classroom = await getPrisma().classroom.findUnique({
+  const classroom = await getPrisma().classroom.findFirst({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });

--- a/apps/slides/app/routes/content.$org.$repo.$/route.tsx
+++ b/apps/slides/app/routes/content.$org.$repo.$/route.tsx
@@ -32,8 +32,7 @@ import getPrisma from '@classmoji/database';
 
 interface ContentRouteMembership {
   classroom?: {
-    term?: string | null;
-    year?: number | null;
+    content_namespace?: string | null;
     git_organization?: {
       login: string;
       settings?: Record<string, string> | null;
@@ -116,8 +115,7 @@ export const loader = async ({
       // Get the expected content repo name for this classroom
       const expectedRepo = getContentRepoName({
         login: gitOrg.login,
-        term: m.classroom?.term ?? undefined,
-        year: m.classroom?.year ?? undefined,
+        content_namespace: m.classroom?.content_namespace ?? undefined,
         settings: gitOrg.settings as Record<string, string> | undefined,
       });
 
@@ -143,8 +141,7 @@ export const loader = async ({
         // Validate the requested repo matches the slide's content repo
         const expectedRepo = getContentRepoName({
           login: gitOrg.login,
-          term: slide.classroom.term ?? undefined,
-          year: slide.classroom.year ?? undefined,
+          content_namespace: slide.classroom.content_namespace,
         });
 
         if (repo === expectedRepo) {

--- a/apps/slides/app/routes/import/route.tsx
+++ b/apps/slides/app/routes/import/route.tsx
@@ -11,7 +11,7 @@ import { useLoaderData, useNavigate } from 'react-router';
 import { useDropzone, type FileRejection } from 'react-dropzone';
 import getPrisma from '@classmoji/database';
 import { ClassmojiService } from '@classmoji/services';
-import { generateTermString, getContentRepoName } from '@classmoji/utils';
+import { getContentRepoName } from '@classmoji/utils';
 import { requireClassroomStaff } from '@classmoji/auth/server';
 import { useUser } from '~/root';
 import { listSavedThemes } from '~/utils/themeService.server';
@@ -20,7 +20,7 @@ import VideoSelectionModal from '~/components/VideoSelectionModal';
 import ImportProgressModal from '~/components/ImportProgressModal';
 import { useImportStream } from '~/hooks/useImportStream';
 
-// Note: prisma, ClassmojiService, generateTermString, getContentRepoName are used in the loader
+// Note: prisma, ClassmojiService, getContentRepoName are used in the loader
 
 // Max file size for ZIP uploads (in bytes)
 const MAX_FILE_SIZE = 150 * 1024 * 1024; // 150MB
@@ -57,23 +57,19 @@ export const loader = async ({ request }: { request: Request }) => {
     throw new Response('Git organization not configured for this classroom', { status: 400 });
   }
 
-  // Derive term string from classroom data
-  const term = generateTermString(classroom.term ?? undefined, classroom.year ?? undefined);
-
   // Get modules for dropdown
   const modules = await ClassmojiService.module.findByClassroomSlug(classroomSlug);
 
   // Get content repo name using utility (same as slidesComImporter)
   const repoName = getContentRepoName({
     login: gitOrgLogin,
-    term: classroom.term ?? undefined,
-    year: classroom.year ?? undefined,
+    content_namespace: classroom.content_namespace ?? undefined,
   });
   const savedThemes = await listSavedThemes(gitOrgLogin, repoName);
 
   return {
     classroomSlug,
-    term,
+    contentNamespace: classroom.content_namespace,
     gitOrgLogin,
     classroom,
     modules: modules.map(m => ({ id: m.id, title: m.title })),

--- a/apps/slides/app/routes/import/route.tsx
+++ b/apps/slides/app/routes/import/route.tsx
@@ -42,7 +42,7 @@ export const loader = async ({ request }: { request: Request }) => {
   });
 
   // Get classroom with git_organization
-  const classroom = await getPrisma().classroom.findUnique({
+  const classroom = await getPrisma().classroom.findFirst({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });

--- a/apps/slides/app/utils/slideService.server.ts
+++ b/apps/slides/app/utils/slideService.server.ts
@@ -24,11 +24,15 @@ function getSharedThemeFromHtml(htmlContent: string): string | null {
 /**
  * Count how many slides are using a specific shared theme
  * @param {string} gitOrgLogin - Git organization login
- * @param {string} term - Term string (e.g., "25w")
+ * @param {string} contentNamespace - Content namespace (e.g., "25w" or a slug)
  * @param {string} themeName - Theme name to check
  * @returns {Promise<{count: number, slides: Array<{id: string, title: string}>}>}
  */
-export async function countSlidesUsingTheme(gitOrgLogin: string, term: string, themeName: string) {
+export async function countSlidesUsingTheme(
+  gitOrgLogin: string,
+  contentNamespace: string,
+  themeName: string
+) {
   // Get git organization for installation ID
   const gitOrg = await getPrisma().gitOrganization.findFirst({
     where: { provider: 'GITHUB', login: gitOrgLogin },
@@ -38,9 +42,9 @@ export async function countSlidesUsingTheme(gitOrgLogin: string, term: string, t
     return { count: 0, slides: [] };
   }
 
-  // Get all slides for this term
+  // Get all slides whose classroom uses this namespace
   const slides = await getPrisma().slide.findMany({
-    where: { term },
+    where: { classroom: { content_namespace: contentNamespace } },
     include: {
       classroom: {
         include: { git_organization: true },
@@ -53,7 +57,7 @@ export async function countSlidesUsingTheme(gitOrgLogin: string, term: string, t
 
   const gitProvider = new GitHubProvider(gitOrg.github_installation_id, gitOrgLogin);
   const octokit = await gitProvider.getOctokit();
-  const repoName = `content-${gitOrgLogin}-${term}`;
+  const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
 
   const slidesUsingTheme = [];
 
@@ -90,10 +94,14 @@ export async function countSlidesUsingTheme(gitOrgLogin: string, term: string, t
 /**
  * Delete a shared theme from GitHub
  * @param {string} gitOrgLogin - Git organization login
- * @param {string} term - Term string
+ * @param {string} contentNamespace - Content namespace (e.g., "25w" or a slug)
  * @param {string} themeName - Theme name to delete
  */
-export async function deleteSharedTheme(gitOrgLogin: string, term: string, themeName: string) {
+export async function deleteSharedTheme(
+  gitOrgLogin: string,
+  contentNamespace: string,
+  themeName: string
+) {
   const gitOrg = await getPrisma().gitOrganization.findFirst({
     where: { provider: 'GITHUB', login: gitOrgLogin },
   });
@@ -102,7 +110,7 @@ export async function deleteSharedTheme(gitOrgLogin: string, term: string, theme
     throw new Error('Git organization not found');
   }
 
-  const repoName = `content-${gitOrgLogin}-${term}`;
+  const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
   const themePath = `${THEMES_FOLDER}/${themeName}`;
 
   await ContentService.deleteFolder({
@@ -151,7 +159,7 @@ export async function deleteSlide({
     throw new Error('GitHub installation not configured');
   }
 
-  const repoName = `content-${gitOrgLogin}-${slide.term}`;
+  const repoName = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const gitProvider = new GitHubProvider(gitOrg.github_installation_id, gitOrgLogin);
   const octokit = await gitProvider.getOctokit();
 
@@ -199,12 +207,16 @@ export async function deleteSlide({
   // Handle shared theme deletion if requested
   if (themeName && deleteTheme) {
     // Count how many OTHER slides are using this theme (excluding the one being deleted)
-    const themeUsage = await countSlidesUsingTheme(gitOrgLogin, slide.term, themeName);
+    const themeUsage = await countSlidesUsingTheme(
+      gitOrgLogin,
+      slide.classroom.content_namespace,
+      themeName
+    );
     otherSlidesUsingTheme = themeUsage.slides.filter(s => s.id !== slideId).length;
 
     if (otherSlidesUsingTheme === 0) {
       try {
-        await deleteSharedTheme(gitOrgLogin, slide.term, themeName);
+        await deleteSharedTheme(gitOrgLogin, slide.classroom.content_namespace, themeName);
         themeDeleted = true;
       } catch (error: unknown) {
         console.error('Failed to delete shared theme:', error);
@@ -264,7 +276,7 @@ export async function getSlideDeleteInfo(slideId: string) {
     return { slide, themeName: null };
   }
 
-  const repoName = `content-${gitOrgLogin}-${slide.term}`;
+  const repoName = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
   const gitProvider = new GitHubProvider(gitOrg.github_installation_id, gitOrgLogin);
 
   let themeName: string | null = null;
@@ -291,7 +303,11 @@ export async function getSlideDeleteInfo(slideId: string) {
   }
 
   // Count other slides using this theme
-  const themeUsage = await countSlidesUsingTheme(gitOrgLogin, slide.term, themeName);
+  const themeUsage = await countSlidesUsingTheme(
+    gitOrgLogin,
+    slide.classroom.content_namespace,
+    themeName
+  );
   const otherSlides = themeUsage.slides.filter(s => s.id !== slideId);
 
   return {

--- a/apps/slides/app/utils/slidesComImporter.server.ts
+++ b/apps/slides/app/utils/slidesComImporter.server.ts
@@ -712,10 +712,6 @@ export async function processZipImport({
     data: {
       title: slideTitle,
       slug,
-      // Slide.term column is dropped in a later migration; populate with
-      // the classroom's content_namespace until then so the NOT NULL
-      // constraint is satisfied.
-      term: contentNamespace,
       content_path: contentPath,
       classroom_id: classroom.id,
       created_by: userId,

--- a/apps/slides/app/utils/slidesComImporter.server.ts
+++ b/apps/slides/app/utils/slidesComImporter.server.ts
@@ -166,7 +166,7 @@ ${slidesContent}
  * @param {string} options.org - Git organization login (for GitHub API calls)
  * @param {string} [options.classroomSlug] - Classroom slug (for database reference)
  * @param {string} options.classroomId - Classroom UUID (for database reference)
- * @param {string} options.term - Term string (e.g., "25w")
+ * @param {string} options.contentNamespace - Classroom content namespace (e.g., "25w" or a slug)
  * @param {string} options.userId - User ID who is importing
  * @param {string[]} [options.cloudinaryVideoPaths] - Paths of videos to upload to Cloudinary instead of GitHub
  * @param {Function} [options.onProgress] - Callback for progress updates ({ type: 'step'|'done'|'error', step?: string, current?: number, total?: number, filename?: string })
@@ -182,7 +182,7 @@ export async function processZipImport({
   org,
   classroomSlug: _classroomSlug,
   classroomId,
-  term,
+  contentNamespace,
   userId,
   cloudinaryVideoPaths = [],
   onProgress = () => {},
@@ -196,7 +196,7 @@ export async function processZipImport({
   org: string;
   classroomSlug?: string;
   classroomId: string;
-  term: string;
+  contentNamespace: string;
   userId: string;
   cloudinaryVideoPaths?: string[];
   onProgress?: (event: {
@@ -253,11 +253,11 @@ export async function processZipImport({
   // 5. Flat content path: slides/{slug}-{timestamp}
   const timestamp = Date.now();
   const contentPath = `slides/${slug}-${timestamp}`;
-  // Build organization-like object for getContentRepoName (adapts new classroom schema)
+  // Build organization-like object for getContentRepoName, using the
+  // classroom's stable content_namespace as the namespace.
   const repoName = getContentRepoName({
     login: classroom.git_organization.login,
-    term: classroom.term ?? undefined,
-    year: classroom.year ?? undefined,
+    content_namespace: classroom.content_namespace,
   });
 
   // 6. Ensure content repo exists (org is git org login for GitHub API)
@@ -267,7 +267,7 @@ export async function processZipImport({
     await gitProvider.createPublicRepository(
       org,
       repoName,
-      `Course content for ${classroom.name || org} - ${term}`
+      `Course content for ${classroom.name || org} - ${contentNamespace}`
     );
     // Give GitHub a moment to initialize the repo
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -712,7 +712,10 @@ export async function processZipImport({
     data: {
       title: slideTitle,
       slug,
-      term,
+      // Slide.term column is dropped in a later migration; populate with
+      // the classroom's content_namespace until then so the NOT NULL
+      // constraint is satisfied.
+      term: contentNamespace,
       content_path: contentPath,
       classroom_id: classroom.id,
       created_by: userId,

--- a/apps/slides/tests/helpers/env.helpers.ts
+++ b/apps/slides/tests/helpers/env.helpers.ts
@@ -52,12 +52,3 @@ export function getTestClassroomSlug(): string {
 export function getTestClassroomOrg(): string {
   return process.env.TEST_CLASSROOM_ORG || 'CS-TestClassroom';
 }
-
-/**
- * Get the test classroom term.
- * Used for import functionality which requires org and term params.
- * Note: The term format is '25w' (short form), not 'winter-2025'.
- */
-export function getTestClassroomTerm(): string {
-  return process.env.TEST_CLASSROOM_TERM || '25w';
-}

--- a/apps/slides/tests/helpers/index.ts
+++ b/apps/slides/tests/helpers/index.ts
@@ -14,7 +14,6 @@ export {
   getSlidesBaseURL,
   getTestClassroomSlug,
   getTestClassroomOrg,
-  getTestClassroomTerm,
 } from './env.helpers';
 
 // Wait helpers

--- a/apps/webapp/app/components/features/landing/AppBar.tsx
+++ b/apps/webapp/app/components/features/landing/AppBar.tsx
@@ -14,17 +14,6 @@ interface AppBarProps {
   membershipRoles?: Record<string, NotificationRole[]>;
 }
 
-const tabBtn = (active: boolean): React.CSSProperties => ({
-  padding: '6px 14px',
-  borderRadius: 6,
-  fontSize: 13.5,
-  fontWeight: active ? 600 : 500,
-  color: active ? 'var(--ink-0)' : 'var(--ink-2)',
-  background: 'transparent',
-  cursor: 'pointer',
-  border: 'none',
-});
-
 const iconBtn: React.CSSProperties = {
   width: 36,
   height: 36,
@@ -59,17 +48,6 @@ export function AppBar({ user, notifications, unreadCount, membershipRoles }: Ap
       <div style={{ display: 'flex', alignItems: 'center', gap: 22 }}>
         <Logo variant="full" size={24} theme="current" />
 
-        <nav style={{ display: 'flex', gap: 2 }}>
-          <button type="button" style={tabBtn(true)}>
-            Classes
-          </button>
-          <button type="button" style={tabBtn(false)}>
-            Inbox
-          </button>
-          <button type="button" style={tabBtn(false)}>
-            Explore
-          </button>
-        </nav>
       </div>
 
       {/* Right group: help / bell / user */}

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -6,9 +6,10 @@ import type { LandingClass } from './types';
 interface ClassroomCardProps {
   c: LandingClass;
   onOpen: () => void;
+  showSlug?: boolean;
 }
 
-export function ClassroomCard({ c, onOpen }: ClassroomCardProps) {
+export function ClassroomCard({ c, onOpen, showSlug = false }: ClassroomCardProps) {
   const roleVerb =
     c.role === 'OWNER' || c.role === 'ASSISTANT'
       ? 'To grade'
@@ -62,16 +63,18 @@ export function ClassroomCard({ c, onOpen }: ClassroomCardProps) {
           >
             {c.name}
           </div>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11.5,
-              color: 'var(--ink-3)',
-              marginTop: 1,
-            }}
-          >
-            {c.slug}
-          </div>
+          {showSlug && (
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11.5,
+                color: 'var(--ink-3)',
+                marginTop: 1,
+              }}
+            >
+              {c.slug}
+            </div>
+          )}
         </div>
         <RoleChip role={c.role} />
       </div>

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -75,7 +75,7 @@ export function ClassroomCard({
     if (fetcher.state !== 'idle') return;
     fetcher.submit(null, {
       method: 'POST',
-      action: `/api/classrooms/${c.id}/pin`,
+      action: `/api/classrooms/${c.classroomId}/pin`,
     });
   };
 

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher } from 'react-router';
 import { IconGithub } from '@classmoji/ui-components';
 import { ClassMark } from './ClassMark';
 import { RoleChip } from './RoleChip';
@@ -7,9 +9,46 @@ interface ClassroomCardProps {
   c: LandingClass;
   onOpen: () => void;
   showSlug?: boolean;
+  /** Called after the pin endpoint responds with the new pin_order. */
+  onPinChanged?: (id: string, pin_order: number | null) => void;
+  /** Drag handlers — supplied only inside the Pinned section. */
+  draggable?: boolean;
+  onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
-export function ClassroomCard({ c, onOpen, showSlug = false }: ClassroomCardProps) {
+function PinIcon({ filled, size = 14 }: { filled: boolean; size?: number }) {
+  // Simple inline pin icon; switches between filled (pinned) and outline.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 2 L15 8 L21 9 L17 13 L18 20 L12 17 L6 20 L7 13 L3 9 L9 8 Z" />
+    </svg>
+  );
+}
+
+export function ClassroomCard({
+  c,
+  onOpen,
+  showSlug = false,
+  onPinChanged,
+  draggable = false,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: ClassroomCardProps) {
   const roleVerb =
     c.role === 'OWNER' || c.role === 'ASSISTANT'
       ? 'To grade'
@@ -17,11 +56,39 @@ export function ClassroomCard({ c, onOpen, showSlug = false }: ClassroomCardProp
         ? 'Open'
         : 'Pending';
 
+  const fetcher = useFetcher<{ pin_order: number | null }>();
+  const [hover, setHover] = useState(false);
+  const lastSubmittedRef = useRef<typeof fetcher.state>('idle');
+
+  const isPinned = c.pin_order != null;
+  const canPin = c.role === 'OWNER' || c.role === 'ASSISTANT';
+
+  useEffect(() => {
+    if (fetcher.state === 'idle' && lastSubmittedRef.current !== 'idle' && fetcher.data) {
+      onPinChanged?.(c.id, fetcher.data.pin_order);
+    }
+    lastSubmittedRef.current = fetcher.state;
+  }, [fetcher.state, fetcher.data, c.id, onPinChanged]);
+
+  const handlePinClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (fetcher.state !== 'idle') return;
+    fetcher.submit(null, {
+      method: 'POST',
+      action: `/api/classrooms/${c.id}/pin`,
+    });
+  };
+
   return (
     <div
       onClick={onOpen}
       role="button"
       tabIndex={0}
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -34,22 +101,50 @@ export function ClassroomCard({ c, onOpen, showSlug = false }: ClassroomCardProp
         border: '1px solid var(--line)',
         borderRadius: 8,
         padding: '14px 14px 12px',
-        cursor: 'pointer',
-        transition: 'border-color 120ms, background 120ms',
+        cursor: draggable ? 'grab' : 'pointer',
+        transition: 'border-color 120ms, background 120ms, opacity 120ms',
         display: 'flex',
         flexDirection: 'column',
         gap: 10,
         minHeight: 150,
+        opacity: fetcher.state !== 'idle' ? 0.7 : 1,
       }}
       onMouseEnter={e => {
+        setHover(true);
         e.currentTarget.style.borderColor = 'var(--line-strong)';
         e.currentTarget.style.background = 'var(--panel-hover)';
       }}
       onMouseLeave={e => {
+        setHover(false);
         e.currentTarget.style.borderColor = 'var(--line)';
         e.currentTarget.style.background = 'var(--bg-1)';
       }}
     >
+      {canPin && (hover || isPinned) && (
+        <button
+          type="button"
+          aria-label={isPinned ? 'Unpin classroom' : 'Pin classroom'}
+          title={isPinned ? 'Unpin' : 'Pin'}
+          onClick={handlePinClick}
+          style={{
+            position: 'absolute',
+            top: 6,
+            right: 6,
+            border: 'none',
+            background: 'transparent',
+            color: isPinned ? 'var(--ink-0)' : 'var(--ink-3)',
+            cursor: 'pointer',
+            padding: 4,
+            borderRadius: 4,
+            display: 'inline-flex',
+            alignItems: 'center',
+            zIndex: 2,
+          }}
+        >
+          <PinIcon filled={isPinned} />
+        </button>
+      )}
+
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <ClassMark hue={c.hue} name={c.name} />
         <div style={{ flex: 1, minWidth: 0 }}>

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -121,40 +121,6 @@ export function ClassroomCard({
         e.currentTarget.style.background = 'var(--bg-1)';
       }}
     >
-      <AnimatePresence>
-        {canPin && (hover || isPinned) && (
-          <motion.button
-            key="pin-btn"
-            type="button"
-            aria-label={isPinned ? 'Unpin classroom' : 'Pin classroom'}
-            title={isPinned ? 'Unpin' : 'Pin'}
-            onClick={handlePinClick}
-            initial={{ opacity: 0, scale: 0.6 }}
-            animate={{ opacity: 1, scale: 1, rotate: isPinned ? -18 : 0 }}
-            exit={{ opacity: 0, scale: 0.6 }}
-            whileHover={{ scale: 1.15 }}
-            whileTap={{ scale: 0.85, rotate: isPinned ? 0 : -18 }}
-            transition={{ type: 'spring', stiffness: 600, damping: 22 }}
-            style={{
-              position: 'absolute',
-              top: 6,
-              right: 6,
-              border: 'none',
-              background: 'transparent',
-              color: isPinned ? 'var(--accent)' : 'var(--ink-3)',
-              cursor: 'pointer',
-              padding: 4,
-              borderRadius: 4,
-              display: 'inline-flex',
-              alignItems: 'center',
-              zIndex: 2,
-            }}
-          >
-            <PinIcon filled={isPinned} />
-          </motion.button>
-        )}
-      </AnimatePresence>
-
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <ClassMark hue={c.hue} name={c.name} />
         <div style={{ flex: 1, minWidth: 0 }}>
@@ -164,6 +130,9 @@ export function ClassroomCard({
               fontWeight: 600,
               color: 'var(--ink-0)',
               letterSpacing: '-0.01em',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
           >
             {c.name}
@@ -175,13 +144,62 @@ export function ClassroomCard({
                 fontSize: 11.5,
                 color: 'var(--ink-3)',
                 marginTop: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
               }}
+              title={c.slug}
             >
               {c.slug}
             </div>
           )}
         </div>
-        <RoleChip role={c.role} />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            flexShrink: 0,
+          }}
+        >
+          <AnimatePresence initial={false}>
+            {canPin && (hover || isPinned) && (
+              <motion.button
+                key="pin-btn"
+                type="button"
+                aria-label={isPinned ? 'Unpin classroom' : 'Pin classroom'}
+                title={isPinned ? 'Unpin' : 'Pin'}
+                onClick={handlePinClick}
+                initial={{ opacity: 0, scale: 0.6, width: 0 }}
+                animate={{
+                  opacity: 1,
+                  scale: 1,
+                  width: 'auto',
+                  rotate: isPinned ? -18 : 0,
+                }}
+                exit={{ opacity: 0, scale: 0.6, width: 0 }}
+                whileHover={{ scale: 1.15 }}
+                whileTap={{ scale: 0.85, rotate: isPinned ? 0 : -18 }}
+                transition={{ type: 'spring', stiffness: 600, damping: 22 }}
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  color: isPinned ? 'var(--accent)' : 'var(--ink-3)',
+                  cursor: 'pointer',
+                  padding: 2,
+                  borderRadius: 4,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                <PinIcon filled={isPinned} />
+              </motion.button>
+            )}
+          </AnimatePresence>
+          <RoleChip role={c.role} />
+        </div>
       </div>
 
       {c.subtitle && (

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -12,12 +12,34 @@ interface ClassroomCardProps {
   showSlug?: boolean;
   /** Called after the pin endpoint responds with the new pin_order. */
   onPinChanged?: (id: string, pin_order: number | null) => void;
+  /** Called after the archive endpoint responds with the new is_active. */
+  onArchiveChanged?: (id: string, is_active: boolean) => void;
   /** Drag handlers — supplied only inside the Pinned section. */
   draggable?: boolean;
   onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
+}
+
+function ArchiveIcon({ filled, size = 14 }: { filled: boolean; size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="4" rx="1" />
+      <path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8" />
+      <path d="M10 12h4" />
+    </svg>
+  );
 }
 
 function PinIcon({ filled, size = 14 }: { filled: boolean; size?: number }) {
@@ -44,6 +66,7 @@ export function ClassroomCard({
   onOpen,
   showSlug = false,
   onPinChanged,
+  onArchiveChanged,
   draggable = false,
   onDragStart,
   onDragOver,
@@ -57,28 +80,65 @@ export function ClassroomCard({
         ? 'Open'
         : 'Pending';
 
-  const fetcher = useFetcher<{ pin_order: number | null }>();
+  const pinFetcher = useFetcher<{ pin_order: number | null }>();
+  const archiveFetcher = useFetcher<{ is_active: boolean }>();
   const [hover, setHover] = useState(false);
-  const lastSubmittedRef = useRef<typeof fetcher.state>('idle');
+  const lastPinStateRef = useRef<typeof pinFetcher.state>('idle');
+  const lastArchiveStateRef = useRef<typeof archiveFetcher.state>('idle');
 
   const isPinned = c.pin_order != null;
-  const canPin = c.role === 'OWNER' || c.role === 'ASSISTANT';
+  // Pinning is a personal organization feature — available to all roles
+  // except pending invites.
+  const canPin = c.role !== 'PENDING INVITE';
+  // Only OWNER can archive/unarchive.
+  const canArchive = c.role === 'OWNER';
 
   useEffect(() => {
-    if (fetcher.state === 'idle' && lastSubmittedRef.current !== 'idle' && fetcher.data) {
-      onPinChanged?.(c.id, fetcher.data.pin_order);
+    if (
+      pinFetcher.state === 'idle' &&
+      lastPinStateRef.current !== 'idle' &&
+      pinFetcher.data
+    ) {
+      onPinChanged?.(c.id, pinFetcher.data.pin_order);
     }
-    lastSubmittedRef.current = fetcher.state;
-  }, [fetcher.state, fetcher.data, c.id, onPinChanged]);
+    lastPinStateRef.current = pinFetcher.state;
+  }, [pinFetcher.state, pinFetcher.data, c.id, onPinChanged]);
+
+  useEffect(() => {
+    if (
+      archiveFetcher.state === 'idle' &&
+      lastArchiveStateRef.current !== 'idle' &&
+      archiveFetcher.data
+    ) {
+      onArchiveChanged?.(c.id, archiveFetcher.data.is_active);
+    }
+    lastArchiveStateRef.current = archiveFetcher.state;
+  }, [archiveFetcher.state, archiveFetcher.data, c.id, onArchiveChanged]);
 
   const handlePinClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (fetcher.state !== 'idle') return;
-    fetcher.submit(null, {
+    if (pinFetcher.state !== 'idle') return;
+    pinFetcher.submit(JSON.stringify({ role: c.membershipRole }), {
       method: 'POST',
       action: `/api/classrooms/${c.classroomId}/pin`,
+      encType: 'application/json',
     });
   };
+
+  const handleArchiveClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (archiveFetcher.state !== 'idle') return;
+    const msg = c.is_active
+      ? `Archive "${c.name}"? You can unarchive it later.`
+      : `Unarchive "${c.name}"?`;
+    if (typeof window !== 'undefined' && !window.confirm(msg)) return;
+    archiveFetcher.submit(null, {
+      method: 'POST',
+      action: `/api/classrooms/${c.classroomId}/archive`,
+    });
+  };
+
+  const fetcher = pinFetcher; // alias used downstream for opacity styling
 
   return (
     <div
@@ -163,6 +223,35 @@ export function ClassroomCard({
           }}
         >
           <AnimatePresence initial={false}>
+            {canArchive && hover && (
+              <motion.button
+                key="archive-btn"
+                type="button"
+                aria-label={c.is_active ? 'Archive classroom' : 'Unarchive classroom'}
+                title={c.is_active ? 'Archive' : 'Unarchive'}
+                onClick={handleArchiveClick}
+                initial={{ opacity: 0, scale: 0.6, width: 0 }}
+                animate={{ opacity: 1, scale: 1, width: 'auto' }}
+                exit={{ opacity: 0, scale: 0.6, width: 0 }}
+                whileHover={{ scale: 1.15 }}
+                whileTap={{ scale: 0.85 }}
+                transition={{ type: 'spring', stiffness: 600, damping: 22 }}
+                style={{
+                  border: 'none',
+                  background: 'transparent',
+                  color: c.is_active ? 'var(--ink-3)' : 'var(--accent)',
+                  cursor: 'pointer',
+                  padding: 2,
+                  borderRadius: 4,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                <ArchiveIcon filled={!c.is_active} />
+              </motion.button>
+            )}
             {canPin && (hover || isPinned) && (
               <motion.button
                 key="pin-btn"

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -22,13 +22,14 @@ interface ClassroomCardProps {
   onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
-function ArchiveIcon({ filled, size = 14 }: { filled: boolean; size?: number }) {
+function ArchiveIcon({ size = 14 }: { size?: number }) {
+  // Box with a downward arrow into it — "archive" gesture.
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill={filled ? 'currentColor' : 'none'}
+      fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
       strokeLinecap="round"
@@ -37,7 +38,28 @@ function ArchiveIcon({ filled, size = 14 }: { filled: boolean; size?: number }) 
     >
       <rect x="3" y="4" width="18" height="4" rx="1" />
       <path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8" />
-      <path d="M10 12h4" />
+      <path d="M12 11v5m0 0-2-2m2 2 2-2" />
+    </svg>
+  );
+}
+
+function UnarchiveIcon({ size = 14 }: { size?: number }) {
+  // Box with an upward arrow out of it — "unarchive" gesture.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="4" rx="1" />
+      <path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8" />
+      <path d="M12 17v-5m0 0-2 2m2-2 2 2" />
     </svg>
   );
 }
@@ -249,7 +271,7 @@ export function ClassroomCard({
                   overflow: 'hidden',
                 }}
               >
-                <ArchiveIcon filled={!c.is_active} />
+                {c.is_active ? <ArchiveIcon /> : <UnarchiveIcon />}
               </motion.button>
             )}
             {canPin && (hover || isPinned) && (

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useFetcher } from 'react-router';
+import { motion, AnimatePresence } from 'framer-motion';
 import { IconGithub } from '@classmoji/ui-components';
 import { ClassMark } from './ClassMark';
 import { RoleChip } from './RoleChip';
@@ -120,30 +121,39 @@ export function ClassroomCard({
         e.currentTarget.style.background = 'var(--bg-1)';
       }}
     >
-      {canPin && (hover || isPinned) && (
-        <button
-          type="button"
-          aria-label={isPinned ? 'Unpin classroom' : 'Pin classroom'}
-          title={isPinned ? 'Unpin' : 'Pin'}
-          onClick={handlePinClick}
-          style={{
-            position: 'absolute',
-            top: 6,
-            right: 6,
-            border: 'none',
-            background: 'transparent',
-            color: isPinned ? 'var(--ink-0)' : 'var(--ink-3)',
-            cursor: 'pointer',
-            padding: 4,
-            borderRadius: 4,
-            display: 'inline-flex',
-            alignItems: 'center',
-            zIndex: 2,
-          }}
-        >
-          <PinIcon filled={isPinned} />
-        </button>
-      )}
+      <AnimatePresence>
+        {canPin && (hover || isPinned) && (
+          <motion.button
+            key="pin-btn"
+            type="button"
+            aria-label={isPinned ? 'Unpin classroom' : 'Pin classroom'}
+            title={isPinned ? 'Unpin' : 'Pin'}
+            onClick={handlePinClick}
+            initial={{ opacity: 0, scale: 0.6 }}
+            animate={{ opacity: 1, scale: 1, rotate: isPinned ? -18 : 0 }}
+            exit={{ opacity: 0, scale: 0.6 }}
+            whileHover={{ scale: 1.15 }}
+            whileTap={{ scale: 0.85, rotate: isPinned ? 0 : -18 }}
+            transition={{ type: 'spring', stiffness: 600, damping: 22 }}
+            style={{
+              position: 'absolute',
+              top: 6,
+              right: 6,
+              border: 'none',
+              background: 'transparent',
+              color: isPinned ? 'var(--accent)' : 'var(--ink-3)',
+              cursor: 'pointer',
+              padding: 4,
+              borderRadius: 4,
+              display: 'inline-flex',
+              alignItems: 'center',
+              zIndex: 2,
+            }}
+          >
+            <PinIcon filled={isPinned} />
+          </motion.button>
+        )}
+      </AnimatePresence>
 
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
         <ClassMark hue={c.hue} name={c.name} />

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -118,41 +118,6 @@ export function ClassroomCard({ c, onOpen }: ClassroomCardProps) {
             {c.pending}
           </span>
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 1, fontSize: 11, flex: 1 }}>
-          <span style={{ color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>Term progress</span>
-          <span
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 12.5,
-              color: 'var(--ink-0)',
-              fontWeight: 500,
-            }}
-          >
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-              <span
-                style={{
-                  width: 48,
-                  height: 4,
-                  borderRadius: 99,
-                  background: 'var(--bg-3)',
-                  position: 'relative',
-                  overflow: 'hidden',
-                  display: 'inline-block',
-                }}
-              >
-                <span
-                  style={{
-                    position: 'absolute',
-                    inset: 0,
-                    width: `${c.progress}%`,
-                    background: c.progress >= 100 ? '#1a6b3e' : 'var(--violet)',
-                  }}
-                />
-              </span>
-              <span style={{ fontSize: 11, color: 'var(--ink-2)' }}>{c.progress}%</span>
-            </span>
-          </span>
-        </div>
       </div>
 
       <div

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { Link } from 'react-router';
+import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { Button, IconGithub, IconPlus, IconX } from '@classmoji/ui-components';
 import { AppBar } from './AppBar';
 import { ClassroomCard } from './ClassroomCard';
@@ -195,20 +196,31 @@ export function ClassroomsLandingScreen({
         gap: 12,
       }}
     >
-      {items.map(c => (
-        <ClassroomCard
-          key={c.id}
-          c={c}
-          onOpen={() => onOpenClass(c)}
-          showSlug={isDuplicate(c.name)}
-          onPinChanged={handlePinChanged}
-          draggable={draggable}
-          onDragStart={draggable ? handleDragStart(c.id) : undefined}
-          onDragOver={draggable ? handleDragOver(c.id) : undefined}
-          onDrop={draggable ? handleDrop(c.id) : undefined}
-          onDragEnd={draggable ? handleDragEnd : undefined}
-        />
-      ))}
+      <AnimatePresence initial={false}>
+        {items.map(c => (
+          <motion.div
+            key={c.id}
+            layout
+            layoutId={c.id}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.92 }}
+            transition={{ type: 'spring', stiffness: 380, damping: 32, mass: 0.6 }}
+          >
+            <ClassroomCard
+              c={c}
+              onOpen={() => onOpenClass(c)}
+              showSlug={isDuplicate(c.name)}
+              onPinChanged={handlePinChanged}
+              draggable={draggable}
+              onDragStart={draggable ? handleDragStart(c.id) : undefined}
+              onDragOver={draggable ? handleDragOver(c.id) : undefined}
+              onDrop={draggable ? handleDrop(c.id) : undefined}
+              onDragEnd={draggable ? handleDragEnd : undefined}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
       {withNewCard && (
         <Link
           to="/create-classroom"
@@ -444,7 +456,7 @@ export function ClassroomsLandingScreen({
             No classrooms yet.
           </div>
         ) : (
-          <>
+          <LayoutGroup>
             {pinnedDisplay.length > 0 && (
               <section style={{ marginBottom: 24 }}>
                 {sectionHeading('Pinned', pinnedDisplay.length)}
@@ -484,7 +496,7 @@ export function ClassroomsLandingScreen({
                 </div>
               </details>
             )}
-          </>
+          </LayoutGroup>
         )}
 
         <footer

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { Link } from 'react-router';
 import { Button, IconGithub, IconPlus, IconX } from '@classmoji/ui-components';
 import { AppBar } from './AppBar';
@@ -63,14 +63,112 @@ export function ClassroomsLandingScreen({
   const [view, setView] = useState<'grid' | 'list'>('grid');
   const [bannerOpen, setBannerOpen] = useState(true);
 
-  const { pinned, active, archived } = useMemo(() => {
-    const pinned = classes
-      .filter(c => c.pin_order != null)
-      .sort((a, b) => (a.pin_order ?? 0) - (b.pin_order ?? 0));
-    const active = classes.filter(c => c.pin_order == null && c.is_active);
-    const archived = classes.filter(c => c.pin_order == null && !c.is_active);
-    return { pinned, active, archived };
+  // Local overrides for optimistic pin/unpin and drag-reorder. Keyed by classroom id.
+  const [pinOverrides, setPinOverrides] = useState<Record<string, number | null>>({});
+
+  // Reset overrides if upstream classes change (e.g. revalidation).
+  const classesSigRef = useRef<string>('');
+  useEffect(() => {
+    const sig = classes.map(c => `${c.id}:${c.pin_order ?? ''}`).join('|');
+    if (sig !== classesSigRef.current) {
+      classesSigRef.current = sig;
+      setPinOverrides({});
+    }
   }, [classes]);
+
+  const effectivePinOrder = (c: LandingClass): number | null =>
+    Object.prototype.hasOwnProperty.call(pinOverrides, c.id) ? pinOverrides[c.id] : c.pin_order;
+
+  const handlePinChanged = (id: string, pin_order: number | null) => {
+    setPinOverrides(prev => ({ ...prev, [id]: pin_order }));
+  };
+
+  const { pinned, active, archived } = useMemo(() => {
+    const withEffective = classes.map(c => ({ c, p: effectivePinOrder(c) }));
+    const pinned = withEffective
+      .filter(x => x.p != null)
+      .sort((a, b) => (a.p ?? 0) - (b.p ?? 0))
+      .map(x => x.c);
+    const active = withEffective.filter(x => x.p == null && x.c.is_active).map(x => x.c);
+    const archived = withEffective.filter(x => x.p == null && !x.c.is_active).map(x => x.c);
+    return { pinned, active, archived };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [classes, pinOverrides]);
+
+  // Drag state for the Pinned section.
+  const dragIdRef = useRef<string | null>(null);
+  const [pinnedOrder, setPinnedOrder] = useState<string[] | null>(null);
+
+  const pinnedDisplay = useMemo(() => {
+    if (!pinnedOrder) return pinned;
+    const byId = new Map(pinned.map(c => [c.id, c]));
+    const ordered = pinnedOrder.map(id => byId.get(id)).filter(Boolean) as LandingClass[];
+    // Append any pinned items not in pinnedOrder (e.g. a freshly pinned card).
+    for (const c of pinned) if (!pinnedOrder.includes(c.id)) ordered.push(c);
+    return ordered;
+  }, [pinned, pinnedOrder]);
+
+  useEffect(() => {
+    // When the upstream pinned set changes shape, drop local drag order.
+    setPinnedOrder(null);
+  }, [classes]);
+
+  const submitReorder = async (ids: string[]) => {
+    const prev = pinnedOrder;
+    setPinnedOrder(ids);
+    try {
+      const res = await fetch('/api/classrooms/reorder-pins', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      });
+      if (!res.ok) {
+        setPinnedOrder(prev);
+      } else {
+        // Reflect new pin_order locally so reload of state is consistent.
+        setPinOverrides(prevOverrides => {
+          const next = { ...prevOverrides };
+          ids.forEach((id, idx) => {
+            next[id] = idx + 1;
+          });
+          return next;
+        });
+      }
+    } catch {
+      setPinnedOrder(prev);
+    }
+  };
+
+  const handleDragStart = (id: string) => (e: React.DragEvent<HTMLDivElement>) => {
+    dragIdRef.current = id;
+    e.dataTransfer.effectAllowed = 'move';
+    try {
+      e.dataTransfer.setData('text/plain', id);
+    } catch {
+      /* noop */
+    }
+  };
+  const handleDragOver = (_id: string) => (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+  const handleDrop = (targetId: string) => (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const sourceId = dragIdRef.current;
+    dragIdRef.current = null;
+    if (!sourceId || sourceId === targetId) return;
+    const currentIds = pinnedDisplay.map(c => c.id);
+    const from = currentIds.indexOf(sourceId);
+    const to = currentIds.indexOf(targetId);
+    if (from < 0 || to < 0) return;
+    const next = currentIds.slice();
+    next.splice(from, 1);
+    next.splice(to, 0, sourceId);
+    void submitReorder(next);
+  };
+  const handleDragEnd = () => {
+    dragIdRef.current = null;
+  };
 
   const counts = useMemo(
     () => ({
@@ -86,7 +184,7 @@ export function ClassroomsLandingScreen({
     return (name: string) => (nameCounts.get(name) ?? 0) > 1;
   }, [classes]);
 
-  const renderGrid = (items: LandingClass[], withNewCard: boolean) => (
+  const renderGrid = (items: LandingClass[], withNewCard: boolean, draggable = false) => (
     <div
       style={{
         display: 'grid',
@@ -100,6 +198,12 @@ export function ClassroomsLandingScreen({
           c={c}
           onOpen={() => onOpenClass(c)}
           showSlug={isDuplicate(c.name)}
+          onPinChanged={handlePinChanged}
+          draggable={draggable}
+          onDragStart={draggable ? handleDragStart(c.id) : undefined}
+          onDragOver={draggable ? handleDragOver(c.id) : undefined}
+          onDrop={draggable ? handleDrop(c.id) : undefined}
+          onDragEnd={draggable ? handleDragEnd : undefined}
         />
       ))}
       {withNewCard && (
@@ -338,10 +442,12 @@ export function ClassroomsLandingScreen({
           </div>
         ) : (
           <>
-            {pinned.length > 0 && (
+            {pinnedDisplay.length > 0 && (
               <section style={{ marginBottom: 24 }}>
-                {sectionHeading('Pinned', pinned.length)}
-                {view === 'grid' ? renderGrid(pinned, false) : renderList(pinned)}
+                {sectionHeading('Pinned', pinnedDisplay.length)}
+                {view === 'grid'
+                  ? renderGrid(pinnedDisplay, false, true)
+                  : renderList(pinnedDisplay)}
               </section>
             )}
 

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -64,37 +64,52 @@ export function ClassroomsLandingScreen({
   const [view, setView] = useState<'grid' | 'list'>('grid');
   const [bannerOpen, setBannerOpen] = useState(true);
 
-  // Local overrides for optimistic pin/unpin and drag-reorder. Keyed by classroom id.
+  // Local overrides for optimistic pin/unpin, drag-reorder, and archive. Keyed by composite landing id.
   const [pinOverrides, setPinOverrides] = useState<Record<string, number | null>>({});
+  const [archiveOverrides, setArchiveOverrides] = useState<Record<string, boolean>>({});
 
   // Reset overrides if upstream classes change (e.g. revalidation).
   const classesSigRef = useRef<string>('');
   useEffect(() => {
-    const sig = classes.map(c => `${c.id}:${c.pin_order ?? ''}`).join('|');
+    const sig = classes
+      .map(c => `${c.id}:${c.pin_order ?? ''}:${c.is_active ? '1' : '0'}`)
+      .join('|');
     if (sig !== classesSigRef.current) {
       classesSigRef.current = sig;
       setPinOverrides({});
+      setArchiveOverrides({});
     }
   }, [classes]);
 
   const effectivePinOrder = (c: LandingClass): number | null =>
     Object.prototype.hasOwnProperty.call(pinOverrides, c.id) ? pinOverrides[c.id] : c.pin_order;
+  const effectiveIsActive = (c: LandingClass): boolean =>
+    Object.prototype.hasOwnProperty.call(archiveOverrides, c.id)
+      ? archiveOverrides[c.id]
+      : c.is_active;
 
   const handlePinChanged = (id: string, pin_order: number | null) => {
     setPinOverrides(prev => ({ ...prev, [id]: pin_order }));
   };
+  const handleArchiveChanged = (id: string, is_active: boolean) => {
+    setArchiveOverrides(prev => ({ ...prev, [id]: is_active }));
+  };
 
   const { pinned, active, archived } = useMemo(() => {
-    const withEffective = classes.map(c => ({ c, p: effectivePinOrder(c) }));
+    const withEffective = classes.map(c => ({
+      c: { ...c, is_active: effectiveIsActive(c), pin_order: effectivePinOrder(c) },
+      p: effectivePinOrder(c),
+      a: effectiveIsActive(c),
+    }));
     const pinned = withEffective
-      .filter(x => x.p != null)
+      .filter(x => x.p != null && x.a)
       .sort((a, b) => (a.p ?? 0) - (b.p ?? 0))
       .map(x => x.c);
-    const active = withEffective.filter(x => x.p == null && x.c.is_active).map(x => x.c);
-    const archived = withEffective.filter(x => x.p == null && !x.c.is_active).map(x => x.c);
+    const active = withEffective.filter(x => x.p == null && x.a).map(x => x.c);
+    const archived = withEffective.filter(x => !x.a).map(x => x.c);
     return { pinned, active, archived };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [classes, pinOverrides]);
+  }, [classes, pinOverrides, archiveOverrides]);
 
   // Drag state for the Pinned section.
   const dragIdRef = useRef<string | null>(null);
@@ -118,13 +133,16 @@ export function ClassroomsLandingScreen({
     const prev = pinnedOrder;
     setPinnedOrder(ids);
     try {
-      // Translate composite UI ids → bare classroom UUIDs for the API.
-      const byId = new Map(classes.map(c => [c.id, c.classroomId]));
-      const classroomIds = ids.map(id => byId.get(id)).filter(Boolean) as string[];
+      // Translate composite UI ids → {classroom_id, role} pairs for the API.
+      const byId = new Map(classes.map(c => [c.id, c]));
+      const items = ids
+        .map(id => byId.get(id))
+        .filter(Boolean)
+        .map(c => ({ classroom_id: (c as LandingClass).classroomId, role: (c as LandingClass).membershipRole }));
       const res = await fetch('/api/classrooms/reorder-pins', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ids: classroomIds }),
+        body: JSON.stringify({ items }),
       });
       if (!res.ok) {
         setPinnedOrder(prev);
@@ -212,6 +230,7 @@ export function ClassroomsLandingScreen({
               onOpen={() => onOpenClass(c)}
               showSlug={isDuplicate(c.name)}
               onPinChanged={handlePinChanged}
+              onArchiveChanged={handleArchiveChanged}
               draggable={draggable}
               onDragStart={draggable ? handleDragStart(c.id) : undefined}
               onDragOver={draggable ? handleDragOver(c.id) : undefined}

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -4,14 +4,12 @@ import { Button, IconGithub, IconPlus, IconChevron, IconX } from '@classmoji/ui-
 import { AppBar } from './AppBar';
 import { ClassroomCard } from './ClassroomCard';
 import { ClassroomRow, ClassroomRowHeader } from './ClassroomRow';
-import type { LandingClass, TermSection } from './types';
+import type { LandingClass } from './types';
 import type { BellNotification, NotificationRole } from '~/components/features/notifications';
 
 interface Props {
   user: { name?: string | null; login?: string | null; avatar_url?: string | null } | null;
   classes: LandingClass[];
-  termSections: TermSection[];
-  activeTermLabel: string | null;
   onOpenClass: (c: LandingClass) => void;
   notifications?: BellNotification[];
   unreadCount?: number;
@@ -59,8 +57,6 @@ function ViewListIcon() {
 export function ClassroomsLandingScreen({
   user,
   classes,
-  termSections,
-  activeTermLabel,
   onOpenClass,
   notifications,
   unreadCount,
@@ -81,17 +77,15 @@ export function ClassroomsLandingScreen({
     [classes]
   );
 
-  const filteredSections = useMemo(() => {
+  const filteredClasses = useMemo(() => {
     const filterClass = (c: LandingClass) => {
       if (tab === 'teaching') return !c.archived && (c.role === 'OWNER' || c.role === 'ASSISTANT');
       if (tab === 'learning') return !c.archived && c.role === 'STUDENT';
       if (tab === 'archived') return c.archived;
       return !c.archived;
     };
-    return termSections
-      .map(s => ({ ...s, classes: s.classes.filter(filterClass) }))
-      .filter(s => s.classes.length > 0);
-  }, [termSections, tab]);
+    return classes.filter(filterClass);
+  }, [classes, tab]);
 
   return (
     <div style={{ background: 'var(--bg-0)', minHeight: '100vh' }}>
@@ -142,13 +136,6 @@ export function ClassroomsLandingScreen({
                 {counts.archived}
               </span>{' '}
               archived
-              {activeTermLabel && (
-                <>
-                  <span style={{ color: 'var(--ink-4)', margin: '0 6px' }}>·</span>
-                  <span style={{ fontFamily: 'var(--font-mono)' }}>{activeTermLabel}</span> in
-                  progress
-                </>
-              )}
             </div>
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
@@ -180,9 +167,9 @@ export function ClassroomsLandingScreen({
           >
             <span style={{ fontSize: 14 }}>🪙</span>
             <span>
-              <b style={{ fontWeight: 600 }}>Token economy is live this term.</b> Students earn
-              tokens for early submissions and spend them on deadline extensions — configure the
-              rate in class settings.
+              <b style={{ fontWeight: 600 }}>Token economy is live.</b> Students earn tokens for
+              early submissions and spend them on deadline extensions — configure the rate in class
+              settings.
             </span>
             <button
               type="button"
@@ -316,7 +303,7 @@ export function ClassroomsLandingScreen({
           </div>
         </div>
 
-        {filteredSections.length === 0 && (
+        {filteredClasses.length === 0 ? (
           <div
             style={{
               border: '1px dashed var(--line-2)',
@@ -328,119 +315,67 @@ export function ClassroomsLandingScreen({
           >
             Nothing here. Try a different filter.
           </div>
-        )}
-
-        {filteredSections.map(term => (
-          <section key={term.id} style={{ marginTop: 26 }}>
-            <div
+        ) : view === 'grid' ? (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+              gap: 12,
+            }}
+          >
+            {filteredClasses.map(c => (
+              <ClassroomCard key={c.id} c={c} onOpen={() => onOpenClass(c)} />
+            ))}
+            <Link
+              to="/create-classroom"
               style={{
+                border: '1px dashed var(--line-2)',
+                background: 'transparent',
                 display: 'flex',
                 alignItems: 'center',
-                gap: 10,
-                paddingBottom: 10,
-                marginBottom: 12,
-                borderBottom: '1px dashed var(--line)',
+                justifyContent: 'center',
+                flexDirection: 'column',
+                gap: 6,
+                color: 'var(--ink-2)',
+                cursor: 'pointer',
+                minHeight: 150,
+                borderRadius: 8,
+                transition: 'border-color 120ms, color 120ms, background 120ms',
+                textDecoration: 'none',
               }}
             >
               <span
                 style={{
-                  fontSize: 11,
-                  fontWeight: 600,
-                  color: 'var(--ink-2)',
-                  letterSpacing: '0.08em',
-                  textTransform: 'uppercase',
-                }}
-              >
-                {term.label}
-              </span>
-              <span
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 11,
-                  color: 'var(--ink-3)',
-                }}
-              >
-                · {term.meta}
-              </span>
-              <div style={{ flex: 1 }} />
-              <span
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 11,
-                  color: 'var(--ink-3)',
-                }}
-              >
-                {term.classes.length} {term.classes.length === 1 ? 'class' : 'classes'}
-              </span>
-            </div>
-
-            {view === 'grid' ? (
-              <div
-                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 6,
                   display: 'grid',
-                  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-                  gap: 12,
+                  placeItems: 'center',
+                  background: 'var(--bg-3)',
+                  color: 'var(--ink-2)',
                 }}
               >
-                {term.classes.map(c => (
-                  <ClassroomCard key={c.id} c={c} onOpen={() => onOpenClass(c)} />
-                ))}
-                {term.id === 'spring' && (
-                  <Link
-                    to="/create-classroom"
-                    style={{
-                      border: '1px dashed var(--line-2)',
-                      background: 'transparent',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flexDirection: 'column',
-                      gap: 6,
-                      color: 'var(--ink-2)',
-                      cursor: 'pointer',
-                      minHeight: 150,
-                      borderRadius: 8,
-                      transition: 'border-color 120ms, color 120ms, background 120ms',
-                      textDecoration: 'none',
-                    }}
-                  >
-                    <span
-                      style={{
-                        width: 28,
-                        height: 28,
-                        borderRadius: 6,
-                        display: 'grid',
-                        placeItems: 'center',
-                        background: 'var(--bg-3)',
-                        color: 'var(--ink-2)',
-                      }}
-                    >
-                      <IconPlus size={14} />
-                    </span>
-                    <span style={{ fontSize: 13, fontWeight: 500 }}>New class</span>
-                    <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>
-                      or import from GitHub
-                    </span>
-                  </Link>
-                )}
-              </div>
-            ) : (
-              <div
-                style={{
-                  background: 'var(--bg-1)',
-                  border: '1px solid var(--line)',
-                  borderRadius: 8,
-                  overflow: 'hidden',
-                }}
-              >
-                <ClassroomRowHeader />
-                {term.classes.map(c => (
-                  <ClassroomRow key={c.id} c={c} onOpen={() => onOpenClass(c)} />
-                ))}
-              </div>
-            )}
-          </section>
-        ))}
+                <IconPlus size={14} />
+              </span>
+              <span style={{ fontSize: 13, fontWeight: 500 }}>New class</span>
+              <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>or import from GitHub</span>
+            </Link>
+          </div>
+        ) : (
+          <div
+            style={{
+              background: 'var(--bg-1)',
+              border: '1px solid var(--line)',
+              borderRadius: 8,
+              overflow: 'hidden',
+            }}
+          >
+            <ClassroomRowHeader />
+            {filteredClasses.map(c => (
+              <ClassroomRow key={c.id} c={c} onOpen={() => onOpenClass(c)} />
+            ))}
+          </div>
+        )}
 
         <footer
           style={{

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { Link } from 'react-router';
-import { Button, IconGithub, IconPlus, IconChevron, IconX } from '@classmoji/ui-components';
+import { Button, IconGithub, IconPlus, IconX } from '@classmoji/ui-components';
 import { AppBar } from './AppBar';
 import { ClassroomCard } from './ClassroomCard';
 import { ClassroomRow, ClassroomRowHeader } from './ClassroomRow';
@@ -15,8 +15,6 @@ interface Props {
   unreadCount?: number;
   membershipRoles?: Record<string, NotificationRole[]>;
 }
-
-type TabId = 'all' | 'teaching' | 'learning' | 'archived';
 
 function ViewGridIcon() {
   return (
@@ -62,30 +60,111 @@ export function ClassroomsLandingScreen({
   unreadCount,
   membershipRoles,
 }: Props) {
-  const [tab, setTab] = useState<TabId>('all');
   const [view, setView] = useState<'grid' | 'list'>('grid');
   const [bannerOpen, setBannerOpen] = useState(true);
+
+  const { pinned, active, archived } = useMemo(() => {
+    const pinned = classes
+      .filter(c => c.pin_order != null)
+      .sort((a, b) => (a.pin_order ?? 0) - (b.pin_order ?? 0));
+    const active = classes.filter(c => c.pin_order == null && c.is_active);
+    const archived = classes.filter(c => c.pin_order == null && !c.is_active);
+    return { pinned, active, archived };
+  }, [classes]);
 
   const counts = useMemo(
     () => ({
       all: classes.filter(c => !c.archived).length,
-      teaching: classes.filter(c => !c.archived && (c.role === 'OWNER' || c.role === 'ASSISTANT'))
-        .length,
-      learning: classes.filter(c => !c.archived && c.role === 'STUDENT').length,
       archived: classes.filter(c => c.archived).length,
     }),
     [classes]
   );
 
-  const filteredClasses = useMemo(() => {
-    const filterClass = (c: LandingClass) => {
-      if (tab === 'teaching') return !c.archived && (c.role === 'OWNER' || c.role === 'ASSISTANT');
-      if (tab === 'learning') return !c.archived && c.role === 'STUDENT';
-      if (tab === 'archived') return c.archived;
-      return !c.archived;
-    };
-    return classes.filter(filterClass);
-  }, [classes, tab]);
+  const isDuplicate = useMemo(() => {
+    const nameCounts = new Map<string, number>();
+    for (const c of classes) nameCounts.set(c.name, (nameCounts.get(c.name) ?? 0) + 1);
+    return (name: string) => (nameCounts.get(name) ?? 0) > 1;
+  }, [classes]);
+
+  const renderGrid = (items: LandingClass[], withNewCard: boolean) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+        gap: 12,
+      }}
+    >
+      {items.map(c => (
+        <ClassroomCard
+          key={c.id}
+          c={c}
+          onOpen={() => onOpenClass(c)}
+          showSlug={isDuplicate(c.name)}
+        />
+      ))}
+      {withNewCard && (
+        <Link
+          to="/create-classroom"
+          style={{
+            border: '1px dashed var(--line-2)',
+            background: 'transparent',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            gap: 6,
+            color: 'var(--ink-2)',
+            cursor: 'pointer',
+            minHeight: 150,
+            borderRadius: 8,
+            transition: 'border-color 120ms, color 120ms, background 120ms',
+            textDecoration: 'none',
+          }}
+        >
+          <span
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 6,
+              display: 'grid',
+              placeItems: 'center',
+              background: 'var(--bg-3)',
+              color: 'var(--ink-2)',
+            }}
+          >
+            <IconPlus size={14} />
+          </span>
+          <span style={{ fontSize: 13, fontWeight: 500 }}>New class</span>
+          <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>or import from GitHub</span>
+        </Link>
+      )}
+    </div>
+  );
+
+  const renderList = (items: LandingClass[]) => (
+    <div
+      style={{
+        background: 'var(--bg-1)',
+        border: '1px solid var(--line)',
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}
+    >
+      <ClassroomRowHeader />
+      {items.map(c => (
+        <ClassroomRow key={c.id} c={c} onOpen={() => onOpenClass(c)} />
+      ))}
+    </div>
+  );
+
+  const sectionHeading = (label: string, count: number) => (
+    <div className="text-sm font-semibold text-gray-500 dark:text-gray-400" style={{ marginBottom: 10, marginTop: 4 }}>
+      {label}{' '}
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--ink-3)', fontWeight: 400 }}>
+        {count}
+      </span>
+    </div>
+  );
 
   return (
     <div style={{ background: 'var(--bg-0)', minHeight: '100vh' }}>
@@ -197,65 +276,7 @@ export function ClassroomsLandingScreen({
             marginBottom: 18,
           }}
         >
-          <div
-            style={{
-              display: 'flex',
-              gap: 2,
-              padding: 2,
-              background: 'var(--bg-3)',
-              border: '1px solid var(--line)',
-              borderRadius: 7,
-            }}
-          >
-            {(
-              [
-                ['all', 'All', counts.all],
-                ['teaching', 'Teaching', counts.teaching],
-                ['learning', 'Learning', counts.learning],
-                ['archived', 'Archived', counts.archived],
-              ] as const
-            ).map(([id, label, n]) => {
-              const active = tab === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setTab(id)}
-                  style={{
-                    padding: '4px 10px',
-                    borderRadius: 5,
-                    fontSize: 12.5,
-                    fontWeight: 500,
-                    color: active ? 'var(--ink-0)' : 'var(--ink-2)',
-                    background: active ? 'var(--bg-1)' : 'transparent',
-                    boxShadow: active ? '0 1px 2px rgba(0,0,0,0.04)' : 'none',
-                    cursor: 'pointer',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 6,
-                    border: 'none',
-                  }}
-                >
-                  {label}{' '}
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 10.5,
-                      color: active ? 'var(--ink-2)' : 'var(--ink-3)',
-                    }}
-                  >
-                    {n}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-
           <div style={{ flex: 1 }} />
-
-          <button type="button" className="btn" style={{ color: 'var(--ink-2)' }}>
-            Sort: Recent <IconChevron size={12} />
-          </button>
 
           <div
             style={{
@@ -303,7 +324,7 @@ export function ClassroomsLandingScreen({
           </div>
         </div>
 
-        {filteredClasses.length === 0 ? (
+        {pinned.length === 0 && active.length === 0 && archived.length === 0 ? (
           <div
             style={{
               border: '1px dashed var(--line-2)',
@@ -313,68 +334,48 @@ export function ClassroomsLandingScreen({
               color: 'var(--ink-3)',
             }}
           >
-            Nothing here. Try a different filter.
-          </div>
-        ) : view === 'grid' ? (
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-              gap: 12,
-            }}
-          >
-            {filteredClasses.map(c => (
-              <ClassroomCard key={c.id} c={c} onOpen={() => onOpenClass(c)} />
-            ))}
-            <Link
-              to="/create-classroom"
-              style={{
-                border: '1px dashed var(--line-2)',
-                background: 'transparent',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexDirection: 'column',
-                gap: 6,
-                color: 'var(--ink-2)',
-                cursor: 'pointer',
-                minHeight: 150,
-                borderRadius: 8,
-                transition: 'border-color 120ms, color 120ms, background 120ms',
-                textDecoration: 'none',
-              }}
-            >
-              <span
-                style={{
-                  width: 28,
-                  height: 28,
-                  borderRadius: 6,
-                  display: 'grid',
-                  placeItems: 'center',
-                  background: 'var(--bg-3)',
-                  color: 'var(--ink-2)',
-                }}
-              >
-                <IconPlus size={14} />
-              </span>
-              <span style={{ fontSize: 13, fontWeight: 500 }}>New class</span>
-              <span style={{ fontSize: 11, color: 'var(--ink-3)' }}>or import from GitHub</span>
-            </Link>
+            No classrooms yet.
           </div>
         ) : (
-          <div
-            style={{
-              background: 'var(--bg-1)',
-              border: '1px solid var(--line)',
-              borderRadius: 8,
-              overflow: 'hidden',
-            }}
-          >
-            <ClassroomRowHeader />
-            {filteredClasses.map(c => (
-              <ClassroomRow key={c.id} c={c} onOpen={() => onOpenClass(c)} />
-            ))}
-          </div>
+          <>
+            {pinned.length > 0 && (
+              <section style={{ marginBottom: 24 }}>
+                {sectionHeading('Pinned', pinned.length)}
+                {view === 'grid' ? renderGrid(pinned, false) : renderList(pinned)}
+              </section>
+            )}
+
+            {active.length > 0 && (
+              <section style={{ marginBottom: 24 }}>
+                {sectionHeading('Active', active.length)}
+                {view === 'grid' ? renderGrid(active, true) : renderList(active)}
+              </section>
+            )}
+
+            {archived.length > 0 && (
+              <details style={{ marginBottom: 24 }}>
+                <summary
+                  className="text-sm font-semibold text-gray-500 dark:text-gray-400"
+                  style={{ cursor: 'pointer', marginBottom: 10, marginTop: 4, listStyle: 'revert' }}
+                >
+                  Archived{' '}
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 12,
+                      color: 'var(--ink-3)',
+                      fontWeight: 400,
+                    }}
+                  >
+                    {archived.length}
+                  </span>
+                </summary>
+                <div style={{ marginTop: 10 }}>
+                  {view === 'grid' ? renderGrid(archived, false) : renderList(archived)}
+                </div>
+              </details>
+            )}
+          </>
         )}
 
         <footer

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -194,10 +194,11 @@ export function ClassroomsLandingScreen({
 
   const counts = useMemo(
     () => ({
-      all: classes.filter(c => !c.archived).length,
-      archived: classes.filter(c => c.archived).length,
+      all: classes.filter(c => effectiveIsActive(c)).length,
+      archived: classes.filter(c => !effectiveIsActive(c)).length,
     }),
-    [classes]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [classes, archiveOverrides]
   );
 
   const isDuplicate = useMemo(() => {
@@ -493,7 +494,7 @@ export function ClassroomsLandingScreen({
             )}
 
             {archived.length > 0 && (
-              <details style={{ marginBottom: 24 }}>
+              <details open style={{ marginBottom: 24 }}>
                 <summary
                   className="text-sm font-semibold text-gray-500 dark:text-gray-400"
                   style={{ cursor: 'pointer', marginBottom: 10, marginTop: 4, listStyle: 'revert' }}

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -117,10 +117,13 @@ export function ClassroomsLandingScreen({
     const prev = pinnedOrder;
     setPinnedOrder(ids);
     try {
+      // Translate composite UI ids → bare classroom UUIDs for the API.
+      const byId = new Map(classes.map(c => [c.id, c.classroomId]));
+      const classroomIds = ids.map(id => byId.get(id)).filter(Boolean) as string[];
       const res = await fetch('/api/classrooms/reorder-pins', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ids }),
+        body: JSON.stringify({ ids: classroomIds }),
       });
       if (!res.ok) {
         setPinnedOrder(prev);

--- a/apps/webapp/app/components/features/landing/index.ts
+++ b/apps/webapp/app/components/features/landing/index.ts
@@ -4,4 +4,4 @@ export { ClassroomRow, ClassroomRowHeader } from './ClassroomRow';
 export { ClassMark } from './ClassMark';
 export { RoleChip } from './RoleChip';
 export { AppBar } from './AppBar';
-export type { LandingClass, LandingRole, TermBucketId, TermSection } from './types';
+export type { LandingClass, LandingRole } from './types';

--- a/apps/webapp/app/components/features/landing/types.ts
+++ b/apps/webapp/app/components/features/landing/types.ts
@@ -6,8 +6,10 @@ export type LandingRole = 'OWNER' | 'ASSISTANT' | 'STUDENT' | 'PENDING INVITE';
 
 export interface LandingClass {
   id: string;
-  /** Bare classroom UUID for API calls (pin/reorder). `id` is composite `${classroomId}:${role}` for UI dedup. */
+  /** Bare classroom UUID for API calls (pin/reorder, archive). `id` is composite `${classroomId}:${role}` for UI dedup. */
   classroomId: string;
+  /** Underlying DB role on the membership (OWNER/ASSISTANT/STUDENT/TEACHER) used to disambiguate pin/archive calls for users with multiple memberships per classroom. */
+  membershipRole: string;
   name: string;
   subtitle: string;
   slug: string;

--- a/apps/webapp/app/components/features/landing/types.ts
+++ b/apps/webapp/app/components/features/landing/types.ts
@@ -4,16 +4,12 @@
 
 export type LandingRole = 'OWNER' | 'ASSISTANT' | 'STUDENT' | 'PENDING INVITE';
 
-export type TermBucketId = 'spring' | 'summer' | 'fall' | 'winter' | 'sandbox';
-
 export interface LandingClass {
   id: string;
   name: string;
   subtitle: string;
   slug: string;
   role: LandingRole;
-  term: TermBucketId;
-  termLabel: string;
   hue: number;
   students: number;
   pending: number;
@@ -27,11 +23,4 @@ export interface LandingClass {
     name?: string | null;
   };
   hasAcceptedInvite: boolean;
-}
-
-export interface TermSection {
-  id: TermBucketId;
-  label: string;
-  meta: string;
-  classes: LandingClass[];
 }

--- a/apps/webapp/app/components/features/landing/types.ts
+++ b/apps/webapp/app/components/features/landing/types.ts
@@ -16,6 +16,9 @@ export interface LandingClass {
   progress: number;
   updated: string;
   archived: boolean;
+  pin_order: number | null;
+  is_active: boolean;
+  updated_at: string | Date;
   // Pass-through for navigation handler
   organization: {
     id: string;

--- a/apps/webapp/app/components/features/landing/types.ts
+++ b/apps/webapp/app/components/features/landing/types.ts
@@ -6,6 +6,8 @@ export type LandingRole = 'OWNER' | 'ASSISTANT' | 'STUDENT' | 'PENDING INVITE';
 
 export interface LandingClass {
   id: string;
+  /** Bare classroom UUID for API calls (pin/reorder). `id` is composite `${classroomId}:${role}` for UI dedup. */
+  classroomId: string;
   name: string;
   subtitle: string;
   slug: string;

--- a/apps/webapp/app/components/layout/navigation/OrgSelect.tsx
+++ b/apps/webapp/app/components/layout/navigation/OrgSelect.tsx
@@ -25,19 +25,6 @@ const roleLabel = (role: string) => {
   return map[role] ?? role.charAt(0) + role.slice(1).toLowerCase();
 };
 
-const termAbbreviation = (term?: string | null, year?: number | null) => {
-  if (!term || !year) return null;
-  const prefix: Record<string, string> = {
-    FALL: 'F',
-    WINTER: 'W',
-    SPRING: 'S',
-    SUMMER: 'X',
-  };
-  const p = prefix[term];
-  if (!p) return null;
-  return `${p}${String(year).slice(-2)}`;
-};
-
 const OrgSelect = ({ memberships }: OrgSelectProps) => {
   const { membership } = useStore();
   const navigate = useNavigate();
@@ -113,17 +100,11 @@ const OrgSelect = ({ memberships }: OrgSelectProps) => {
         labelInValue={true}
         labelRender={() => {
           if (!membership) return null;
-          const term = termAbbreviation(membership.organization.term, membership.organization.year);
           return (
             <div className="min-w-0 px-1 flex items-baseline gap-1.5">
               <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
                 {membership.organization.name}
               </span>
-              {term && (
-                <span className="text-xs font-medium text-gray-400 dark:text-gray-500 shrink-0">
-                  {term}
-                </span>
-              )}
             </div>
           );
         }}
@@ -150,17 +131,6 @@ const OrgSelect = ({ memberships }: OrgSelectProps) => {
                   <div className="font-medium text-[13px] text-gray-900 dark:text-gray-100 truncate leading-tight">
                     {membershipOption.organization.name}
                   </div>
-                  {(() => {
-                    const term = termAbbreviation(
-                      membershipOption.organization.term,
-                      membershipOption.organization.year
-                    );
-                    return term ? (
-                      <span className="text-[11px] font-medium text-gray-400 dark:text-gray-500 shrink-0">
-                        {term}
-                      </span>
-                    ) : null;
-                  })()}
                 </div>
                 <div className="text-[11px] text-gray-500 dark:text-gray-400 truncate leading-tight">
                   {roleLabel(membershipOption.role)}

--- a/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
@@ -7,11 +7,10 @@ import type { GitOrganizationOption } from './types';
 interface StepBasicInfoProps {
   gitOrgs: GitOrganizationOption[];
   slugPreview: string;
-  years: number[];
   githubAppName?: string | null;
 }
 
-const StepBasicInfo = ({ gitOrgs, slugPreview, years, githubAppName }: StepBasicInfoProps) => {
+const StepBasicInfo = ({ gitOrgs, slugPreview, githubAppName }: StepBasicInfoProps) => {
   const {
     control,
     formState: { errors },
@@ -100,63 +99,6 @@ const StepBasicInfo = ({ gitOrgs, slugPreview, years, githubAppName }: StepBasic
           {errors.name && (
             <span className="text-red-500 text-sm">{errors.name.message as string}</span>
           )}
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <p className="block text-sm font-medium mb-1">
-              <span className="text-red-500">*</span> Term
-            </p>
-            <Controller
-              name="term"
-              control={control}
-              rules={{ required: 'Please select a term' }}
-              render={({ field }) => (
-                <Select
-                  {...field}
-                  placeholder="Select Term"
-                  className="w-full"
-                  status={errors.term ? 'error' : ''}
-                >
-                  <Select.Option value="FALL">Fall</Select.Option>
-                  <Select.Option value="SPRING">Spring</Select.Option>
-                  <Select.Option value="SUMMER">Summer</Select.Option>
-                  <Select.Option value="WINTER">Winter</Select.Option>
-                </Select>
-              )}
-            />
-            {errors.term && (
-              <span className="text-red-500 text-sm">{errors.term.message as string}</span>
-            )}
-          </div>
-
-          <div>
-            <p className="block text-sm font-medium mb-1">
-              <span className="text-red-500">*</span> Year
-            </p>
-            <Controller
-              name="year"
-              control={control}
-              rules={{ required: 'Please select a year' }}
-              render={({ field }) => (
-                <Select
-                  {...field}
-                  placeholder="Select Year"
-                  className="w-full"
-                  status={errors.year ? 'error' : ''}
-                >
-                  {years.map(year => (
-                    <Select.Option key={year} value={year}>
-                      {year}
-                    </Select.Option>
-                  ))}
-                </Select>
-              )}
-            />
-            {errors.year && (
-              <span className="text-red-500 text-sm">{errors.year.message as string}</span>
-            )}
-          </div>
         </div>
 
         {slugPreview && (

--- a/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
@@ -1,21 +1,57 @@
+import { useState } from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { Input, Select, Avatar, Button, Divider, Spin } from 'antd';
-import { PlusOutlined, LoadingOutlined } from '@ant-design/icons';
+import { PlusOutlined, LoadingOutlined, EditOutlined } from '@ant-design/icons';
 import { useGitHubAppInstallPopup } from '~/hooks';
 import type { GitOrganizationOption } from './types';
+import { slugify } from './utils';
+
+interface AvailabilityResponse {
+  slug_available: boolean;
+  slug_suggestion?: string;
+}
 
 interface StepBasicInfoProps {
   gitOrgs: GitOrganizationOption[];
   slugPreview: string;
   githubAppName?: string | null;
+  availability?: AvailabilityResponse;
+  availabilityLoading?: boolean;
 }
 
-const StepBasicInfo = ({ gitOrgs, slugPreview, githubAppName }: StepBasicInfoProps) => {
+const StepBasicInfo = ({
+  gitOrgs,
+  slugPreview,
+  githubAppName,
+  availability,
+  availabilityLoading,
+}: StepBasicInfoProps) => {
   const {
     control,
+    setValue,
+    watch,
     formState: { errors },
   } = useFormContext();
   const { openInstallPopup, isRefreshing } = useGitHubAppInstallPopup(githubAppName ?? undefined);
+
+  const slugOverride = watch('slug') as string | undefined;
+  const effectiveSlug = slugOverride && slugOverride.length > 0 ? slugOverride : slugPreview;
+
+  const [editingSlug, setEditingSlug] = useState(false);
+
+  const showResult = !!effectiveSlug && !availabilityLoading && !!availability;
+  const slugTaken = showResult && availability!.slug_available === false;
+  const slugAvailable = showResult && availability!.slug_available === true;
+
+  const applySuggestion = () => {
+    if (availability?.slug_suggestion) {
+      setValue('slug', availability.slug_suggestion, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      setEditingSlug(false);
+    }
+  };
 
   // Custom dropdown footer with "Install on another organization" button
   const dropdownRender = (menu: React.ReactNode) => (
@@ -93,6 +129,14 @@ const StepBasicInfo = ({ gitOrgs, slugPreview, githubAppName }: StepBasicInfoPro
                 {...field}
                 placeholder="e.g., CS 101, Introduction to Programming"
                 status={errors.name ? 'error' : ''}
+                onChange={e => {
+                  field.onChange(e);
+                  // Reset any manual slug override so the slug re-derives from name,
+                  // unless the user is actively editing the slug field.
+                  if (!editingSlug) {
+                    setValue('slug', '', { shouldDirty: false });
+                  }
+                }}
               />
             )}
           />
@@ -101,12 +145,83 @@ const StepBasicInfo = ({ gitOrgs, slugPreview, githubAppName }: StepBasicInfoPro
           )}
         </div>
 
-        {slugPreview && (
-          <div className="text-sm text-gray-600 dark:text-gray-300">
-            Slug:{' '}
-            <code className="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 px-2 py-1 rounded">
-              {slugPreview}
-            </code>
+        {(slugPreview || slugOverride) && (
+          <div>
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+              <span>Slug:</span>
+              {editingSlug ? (
+                <Controller
+                  name="slug"
+                  control={control}
+                  render={({ field }) => (
+                    <Input
+                      {...field}
+                      size="small"
+                      style={{ width: 240 }}
+                      onChange={e => field.onChange(slugify(e.target.value))}
+                      onBlur={() => {
+                        field.onBlur();
+                        setEditingSlug(false);
+                      }}
+                      autoFocus
+                    />
+                  )}
+                />
+              ) : (
+                <>
+                  <code
+                    className={
+                      slugTaken
+                        ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 px-2 py-1 rounded'
+                        : 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 px-2 py-1 rounded'
+                    }
+                  >
+                    {effectiveSlug}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => setEditingSlug(true)}
+                    className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                    aria-label="Edit slug"
+                  >
+                    <EditOutlined /> edit
+                  </button>
+                </>
+              )}
+            </div>
+
+            {/* Availability feedback */}
+            <div className="mt-1 text-sm min-h-[1.25rem]">
+              {availabilityLoading && (
+                <span className="text-gray-400 dark:text-gray-500">Checking availability…</span>
+              )}
+              {!availabilityLoading && slugAvailable && (
+                <span className="text-emerald-600 dark:text-emerald-400">✓ available</span>
+              )}
+              {!availabilityLoading && slugTaken && (
+                <span className="text-red-600 dark:text-red-400 inline-flex items-center gap-2 flex-wrap">
+                  <span>
+                    &lsquo;{effectiveSlug}&rsquo; is taken
+                    {availability?.slug_suggestion ? (
+                      <>
+                        {' '}
+                        — try &lsquo;
+                        <span className="font-mono">{availability.slug_suggestion}</span>&rsquo;
+                      </>
+                    ) : null}
+                  </span>
+                  {availability?.slug_suggestion && (
+                    <button
+                      type="button"
+                      onClick={applySuggestion}
+                      className="px-2 py-0.5 rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/40 text-xs"
+                    >
+                      Use suggestion
+                    </button>
+                  )}
+                </span>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
@@ -133,9 +133,6 @@ const StepImportModules = ({
                           />
                         )}
                         <span>{classroom.name}</span>
-                        <span className="text-gray-400">
-                          ({classroom.term} {classroom.year})
-                        </span>
                         <span className="text-gray-400 ml-auto">
                           {classroom.modules?.length || 0} modules
                         </span>

--- a/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
@@ -29,7 +29,7 @@ const StepReview = ({
   sourceClassroom,
   selectedModules,
 }: StepReviewProps) => {
-  const { git_org_id, name, term, year } = formValues;
+  const { git_org_id, name } = formValues;
   const selectedOrg = gitOrgs.find(o => o.id === git_org_id);
 
   // Calculate totals
@@ -72,12 +72,6 @@ const StepReview = ({
             <span className="font-medium">{name}</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-gray-500">Term</span>
-            <span>
-              {term} {year}
-            </span>
-          </div>
-          <div className="flex justify-between">
             <span className="text-gray-500">Slug</span>
             <code className="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 px-2 py-0.5 rounded text-sm">
               {slugPreview}
@@ -104,9 +98,6 @@ const StepReview = ({
                   <Avatar src={sourceClassroom.git_organization.avatar_url} size={16} />
                 )}
                 <span>{sourceClassroom?.name}</span>
-                <span className="text-gray-400">
-                  ({sourceClassroom?.term} {sourceClassroom?.year})
-                </span>
               </div>
             </div>
             <div className="flex justify-between items-center">

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -5,10 +5,10 @@ import {
   GitHubProvider,
   getGitProvider,
   ensureClassroomTeam,
-  classroomService,
 } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import getPrisma from '@classmoji/database';
+import { slugify } from './utils';
 
 export const action = checkAuth(async ({ request }: { request: Request }) => {
   const authData = await getAuthSession(request);
@@ -22,10 +22,10 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     return { error: 'Unauthorized' };
   }
 
-  const { git_org_id, name, term, year, importConfig } = await request.json();
+  const { git_org_id, name, importConfig } = await request.json();
 
-  if (!term || !year) {
-    return { error: 'Term and year are required' };
+  if (!name) {
+    return { error: 'Classroom name is required' };
   }
 
   // Get GitOrganization
@@ -65,8 +65,8 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     };
   }
 
-  // Generate unique slug (name, term, year - no gitOrg)
-  const slug = await classroomService.generateSlug(name, term, year);
+  // Slug derived from name only
+  const slug = slugify(name);
 
   // Create Classroom, Settings, and Membership in transaction
   const classroom = await getPrisma().$transaction(async tx => {
@@ -75,8 +75,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
         git_org_id,
         slug,
         name,
-        term,
-        year: Number(year),
+        content_namespace: slug,
       },
     });
 

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -22,7 +22,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     return { error: 'Unauthorized' };
   }
 
-  const { git_org_id, name, importConfig } = await request.json();
+  const { git_org_id, name, slug: slugInput, importConfig } = await request.json();
 
   if (!name) {
     return { error: 'Classroom name is required' };
@@ -65,8 +65,8 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     };
   }
 
-  // Slug derived from name only
-  const slug = slugify(name);
+  // Slug: prefer client-provided (user override / suggestion) when present, else derive from name.
+  const slug = slugInput && typeof slugInput === 'string' ? slugify(slugInput) : slugify(name);
 
   // Create Classroom, Settings, and Membership in transaction
   const classroom = await getPrisma().$transaction(async tx => {

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -12,7 +12,7 @@ import getPrisma from '@classmoji/database';
 import StepBasicInfo from './StepBasicInfo';
 import StepImportModules from './StepImportModules';
 import StepReview from './StepReview';
-import { slugify, getTermCode, STEPS } from './utils';
+import { slugify, STEPS } from './utils';
 import type { Route } from './+types/route';
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
@@ -147,8 +147,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
       id: true,
       slug: true,
       name: true,
-      term: true,
-      year: true,
       git_organization: {
         select: {
           login: true,
@@ -189,16 +187,11 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
   const { fetcher, notify } = useGlobalFetcher();
   const { openInstallPopup, isRefreshing } = useGitHubAppInstallPopup(githubAppName);
 
-  const currentYear = new Date().getFullYear();
-  const years = [currentYear - 1, currentYear, currentYear + 1, currentYear + 2];
-
   // React Hook Form - persists values across step changes
   const methods = useForm({
     defaultValues: {
       git_org_id: '',
       name: '',
-      term: '',
-      year: currentYear,
     },
   });
 
@@ -224,20 +217,11 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
   }, [fetcher!.data, navigate]);
 
   // Compute slug preview from watched form values
-  const slugPreview = (() => {
-    const { name, term, year } = formValues;
-    if (name && term && year) {
-      const termCode = getTermCode(term, year);
-      return `${slugify(name)}-${termCode}`;
-    } else if (name) {
-      return slugify(name);
-    }
-    return '';
-  })();
+  const slugPreview = formValues.name ? slugify(formValues.name) : '';
 
   const handleNext = async () => {
     if (currentStep === 0) {
-      const isValid = await trigger(['git_org_id', 'name', 'term', 'year']);
+      const isValid = await trigger(['git_org_id', 'name']);
       if (isValid) {
         setCurrentStep(1);
       }
@@ -315,7 +299,6 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
               <StepBasicInfo
                 gitOrgs={gitOrgs}
                 slugPreview={slugPreview}
-                years={years}
                 githubAppName={githubAppName}
               />
             )}

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -1,5 +1,5 @@
-import { redirect, useNavigate } from 'react-router';
-import { useState, useEffect } from 'react';
+import { redirect, useNavigate, useFetcher } from 'react-router';
+import { useState, useEffect, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { Button, Card, Alert, Steps } from 'antd';
 
@@ -192,6 +192,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     defaultValues: {
       git_org_id: '',
       name: '',
+      slug: '',
     },
   });
 
@@ -218,11 +219,40 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
 
   // Compute slug preview from watched form values
   const slugPreview = formValues.name ? slugify(formValues.name) : '';
+  const slugOverride = (formValues as { slug?: string }).slug;
+  const effectiveSlug = slugOverride && slugOverride.length > 0 ? slugOverride : slugPreview;
+
+  // Debounced availability check (shared with StepBasicInfo via props)
+  const availabilityFetcher = useFetcher<{
+    slug_available: boolean;
+    slug_suggestion?: string;
+  }>();
+  const lastQueriedRef = useRef<string>('');
+  useEffect(() => {
+    if (!formValues.git_org_id || !effectiveSlug) return;
+    const key = `${formValues.git_org_id}::${effectiveSlug}`;
+    if (lastQueriedRef.current === key) return;
+    const handle = setTimeout(() => {
+      lastQueriedRef.current = key;
+      const params = new URLSearchParams({
+        git_org_id: formValues.git_org_id,
+        slug: effectiveSlug,
+      });
+      availabilityFetcher.load(`/api/classrooms/availability?${params.toString()}`);
+    }, 300);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formValues.git_org_id, effectiveSlug]);
+
+  const slugIsTaken =
+    !!availabilityFetcher.data &&
+    availabilityFetcher.data.slug_available === false &&
+    availabilityFetcher.state === 'idle';
 
   const handleNext = async () => {
     if (currentStep === 0) {
       const isValid = await trigger(['git_org_id', 'name']);
-      if (isValid) {
+      if (isValid && !slugIsTaken) {
         setCurrentStep(1);
       }
     } else if (currentStep === 1) {
@@ -252,7 +282,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     notify(ActionTypes.CREATE_CLASSROOM, 'Creating classroom...');
 
     fetcher!.submit(
-      { ...values, importConfig },
+      { ...values, slug: effectiveSlug, importConfig },
       {
         method: 'post',
         action: '/create-classroom',
@@ -300,6 +330,8 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                 gitOrgs={gitOrgs}
                 slugPreview={slugPreview}
                 githubAppName={githubAppName}
+                availability={availabilityFetcher.data}
+                availabilityLoading={availabilityFetcher.state !== 'idle'}
               />
             )}
 
@@ -333,7 +365,11 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                   <Button onClick={() => navigate('/select-organization')}>Cancel</Button>
                 )}
                 {currentStep < 2 ? (
-                  <Button type="primary" onClick={handleNext}>
+                  <Button
+                    type="primary"
+                    onClick={handleNext}
+                    disabled={currentStep === 0 && slugIsTaken}
+                  >
                     Next
                   </Button>
                 ) : (

--- a/apps/webapp/app/routes/_user.create-classroom/types.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/types.ts
@@ -26,8 +26,6 @@ export interface OwnedClassroom {
   id: string;
   slug?: string;
   name: string;
-  term: string | null;
-  year: number | null;
   git_organization?: {
     login: string;
     avatar_url?: string | null;
@@ -43,6 +41,4 @@ export interface ModuleConfig {
 export interface CreateClassroomFormValues {
   git_org_id: string;
   name: string;
-  term: string;
-  year: number;
 }

--- a/apps/webapp/app/routes/_user.create-classroom/utils.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/utils.ts
@@ -5,10 +5,4 @@ export const slugify = (str: string) => {
     .replace(/^-+|-+$/g, '');
 };
 
-export const getTermCode = (term: string, year: string | number) => {
-  const termMap: Record<string, string> = { WINTER: 'w', SPRING: 's', SUMMER: 'x', FALL: 'f' };
-  const shortYear = String(year).slice(-2);
-  return `${shortYear}${termMap[term] || 'x'}`;
-};
-
 export const STEPS = [{ title: 'Basic Info' }, { title: 'Import' }, { title: 'Review' }];

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -156,6 +156,7 @@ function buildLandingClasses(memberships: SelectOrganizationMembership[]): Landi
     return {
       landing: {
         id: `${org.id}:${m.role}`,
+        classroomId: org.id,
         name: org.name ?? orgLogin,
         subtitle: '',
         slug: `@${gitLogin}/${orgLogin}`,

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -23,8 +23,6 @@ import {
   ClassroomsLandingScreen,
   type LandingClass,
   type LandingRole,
-  type TermBucketId,
-  type TermSection,
 } from '~/components/features/landing';
 import type { NotificationRole } from '~/components/features/notifications';
 
@@ -115,20 +113,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
 // ───────── helpers ─────────
 
-const TERM_BUCKETS: Record<string, { id: TermBucketId; name: string }> = {
-  SPRING: { id: 'spring', name: 'Spring' },
-  SUMMER: { id: 'summer', name: 'Summer' },
-  FALL: { id: 'fall', name: 'Fall' },
-  WINTER: { id: 'winter', name: 'Winter' },
-};
-
-const SEASON_ORDER: TermBucketId[] = ['spring', 'summer', 'fall', 'winter', 'sandbox'];
-
-function isSandboxOrg(login: string | null | undefined, name: string | null | undefined): boolean {
-  const s = `${login ?? ''} ${name ?? ''}`.toLowerCase();
-  return /\b(sandbox|dev[-\s]?test|demo|test)\b/.test(s);
-}
-
 function deriveRole(role: string, hasAcceptedInvite: boolean): LandingRole {
   if (!hasAcceptedInvite && role !== 'OWNER') return 'PENDING INVITE';
   if (role === 'TEACHER' || role === 'OWNER') return 'OWNER';
@@ -155,78 +139,41 @@ function formatUpdated(d: Date | string | null | undefined): string {
 }
 
 function buildLandingClasses(memberships: SelectOrganizationMembership[]): LandingClass[] {
-  return memberships.map(m => {
+  const items = memberships.map(m => {
     const org = m.organization;
     const orgLogin = org.login;
     const gitLogin = org.git_organization?.login ?? orgLogin;
-    const term = org.term ? TERM_BUCKETS[org.term] : null;
-    const sandbox = isSandboxOrg(orgLogin, org.name);
-    const bucketId: TermBucketId = sandbox ? 'sandbox' : (term?.id ?? 'fall');
-    const termLabel = sandbox
-      ? 'Sandbox'
-      : `${org.year ?? ''}${org.year && term ? ' · ' : ''}${term?.name ?? ''}`.trim() ||
-        'Unscheduled';
 
     const archived = org.is_active === false;
     const updatedAt =
       org.settings?.updated_at ?? (org as { updated_at?: Date | string | null }).updated_at;
+    const updatedTs = updatedAt
+      ? new Date(updatedAt as string | Date).getTime() || 0
+      : 0;
 
     return {
-      id: `${org.id}:${m.role}`,
-      name: org.name ?? orgLogin,
-      subtitle: '', // TODO: wire description if Classroom gets one
-      slug: `@${gitLogin}/${orgLogin}`,
-      role: deriveRole(m.role, m.has_accepted_invite),
-      term: bucketId,
-      termLabel,
-      hue: hashHue(org.id),
-      students: 0, // TODO: wire aggregates (roster count)
-      pending: 0, // TODO: wire aggregates (to-grade / open count)
-      progress: 0, // TODO: wire aggregates (term progress)
-      updated: archived ? 'archived' : formatUpdated(updatedAt),
-      archived,
-      organization: { id: org.id, login: orgLogin, name: org.name },
-      hasAcceptedInvite: m.has_accepted_invite,
-    } satisfies LandingClass;
-  });
-}
-
-function buildTermSections(classes: LandingClass[]): TermSection[] {
-  // Group by (year, bucket). Sandbox is its own bucket regardless of year.
-  const buckets = new Map<string, LandingClass[]>();
-  for (const c of classes) {
-    const key = c.termLabel;
-    if (!buckets.has(key)) buckets.set(key, []);
-    buckets.get(key)!.push(c);
-  }
-
-  const sections: TermSection[] = [];
-  for (const [label, items] of buckets) {
-    const first = items[0]!;
-    sections.push({
-      id: first.term,
-      label,
-      meta:
-        first.term === 'sandbox'
-          ? 'for development & testing'
-          : items[0]!.archived
-            ? 'archived'
-            : 'in progress',
-      classes: items,
-    });
-  }
-
-  // Sort: non-archived first, then by season order; sandbox last.
-  sections.sort((a, b) => {
-    if (a.id === 'sandbox' && b.id !== 'sandbox') return 1;
-    if (b.id === 'sandbox' && a.id !== 'sandbox') return -1;
-    const aArch = a.classes.every(c => c.archived);
-    const bArch = b.classes.every(c => c.archived);
-    if (aArch !== bArch) return aArch ? 1 : -1;
-    return SEASON_ORDER.indexOf(a.id) - SEASON_ORDER.indexOf(b.id);
+      landing: {
+        id: `${org.id}:${m.role}`,
+        name: org.name ?? orgLogin,
+        subtitle: '',
+        slug: `@${gitLogin}/${orgLogin}`,
+        role: deriveRole(m.role, m.has_accepted_invite),
+        hue: hashHue(org.id),
+        students: 0,
+        pending: 0,
+        progress: 0,
+        updated: archived ? 'archived' : formatUpdated(updatedAt),
+        archived,
+        organization: { id: org.id, login: orgLogin, name: org.name },
+        hasAcceptedInvite: m.has_accepted_invite,
+      } satisfies LandingClass,
+      updatedTs,
+    };
   });
 
-  return sections;
+  // Recency sort: most recently updated first (intermediate; Task 7 adds full Pinned/Active/Archived)
+  items.sort((a, b) => b.updatedTs - a.updatedTs);
+  return items.map(i => i.landing);
 }
 
 // ───────── component ─────────
@@ -246,11 +193,6 @@ const SelectOrganization = ({ loaderData }: Route.ComponentProps) => {
 
   const memberList = memberships as SelectOrganizationMembership[];
   const classes = useMemo(() => buildLandingClasses(memberList), [memberList]);
-  const termSections = useMemo(() => buildTermSections(classes), [classes]);
-  const activeTermLabel = useMemo(() => {
-    const active = termSections.find(s => s.id !== 'sandbox' && s.classes.some(c => !c.archived));
-    return active?.label ?? null;
-  }, [termSections]);
 
   if (!user) return null;
 
@@ -338,8 +280,6 @@ const SelectOrganization = ({ loaderData }: Route.ComponentProps) => {
               : null
           }
           classes={classes}
-          termSections={termSections}
-          activeTermLabel={activeTermLabel}
           onOpenClass={onOpenClass}
           notifications={notifications}
           unreadCount={unreadCount}

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -140,16 +140,18 @@ function formatUpdated(d: Date | string | null | undefined): string {
 
 function buildLandingClasses(memberships: SelectOrganizationMembership[]): LandingClass[] {
   const items = memberships.map(m => {
-    const org = m.organization;
+    const org = m.organization as SelectOrganizationMembership['organization'] & {
+      pin_order?: number | null;
+      updated_at?: Date | string | null;
+    };
     const orgLogin = org.login;
     const gitLogin = org.git_organization?.login ?? orgLogin;
 
     const archived = org.is_active === false;
     const updatedAt =
       org.settings?.updated_at ?? (org as { updated_at?: Date | string | null }).updated_at;
-    const updatedTs = updatedAt
-      ? new Date(updatedAt as string | Date).getTime() || 0
-      : 0;
+    const updatedTs = updatedAt ? new Date(updatedAt as string | Date).getTime() || 0 : 0;
+    const pinOrder = org.pin_order ?? null;
 
     return {
       landing: {
@@ -164,15 +166,26 @@ function buildLandingClasses(memberships: SelectOrganizationMembership[]): Landi
         progress: 0,
         updated: archived ? 'archived' : formatUpdated(updatedAt),
         archived,
+        pin_order: pinOrder,
+        is_active: !archived,
+        updated_at: (updatedAt as string | Date | null) ?? new Date(0),
         organization: { id: org.id, login: orgLogin, name: org.name },
         hasAcceptedInvite: m.has_accepted_invite,
       } satisfies LandingClass,
       updatedTs,
+      pinOrder,
     };
   });
 
-  // Recency sort: most recently updated first (intermediate; Task 7 adds full Pinned/Active/Archived)
-  items.sort((a, b) => b.updatedTs - a.updatedTs);
+  // Sort: pin_order ASC NULLS LAST, then updated_at DESC
+  items.sort((a, b) => {
+    const ap = a.pinOrder;
+    const bp = b.pinOrder;
+    if (ap != null && bp != null && ap !== bp) return ap - bp;
+    if (ap != null && bp == null) return -1;
+    if (ap == null && bp != null) return 1;
+    return b.updatedTs - a.updatedTs;
+  });
   return items.map(i => i.landing);
 }
 

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -71,10 +71,9 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
   if (user) {
     const typedUser = user as AppUser;
-    const memberships = (typedUser.memberships ?? []) as SelectOrganizationMembership[];
-    typedUser.memberships = memberships.filter(
-      ({ organization }) => organization.is_active !== false
-    );
+    // Surface ALL memberships — including archived classrooms — so the
+    // landing screen can show them in the Archived section.
+    typedUser.memberships = (typedUser.memberships ?? []) as SelectOrganizationMembership[];
 
     const { items, unreadCount } = await notificationService.getForBell(typedUser.id);
     const notifications = items.map(n => ({

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -141,7 +141,6 @@ function formatUpdated(d: Date | string | null | undefined): string {
 function buildLandingClasses(memberships: SelectOrganizationMembership[]): LandingClass[] {
   const items = memberships.map(m => {
     const org = m.organization as SelectOrganizationMembership['organization'] & {
-      pin_order?: number | null;
       updated_at?: Date | string | null;
     };
     const orgLogin = org.login;
@@ -151,12 +150,13 @@ function buildLandingClasses(memberships: SelectOrganizationMembership[]): Landi
     const updatedAt =
       org.settings?.updated_at ?? (org as { updated_at?: Date | string | null }).updated_at;
     const updatedTs = updatedAt ? new Date(updatedAt as string | Date).getTime() || 0 : 0;
-    const pinOrder = org.pin_order ?? null;
+    const pinOrder = (m as { pin_order?: number | null }).pin_order ?? null;
 
     return {
       landing: {
         id: `${org.id}:${m.role}`,
         classroomId: org.id,
+        membershipRole: m.role,
         name: org.name ?? orgLogin,
         subtitle: '',
         slug: `@${gitLogin}/${orgLogin}`,

--- a/apps/webapp/app/routes/admin.$class.pages.$pageId/action.ts
+++ b/apps/webapp/app/routes/admin.$class.pages.$pageId/action.ts
@@ -9,8 +9,6 @@ const extractBodyContent = (html: string): string => {
   const bodyMatch = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
   return bodyMatch ? bodyMatch[1] : html;
 };
-import { generateTermString } from '@classmoji/utils';
-
 import type { Route } from './+types/route';
 
 interface PageWithClassroom {
@@ -19,8 +17,7 @@ interface PageWithClassroom {
   content_path: string;
   width: number;
   classroom: {
-    term: string | undefined;
-    year: number | undefined;
+    content_namespace: string;
     git_organization: {
       login: string;
       provider: string;
@@ -99,11 +96,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const term = generateTermString(
-        pageData.classroom.term,
-        pageData.classroom.year ?? undefined
-      );
-      const repo = `content-${gitOrg.login}-${term}`;
+      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
       const assetsFolder = `${page.content_path}/assets`;
 
       console.error('[upload-image action] Uploading to repo:', repo, 'folder:', assetsFolder);
@@ -174,11 +167,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const term = generateTermString(
-        pageData.classroom.term,
-        pageData.classroom.year ?? undefined
-      );
-      const repo = `content-${gitOrg.login}-${term}`;
+      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
       const assetsFolder = `${page.content_path}/assets`;
 
       const buffer = Buffer.from(await file.arrayBuffer());
@@ -342,11 +331,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const term = generateTermString(
-        pageData.classroom.term,
-        pageData.classroom.year ?? undefined
-      );
-      const repo = `content-${gitOrg.login}-${term}`;
+      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
 
       // Upload header image to content repo (in page folder, not assets)
       const buffer = Buffer.from(await file.arrayBuffer());
@@ -459,11 +444,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const term = generateTermString(
-        pageData.classroom.term,
-        pageData.classroom.year ?? undefined
-      );
-      const repo = `content-${gitOrg.login}-${term}`;
+      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
       const assetsFolder = `${page.content_path}/assets`;
 
       // Read markdown content
@@ -614,11 +595,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
     const savePageData = page as unknown as PageWithClassroom;
     const gitOrg = savePageData.classroom.git_organization;
-    const term = generateTermString(
-      savePageData.classroom.term,
-      savePageData.classroom.year ?? undefined
-    );
-    const repo = `content-${gitOrg.login}-${term}`;
+    const repo = `content-${gitOrg.login}-${savePageData.classroom.content_namespace}`;
     const filePath = `${page.content_path}/index.html`;
 
     // Wrap HTML content in full document with the page's width setting

--- a/apps/webapp/app/routes/admin.$class.pages.new/BatchImportTab.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages.new/BatchImportTab.tsx
@@ -18,11 +18,14 @@ interface ImportedPage {
 }
 
 interface BatchImportTabProps {
-  term: string;
+  contentNamespace: string;
   onPagesChange: (pages: ImportedPage[]) => void;
 }
 
-export default function BatchImportTab({ term, onPagesChange }: BatchImportTabProps) {
+export default function BatchImportTab({
+  contentNamespace,
+  onPagesChange,
+}: BatchImportTabProps) {
   const [pages, setPages] = useState<ImportedPage[]>([]);
   const [isExtracting, setIsExtracting] = useState(false);
   const [extractError, setExtractError] = useState<string | null>(null);
@@ -191,7 +194,7 @@ export default function BatchImportTab({ term, onPagesChange }: BatchImportTabPr
 
       {/* Hidden inputs for form data */}
       <input type="hidden" name="intent" value="batch-import" />
-      <input type="hidden" name="term" value={term} />
+      <input type="hidden" name="contentNamespace" value={contentNamespace} />
     </div>
   );
 }

--- a/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
@@ -11,7 +11,6 @@ import { wrapHtmlContent } from '~/utils/htmlWrapper';
 import ImportTab from './ImportTab';
 import CreateBlankTab from './CreateBlankTab';
 import BatchImportTab from './BatchImportTab';
-import { generateTermString } from '@classmoji/utils';
 import { useRouteDrawer } from '~/hooks';
 import { generatePageTemplate } from './utils';
 import type { Route } from './+types/route';
@@ -27,12 +26,11 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     attemptedAction: 'create_page',
   });
 
-  // Generate term from classroom settings
-  const term = generateTermString(classroom.term ?? undefined, classroom.year ?? undefined);
+  const contentNamespace = classroom.content_namespace;
 
   // Include slug for navigation and gitOrgLogin for API calls
   return {
-    term,
+    contentNamespace,
     classroom: {
       ...classroom,
       slug: classroom.slug, // For navigation URLs
@@ -60,7 +58,10 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     return { error: 'Git organization not configured' };
   }
 
-  const term = formData.get('term');
+  const contentNamespace = classroom.content_namespace;
+  if (!contentNamespace) {
+    return { error: 'Classroom content namespace not configured' };
+  }
 
   // Single page import/create
   const title = formData.get('title') as string;
@@ -71,8 +72,8 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 
-  // Content repo name: content-{gitOrgLogin}-{term}
-  const repoName = `content-${gitOrgLogin}-${term}`;
+  // Content repo name: content-{gitOrgLogin}-{contentNamespace}
+  const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
 
   // Flat content path: pages/{slug}
   const contentPath = `pages/${slug}`;
@@ -86,7 +87,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         await gitProvider.createPublicRepository(
           gitOrgLogin,
           repoName,
-          `Course content for ${classroom.name || gitOrgLogin} - ${term}`
+          `Course content for ${classroom.name || gitOrgLogin} - ${contentNamespace}`
         );
 
         // Give GitHub a moment to initialize the repo
@@ -275,7 +276,7 @@ interface BatchPage {
 }
 
 export default function NewPage({ loaderData }: Route.ComponentProps) {
-  const { term, classroom } = loaderData;
+  const { contentNamespace, classroom } = loaderData;
   const fetcher = useFetcher();
   const navigate = useNavigate();
   const { opened, close } = useRouteDrawer({});
@@ -329,7 +330,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
       const initFormData = new FormData();
       initFormData.append('intent', 'batch-init');
       initFormData.append('classSlug', classroom.slug);
-      initFormData.append('term', String(term));
+      initFormData.append('contentNamespace', String(contentNamespace ?? ''));
 
       const initResponse = await fetch('/api/pages/batch', {
         method: 'POST',
@@ -352,7 +353,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
         const formData = new FormData();
         formData.append('intent', 'batch-import-single');
         formData.append('classSlug', classroom.slug);
-        formData.append('term', String(term));
+        formData.append('contentNamespace', String(contentNamespace ?? ''));
         formData.append('title', page.title);
         if (page.module) formData.append('module', page.module);
         if (page.assignmentId) formData.append('assignmentId', page.assignmentId);
@@ -412,7 +413,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
 
   const handleSubmit = (values: Record<string, string>) => {
     const formData = new FormData();
-    formData.append('term', String(term));
+    formData.append('contentNamespace', String(contentNamespace ?? ''));
 
     if (activeTab === 'batch') {
       // Handle batch import with progress
@@ -456,7 +457,9 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
     {
       key: 'batch',
       label: 'Batch Import',
-      children: <BatchImportTab term={term ?? ''} onPagesChange={setBatchPages} />,
+      children: (
+        <BatchImportTab contentNamespace={contentNamespace ?? ''} onPagesChange={setBatchPages} />
+      ),
     },
   ];
 

--- a/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
@@ -5,6 +5,7 @@ import { IconInfoCircle, IconExternalLink } from '@tabler/icons-react';
 import { namedAction } from 'remix-utils/named-action';
 
 import { ClassmojiService } from '@classmoji/services';
+import { getContentRepoName } from '@classmoji/utils';
 import { SettingSection } from '~/components';
 import { ActionTypes } from '~/constants';
 import { useGlobalFetcher } from '~/hooks';
@@ -28,19 +29,6 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   return { organization: classroom, aiAgentAvailable: isAIAgentConfigured() };
 };
 
-/**
- * Generate a suggested content repository name based on classSlug and term
- */
-function generateSuggestedRepoName(classSlug: string, term: string, year: number) {
-  if (!term || !year) return `content-${classSlug}`;
-
-  const termMap: Record<string, string> = { WINTER: 'w', SPRING: 's', SUMMER: 'u', FALL: 'f' };
-  const termCode = termMap[term] || term.charAt(0).toLowerCase();
-  const yearShort = String(year).slice(-2);
-
-  return `content-${classSlug}-${yearShort}${termCode}`;
-}
-
 const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
   const { organization, aiAgentAvailable } = loaderData;
   const { class: classSlug } = useParams();
@@ -49,11 +37,10 @@ const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
 
   // Generate repo name and URL for display
   const gitOrgLogin = organization.git_organization?.login || classSlug || '';
-  const repoName = generateSuggestedRepoName(
-    gitOrgLogin,
-    String(organization.term ?? ''),
-    organization.year ?? 0
-  );
+  const repoName = getContentRepoName({
+    login: gitOrgLogin,
+    content_namespace: organization.content_namespace ?? undefined,
+  });
   const repoUrl = `https://github.com/${gitOrgLogin}/${repoName}`;
 
   // Handler for customizable repo name (currently disabled in UI)

--- a/apps/webapp/app/routes/admin.$class.settings.general/ProfileSection.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.general/ProfileSection.tsx
@@ -1,18 +1,15 @@
-import { Button, Form, Input, Select } from 'antd';
-import dayjs from 'dayjs';
+import { Button, Form, Input } from 'antd';
 import { useState } from 'react';
 
 import { useGlobalFetcher } from '~/hooks';
 import { SettingSection } from '~/components';
 
 interface ProfileSectionProps {
-  organization: { name: string; term: string; year: string };
+  organization: { name: string };
 }
 
 const ProfileSection = ({ organization }: ProfileSectionProps) => {
   const [name, setName] = useState(organization.name);
-  const [term, setTerm] = useState(organization.term);
-  const [year, setYear] = useState(organization.year);
 
   const { fetcher } = useGlobalFetcher();
 
@@ -20,11 +17,7 @@ const ProfileSection = ({ organization }: ProfileSectionProps) => {
     if (!fetcher) return;
 
     fetcher.submit(
-      {
-        name,
-        term,
-        year,
-      },
+      { name },
       {
         action: '?/saveProfile',
         method: 'POST',
@@ -33,40 +26,12 @@ const ProfileSection = ({ organization }: ProfileSectionProps) => {
     );
   };
 
-  const currentYear = dayjs().year();
-
-  const yearOptions = Array.from({ length: 10 }, (_, i) => currentYear + i).map(year => {
-    return (
-      <Select.Option key={year} value={year}>
-        {year}
-      </Select.Option>
-    );
-  });
-
   return (
     <SettingSection title="Profile" description="Change the profile of your classroom.">
       <Form layout="vertical">
         <Form.Item label="Course name">
           <Input value={name} onChange={e => setName(e.target.value)} />
         </Form.Item>
-
-        <div className="@container">
-          <div className="grid grid-cols-1 @xs:grid-cols-2 gap-3">
-            <Form.Item label="Term">
-              <Select value={term} onChange={setTerm}>
-                <Select.Option value="FALL">Fall</Select.Option>
-                <Select.Option value="SPRING">Spring</Select.Option>
-                <Select.Option value="SUMMER">Summer</Select.Option>
-                <Select.Option value="WINTER">Winter</Select.Option>
-              </Select>
-            </Form.Item>
-            <Form.Item label="Year">
-              <Select value={year} onChange={setYear}>
-                {yearOptions}
-              </Select>
-            </Form.Item>
-          </div>
-        </div>
 
         <Button type="primary" onClick={saveProfile}>
           Save

--- a/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
@@ -46,8 +46,6 @@ const SettingsGeneral = ({ loaderData }: Route.ComponentProps) => {
       <ProfileSection
         organization={{
           name: classroom.name,
-          term: classroom.term ?? '',
-          year: String(classroom.year ?? ''),
         }}
       />
       <DefaultPageSection

--- a/apps/webapp/app/routes/api.classrooms.$id.archive/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$id.archive/route.ts
@@ -1,0 +1,49 @@
+/**
+ * Toggle archive (is_active) on a classroom.
+ *
+ * POST /api/classrooms/:id/archive
+ *
+ * Only OWNER can archive or unarchive a classroom. Returns `{ is_active: boolean }`.
+ */
+
+import { requireAuth } from '@classmoji/auth/server';
+import getPrisma from '@classmoji/database';
+import type { Route } from './+types/route';
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const { userId } = await requireAuth(request);
+  const classroomId = params.id;
+  if (!classroomId) {
+    return new Response('Missing classroom id', { status: 400 });
+  }
+
+  const prisma = getPrisma();
+
+  const ownerMembership = await prisma.classroomMembership.findFirst({
+    where: { classroom_id: classroomId, user_id: userId, role: 'OWNER' },
+    select: { id: true },
+  });
+  if (!ownerMembership) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const classroom = await prisma.classroom.findUnique({
+    where: { id: classroomId },
+    select: { is_active: true },
+  });
+  if (!classroom) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  const updated = await prisma.classroom.update({
+    where: { id: classroomId },
+    data: { is_active: !classroom.is_active },
+    select: { is_active: true },
+  });
+
+  return Response.json({ is_active: updated.is_active });
+};

--- a/apps/webapp/app/routes/api.classrooms.$id.pin/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$id.pin/route.ts
@@ -2,23 +2,20 @@
  * Pin/unpin a classroom for the current user.
  *
  * POST /api/classrooms/:id/pin
+ * Body: { role: string } — the membership role to pin (a user may have
+ *   multiple memberships in the same classroom; pinning is per-membership).
  *
- * Toggles `pin_order` on the classroom. If currently null, sets it to
- * `max(pin_order) + 1` scoped per `git_org_id` (the simpler scope — two orgs
- * may each have their own pin_order=1; the landing screen sorts within each).
- * If non-null, sets it back to null.
+ * Toggles `pin_order` on the user's ClassroomMembership row. If currently
+ * null, sets it to `max(pin_order) + 1` across all of this user's memberships.
+ * If non-null, clears it. Returns `{ pin_order: number | null }`.
  *
- * Returns `{ pin_order: number | null }`.
- *
- * Auth: requires the user to be on the classroom's teaching team
- * (OWNER / TEACHER / ASSISTANT). Students cannot pin.
+ * Auth: any signed-in user — pinning is a personal organization feature,
+ * not tied to a role.
  */
 
 import { requireAuth } from '@classmoji/auth/server';
 import getPrisma from '@classmoji/database';
 import type { Route } from './+types/route';
-
-const TEACHING_ROLES = ['OWNER', 'TEACHER', 'ASSISTANT'] as const;
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   if (request.method !== 'POST') {
@@ -26,50 +23,47 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   }
 
   const { userId } = await requireAuth(request);
-  const id = params.id;
-  if (!id) {
+  const classroomId = params.id;
+  if (!classroomId) {
     return new Response('Missing classroom id', { status: 400 });
   }
 
-  const prisma = getPrisma();
-
-  const classroom = await prisma.classroom.findUnique({
-    where: { id },
-    select: { id: true, git_org_id: true, pin_order: true },
-  });
-  if (!classroom) {
-    return new Response('Not Found', { status: 404 });
+  let role: string | null = null;
+  try {
+    const body = (await request.json()) as { role?: string };
+    role = body?.role ?? null;
+  } catch {
+    /* no body / not JSON */
+  }
+  if (!role) {
+    return new Response('Missing role', { status: 400 });
   }
 
-  // Authorize: user must have a teaching-team membership in this classroom.
-  const membership = await prisma.classroomMembership.findFirst({
-    where: {
-      classroom_id: classroom.id,
-      user_id: userId,
-      role: { in: TEACHING_ROLES as unknown as string[] },
-    },
-    select: { id: true },
+  const prisma = getPrisma();
+  const membership = await prisma.classroomMembership.findUnique({
+    where: { classroom_id_user_id_role: { classroom_id: classroomId, user_id: userId, role } },
+    select: { id: true, pin_order: true },
   });
   if (!membership) {
     return new Response('Forbidden', { status: 403 });
   }
 
   const newPinOrder = await prisma.$transaction(async tx => {
-    if (classroom.pin_order != null) {
-      await tx.classroom.update({
-        where: { id: classroom.id },
+    if (membership.pin_order != null) {
+      await tx.classroomMembership.update({
+        where: { id: membership.id },
         data: { pin_order: null },
       });
       return null;
     }
-    // Scope: per git_org_id (simpler than per-user across all memberships).
-    const agg = await tx.classroom.aggregate({
+    // Scope: per user across all of their memberships.
+    const agg = await tx.classroomMembership.aggregate({
       _max: { pin_order: true },
-      where: { git_org_id: classroom.git_org_id },
+      where: { user_id: userId },
     });
     const next = (agg._max.pin_order ?? 0) + 1;
-    await tx.classroom.update({
-      where: { id: classroom.id },
+    await tx.classroomMembership.update({
+      where: { id: membership.id },
       data: { pin_order: next },
     });
     return next;

--- a/apps/webapp/app/routes/api.classrooms.$id.pin/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$id.pin/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Pin/unpin a classroom for the current user.
+ *
+ * POST /api/classrooms/:id/pin
+ *
+ * Toggles `pin_order` on the classroom. If currently null, sets it to
+ * `max(pin_order) + 1` scoped per `git_org_id` (the simpler scope — two orgs
+ * may each have their own pin_order=1; the landing screen sorts within each).
+ * If non-null, sets it back to null.
+ *
+ * Returns `{ pin_order: number | null }`.
+ *
+ * Auth: requires the user to be on the classroom's teaching team
+ * (OWNER / TEACHER / ASSISTANT). Students cannot pin.
+ */
+
+import { requireAuth } from '@classmoji/auth/server';
+import getPrisma from '@classmoji/database';
+import type { Route } from './+types/route';
+
+const TEACHING_ROLES = ['OWNER', 'TEACHER', 'ASSISTANT'] as const;
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const { userId } = await requireAuth(request);
+  const id = params.id;
+  if (!id) {
+    return new Response('Missing classroom id', { status: 400 });
+  }
+
+  const prisma = getPrisma();
+
+  const classroom = await prisma.classroom.findUnique({
+    where: { id },
+    select: { id: true, git_org_id: true, pin_order: true },
+  });
+  if (!classroom) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  // Authorize: user must have a teaching-team membership in this classroom.
+  const membership = await prisma.classroomMembership.findFirst({
+    where: {
+      classroom_id: classroom.id,
+      user_id: userId,
+      role: { in: TEACHING_ROLES as unknown as string[] },
+    },
+    select: { id: true },
+  });
+  if (!membership) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const newPinOrder = await prisma.$transaction(async tx => {
+    if (classroom.pin_order != null) {
+      await tx.classroom.update({
+        where: { id: classroom.id },
+        data: { pin_order: null },
+      });
+      return null;
+    }
+    // Scope: per git_org_id (simpler than per-user across all memberships).
+    const agg = await tx.classroom.aggregate({
+      _max: { pin_order: true },
+      where: { git_org_id: classroom.git_org_id },
+    });
+    const next = (agg._max.pin_order ?? 0) + 1;
+    await tx.classroom.update({
+      where: { id: classroom.id },
+      data: { pin_order: next },
+    });
+    return next;
+  });
+
+  return Response.json({ pin_order: newPinOrder });
+};

--- a/apps/webapp/app/routes/api.classrooms.availability/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.availability/route.ts
@@ -1,0 +1,47 @@
+/**
+ * Classroom availability check.
+ *
+ * GET /api/classrooms/availability?git_org_id=...&slug=...
+ *
+ * Returns `{ slug_available, slug_suggestion? }`. When the slug is already taken
+ * inside the org, the loader returns the first free `slug-N` suggestion (N up to 99).
+ */
+
+import { requireAuth } from '@classmoji/auth/server';
+import getPrisma from '@classmoji/database';
+import type { Route } from './+types/route';
+
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  await requireAuth(request);
+
+  const url = new URL(request.url);
+  const git_org_id = url.searchParams.get('git_org_id') ?? '';
+  const slug = url.searchParams.get('slug') ?? '';
+
+  if (!git_org_id || !slug) {
+    return Response.json({ slug_available: true });
+  }
+
+  const prisma = getPrisma();
+  const bySlug = await prisma.classroom.findFirst({
+    where: { git_org_id, slug },
+    select: { id: true },
+  });
+
+  let slug_suggestion: string | undefined;
+  if (bySlug) {
+    for (let n = 2; n < 100; n++) {
+      const candidate = `${slug}-${n}`;
+      const hit = await prisma.classroom.findFirst({
+        where: { git_org_id, slug: candidate },
+        select: { id: true },
+      });
+      if (!hit) {
+        slug_suggestion = candidate;
+        break;
+      }
+    }
+  }
+
+  return Response.json({ slug_available: !bySlug, slug_suggestion });
+};

--- a/apps/webapp/app/routes/api.classrooms.reorder-pins/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.reorder-pins/route.ts
@@ -1,12 +1,13 @@
 /**
- * Reorder pinned classrooms.
+ * Reorder pinned classrooms for the current user.
  *
  * POST /api/classrooms/reorder-pins
- * Body: { ids: string[] }
+ * Body: { items: Array<{ classroom_id: string; role: string }> }
  *
- * The order in the array is the new `pin_order` (1..N).
- * Auth: requires the user to have a teaching-team membership on EVERY
- * classroom in the payload; otherwise 403.
+ * The order in the array is the new per-user `pin_order` (1..N), applied to
+ * each matching `ClassroomMembership` row owned by the user. Any signed-in
+ * user may reorder their own pins; the endpoint only updates memberships the
+ * user already owns, so non-owned classrooms are silently ignored.
  *
  * Returns `{ ok: true }`.
  */
@@ -15,7 +16,10 @@ import { requireAuth } from '@classmoji/auth/server';
 import getPrisma from '@classmoji/database';
 import type { Route } from './+types/route';
 
-const TEACHING_ROLES = ['OWNER', 'TEACHER', 'ASSISTANT'] as const;
+interface ReorderItem {
+  classroom_id: string;
+  role: string;
+}
 
 export const action = async ({ request }: Route.ActionArgs) => {
   if (request.method !== 'POST') {
@@ -31,35 +35,31 @@ export const action = async ({ request }: Route.ActionArgs) => {
     return new Response('Invalid JSON', { status: 400 });
   }
 
-  const ids =
-    body && typeof body === 'object' && Array.isArray((body as { ids?: unknown }).ids)
-      ? ((body as { ids: unknown[] }).ids.filter(v => typeof v === 'string') as string[])
-      : null;
+  const raw = (body as { items?: unknown }).items;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return new Response('Missing items', { status: 400 });
+  }
+  const items: ReorderItem[] = raw
+    .filter((v): v is ReorderItem => {
+      return (
+        !!v &&
+        typeof v === 'object' &&
+        typeof (v as ReorderItem).classroom_id === 'string' &&
+        typeof (v as ReorderItem).role === 'string'
+      );
+    })
+    .map(v => ({ classroom_id: v.classroom_id, role: v.role }));
 
-  if (!ids || ids.length === 0) {
-    return new Response('Missing ids', { status: 400 });
+  if (items.length === 0) {
+    return new Response('Missing items', { status: 400 });
   }
 
   const prisma = getPrisma();
 
-  // Verify the user has a teaching-team membership on every classroom in the list.
-  const memberships = await prisma.classroomMembership.findMany({
-    where: {
-      user_id: userId,
-      classroom_id: { in: ids },
-      role: { in: TEACHING_ROLES as unknown as string[] },
-    },
-    select: { classroom_id: true },
-  });
-  const allowed = new Set(memberships.map(m => m.classroom_id));
-  if (ids.some(id => !allowed.has(id))) {
-    return new Response('Forbidden', { status: 403 });
-  }
-
   await prisma.$transaction(
-    ids.map((id, idx) =>
-      prisma.classroom.update({
-        where: { id },
+    items.map((item, idx) =>
+      prisma.classroomMembership.updateMany({
+        where: { user_id: userId, classroom_id: item.classroom_id, role: item.role },
         data: { pin_order: idx + 1 },
       })
     )

--- a/apps/webapp/app/routes/api.classrooms.reorder-pins/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.reorder-pins/route.ts
@@ -1,0 +1,69 @@
+/**
+ * Reorder pinned classrooms.
+ *
+ * POST /api/classrooms/reorder-pins
+ * Body: { ids: string[] }
+ *
+ * The order in the array is the new `pin_order` (1..N).
+ * Auth: requires the user to have a teaching-team membership on EVERY
+ * classroom in the payload; otherwise 403.
+ *
+ * Returns `{ ok: true }`.
+ */
+
+import { requireAuth } from '@classmoji/auth/server';
+import getPrisma from '@classmoji/database';
+import type { Route } from './+types/route';
+
+const TEACHING_ROLES = ['OWNER', 'TEACHER', 'ASSISTANT'] as const;
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const { userId } = await requireAuth(request);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  const ids =
+    body && typeof body === 'object' && Array.isArray((body as { ids?: unknown }).ids)
+      ? ((body as { ids: unknown[] }).ids.filter(v => typeof v === 'string') as string[])
+      : null;
+
+  if (!ids || ids.length === 0) {
+    return new Response('Missing ids', { status: 400 });
+  }
+
+  const prisma = getPrisma();
+
+  // Verify the user has a teaching-team membership on every classroom in the list.
+  const memberships = await prisma.classroomMembership.findMany({
+    where: {
+      user_id: userId,
+      classroom_id: { in: ids },
+      role: { in: TEACHING_ROLES as unknown as string[] },
+    },
+    select: { classroom_id: true },
+  });
+  const allowed = new Set(memberships.map(m => m.classroom_id));
+  if (ids.some(id => !allowed.has(id))) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  await prisma.$transaction(
+    ids.map((id, idx) =>
+      prisma.classroom.update({
+        where: { id },
+        data: { pin_order: idx + 1 },
+      })
+    )
+  );
+
+  return Response.json({ ok: true });
+};

--- a/apps/webapp/app/routes/api.pages.batch/route.ts
+++ b/apps/webapp/app/routes/api.pages.batch/route.ts
@@ -12,8 +12,6 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const formData = await request.formData();
   const intent = formData.get('intent') as string;
   const classSlug = formData.get('classSlug') as string;
-  const term = formData.get('term') as string;
-
   const { classroom, userId } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
@@ -28,9 +26,14 @@ export const action = async ({ request }: Route.ActionArgs) => {
     return Response.json({ error: 'Git organization not configured' });
   }
 
+  const contentNamespace = classroom.content_namespace;
+  if (!contentNamespace) {
+    return Response.json({ error: 'Classroom content namespace not configured' });
+  }
+
   // Initialize batch import - creates repo if needed
   if (intent === 'batch-init') {
-    const repoName = `content-${gitOrgLogin}-${term}`;
+    const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
     const gitProvider = getGitProvider(classroom.git_organization);
 
     const repoExists = await gitProvider.repositoryExists(gitOrgLogin, repoName);
@@ -39,7 +42,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
         await gitProvider.createPublicRepository(
           gitOrgLogin,
           repoName,
-          `Course content for ${classroom.name || gitOrgLogin} - ${term}`
+          `Course content for ${classroom.name || gitOrgLogin} - ${contentNamespace}`
         );
         await new Promise(resolve => setTimeout(resolve, 2000));
       } catch (repoError) {
@@ -67,7 +70,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   if (intent === 'batch-import-single') {
     const title = formData.get('title') as string;
     const moduleId = (formData.get('assignmentId') as string) || null; // Optional - for linking
-    const repoName = `content-${gitOrgLogin}-${term}`;
+    const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
 
     try {
       // Generate slug from title

--- a/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
@@ -64,8 +64,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   // Check if we have a content repo (either explicitly set or can be derived)
   const contentRepoName = getContentRepoName({
     login: classroom.git_organization?.login,
-    term: classroom.term ?? undefined,
-    year: classroom.year ?? undefined,
+    content_namespace: classroom.content_namespace ?? undefined,
   });
 
   return jsonResponse({
@@ -155,8 +154,7 @@ async function handleInitConversation(request: Request, classSlug: string, formD
     settings?.content_repo_name ||
     getContentRepoName({
       login: classroom.git_organization?.login,
-      term: classroom.term ?? undefined,
-      year: classroom.year ?? undefined,
+      content_namespace: classroom.content_namespace ?? undefined,
     });
   if (contentRepoNameForClone && classroom.git_organization?.github_installation_id) {
     try {

--- a/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
@@ -74,7 +74,6 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     isInstructor,
     orgName: classroom.name,
     courseName: (settings as { course_name?: string })?.course_name,
-    term: classroom.term,
     slidesUrl: process.env.SLIDES_URL || 'http://localhost:6500',
   });
 }
@@ -134,7 +133,6 @@ async function handleInitConversation(request: Request, classSlug: string, formD
     gitOrgLogin: classroom.git_organization?.login, // GitHub org for content repo cloning
     orgName: classroom.name,
     courseName: (settings as { course_name?: string })?.course_name || classroom.name,
-    term: classroom.term || 'Current',
     userRole: contextRole,
   };
 

--- a/apps/webapp/app/routes/student.$class.assignments/route.tsx
+++ b/apps/webapp/app/routes/student.$class.assignments/route.tsx
@@ -112,13 +112,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
       total: progressBuckets.length,
     };
 
-    const termPretty = classroom.term
-      ? String(classroom.term).charAt(0) + String(classroom.term).slice(1).toLowerCase()
-      : null;
-    const termLabel = [termPretty, classroom.year ? String(classroom.year) : null]
-      .filter(Boolean)
-      .join(' ');
-    const subtitleParts = [gitOrgLogin, termLabel].filter((p): p is string => Boolean(p));
+    const subtitleParts = [gitOrgLogin].filter((p): p is string => Boolean(p));
 
     return {
       classroomTitle: classroom.name ?? 'Class',

--- a/apps/webapp/app/utils/helpers.ts
+++ b/apps/webapp/app/utils/helpers.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import pWaitFor from 'p-wait-for';
 import { runs } from '@trigger.dev/sdk';
 import { redirect } from 'react-router';
@@ -11,47 +10,6 @@ export const sleep = async (ms: number) => {
 };
 
 export const roundToTwo = (num: number) => Math.round((num + Number.EPSILON) * 100) / 100;
-
-interface MembershipWithClassroom {
-  classroom: {
-    term: string;
-    year: number;
-    [key: string]: unknown;
-  };
-  [key: string]: unknown;
-}
-
-export const groupByYearAndTerm = (memberships: MembershipWithClassroom[]) => {
-  const seasonOrder: Record<string, number> = {
-    Winter: 1,
-    Spring: 2,
-    Summer: 3,
-    Fall: 4,
-  };
-
-  // Group memberships by a combination of year and term from the classroom object
-  const grouped = _.groupBy(memberships, membership => {
-    const { term, year } = membership.classroom;
-    return `${year} ${term}`;
-  });
-
-  // Sort the keys based on year and season order
-  const sortedKeys = _.orderBy(
-    Object.keys(grouped),
-    [
-      key => parseInt(key.split(' ')[0]), // Sort by year first
-      key => seasonOrder[key.split(' ')[1]], // Then by season order (Winter, Spring, etc.)
-    ],
-    ['asc', 'asc'] // Sort both year and term in ascending order
-  );
-
-  const sortedGrouped: Record<string, typeof memberships> = {};
-  sortedKeys.forEach(key => {
-    sortedGrouped[key] = grouped[key];
-  });
-
-  return sortedGrouped;
-};
 
 // Server functions
 export const pollRunStatus = async (runId: string, interval = 1000) => {

--- a/packages/database/migrations/20260521124056_remove_terms/migration.sql
+++ b/packages/database/migrations/20260521124056_remove_terms/migration.sql
@@ -8,11 +8,13 @@ UPDATE "classrooms"
 SET "content_namespace" = (
   SUBSTRING(CAST("year" AS TEXT) FROM LENGTH(CAST("year" AS TEXT)) - 1)
   ||
+  -- Term enum values are stored uppercase in Postgres
   CASE "term"
     WHEN 'WINTER' THEN 'w'
     WHEN 'SPRING' THEN 's'
     WHEN 'SUMMER' THEN 'u'
     WHEN 'FALL'   THEN 'f'
+    ELSE LOWER(LEFT("term"::text, 1))
   END
 )
 WHERE "term" IS NOT NULL AND "year" IS NOT NULL;
@@ -30,8 +32,8 @@ UPDATE "classrooms"
 SET "name" = "name" || ' ' || INITCAP(LOWER("term"::text)) || ' ' || "year"
 WHERE "term" IS NOT NULL
   AND "year" IS NOT NULL
-  AND "name" NOT ILIKE '%' || INITCAP(LOWER("term"::text)) || '%'
-  AND "name" NOT LIKE '%' || "year"::text || '%';
+  AND "name" !~* ('\m' || INITCAP(LOWER("term"::text)) || '\M')
+  AND "name" !~* ('\m' || "year"::text || '\M');
 
 -- Pre-check: any duplicate (git_org_id, slug) pairs? Should be impossible because slug is currently globally unique.
 DO $$

--- a/packages/database/migrations/20260521124056_remove_terms/migration.sql
+++ b/packages/database/migrations/20260521124056_remove_terms/migration.sql
@@ -1,0 +1,51 @@
+-- Add new columns nullable for backfill
+ALTER TABLE "classrooms" ADD COLUMN "content_namespace" TEXT;
+ALTER TABLE "classrooms" ADD COLUMN "pin_order" INTEGER;
+
+-- Backfill content_namespace
+-- Legacy term/year -> "25f" style
+UPDATE "classrooms"
+SET "content_namespace" = (
+  SUBSTRING(CAST("year" AS TEXT) FROM LENGTH(CAST("year" AS TEXT)) - 1)
+  ||
+  CASE "term"
+    WHEN 'WINTER' THEN 'w'
+    WHEN 'SPRING' THEN 's'
+    WHEN 'SUMMER' THEN 'u'
+    WHEN 'FALL'   THEN 'f'
+  END
+)
+WHERE "term" IS NOT NULL AND "year" IS NOT NULL;
+
+-- Rows with no term -> use slug
+UPDATE "classrooms"
+SET "content_namespace" = "slug"
+WHERE "content_namespace" IS NULL;
+
+-- Make NOT NULL
+ALTER TABLE "classrooms" ALTER COLUMN "content_namespace" SET NOT NULL;
+
+-- Append term/year to name where missing, to preserve human-readable disambiguation
+UPDATE "classrooms"
+SET "name" = "name" || ' ' || INITCAP(LOWER("term"::text)) || ' ' || "year"
+WHERE "term" IS NOT NULL
+  AND "year" IS NOT NULL
+  AND "name" NOT ILIKE '%' || INITCAP(LOWER("term"::text)) || '%'
+  AND "name" NOT LIKE '%' || "year"::text || '%';
+
+-- Pre-check: any duplicate (git_org_id, slug) pairs? Should be impossible because slug is currently globally unique.
+DO $$
+DECLARE dup_count INT;
+BEGIN
+  SELECT COUNT(*) INTO dup_count FROM (
+    SELECT git_org_id, slug FROM classrooms GROUP BY git_org_id, slug HAVING COUNT(*) > 1
+  ) x;
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Cannot apply unique(git_org_id, slug): % duplicates exist', dup_count;
+  END IF;
+END $$;
+
+-- Drop the global unique index on slug, add composite unique on (git_org_id, slug)
+DROP INDEX IF EXISTS "classrooms_slug_key";
+ALTER TABLE "classrooms" ADD CONSTRAINT "classrooms_git_org_id_slug_key" UNIQUE ("git_org_id", "slug");
+-- Name uniqueness is intentionally NOT enforced; landing screen disambiguates duplicates visually.

--- a/packages/database/migrations/20260521131834_move_pin_order_to_membership/migration.sql
+++ b/packages/database/migrations/20260521131834_move_pin_order_to_membership/migration.sql
@@ -1,0 +1,16 @@
+-- Move pin_order from Classroom to ClassroomMembership so it is per-user
+-- (a single user may have multiple memberships in the same classroom across
+-- different roles; pinning one role should not pin the other).
+
+ALTER TABLE "classroom_memberships" ADD COLUMN "pin_order" INTEGER;
+
+-- Best-effort backfill: copy each classroom's pin_order onto every existing
+-- membership. Loses some information for users with multiple memberships in
+-- the same classroom — but in practice that's rare and the existing pin set
+-- was effectively per-classroom anyway.
+UPDATE "classroom_memberships" m
+SET "pin_order" = c."pin_order"
+FROM "classrooms" c
+WHERE m."classroom_id" = c."id" AND c."pin_order" IS NOT NULL;
+
+ALTER TABLE "classrooms" DROP COLUMN "pin_order";

--- a/packages/database/migrations/20260521140000_drop_term_columns/migration.sql
+++ b/packages/database/migrations/20260521140000_drop_term_columns/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "classrooms" DROP COLUMN "term";
+ALTER TABLE "classrooms" DROP COLUMN "year";
+ALTER TABLE "slides" DROP COLUMN "term";
+DROP TYPE "Term";

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -273,7 +273,6 @@ model Classroom {
   name              String
   content_namespace String
   is_active         Boolean  @default(true)
-  pin_order         Int?
   created_at        DateTime @default(now())
   updated_at        DateTime @default(now()) @updatedAt
 
@@ -340,6 +339,7 @@ model ClassroomMembership {
   has_accepted_invite Boolean  @default(false)
   comment             String?
   letter_grade        String?
+  pin_order           Int?
   created_at          DateTime @default(now())
   updated_at          DateTime @default(now()) @updatedAt
 

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -37,13 +37,6 @@ enum NotificationType {
   TA_REGRADE_ASSIGNED
 }
 
-enum Term {
-  FALL
-  SPRING
-  SUMMER
-  WINTER
-}
-
 enum AssignmentType {
   INDIVIDUAL
   GROUP
@@ -279,8 +272,6 @@ model Classroom {
   git_org_id        String
   name              String
   content_namespace String
-  term              Term?
-  year              Int?
   is_active         Boolean  @default(true)
   pin_order         Int?
   created_at        DateTime @default(now())
@@ -801,7 +792,6 @@ model Slide {
   classroom_id       String
   title              String
   slug               String
-  term               String
   content_path       String
   multiplex_id       String?
   multiplex_secret   String?

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -274,15 +274,17 @@ model GitOrganization {
 }
 
 model Classroom {
-  id         String   @id @default(uuid())
-  slug       String   @unique // URL slug: "cs101-fall-2025"
-  git_org_id String
-  name       String
-  term       Term?
-  year       Int?
-  is_active  Boolean  @default(true)
-  created_at DateTime @default(now())
-  updated_at DateTime @default(now()) @updatedAt
+  id                String   @id @default(uuid())
+  slug              String // URL slug: "cs101-fall-2025"
+  git_org_id        String
+  name              String
+  content_namespace String
+  term              Term?
+  year              Int?
+  is_active         Boolean  @default(true)
+  pin_order         Int?
+  created_at        DateTime @default(now())
+  updated_at        DateTime @default(now()) @updatedAt
 
   git_organization      GitOrganization       @relation(fields: [git_org_id], references: [id], onDelete: Cascade)
   settings              ClassroomSettings?
@@ -305,6 +307,7 @@ model Classroom {
   resource_views        ResourceView[]
   notifications         Notification[]
 
+  @@unique([git_org_id, slug])
   @@index([git_org_id])
   @@map("classrooms")
 }

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -46,7 +46,7 @@ export const findById = async (id: string) => {
  * @returns {Promise<Object|null>}
  */
 export const findBySlug = async (slug: string) => {
-  return getPrisma().classroom.findUnique({
+  return getPrisma().classroom.findFirst({
     where: { slug },
     include: {
       git_organization: true,

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -1,5 +1,4 @@
 import getPrisma from '@classmoji/database';
-import { getTermCode } from '../git/index.ts';
 import type { Prisma, Role } from '@prisma/client';
 
 /**
@@ -338,32 +337,3 @@ export const updateSettings = async (
   });
 };
 
-/**
- * Generate a unique slug for a classroom
- * @param {string} name - Classroom name
- * @param {string} term - Term (WINTER, SPRING, SUMMER, FALL) - required
- * @param {number} year - Year - required
- * @returns {Promise<string>}
- */
-export const generateSlug = async (name: string, term: string, year: number) => {
-  // Start with base slug from name
-  let baseSlug = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  // Add short term code (e.g., "25w" for Winter 2025)
-  const termCode = getTermCode(term, year);
-  baseSlug = `${baseSlug}-${termCode}`;
-
-  // Check if slug exists
-  let slug = baseSlug;
-  let counter = 1;
-
-  while (await getPrisma().classroom.findUnique({ where: { slug } })) {
-    slug = `${baseSlug}-${counter}`;
-    counter++;
-  }
-
-  return slug;
-};

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -127,8 +127,7 @@ export const findAll = async (query: Prisma.ClassroomWhereInput = {}) => {
  * @param {string} data.git_org_id - UUID of the GitOrganization
  * @param {string} data.slug - URL-friendly slug
  * @param {string} data.name - Display name
- * @param {string} [data.term] - Term (FALL, SPRING, SUMMER, WINTER)
- * @param {number} [data.year] - Year
+ * @param {string} data.content_namespace - Identifier embedded in content repo name
  * @param {string} [data.emoji] - Emoji (default: "dart")
  * @returns {Promise<Object>}
  */

--- a/packages/services/src/classmoji/contentManifest.service.ts
+++ b/packages/services/src/classmoji/contentManifest.service.ts
@@ -1,6 +1,5 @@
 import getPrisma from '@classmoji/database';
 import { ContentService } from '@classmoji/content';
-import { generateTermString } from '@classmoji/utils';
 
 interface ManifestAssignmentEntry {
   pages: string[];
@@ -92,8 +91,7 @@ export async function saveManifest(classroomId: string): Promise<void> {
     .map(s => s.slug ?? String(s.id));
 
   // Write to repo
-  const term = generateTermString(classroom.term ?? undefined, classroom.year ?? undefined);
-  const repoName = `content-${classroom.git_organization.login}-${term}`;
+  const repoName = `content-${classroom.git_organization.login}-${classroom.content_namespace}`;
 
   try {
     await ContentService.put({

--- a/packages/services/src/classmoji/page.service.ts
+++ b/packages/services/src/classmoji/page.service.ts
@@ -1,5 +1,5 @@
 import getPrisma from '@classmoji/database';
-import { titleToIdentifier, generateTermString } from '@classmoji/utils';
+import { titleToIdentifier } from '@classmoji/utils';
 import { ContentService } from '@classmoji/content';
 import * as contentManifestService from './contentManifest.service.ts';
 import * as notificationService from './notification.service.ts';
@@ -292,11 +292,7 @@ export async function deletePage(pageId: string) {
 
   // Delete from GitHub if configured
   if (gitOrgLogin && page.content_path) {
-    const term = generateTermString(
-      page.classroom.term ?? undefined,
-      page.classroom.year ?? undefined
-    );
-    const repoName = `content-${gitOrgLogin}-${term}`;
+    const repoName = `content-${gitOrgLogin}-${page.classroom.content_namespace}`;
 
     try {
       await ContentService.deleteFolder({

--- a/packages/services/src/git/index.ts
+++ b/packages/services/src/git/index.ts
@@ -76,18 +76,6 @@ export function getGitHubProvider(installationId: string, orgLogin: string | nul
 }
 
 /**
- * Get short term code (e.g., "25w" for Winter 2025)
- * @param {string} term - Term enum (WINTER, SPRING, SUMMER, FALL)
- * @param {number} year - Full year (e.g., 2025)
- * @returns {string} Short term code (e.g., "25w")
- */
-export function getTermCode(term: string, year: number) {
-  const termMap: Record<string, string> = { WINTER: 'w', SPRING: 's', SUMMER: 'x', FALL: 'f' };
-  const shortYear = String(year).slice(-2);
-  return `${shortYear}${termMap[term] || 'x'}`;
-}
-
-/**
  * Get team name for a classroom based on role
  * Format: {classroom-slug}-{students|assistants}
  * Example: cs101-25w-students (CS101 Winter 2025 students)

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -19,7 +19,6 @@ export {
   getGitHubProvider,
   getTeamNameForClassroom,
   ensureClassroomTeam,
-  getTermCode,
   Octokit,
 } from './git/index.ts';
 

--- a/packages/tasks/src/scripts/migrate-pages-to-blocknote.ts
+++ b/packages/tasks/src/scripts/migrate-pages-to-blocknote.ts
@@ -1,7 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { ContentService } from '@classmoji/content';
 import { migrateHtmlToBlockNote } from '../../../../apps/pages/app/utils/migration.server.ts';
-import { generateTermString } from '@classmoji/utils';
 import { BlockNoteSchema, defaultBlockSpecs, createCodeBlockSpec } from '@blocknote/core';
 import { multiColumnSchema } from '@blocknote/xl-multi-column';
 import { codeBlockOptions } from '@blocknote/code-block';
@@ -118,18 +117,14 @@ async function migratePagesToBlockNote(): Promise<void> {
           ? { ...gitOrg, login: OVERRIDE_GIT_ORG_LOGIN }
           : gitOrg;
 
-        const term = generateTermString(
-          (page.classroom.term as string) ?? undefined,
-          page.classroom.year ?? undefined
-        );
-        const repo = `content-${effectiveGitOrg.login}-${term}`;
+        const contentNamespace = page.classroom.content_namespace as string;
+        const repo = `content-${effectiveGitOrg.login}-${contentNamespace}`;
 
         console.log(`\n🔍 Processing: ${page.slug}`);
         console.log(
           `   Git Org: ${gitOrg.login} ${OVERRIDE_GIT_ORG_LOGIN ? `→ ${effectiveGitOrg.login} (overridden)` : ''}`
         );
-        console.log(`   Term: ${page.classroom.term}, Year: ${page.classroom.year}`);
-        console.log(`   Generated term string: ${term}`);
+        console.log(`   Content namespace: ${contentNamespace}`);
         console.log(`   Repo: ${repo}`);
         console.log(`   Path: ${page.content_path}`);
 

--- a/packages/utils/src/__tests__/content.test.ts
+++ b/packages/utils/src/__tests__/content.test.ts
@@ -1,49 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { generateTermString, getContentRepoName } from '../content.ts';
-
-describe('generateTermString', () => {
-  it('returns null when term or year is missing', () => {
-    expect(generateTermString(undefined, 2026)).toBeNull();
-    expect(generateTermString('Winter', undefined)).toBeNull();
-    expect(generateTermString(undefined, undefined)).toBeNull();
-  });
-
-  it('encodes known terms as <yy><letter>', () => {
-    expect(generateTermString('Winter', 2025)).toBe('25w');
-    expect(generateTermString('Spring', 2025)).toBe('25s');
-    expect(generateTermString('Summer', 2025)).toBe('25u');
-    expect(generateTermString('Fall', 2025)).toBe('25f');
-  });
-
-  it('falls back to lowercase first char for unknown terms', () => {
-    expect(generateTermString('Quarter', 2026)).toBe('26q');
-  });
-
-  it('uses the last two digits of the year', () => {
-    expect(generateTermString('Fall', 2099)).toBe('99f');
-    expect(generateTermString('Fall', 2007)).toBe('07f');
-  });
-});
+import { getContentRepoName } from '../content.ts';
 
 describe('getContentRepoName', () => {
   it('uses settings.content_repo_name when set', () => {
     expect(
       getContentRepoName({
         login: 'cs101',
-        term: 'Fall',
-        year: 2025,
         settings: { content_repo_name: 'custom-repo' },
       })
     ).toBe('custom-repo');
   });
 
-  it('falls back to content-<login>-<term> pattern', () => {
-    expect(getContentRepoName({ login: 'cs101', term: 'Fall', year: 2025 })).toBe(
-      'content-cs101-25f'
-    );
-  });
-
-  it('omits term suffix when term info missing', () => {
+  it('falls back to content-<login> pattern', () => {
     expect(getContentRepoName({ login: 'cs101' })).toBe('content-cs101');
   });
 });

--- a/packages/utils/src/content.ts
+++ b/packages/utils/src/content.ts
@@ -4,44 +4,22 @@
 
 interface Organization {
   login: string;
-  term?: string;
-  year?: number;
-  content_namespace?: string;
   settings?: {
     content_repo_name?: string;
   };
 }
 
 /**
- * Generate term string from term enum and year (e.g., Winter 2025 -> "25w")
- *
- * @deprecated kept temporarily for backward compatibility during the term
- * removal migration. New code should use `classroom.content_namespace`.
- */
-export function generateTermString(
-  term: string | undefined,
-  year: number | undefined
-): string | null {
-  if (!term || !year) return null;
-  const termMap: Record<string, string> = { Winter: 'w', Spring: 's', Summer: 'u', Fall: 'f' };
-  const yearShort = String(year).slice(-2);
-  return `${yearShort}${termMap[term] || term.charAt(0).toLowerCase()}`;
-}
-
-/**
  * Generate the content repository name for an organization.
- * Uses settings.content_repo_name if set, otherwise falls back to the default pattern.
+ * Uses settings.content_repo_name if set, otherwise falls back to `content-{login}`.
  *
- * If a `content_namespace` is provided, the repo is namespaced as
- * `content-{login}-{namespace}`; otherwise it falls back to `content-{login}`.
+ * Per-classroom repo names (`content-{org}-{namespace}`) are built inline at
+ * call sites with `classroom.content_namespace`. This helper is for org-level
+ * fallback only.
  */
 export const getContentRepoName = (organization: Organization): string => {
   if (organization.settings?.content_repo_name) {
     return organization.settings.content_repo_name;
   }
-
-  const orgLogin = organization.login;
-  const namespace = organization.content_namespace;
-
-  return namespace ? `content-${orgLogin}-${namespace}` : `content-${orgLogin}`;
+  return `content-${organization.login}`;
 };

--- a/packages/utils/src/content.ts
+++ b/packages/utils/src/content.ts
@@ -6,6 +6,7 @@ interface Organization {
   login: string;
   term?: string;
   year?: number;
+  content_namespace?: string;
   settings?: {
     content_repo_name?: string;
   };
@@ -13,6 +14,9 @@ interface Organization {
 
 /**
  * Generate term string from term enum and year (e.g., Winter 2025 -> "25w")
+ *
+ * @deprecated kept temporarily for backward compatibility during the term
+ * removal migration. New code should use `classroom.content_namespace`.
  */
 export function generateTermString(
   term: string | undefined,
@@ -27,6 +31,9 @@ export function generateTermString(
 /**
  * Generate the content repository name for an organization.
  * Uses settings.content_repo_name if set, otherwise falls back to the default pattern.
+ *
+ * If a `content_namespace` is provided, the repo is namespaced as
+ * `content-{login}-{namespace}`; otherwise it falls back to `content-{login}`.
  */
 export const getContentRepoName = (organization: Organization): string => {
   if (organization.settings?.content_repo_name) {
@@ -34,7 +41,7 @@ export const getContentRepoName = (organization: Organization): string => {
   }
 
   const orgLogin = organization.login;
-  const termCode = generateTermString(organization.term, organization.year);
+  const namespace = organization.content_namespace;
 
-  return termCode ? `content-${orgLogin}-${termCode}` : `content-${orgLogin}`;
+  return namespace ? `content-${orgLogin}-${namespace}` : `content-${orgLogin}`;
 };


### PR DESCRIPTION
## Summary
- Remove the Term enum, Classroom.term, Classroom.year, and Slide.term from the schema and codebase
- Replace term-based content-repo naming with a new Classroom.content_namespace column (backfilled to legacy 25f-style codes for existing rows; equal to slug for new classrooms) so existing Git content repos keep working untouched
- Replace the term-grouped landing screen with Pinned / Active / Archived sections plus per-user duplicate-name slug subtitle; add pin/unpin endpoint and HTML5 drag-to-reorder on the Pinned section
- Tighten slug uniqueness to per-org (\`@@unique([git_org_id, slug])\`); add an inline slug-availability check in the create-classroom wizard with auto-suggestion (\`cs101-2\`) on collisions
- Drop generateTermString and getTermCode helpers and clean up all UI/API surfaces that referenced term/year (settings, OrgSelect, syllabus-bot, select-organization, student assignments, helpers, BatchImportTab)

## Schema changes
1. \`20260521124056_remove_terms\`: adds \`content_namespace\` + \`pin_order\`, backfills, swaps global slug unique for \`(git_org_id, slug)\`
2. \`20260521140000_drop_term_columns\`: drops \`Classroom.term\`, \`Classroom.year\`, \`Slide.term\`, and the \`Term\` enum

Legacy classrooms keep their existing \`content-{org}-{termCode}\` repos because \`content_namespace\` is backfilled to the same code. New classrooms get their own repo named \`content-{org}-{slug}\`.

## Test plan
- [ ] Verify dev server still boots (\`npm run dev\`) and the landing page renders Pinned / Active / Archived sections
- [ ] Create a new classroom — confirm the wizard no longer asks for term/year and that the slug availability check fires (try a colliding slug, confirm the suggestion button fills it in)
- [ ] Open an existing legacy classroom and verify its slides + pages still load (content repo unchanged)
- [ ] Pin a classroom from a card; confirm it moves to the Pinned section; drag to reorder and confirm the order survives a refresh
- [ ] Confirm two classrooms in the same org sharing a display name show their slugs as a muted subtitle on the landing screen
- [ ] \`npm run web:test\` (Playwright) — full suite green
- [ ] \`npm run slides:test\` (Playwright) — full suite green