### PR TITLE
fix(webapp): align dnd-kit DragOverlay with cursor on calendar

### DIFF
--- a/apps/webapp/app/hooks/useDarkMode.ts
+++ b/apps/webapp/app/hooks/useDarkMode.ts
@@ -334,6 +334,8 @@ export function applyTweaks({
 
   const contrastClamped = Math.min(CONTRAST_MAX, Math.max(CONTRAST_MIN, uiContrast));
   root.style.setProperty('--ui-contrast', String(contrastClamped));
+  if (contrastClamped !== 50) root.classList.add('ui-contrast-active');
+  else root.classList.remove('ui-contrast-active');
 
   if (pointerCursors) root.classList.add('pointer-cursors');
   else root.classList.remove('pointer-cursors');

--- a/apps/webapp/app/styles/global.css
+++ b/apps/webapp/app/styles/global.css
@@ -213,8 +213,12 @@ html.translucent-sidebar:not(.dark) [data-cm-sidebar] .bg-stone-200 {
 /* UI contrast: filters main content. Slider 50 is the neutral default.
    Range is intentionally narrow so neither extreme washes out card
    borders or near-white surfaces: 0 → 90%, 50 → 100%, 100 → 110%. */
-[data-cm-main],
-[data-cm-sidebar] {
+/* Only apply the filter when the user has actually moved the slider off the
+   default. A non-`none` filter establishes a containing block for
+   `position: fixed` descendants, which breaks libraries like dnd-kit that
+   assume the viewport is the containing block (e.g. DragOverlay). */
+html.ui-contrast-active [data-cm-main],
+html.ui-contrast-active [data-cm-sidebar] {
   filter: contrast(calc(100% + (var(--ui-contrast, 50) - 50) * 0.2%));
 }
 


### PR DESCRIPTION
## Summary
- Calendar drag was visually offset from the cursor by ~the sidebar width.
- Root cause: `filter: contrast(...)` on `[data-cm-main]` is applied unconditionally in `global.css`. A non-`none` `filter` establishes a containing block for `position: fixed` descendants, so dnd-kit's `<DragOverlay>` was positioned relative to the main pane (which has a ~256px left margin for the sidebar) instead of the viewport. Default `--ui-contrast: 50` produces `contrast(100%)` — a visual no-op that still creates the containing block, so the bug was present out of the box.
- Fix: only apply the filter when the contrast slider is off the default. `useDarkMode` now toggles a `ui-contrast-active` class on `<html>` when `contrastClamped !== 50`, and `global.css` gates the filter behind it.

## Test plan
- [ ] Open the admin/student calendar and drag an event — cursor should stay glued to the dragged ghost in both week and month views.
- [ ] Verify other `position: fixed` UI inside the main pane (modals, tooltips, dropdowns) still renders correctly.
- [ ] Move the UI contrast slider off 50 in settings — confirm the contrast effect still applies. Drag in calendar will now offset again while contrast is non-default (known trade-off; portal the overlay later if needed).
- [ ] Reset contrast to 50 — confirm class is removed and drag is aligned again.