### PR TITLE
feat: classroom status modes (Active / Locked / Unpublished) + archive

### DIFF
--- a/apps/webapp/app/components/features/classroom/LockedBanner.tsx
+++ b/apps/webapp/app/components/features/classroom/LockedBanner.tsx
@@ -1,0 +1,7 @@
+export function LockedBanner() {
+  return (
+    <div className="bg-amber-50 dark:bg-amber-950/40 text-amber-900 dark:text-amber-200 ring-1 ring-amber-200 dark:ring-amber-900 rounded-lg px-3 py-2 text-sm mb-3">
+      Read-only mode: this class has been locked by the owner. You can view everything but cannot make changes.
+    </div>
+  );
+}

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -90,7 +90,9 @@ export function ClassroomCard({
 
   const fetcher = pinFetcher; // alias used downstream for opacity styling
 
-  const blockedUnpublished = c.status === 'UNPUBLISHED' && c.role !== 'OWNER';
+  // Use raw DB role: derived `c.role` collapses TEACHER into 'OWNER' for display,
+  // but the unpublished gate must match the server (OWNER only).
+  const blockedUnpublished = c.status === 'UNPUBLISHED' && c.membershipRole !== 'OWNER';
   const handleOpenGuarded = () => {
     if (blockedUnpublished) {
       showUnpublishedModal();

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -5,6 +5,7 @@ import { IconGithub } from '@classmoji/ui-components';
 import { ClassMark } from './ClassMark';
 import { RoleChip } from './RoleChip';
 import type { LandingClass } from './types';
+import { showUnpublishedModal } from '~/utils/classroomStatusModals';
 
 interface ClassroomCardProps {
   c: LandingClass;
@@ -89,9 +90,18 @@ export function ClassroomCard({
 
   const fetcher = pinFetcher; // alias used downstream for opacity styling
 
+  const blockedUnpublished = c.status === 'UNPUBLISHED' && c.role !== 'OWNER';
+  const handleOpenGuarded = () => {
+    if (blockedUnpublished) {
+      showUnpublishedModal();
+      return;
+    }
+    onOpen();
+  };
+
   return (
     <div
-      onClick={onOpen}
+      onClick={handleOpenGuarded}
       role="button"
       tabIndex={0}
       draggable={draggable}
@@ -102,7 +112,7 @@ export function ClassroomCard({
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          onOpen();
+          handleOpenGuarded();
         }
       }}
       style={{
@@ -207,6 +217,16 @@ export function ClassroomCard({
               </motion.button>
             )}
           </AnimatePresence>
+          {c.status === 'LOCKED' && (
+            <span className="inline-flex items-center rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 px-2 py-0.5 text-xs">
+              Read-only
+            </span>
+          )}
+          {c.status === 'UNPUBLISHED' && (
+            <span className="inline-flex items-center rounded-full bg-gray-200 text-gray-700 dark:bg-gray-800 dark:text-gray-300 px-2 py-0.5 text-xs">
+              Unpublished
+            </span>
+          )}
           <RoleChip role={c.role} />
         </div>
       </div>

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -12,56 +12,12 @@ interface ClassroomCardProps {
   showSlug?: boolean;
   /** Called after the pin endpoint responds with the new pin_order. */
   onPinChanged?: (id: string, pin_order: number | null) => void;
-  /** Called after the archive endpoint responds with the new is_active. */
-  onArchiveChanged?: (id: string, is_active: boolean) => void;
   /** Drag handlers — supplied only inside the Pinned section. */
   draggable?: boolean;
   onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragOver?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDrop?: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd?: (e: React.DragEvent<HTMLDivElement>) => void;
-}
-
-function ArchiveIcon({ size = 14 }: { size?: number }) {
-  // Box with a downward arrow into it — "archive" gesture.
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="3" y="4" width="18" height="4" rx="1" />
-      <path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8" />
-      <path d="M12 11v5m0 0-2-2m2 2 2-2" />
-    </svg>
-  );
-}
-
-function UnarchiveIcon({ size = 14 }: { size?: number }) {
-  // Box with an upward arrow out of it — "unarchive" gesture.
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="3" y="4" width="18" height="4" rx="1" />
-      <path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8" />
-      <path d="M12 17v-5m0 0-2 2m2-2 2 2" />
-    </svg>
-  );
 }
 
 function PinIcon({ filled, size = 14 }: { filled: boolean; size?: number }) {
@@ -88,7 +44,6 @@ export function ClassroomCard({
   onOpen,
   showSlug = false,
   onPinChanged,
-  onArchiveChanged,
   draggable = false,
   onDragStart,
   onDragOver,
@@ -103,17 +58,13 @@ export function ClassroomCard({
         : 'Pending';
 
   const pinFetcher = useFetcher<{ pin_order: number | null }>();
-  const archiveFetcher = useFetcher<{ is_active: boolean }>();
   const [hover, setHover] = useState(false);
   const lastPinStateRef = useRef<typeof pinFetcher.state>('idle');
-  const lastArchiveStateRef = useRef<typeof archiveFetcher.state>('idle');
 
   const isPinned = c.pin_order != null;
   // Pinning is a personal organization feature — available to all roles
   // except pending invites.
   const canPin = c.role !== 'PENDING INVITE';
-  // Only OWNER can archive/unarchive.
-  const canArchive = c.role === 'OWNER';
 
   useEffect(() => {
     if (
@@ -126,17 +77,6 @@ export function ClassroomCard({
     lastPinStateRef.current = pinFetcher.state;
   }, [pinFetcher.state, pinFetcher.data, c.id, onPinChanged]);
 
-  useEffect(() => {
-    if (
-      archiveFetcher.state === 'idle' &&
-      lastArchiveStateRef.current !== 'idle' &&
-      archiveFetcher.data
-    ) {
-      onArchiveChanged?.(c.id, archiveFetcher.data.is_active);
-    }
-    lastArchiveStateRef.current = archiveFetcher.state;
-  }, [archiveFetcher.state, archiveFetcher.data, c.id, onArchiveChanged]);
-
   const handlePinClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (pinFetcher.state !== 'idle') return;
@@ -144,19 +84,6 @@ export function ClassroomCard({
       method: 'POST',
       action: `/api/classrooms/${c.classroomId}/pin`,
       encType: 'application/json',
-    });
-  };
-
-  const handleArchiveClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (archiveFetcher.state !== 'idle') return;
-    const msg = c.is_active
-      ? `Archive "${c.name}"? You can unarchive it later.`
-      : `Unarchive "${c.name}"?`;
-    if (typeof window !== 'undefined' && !window.confirm(msg)) return;
-    archiveFetcher.submit(null, {
-      method: 'POST',
-      action: `/api/classrooms/${c.classroomId}/archive`,
     });
   };
 
@@ -245,35 +172,6 @@ export function ClassroomCard({
           }}
         >
           <AnimatePresence initial={false}>
-            {canArchive && hover && (
-              <motion.button
-                key="archive-btn"
-                type="button"
-                aria-label={c.is_active ? 'Archive classroom' : 'Unarchive classroom'}
-                title={c.is_active ? 'Archive' : 'Unarchive'}
-                onClick={handleArchiveClick}
-                initial={{ opacity: 0, scale: 0.6, width: 0 }}
-                animate={{ opacity: 1, scale: 1, width: 'auto' }}
-                exit={{ opacity: 0, scale: 0.6, width: 0 }}
-                whileHover={{ scale: 1.15 }}
-                whileTap={{ scale: 0.85 }}
-                transition={{ type: 'spring', stiffness: 600, damping: 22 }}
-                style={{
-                  border: 'none',
-                  background: 'transparent',
-                  color: c.is_active ? 'var(--ink-3)' : 'var(--accent)',
-                  cursor: 'pointer',
-                  padding: 2,
-                  borderRadius: 4,
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  overflow: 'hidden',
-                }}
-              >
-                {c.is_active ? <ArchiveIcon /> : <UnarchiveIcon />}
-              </motion.button>
-            )}
             {canPin && (hover || isPinned) && (
               <motion.button
                 key="pin-btn"

--- a/apps/webapp/app/components/features/landing/ClassroomCard.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomCard.tsx
@@ -5,7 +5,7 @@ import { IconGithub } from '@classmoji/ui-components';
 import { ClassMark } from './ClassMark';
 import { RoleChip } from './RoleChip';
 import type { LandingClass } from './types';
-import { showUnpublishedModal } from '~/utils/classroomStatusModals';
+import { useClassroomStatusModals } from '~/utils/classroomStatusModals';
 
 interface ClassroomCardProps {
   c: LandingClass;
@@ -89,13 +89,14 @@ export function ClassroomCard({
   };
 
   const fetcher = pinFetcher; // alias used downstream for opacity styling
+  const { showUnpublished } = useClassroomStatusModals();
 
   // Use raw DB role: derived `c.role` collapses TEACHER into 'OWNER' for display,
   // but the unpublished gate must match the server (OWNER only).
   const blockedUnpublished = c.status === 'UNPUBLISHED' && c.membershipRole !== 'OWNER';
   const handleOpenGuarded = () => {
     if (blockedUnpublished) {
-      showUnpublishedModal();
+      showUnpublished();
       return;
     }
     onOpen();

--- a/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
+++ b/apps/webapp/app/components/features/landing/ClassroomsLandingScreen.tsx
@@ -63,6 +63,7 @@ export function ClassroomsLandingScreen({
 }: Props) {
   const [view, setView] = useState<'grid' | 'list'>('grid');
   const [bannerOpen, setBannerOpen] = useState(true);
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
 
   // Local overrides for optimistic pin/unpin, drag-reorder, and archive. Keyed by composite landing id.
   const [pinOverrides, setPinOverrides] = useState<Record<string, number | null>>({});
@@ -72,7 +73,7 @@ export function ClassroomsLandingScreen({
   const classesSigRef = useRef<string>('');
   useEffect(() => {
     const sig = classes
-      .map(c => `${c.id}:${c.pin_order ?? ''}:${c.is_active ? '1' : '0'}`)
+      .map(c => `${c.id}:${c.pin_order ?? ''}:${c.is_archived ? '1' : '0'}`)
       .join('|');
     if (sig !== classesSigRef.current) {
       classesSigRef.current = sig;
@@ -83,30 +84,27 @@ export function ClassroomsLandingScreen({
 
   const effectivePinOrder = (c: LandingClass): number | null =>
     Object.prototype.hasOwnProperty.call(pinOverrides, c.id) ? pinOverrides[c.id] : c.pin_order;
-  const effectiveIsActive = (c: LandingClass): boolean =>
+  const effectiveIsArchived = (c: LandingClass): boolean =>
     Object.prototype.hasOwnProperty.call(archiveOverrides, c.id)
       ? archiveOverrides[c.id]
-      : c.is_active;
+      : c.is_archived;
 
   const handlePinChanged = (id: string, pin_order: number | null) => {
     setPinOverrides(prev => ({ ...prev, [id]: pin_order }));
   };
-  const handleArchiveChanged = (id: string, is_active: boolean) => {
-    setArchiveOverrides(prev => ({ ...prev, [id]: is_active }));
-  };
 
   const { pinned, active, archived } = useMemo(() => {
     const withEffective = classes.map(c => ({
-      c: { ...c, is_active: effectiveIsActive(c), pin_order: effectivePinOrder(c) },
+      c: { ...c, is_archived: effectiveIsArchived(c), pin_order: effectivePinOrder(c) },
       p: effectivePinOrder(c),
-      a: effectiveIsActive(c),
+      a: effectiveIsArchived(c),
     }));
     const pinned = withEffective
-      .filter(x => x.p != null && x.a)
+      .filter(x => x.p != null && !x.a)
       .sort((a, b) => (a.p ?? 0) - (b.p ?? 0))
       .map(x => x.c);
-    const active = withEffective.filter(x => x.p == null && x.a).map(x => x.c);
-    const archived = withEffective.filter(x => !x.a).map(x => x.c);
+    const active = withEffective.filter(x => x.p == null && !x.a).map(x => x.c);
+    const archived = withEffective.filter(x => x.a).map(x => x.c);
     return { pinned, active, archived };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [classes, pinOverrides, archiveOverrides]);
@@ -194,8 +192,8 @@ export function ClassroomsLandingScreen({
 
   const counts = useMemo(
     () => ({
-      all: classes.filter(c => effectiveIsActive(c)).length,
-      archived: classes.filter(c => !effectiveIsActive(c)).length,
+      all: classes.filter(c => !effectiveIsArchived(c)).length,
+      archived: classes.filter(c => effectiveIsArchived(c)).length,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [classes, archiveOverrides]
@@ -231,7 +229,6 @@ export function ClassroomsLandingScreen({
               onOpen={() => onOpenClass(c)}
               showSlug={isDuplicate(c.name)}
               onPinChanged={handlePinChanged}
-              onArchiveChanged={handleArchiveChanged}
               draggable={draggable}
               onDragStart={draggable ? handleDragStart(c.id) : undefined}
               onDragOver={draggable ? handleDragOver(c.id) : undefined}
@@ -494,12 +491,26 @@ export function ClassroomsLandingScreen({
             )}
 
             {archived.length > 0 && (
-              <details open style={{ marginBottom: 24 }}>
-                <summary
+              <section style={{ marginBottom: 24 }}>
+                <button
+                  type="button"
+                  onClick={() => setArchivedExpanded(v => !v)}
+                  aria-expanded={archivedExpanded}
                   className="text-sm font-semibold text-gray-500 dark:text-gray-400"
-                  style={{ cursor: 'pointer', marginBottom: 10, marginTop: 4, listStyle: 'revert' }}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    cursor: 'pointer',
+                    marginBottom: 10,
+                    marginTop: 4,
+                    background: 'transparent',
+                    border: 'none',
+                    padding: 0,
+                  }}
                 >
-                  Archived{' '}
+                  <span aria-hidden>{archivedExpanded ? '▾' : '▸'}</span>
+                  <span>Archived</span>
                   <span
                     style={{
                       fontFamily: 'var(--font-mono)',
@@ -510,11 +521,13 @@ export function ClassroomsLandingScreen({
                   >
                     {archived.length}
                   </span>
-                </summary>
-                <div style={{ marginTop: 10 }}>
-                  {view === 'grid' ? renderGrid(archived, false) : renderList(archived)}
-                </div>
-              </details>
+                </button>
+                {archivedExpanded && (
+                  <div style={{ marginTop: 10 }}>
+                    {view === 'grid' ? renderGrid(archived, false) : renderList(archived)}
+                  </div>
+                )}
+              </section>
             )}
           </LayoutGroup>
         )}

--- a/apps/webapp/app/components/features/landing/types.ts
+++ b/apps/webapp/app/components/features/landing/types.ts
@@ -21,7 +21,8 @@ export interface LandingClass {
   updated: string;
   archived: boolean;
   pin_order: number | null;
-  is_active: boolean;
+  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+  is_archived: boolean;
   updated_at: string | Date;
   // Pass-through for navigation handler
   organization: {

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -13,6 +13,7 @@ import useStore from '~/store';
 import tokenImage from '~/assets/images/token.png';
 import githubLogo from '~/assets/images/github_logo.svg';
 import ProfileDropdown from '../../features/profile/ProfileDropdown';
+import { LockedBanner } from '~/components/features/classroom/LockedBanner';
 import type { AppUser, MembershipWithOrganization } from '~/types';
 
 interface MenuPage {
@@ -504,6 +505,7 @@ const CommonLayout = ({
             }
           >
             <CalloutSlot />
+            {classroom?.status === 'LOCKED' && role !== 'OWNER' && <LockedBanner />}
             {children}
           </div>
         </div>

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -14,7 +14,7 @@ import axios from 'axios';
 
 import React, { useEffect } from 'react';
 import dayjs from 'dayjs';
-import { ConfigProvider, theme } from 'antd';
+import { ConfigProvider, theme, App as AntdApp } from 'antd';
 import { IconMoodSad } from '@tabler/icons-react';
 import { auth as triggerAuth } from '@trigger.dev/sdk';
 
@@ -439,20 +439,22 @@ const App = ({ loaderData }: Route.ComponentProps) => {
               </div>
             )}
           >
-            <UserContext.Provider value={{ user }}>
-              <CalloutProvider>
-                <FetcherProvider>
-                  <ImpersonationBanner
-                    key={(session as Record<string, Record<string, string>>)?.session?.id}
-                    session={session}
-                  />
-                  <Outlet />
-                  <SyllabusBotRoot />
-                  <ScrollRestoration />
-                  <Scripts />
-                </FetcherProvider>
-              </CalloutProvider>
-            </UserContext.Provider>
+            <AntdApp>
+              <UserContext.Provider value={{ user }}>
+                <CalloutProvider>
+                  <FetcherProvider>
+                    <ImpersonationBanner
+                      key={(session as Record<string, Record<string, string>>)?.session?.id}
+                      session={session}
+                    />
+                    <Outlet />
+                    <SyllabusBotRoot />
+                    <ScrollRestoration />
+                    <Scripts />
+                  </FetcherProvider>
+                </CalloutProvider>
+              </UserContext.Provider>
+            </AntdApp>
           </ConfigProvider>
         </RenderErrorBoundary>
       </body>

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -29,7 +29,8 @@ import type { NotificationRole } from '~/components/features/notifications';
 interface SelectOrganizationMembership extends MembershipWithOrganization {
   has_accepted_invite: boolean;
   organization: MembershipOrganization & {
-    is_active?: boolean;
+    status?: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+    is_archived?: boolean;
   };
 }
 
@@ -145,7 +146,8 @@ function buildLandingClasses(memberships: SelectOrganizationMembership[]): Landi
     const orgLogin = org.login;
     const gitLogin = org.git_organization?.login ?? orgLogin;
 
-    const archived = org.is_active === false;
+    const status = (org.status ?? 'ACTIVE') as 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+    const archived = org.is_archived === true;
     const updatedAt =
       org.settings?.updated_at ?? (org as { updated_at?: Date | string | null }).updated_at;
     const updatedTs = updatedAt ? new Date(updatedAt as string | Date).getTime() || 0 : 0;
@@ -167,7 +169,8 @@ function buildLandingClasses(memberships: SelectOrganizationMembership[]): Landi
         updated: archived ? 'archived' : formatUpdated(updatedAt),
         archived,
         pin_order: pinOrder,
-        is_active: !archived,
+        status,
+        is_archived: archived,
         updated_at: (updatedAt as string | Date | null) ?? new Date(0),
         organization: { id: org.id, login: orgLogin, name: org.name },
         hasAcceptedInvite: m.has_accepted_invite,

--- a/apps/webapp/app/routes/admin.$class.assistants/action.ts
+++ b/apps/webapp/app/routes/admin.$class.assistants/action.ts
@@ -5,7 +5,7 @@ import { ClassmojiService, getGitProvider, ensureClassroomTeam } from '@classmoj
 import getPrisma from '@classmoji/database';
 import { ActionTypes } from '~/constants';
 import { waitForRunCompletion } from '~/utils/helpers';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 interface AssistantPayload {
@@ -31,10 +31,11 @@ interface AssistantClassroom {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'ASSISTANTS',
     action: 'manage_assistants',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.calendar/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.calendar/route.tsx
@@ -6,7 +6,7 @@ import { data, useFetcher, useParams } from 'react-router';
 import { ClassmojiService } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import getPrisma from '@classmoji/database';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { buildCalendarUrl, getCalendarDateRange } from '~/utils/calendar.server';
 import type { Route } from './+types/route';
 import CourseCalendar from '~/components/features/calendar/CourseCalendar';
@@ -114,6 +114,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     resourceType: 'CALENDAR',
     attemptedAction: 'modify',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const isAdmin = ['OWNER', 'TEACHER'].includes(membership!.role);
 

--- a/apps/webapp/app/routes/admin.$class.grades.$login/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.grades.$login/route.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import { ClassmojiService } from '@classmoji/services';
 import { useGlobalFetcher } from '~/hooks';
 import { UserThumbnailView } from '~/components';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -87,13 +87,14 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
   // Authorize: only OWNER/ASSISTANT can modify student grade comments
-  await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug!,
     allowedRoles: ['OWNER', 'ASSISTANT'],
     resourceType: 'GRADES',
     attemptedAction: 'modify_student_grade',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const { membershipId, comment } = data;

--- a/apps/webapp/app/routes/admin.$class.grades/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.grades/route.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from 'antd';
 import GradesTable from './GradesTable';
 import { ClassmojiService } from '@classmoji/services';
 import { addAuditLog } from '~/utils/helpers';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
@@ -86,10 +86,11 @@ const Grades = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  await requireClassroomAdmin(request, classSlug!, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug!, {
     resourceType: 'GRADES',
     action: 'update_grades',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const { membership_id, letter_grade } = data;

--- a/apps/webapp/app/routes/admin.$class.modules.form/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.modules.form/route.tsx
@@ -2,7 +2,7 @@ import { Modal } from 'antd';
 import { namedAction } from 'remix-utils/named-action';
 
 import { getAuthSession } from '@classmoji/auth/server';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import FormModule from './FormModule';
 import { ClassmojiService } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
@@ -141,10 +141,11 @@ const ModuleForm = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  const { classroom, userId: _userId } = await requireClassroomAdmin(request, classSlug!, {
+  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(request, classSlug!, {
     resourceType: 'MODULES',
     action: 'create_module',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.modules/action.ts
+++ b/apps/webapp/app/routes/admin.$class.modules/action.ts
@@ -3,16 +3,17 @@ import { namedAction } from 'remix-utils/named-action';
 import { ClassmojiService } from '@classmoji/services';
 import { publishAssignment, syncAssignment } from './helpers';
 import { ActionTypes } from '~/constants';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom, userId } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, userId, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'MODULES',
     action: 'manage_modules',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const assignmentId = data.assignment_id;

--- a/apps/webapp/app/routes/admin.$class.modules_.$title.assign-graders/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.modules_.$title.assign-graders/route.tsx
@@ -8,7 +8,7 @@ import { useDisclosure, useGlobalFetcher } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import { assignGradersToAssignmentsHandler } from './utils';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -131,7 +131,7 @@ const AssignGraders = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  const { classroom: _classroom, userId: _userId } = await requireClassroomAdmin(
+  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(
     request,
     classSlug!,
     {
@@ -139,6 +139,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
       action: 'assign_graders',
     }
   );
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const sessionId = nanoid();

--- a/apps/webapp/app/routes/admin.$class.modules_.$title.update/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.modules_.$title.update/route.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { auth, tasks } from '@trigger.dev/sdk';
 import { nanoid } from 'nanoid';
 import { ClassmojiService, getGitProvider, GitHubProvider } from '@classmoji/services';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import { useDisclosure, useGlobalFetcher } from '~/hooks';
 import type { Route } from './+types/route';
 
@@ -89,10 +89,11 @@ const UpdateRepositories = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug!, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug!, {
     resourceType: 'MODULES',
     action: 'update_module',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const { values, module } = await request.json();
   const sessionId = nanoid();

--- a/apps/webapp/app/routes/admin.$class.modules_.$title/action.ts
+++ b/apps/webapp/app/routes/admin.$class.modules_.$title/action.ts
@@ -1,7 +1,7 @@
 import { namedAction } from 'remix-utils/named-action';
 import { calculateContributions } from './helpers';
 import { HelperService } from '@classmoji/services';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import { ActionTypes } from '~/constants';
 import { tasks } from '@trigger.dev/sdk/v3';
 import type { Route } from './+types/route';
@@ -9,10 +9,11 @@ import type { Route } from './+types/route';
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom, userId: _userId } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'MODULES',
     action: 'module_action',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.pages.$pageId/action.ts
+++ b/apps/webapp/app/routes/admin.$class.pages.$pageId/action.ts
@@ -1,5 +1,5 @@
 import { redirect } from 'react-router';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { ClassmojiService } from '@classmoji/services';
 import { ContentService } from '@classmoji/content';
 import { wrapHtmlContent } from '~/utils/htmlWrapper';
@@ -67,13 +67,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       // Wrap assertClassroomAccess in try-catch to ensure we always return JSON
       try {
-        await assertClassroomAccess({
+        const { classroom, membership } = await assertClassroomAccess({
           request,
           classroomSlug: classSlug,
           allowedRoles: ['OWNER', 'TEACHER'],
           resourceType: 'PAGES',
           attemptedAction: 'upload_image',
         });
+        assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
       } catch (authError) {
         console.error('[upload-image action] Authorization failed:', authError);
         return Response.json(
@@ -139,13 +140,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       }
 
       try {
-        await assertClassroomAccess({
+        const { classroom, membership } = await assertClassroomAccess({
           request,
           classroomSlug: classSlug,
           allowedRoles: ['OWNER', 'TEACHER'],
           resourceType: 'PAGES',
           attemptedAction: 'upload_file',
         });
+        assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
       } catch (authError) {
         console.log(authError);
         return Response.json(
@@ -199,13 +201,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   }
 
   if (intent === 'delete') {
-    await assertClassroomAccess({
+    const { classroom, membership } = await assertClassroomAccess({
       request,
       classroomSlug: classSlug,
       allowedRoles: ['OWNER', 'TEACHER'],
       resourceType: 'PAGES',
       attemptedAction: 'delete_page',
     });
+    assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
     try {
       // Use deletePage to also delete from GitHub and update manifest
@@ -225,13 +228,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     if (!formData) formData = await request.formData();
     const width = parseInt(formData.get('width') as string, 10);
 
-    await assertClassroomAccess({
+    const { classroom, membership } = await assertClassroomAccess({
       request,
       classroomSlug: classSlug,
       allowedRoles: ['OWNER', 'TEACHER'],
       resourceType: 'PAGES',
       attemptedAction: 'update_width',
     });
+    assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
     try {
       await ClassmojiService.page.quickUpdate(pageId, {
@@ -250,13 +254,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   }
 
   if (intent === 'toggleStudentMenu') {
-    await assertClassroomAccess({
+    const { classroom, membership } = await assertClassroomAccess({
       request,
       classroomSlug: classSlug,
       allowedRoles: ['OWNER', 'TEACHER'],
       resourceType: 'PAGES',
       attemptedAction: 'toggle_student_menu',
     });
+    assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
     try {
       const data = await request.json();
@@ -274,13 +279,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   }
 
   if (intent === 'togglePublic') {
-    await assertClassroomAccess({
+    const { classroom, membership } = await assertClassroomAccess({
       request,
       classroomSlug: classSlug,
       allowedRoles: ['OWNER', 'TEACHER'],
       resourceType: 'PAGES',
       attemptedAction: 'toggle_public',
     });
+    assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
     try {
       const data = await request.json();
@@ -310,13 +316,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         );
       }
 
-      await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
         resourceType: 'PAGES',
         attemptedAction: 'upload_header_image',
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const page = await ClassmojiService.page.findById(pageId, {
         includeClassroom: true,
@@ -370,13 +377,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   if (intent === 'set-header-image') {
     try {
-      await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
         resourceType: 'PAGES',
         attemptedAction: 'set_header_image',
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const data = await request.json();
       const { url, position } = data;
@@ -423,13 +431,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         );
       }
 
-      await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
         resourceType: 'PAGES',
         attemptedAction: 'import_markdown',
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const page = await ClassmojiService.page.findById(pageId, {
         includeClassroom: true,
@@ -577,13 +586,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     const markdownContent = formData.get('content') as string | null;
     const newTitle = formData.get('title') as string | null;
 
-    await assertClassroomAccess({
+    const { classroom, membership } = await assertClassroomAccess({
       request,
       classroomSlug: classSlug,
       allowedRoles: ['OWNER', 'TEACHER'],
       resourceType: 'PAGES',
       attemptedAction: 'edit_page',
     });
+    assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
     const page = await ClassmojiService.page.findById(pageId, {
       includeClassroom: true,

--- a/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useFetcher } from 'react-router';
 import { Form, Button, Alert, Modal, Tabs } from 'antd';
 import { FileTextOutlined, UploadOutlined } from '@ant-design/icons';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import { ContentService } from '@classmoji/content';
@@ -44,13 +44,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   const formData = await request.formData();
   const intent = formData.get('intent');
 
-  const { classroom, userId } = await assertClassroomAccess({
+  const { classroom, userId, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug!,
     allowedRoles: ['OWNER', 'TEACHER'],
     resourceType: 'PAGES',
     attemptedAction: 'create_page',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   // Use git_organization.login for GitHub API calls, not the classroom slug
   const gitOrgLogin = classroom.git_organization?.login;

--- a/apps/webapp/app/routes/admin.$class.pages/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages/route.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useFetcher, Link, Outlet, useSearchParams, useNavigate } from 'react-router';
 import { Table, Button, Input, Select, Switch, Tooltip } from 'antd';
 import { IconPlus, IconEyeOff, IconLock, IconWorld, IconMenu2 } from '@tabler/icons-react';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { ClassmojiService } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import getPrisma from '@classmoji/database';
@@ -50,13 +50,14 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug!,
     allowedRoles: ['OWNER', 'TEACHER'],
     resourceType: 'PAGES',
     attemptedAction: 'manage',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const formData = await request.formData();
   const intent = formData.get('intent') as string | null;

--- a/apps/webapp/app/routes/admin.$class.quizzes/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.quizzes/route.tsx
@@ -4,7 +4,7 @@ import { IconSend, IconBook, IconCalendar, IconTrash } from '@tabler/icons-react
 import { TableActionButtons, EditableCell, ButtonNew } from '~/components';
 import { ClassmojiService } from '@classmoji/services';
 import { namedAction } from 'remix-utils/named-action';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 import type React from 'react';
 import type { TablerIconsProps } from '@tabler/icons-react';
@@ -124,7 +124,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   const data = await request.json();
 
-  const { userId, classroom } = await assertClassroomAccess({
+  const { userId, classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER', 'ASSISTANT'],
@@ -134,6 +134,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
       quiz_id: data.id || null,
     },
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   // Create FormData with the action from the JSON
   const formData = new FormData();

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.tsx
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.tsx
@@ -9,6 +9,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { UserThumbnailView, GradeBadge, SectionHeader } from '~/components';
 import { formatDuration, checkForCompletion } from '~/utils/quizUtils';
 import { namedAction } from 'remix-utils/named-action';
+import { assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 
 dayjs.extend(relativeTime);
 
@@ -310,7 +311,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     async clearMyAttempts() {
       // SECURITY: Only admins (OWNER/ASSISTANT) can clear preview attempts
       // The service layer scopes deletion to only the authenticated user's attempts
-      const { userId, classroom } = await assertClassroomAccess({
+      const { userId, classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'ASSISTANT'],
@@ -320,6 +321,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
           quiz_id: quizId,
         },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       // Delete only this authenticated user's attempts for this specific quiz
       // The userId from assertClassroomAccess ensures we only clear the authenticated user's attempts

--- a/apps/webapp/app/routes/admin.$class.repositories/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.repositories/route.tsx
@@ -13,7 +13,7 @@ import { ActionTypes } from '~/constants';
 import { ClassmojiService, getGitProvider, GitHubProvider } from '@classmoji/services';
 import { useGlobalFetcher } from '~/hooks';
 import { waitForRunCompletion } from '~/utils/helpers';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 interface OrganizationRepositoryPageInfo {
@@ -534,10 +534,11 @@ const GithubRepositories = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom, userId: _userId } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'REPOSITORIES',
     action: 'manage_repositories',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   return namedAction(request, {
     async deleteSingleRepository() {

--- a/apps/webapp/app/routes/admin.$class.resources/action.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/action.ts
@@ -1,19 +1,20 @@
 import { namedAction } from 'remix-utils/named-action';
 import getPrisma from '@classmoji/database';
 import { ClassmojiService } from '@classmoji/services';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER', 'TEACHER'],
     resourceType: 'RESOURCES',
     attemptedAction: 'manage_links',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   return namedAction(request, {
     async addLink() {

--- a/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
@@ -9,7 +9,7 @@ import { getContentRepoName } from '@classmoji/utils';
 import { SettingSection } from '~/components';
 import { ActionTypes } from '~/constants';
 import { useGlobalFetcher } from '~/hooks';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { isAIAgentConfigured } from '~/utils/aiFeatures.server';
 import type { Route } from './+types/route';
 
@@ -201,13 +201,14 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
   // Authorize: only OWNER can modify content settings
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER'],
     resourceType: 'CONTENT_SETTINGS',
     attemptedAction: 'modify',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
@@ -6,7 +6,7 @@ import { useNavigate, useParams } from 'react-router';
 import { useGlobalFetcher, useDisclosure } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 const DangerZone = () => {
@@ -61,10 +61,11 @@ const DangerZone = () => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'SETTINGS',
     action: 'delete_classroom',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   return namedAction(request, {
     async removeClassroom() {

--- a/apps/webapp/app/routes/admin.$class.settings.extension/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.extension/route.tsx
@@ -7,7 +7,7 @@ import { ClassmojiService } from '@classmoji/services';
 import { SettingSection } from '~/components';
 import { ActionTypes } from '~/constants';
 import { useGlobalFetcher } from '~/hooks';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -79,13 +79,14 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
   // Authorize: only OWNER can modify extension settings
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER'],
     resourceType: 'SETTINGS',
     attemptedAction: 'modify_extension_settings',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.settings.general/StatusSection.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.general/StatusSection.tsx
@@ -1,48 +1,96 @@
+import { Modal, Radio, Button } from 'antd';
 import { SettingSection } from '~/components';
-import { Form, Radio } from 'antd';
-import { useGlobalFetcher } from '~/hooks';
+
+type Status = 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
 
 interface StatusSectionProps {
-  organization: { is_active: boolean };
+  classroomId: string;
+  status: Status;
+  isArchived: boolean;
 }
 
-const StatusSection = ({ organization }: StatusSectionProps) => {
-  const { fetcher } = useGlobalFetcher();
+const STATUS_OPTIONS: { value: Status; label: string; desc: string }[] = [
+  {
+    value: 'ACTIVE',
+    label: 'Active',
+    desc: 'Normal access. Members can read and write according to their role.',
+  },
+  {
+    value: 'LOCKED',
+    label: 'Locked (read-only)',
+    desc: 'Members can view everything but cannot make changes.',
+  },
+  {
+    value: 'UNPUBLISHED',
+    label: 'Unpublished',
+    desc: 'Members see the card but cannot enter the class.',
+  },
+];
 
-  const handleStatusChange = async (isActive: boolean) => {
-    fetcher!.submit(
-      {
-        is_active: isActive,
+const StatusSection = ({ classroomId, status, isArchived }: StatusSectionProps) => {
+  const setStatus = async (next: Status) => {
+    await fetch(`/api/classrooms/${classroomId}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: next }),
+    });
+    window.location.reload();
+  };
+
+  const setArchived = (next: boolean) => {
+    Modal.confirm({
+      title: next ? 'Archive class?' : 'Unarchive class?',
+      content: next
+        ? 'The class will be moved to the Archived section on the landing page. Access is not changed.'
+        : 'The class will be returned to the active list.',
+      okText: next ? 'Archive' : 'Unarchive',
+      onOk: async () => {
+        await fetch(`/api/classrooms/${classroomId}/archive`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ is_archived: next }),
+        });
+        window.location.reload();
       },
-      {
-        action: '?/saveProfile',
-        method: 'POST',
-        encType: 'application/json',
-      }
-    );
+    });
   };
 
   return (
-    <SettingSection
-      title="Status"
-      description="Change the status of your organization. Note that statistics are not computed for inactive classes"
-    >
-      <Form layout="vertical">
-        <Form.Item label="Current status">
-          <Radio.Group
-            block
-            options={[
-              { label: 'Active', value: true },
-              { label: 'Inactive', value: false },
-            ]}
-            optionType="button"
-            value={organization.is_active}
-            onChange={e => handleStatusChange(e.target.value)}
-            className="w-1/2"
-          />
-        </Form.Item>
-      </Form>
-    </SettingSection>
+    <>
+      <SettingSection
+        title="Class status"
+        description="Applies to teaching assistants and students only — owners always retain full access."
+      >
+        <div className="space-y-3">
+          {STATUS_OPTIONS.map(opt => (
+            <label
+              key={opt.value}
+              className="flex items-start gap-3 cursor-pointer"
+            >
+              <Radio
+                checked={status === opt.value}
+                onChange={() => setStatus(opt.value)}
+              />
+              <span>
+                <span className="font-medium">{opt.label}</span>
+                <span className="block text-sm text-gray-500 dark:text-gray-400">
+                  {opt.desc}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </SettingSection>
+
+      <SettingSection
+        title="Archive"
+        description="Move this class out of the way on your landing page. Archiving does not change access."
+      >
+        <Button onClick={() => setArchived(!isArchived)}>
+          {isArchived ? 'Unarchive class' : 'Archive class'}
+        </Button>
+      </SettingSection>
+    </>
   );
 };
 

--- a/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
@@ -9,7 +9,7 @@ import ProfileSection from './ProfileSection';
 import StatusSection from './StatusSection';
 import DefaultPageSection from './DefaultPageSection';
 import TweaksSection from '~/components/features/tweaks/TweaksSection';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -83,13 +83,14 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
   // Authorize: only OWNER can modify general settings
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER'],
     resourceType: 'SETTINGS',
     attemptedAction: 'modify_general_settings',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
@@ -6,6 +6,7 @@ import { SettingSection } from '~/components';
 import { ActionTypes } from '~/constants';
 import { useGlobalFetcher } from '~/hooks';
 import ProfileSection from './ProfileSection';
+import StatusSection from './StatusSection';
 import DefaultPageSection from './DefaultPageSection';
 import TweaksSection from '~/components/features/tweaks/TweaksSection';
 import { assertClassroomAccess } from '~/utils/helpers';
@@ -47,6 +48,11 @@ const SettingsGeneral = ({ loaderData }: Route.ComponentProps) => {
         organization={{
           name: classroom.name,
         }}
+      />
+      <StatusSection
+        classroomId={classroom.id}
+        status={classroom.status as 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED'}
+        isArchived={classroom.is_archived}
       />
       <DefaultPageSection
         currentDefault={classroom.settings?.default_student_page || 'dashboard'}

--- a/apps/webapp/app/routes/admin.$class.settings.grades/action.ts
+++ b/apps/webapp/app/routes/admin.$class.settings.grades/action.ts
@@ -2,16 +2,17 @@ import { namedAction } from 'remix-utils/named-action';
 
 import { ClassmojiService } from '@classmoji/services';
 import { DEFAULT_EMOJI_MAPPINGS, DEFAULT_LETTER_GRADE_MAPPINGS } from '@classmoji/utils';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'SETTINGS',
     action: 'update_grade_settings',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.settings.quizzes/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.quizzes/route.tsx
@@ -20,7 +20,7 @@ import { ClassmojiService } from '@classmoji/services';
 import { SettingSection } from '~/components';
 import { ActionTypes } from '~/constants';
 import { useGlobalFetcher } from '~/hooks';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { isAIAgentConfigured } from '~/utils/aiFeatures.server';
 import type { Route } from './+types/route';
 
@@ -341,13 +341,14 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
   // Authorize: only OWNER can modify quiz settings
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER'],
     resourceType: 'QUIZ_SETTINGS',
     attemptedAction: 'modify',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.settings.repos/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.repos/route.tsx
@@ -1,7 +1,7 @@
 import { Select, Switch, Alert } from 'antd';
 import { useNotifiedFetcher } from '~/hooks';
 
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { getGitProvider } from '@classmoji/services';
 import type { Route } from './+types/route';
 
@@ -147,13 +147,14 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
   // Get classroom with git_organization to find the GitHub org login
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER'],
     resourceType: 'REPO_SETTINGS',
     attemptedAction: 'modify',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const gitOrgLogin = classroom.git_organization?.login;
   if (!gitOrgLogin) {

--- a/apps/webapp/app/routes/admin.$class.settings.team/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.team/route.tsx
@@ -2,7 +2,7 @@ import { namedAction } from 'remix-utils/named-action';
 
 import { ClassmojiService } from '@classmoji/services';
 import TagSection from './TagSection';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -30,10 +30,11 @@ const SettingsTeams = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'SETTINGS',
     action: 'update_team_settings',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.slides/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.slides/route.tsx
@@ -10,7 +10,7 @@ import {
   IconNotes,
 } from '@tabler/icons-react';
 import getPrisma from '@classmoji/database';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { ClassmojiService } from '@classmoji/services';
 import { TableActionButtons, RecentViewers } from '~/components';
 import type { Route } from './+types/route';
@@ -70,13 +70,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   const value = formData.get('value') as string;
 
   // Authorization: require OWNER or TEACHER to modify slide settings
-  await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER', 'TEACHER'],
     resourceType: 'SLIDES',
     attemptedAction: 'update_slide_visibility',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   // Handle status changes (combines is_draft and is_public)
   if (field === 'status') {

--- a/apps/webapp/app/routes/admin.$class.students.add/action.ts
+++ b/apps/webapp/app/routes/admin.$class.students.add/action.ts
@@ -1,16 +1,17 @@
 import { ClassmojiService } from '@classmoji/services';
 import Tasks from '@classmoji/tasks';
 import getPrisma from '@classmoji/database';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom, userId: _userId } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'STUDENT_ROSTER',
     action: 'bulk_add_students',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = (await request.json()) as { students: Array<{ email: string; name?: string }> };
   const emails = data.students.map(s => s.email.toLowerCase());

--- a/apps/webapp/app/routes/admin.$class.students/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/route.tsx
@@ -10,7 +10,7 @@ import { ClassmojiService } from '@classmoji/services';
 import StudentsTable from './StudentsTable';
 import { ActionTypes } from '~/constants';
 import { waitForRunCompletion } from '~/utils/helpers';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import { RequireRole, SearchInput } from '~/components';
 import type { Route } from './+types/route';
 
@@ -101,10 +101,11 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'STUDENT_ROSTER',
     action: 'remove_student',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
@@ -5,7 +5,7 @@ import { sleep } from '~/utils/helpers';
 import getPrisma from '@classmoji/database';
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 interface RepoRename {
@@ -19,10 +19,11 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   invariant(slug, 'Team slug is required');
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'TEAMS',
     action: 'edit_team',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
 

--- a/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
@@ -7,7 +7,7 @@ import { useGlobalFetcher, useDisclosure } from '~/hooks';
 import { ClassmojiService, getGitProvider, GitHubProvider } from '@classmoji/services';
 import { GetTeamAvatarQuery } from './queries';
 import { ActionTypes } from '~/constants';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -115,10 +115,11 @@ const AdminNewTeam = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'TEAMS',
     action: 'create_team',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const { name, visibility: _visibility, tags } = data;

--- a/apps/webapp/app/routes/admin.$class.teams/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams/route.tsx
@@ -13,7 +13,7 @@ import {
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
 import { useGlobalFetcher } from '~/hooks';
 import { ActionTypes } from '~/constants';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 interface Team {
@@ -178,10 +178,11 @@ const AdminTeams = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'TEAMS',
     action: 'manage_teams',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const { team } = data;

--- a/apps/webapp/app/routes/admin.$class.tokens.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.tokens.new/route.tsx
@@ -9,7 +9,7 @@ import { nanoid } from 'nanoid';
 import { ClassmojiService } from '@classmoji/services';
 import { useGlobalFetcher, useRouteDrawer } from '~/hooks';
 import Tasks from '@classmoji/tasks';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 const InlineRow = ({
@@ -249,10 +249,11 @@ const AdminTokensNew = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  const { classroom, userId: _userId } = await requireClassroomAdmin(request, classSlug!, {
+  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(request, classSlug!, {
     resourceType: 'TOKEN_GRANT',
     action: 'assign_tokens_bulk',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const sessionId = nanoid();

--- a/apps/webapp/app/routes/api.$operation/route.ts
+++ b/apps/webapp/app/routes/api.$operation/route.ts
@@ -5,7 +5,7 @@ import { nanoid } from 'nanoid';
 import { getAuthSession } from '@classmoji/auth/server';
 
 import { ClassmojiService } from '@classmoji/services';
-import { checkAuth, waitForRunCompletion, assertClassroomAccess } from '~/utils/helpers';
+import { checkAuth, waitForRunCompletion, assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 
 export const loader = checkAuth(
   async ({ request, params }: { request: Request; params: Record<string, string | undefined> }) => {
@@ -180,13 +180,14 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
         return data({ error: 'Classroom not found' }, { status: 404 });
       }
 
-      await assertClassroomAccess({
+      const { classroom: accessClassroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classroom.slug,
         allowedRoles: ['OWNER'],
         resourceType: 'REPOSITORY',
         attemptedAction: 'delete_repositories',
       });
+      assertClassroomMutationAllowed({ status: accessClassroom.status, role: membership!.role });
 
       const sessionId = nanoid();
       const payloads = await Promise.all(

--- a/apps/webapp/app/routes/api.classrooms.$id.status/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$id.status/route.ts
@@ -1,14 +1,17 @@
 /**
- * Set the archive flag on a classroom (idempotent).
+ * Set the status on a classroom.
  *
- * PATCH /api/classrooms/:id/archive  body: { is_archived: boolean }
+ * PATCH /api/classrooms/:id/status  body: { status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED' }
  *
- * Only OWNER. Returns `{ is_archived: boolean }`.
+ * Only OWNER. Returns `{ status }`.
  */
 
 import { requireAuth } from '@classmoji/auth/server';
 import getPrisma from '@classmoji/database';
 import type { Route } from './+types/route';
+
+const STATUSES = ['ACTIVE', 'LOCKED', 'UNPUBLISHED'] as const;
+type Status = (typeof STATUSES)[number];
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   if (request.method !== 'PATCH' && request.method !== 'POST') {
@@ -21,9 +24,9 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     return new Response('Missing classroom id', { status: 400 });
   }
 
-  const body = (await request.json().catch(() => ({}))) as { is_archived?: boolean };
-  if (typeof body.is_archived !== 'boolean') {
-    return new Response('Invalid body', { status: 400 });
+  const body = (await request.json().catch(() => ({}))) as { status?: Status };
+  if (!body.status || !STATUSES.includes(body.status)) {
+    return new Response('Invalid status', { status: 400 });
   }
 
   const prisma = getPrisma();
@@ -38,8 +41,8 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   const updated = await prisma.classroom.update({
     where: { id: classroomId },
-    data: { is_archived: body.is_archived },
-    select: { is_archived: true },
+    data: { status: body.status },
+    select: { status: true },
   });
 
   return Response.json(updated);

--- a/apps/webapp/app/routes/api.extension.$class/route.ts
+++ b/apps/webapp/app/routes/api.extension.$class/route.ts
@@ -2,7 +2,7 @@ import { namedAction } from 'remix-utils/named-action';
 import { tasks } from '@trigger.dev/sdk';
 
 import { ActionTypes } from '~/constants';
-import { assertClassroomAccess, waitForRunCompletion } from '~/utils/helpers';
+import { assertClassroomAccess, waitForRunCompletion, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export const loader = async () => {
@@ -15,7 +15,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async createExtension() {
-      const { classroom } = await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -23,6 +23,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'create_extension',
         metadata: { student_id: data.student_id, hours: data.hours },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       try {
         const run = await tasks.trigger('request_extension', {
@@ -46,7 +47,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async updateExtension() {
-      await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -54,6 +55,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'update_extension',
         metadata: { extension_id: data.extension_id },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       try {
         const run = await tasks.trigger('update_extension', {

--- a/apps/webapp/app/routes/api.pages.batch/route.ts
+++ b/apps/webapp/app/routes/api.pages.batch/route.ts
@@ -1,4 +1,4 @@
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
 import { ContentService } from '@classmoji/content';
 import { processMarkdownImport } from '~/utils/markdownImporter.server';
@@ -12,13 +12,14 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const formData = await request.formData();
   const intent = formData.get('intent') as string;
   const classSlug = formData.get('classSlug') as string;
-  const { classroom, userId } = await assertClassroomAccess({
+  const { classroom, userId, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER', 'TEACHER'],
     resourceType: 'PAGES',
     attemptedAction: 'create_page',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   // Use git_organization.login for GitHub API calls, not the classroom slug
   const gitOrgLogin = classroom.git_organization?.login;

--- a/apps/webapp/app/routes/api.quiz.prompt-assistant/route.ts
+++ b/apps/webapp/app/routes/api.quiz.prompt-assistant/route.ts
@@ -12,6 +12,7 @@
  */
 
 import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import { isAIAgentConfigured } from '~/utils/aiFeatures.server';
 import { sendRequest } from '~/services/aiAgentConnection.server';
 import agentStreamManager from '~/utils/agentStreamManager';
@@ -59,13 +60,14 @@ async function handleInitSession(request: Request, formData: FormData) {
   const exampleRepoUrl = formData.get('exampleRepoUrl') as string | null;
 
   // Verify instructor has access to the classroom
-  const { userId, classroom } = await assertClassroomAccess({
+  const { userId, classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug,
     allowedRoles: ['OWNER', 'ASSISTANT'],
     resourceType: 'PROMPT_ASSISTANT',
     attemptedAction: 'init_session',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   // Get classroom settings for LLM config
   const { ClassmojiService } = await import('@classmoji/services');
@@ -149,13 +151,14 @@ async function handleSendMessage(request: Request, formData: FormData) {
   const content = formData.get('content') as string | null;
 
   // Verify instructor has access
-  await assertClassroomAccess({
+  const { classroom: smClassroom, membership: smMembership } = await assertClassroomAccess({
     request,
     classroomSlug,
     allowedRoles: ['OWNER', 'ASSISTANT'],
     resourceType: 'PROMPT_ASSISTANT',
     attemptedAction: 'send_message',
   });
+  assertClassroomMutationAllowed({ status: smClassroom.status, role: smMembership!.role });
 
   if (!sessionId || !content) {
     return jsonResponse({ error: 'Missing sessionId or content' }, 400);

--- a/apps/webapp/app/routes/api.quiz/route.ts
+++ b/apps/webapp/app/routes/api.quiz/route.ts
@@ -21,6 +21,7 @@
  * - restartQuiz: Deletes and restarts a quiz attempt (dev mode only)
  */
 import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import { isAIAgentConfigured } from '~/utils/aiFeatures.server';
 import { getQuestionProgressFromMessage, checkForCompletion } from '@classmoji/utils';
 import type { Role } from '@prisma/client';
@@ -289,6 +290,7 @@ export async function action({ request }: Route.ActionArgs) {
       attemptedAction: data._action,
       metadata: context.metadata,
     });
+    assertClassroomMutationAllowed({ status: access.classroom.status, role: access.membership!.role });
 
     // Check AI agent availability AFTER auth (preserves audit logging)
     if (!isAIAgentConfigured()) {

--- a/apps/webapp/app/routes/api.repos.$id.contributor-link/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.contributor-link/route.ts
@@ -1,6 +1,6 @@
 import { ClassmojiService } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
-import { assertClassroomAccess } from '~/utils/routeAuth.server';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 /**
@@ -38,7 +38,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     });
   }
 
-  await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: repo.classroom.slug,
     allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
@@ -46,6 +46,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     attemptedAction: 'link_contributor',
     metadata: { repository_id: repositoryId },
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   let body: { github_login?: string; user_id?: string | null };
   try {

--- a/apps/webapp/app/routes/api.repos.$id.refresh/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.refresh/route.ts
@@ -1,7 +1,7 @@
 import { tasks } from '@trigger.dev/sdk';
 
 import { ClassmojiService } from '@classmoji/services';
-import { assertClassroomAccess } from '~/utils/routeAuth.server';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 /**
@@ -42,7 +42,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     });
   }
 
-  await assertClassroomAccess({
+  const { classroom: accessClassroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classroom.slug,
     allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
@@ -50,6 +50,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     attemptedAction: 'refresh_repo_analytics',
     metadata: { repository_assignment_id: repositoryAssignmentId },
   });
+  assertClassroomMutationAllowed({ status: accessClassroom.status, role: membership!.role });
 
   const handle = await tasks.trigger('refresh-repo-analytics', {
     repositoryAssignmentId,

--- a/apps/webapp/app/routes/api.repositoryAssignment.$class/route.ts
+++ b/apps/webapp/app/routes/api.repositoryAssignment.$class/route.ts
@@ -4,7 +4,7 @@ import { tasks } from '@trigger.dev/sdk';
 
 import { ClassmojiService, HelperService } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
-import { assertClassroomAccess, waitForRunCompletion } from '~/utils/helpers';
+import { assertClassroomAccess, waitForRunCompletion, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export const action = async ({ params, request }: Route.ActionArgs) => {
@@ -13,7 +13,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async autograde() {
-      const { userId: _userId, classroom: _classroom } = await assertClassroomAccess({
+      const { userId: _userId, classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -21,6 +21,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'autograde',
         metadata: { workflowName: data.workflowName },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       try {
         const run = await tasks.trigger('dispatch_autograde_workflow', {
@@ -43,7 +44,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async addGrade() {
-      const { userId: _userId, classroom } = await assertClassroomAccess({
+      const { userId: _userId, classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
@@ -51,6 +52,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'add_grade',
         metadata: { assignment_id: data.repositoryAssignment?.assignment_id },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const { repositoryAssignment, graderId, grade, studentId, teamId } = data;
 
@@ -70,7 +72,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async removeGrade() {
-      const { userId: _userId2, classroom } = await assertClassroomAccess({
+      const { userId: _userId2, classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
@@ -78,6 +80,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'remove_grade',
         metadata: { assignment_id: data.repositoryAssignment?.assignment_id },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const { grade, repositoryAssignment } = data;
 
@@ -94,7 +97,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async updateLateOverride() {
-      const { userId: _userId3, classroom: _classroom2 } = await assertClassroomAccess({
+      const { userId: _userId3, classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -102,6 +105,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'update_late_override',
         metadata: { repository_assignment_id: data.repository_assignment_id },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const { repository_assignment_id, is_late_override } = data;
       const message = is_late_override ? 'Added override' : 'Removed override';
@@ -117,7 +121,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async updateGradeRelease() {
-      const { classroom: _classroom3 } = await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -125,6 +129,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
         attemptedAction: 'update_grade_release',
         metadata: { assignment_id: data.assignment_id },
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const { assignment_id, grades_released } = data;
       const message = grades_released

--- a/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
@@ -15,6 +15,7 @@
  */
 
 import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import { isAIAgentConfigured } from '~/utils/aiFeatures.server';
 import { getContentRepoName } from '@classmoji/utils';
 import { sendRequest } from '~/services/aiAgentConnection.server';
@@ -114,6 +115,7 @@ async function handleInitConversation(request: Request, classSlug: string, formD
     resourceType: 'SYLLABUS_BOT',
     attemptedAction: 'init_conversation',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const settings = await ClassmojiService.classroom.getClassroomSettingsForServer(classroom.id);
 
@@ -215,13 +217,14 @@ async function handleSendMessage(request: Request, classSlug: string, formData: 
   const content = formData.get('content') as string | null;
 
   // Verify user has access
-  await assertClassroomAccess({
+  const { classroom: smClassroom, membership: smMembership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT'],
     resourceType: 'SYLLABUS_BOT',
     attemptedAction: 'send_message',
   });
+  assertClassroomMutationAllowed({ status: smClassroom.status, role: smMembership!.role });
 
   if (!conversationId || !content) {
     return jsonResponse({ error: 'Missing conversationId or content' }, 400);

--- a/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
@@ -16,7 +16,7 @@ import EditEventModal, { type EventFormData } from '~/components/features/calend
 import EventCard from '~/components/features/calendar/EventCard';
 import EventLinks from '~/components/features/calendar/EventLinks';
 import type { CalendarEventWithLinks } from '~/components/features/calendar/types';
-import { showStatusErrorFromResponse } from '~/utils/classroomStatusModals';
+import { useClassroomStatusModals } from '~/utils/classroomStatusModals';
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const { class: classSlug } = params;
@@ -282,6 +282,7 @@ const AssistantCalendar = ({ loaderData }: Route.ComponentProps) => {
   const fetcher = useFetcher();
   const eventsFetcher = useFetcher();
   const callout = useCallout();
+  const { showStatusErrorFromResponse } = useClassroomStatusModals();
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<CalendarEventWithLinks | null>(null);

--- a/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
@@ -7,7 +7,7 @@ import type { Route } from './+types/route';
 import { ClassmojiService } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import getPrisma from '@classmoji/database';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { buildCalendarUrl, getCalendarDateRange } from '~/utils/calendar.server';
 import CourseCalendar from '~/components/features/calendar/CourseCalendar';
 import CalendarSubscriptionCard from '~/components/features/calendar/CalendarSubscriptionCard';
@@ -98,13 +98,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   const { class: classSlug } = params;
   invariant(classSlug, 'Classroom is required');
 
-  const { userId, classroom } = await assertClassroomAccess({
+  const { userId, classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['ASSISTANT', 'OWNER', 'TEACHER'],
     resourceType: 'CALENDAR',
     attemptedAction: 'modify',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const formData = await request.formData();
   const intent = formData.get('intent');

--- a/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.calendar/route.tsx
@@ -16,6 +16,7 @@ import EditEventModal, { type EventFormData } from '~/components/features/calend
 import EventCard from '~/components/features/calendar/EventCard';
 import EventLinks from '~/components/features/calendar/EventLinks';
 import type { CalendarEventWithLinks } from '~/components/features/calendar/types';
+import { showStatusErrorFromResponse } from '~/utils/classroomStatusModals';
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const { class: classSlug } = params;
@@ -306,6 +307,7 @@ const AssistantCalendar = ({ loaderData }: Route.ComponentProps) => {
   // Close modals and show toast when fetcher completes
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data) {
+      showStatusErrorFromResponse(fetcher.data as { error?: string } | undefined);
       if (fetcher.data.success) {
         setOptimisticEvents(null); // Clear optimistic state, let fresh data take over
         setAddModalOpen(false);

--- a/apps/webapp/app/routes/student.$class.dashboard/route.tsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/route.tsx
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import getPrisma from '@classmoji/database';
 import { ClassmojiService } from '@classmoji/services';
 import type { Route } from './+types/route';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import WeeklyCalendarCard, { type WeekEvent } from './WeeklyCalendarCard';
 import ModuleSpotlightCard, { type SpotlightModule } from './ModuleSpotlightCard';
 import RetroTabsCard, {
@@ -247,7 +247,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async purchaseExtensionHours() {
-      const { classroom } = await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -260,6 +260,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         resourceOwnerId: data.student_id,
         selfAccessRoles: ['STUDENT'],
       });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       if (!data.hours_purchased || data.hours_purchased <= 0) {
         throw new Error('Invalid hours: Must be a positive number.');

--- a/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
+++ b/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
@@ -9,7 +9,7 @@ import { useCallout } from '@classmoji/ui-components';
 import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { titleToIdentifier } from '@classmoji/utils';
 import { tasks } from '@trigger.dev/sdk/v3';
-import { showStatusErrorFromResponse } from '~/utils/classroomStatusModals';
+import { useClassroomStatusModals } from '~/utils/classroomStatusModals';
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const classSlug = params.class!;
@@ -266,6 +266,7 @@ const StudentTeamPage = ({ loaderData }: Route.ComponentProps) => {
   const [teamName, setTeamName] = useState('');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const callout = useCallout();
+  const { showStatusErrorFromResponse } = useClassroomStatusModals();
 
   const isSubmitting = fetcher.state !== 'idle';
 

--- a/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
+++ b/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
@@ -6,7 +6,7 @@ import { namedAction } from 'remix-utils/named-action';
 import type { Route } from './+types/route';
 import { ClassmojiService, getGitProvider } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
-import { assertClassroomAccess } from '~/utils/helpers';
+import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { titleToIdentifier } from '@classmoji/utils';
 import { tasks } from '@trigger.dev/sdk/v3';
 import { showStatusErrorFromResponse } from '~/utils/classroomStatusModals';
@@ -71,13 +71,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
   const moduleSlug = params.module!;
 
-  const { userId, classroom } = await assertClassroomAccess({
+  const { userId, classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug,
     allowedRoles: ['STUDENT', 'OWNER', 'TEACHER'],
     resourceType: 'TEAM',
     attemptedAction: 'modify_team',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   // Get the module
   const module = await ClassmojiService.module.findByClassroomSlugAndModuleSlug(

--- a/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
+++ b/apps/webapp/app/routes/student.$class.modules_.$module.team/route.tsx
@@ -9,6 +9,7 @@ import { useCallout } from '@classmoji/ui-components';
 import { assertClassroomAccess } from '~/utils/helpers';
 import { titleToIdentifier } from '@classmoji/utils';
 import { tasks } from '@trigger.dev/sdk/v3';
+import { showStatusErrorFromResponse } from '~/utils/classroomStatusModals';
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const classSlug = params.class!;
@@ -269,6 +270,7 @@ const StudentTeamPage = ({ loaderData }: Route.ComponentProps) => {
 
   // Show feedback from action
   useEffect(() => {
+    showStatusErrorFromResponse(fetcher.data as { error?: string } | undefined);
     if (fetcher.data?.success) {
       callout.show({ variant: 'success', title: fetcher.data.success, autoDismissMs: 3000 });
     }

--- a/apps/webapp/app/routes/student.$class.regrade-requests.new/route.tsx
+++ b/apps/webapp/app/routes/student.$class.regrade-requests.new/route.tsx
@@ -7,7 +7,7 @@ import { tasks } from '@trigger.dev/sdk';
 import type { Route } from './+types/route';
 import { useDisclosure, useGlobalFetcher } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
-import { requireStudentAccess, waitForRunCompletion } from '~/utils/helpers';
+import { requireStudentAccess, waitForRunCompletion, assertClassroomMutationAllowed } from '~/utils/helpers';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const { userId } = await requireStudentAccess(request, params.class!, {
@@ -110,10 +110,11 @@ const NewRegradeRequest = ({ loaderData }: Route.ComponentProps) => {
 };
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
-  const { userId, classroom } = await requireStudentAccess(request, params.class!, {
+  const { userId, classroom, membership } = await requireStudentAccess(request, params.class!, {
     resourceType: 'REGRADE_REQUESTS',
     action: 'submit_regrade_request',
   });
+  assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
   const repositoryAssignment = await ClassmojiService.repositoryAssignment.findById(

--- a/apps/webapp/app/routes/test-login/route.tsx
+++ b/apps/webapp/app/routes/test-login/route.tsx
@@ -153,7 +153,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         user_id: user.id,
         role: expectedMembershipRole as 'OWNER' | 'ASSISTANT' | 'STUDENT',
         classroom: {
-          is_active: true,
+          is_archived: false,
           slug: testClassroom, // Target specific test classroom
         },
       },

--- a/apps/webapp/app/utils/classroomStatusModals.ts
+++ b/apps/webapp/app/utils/classroomStatusModals.ts
@@ -1,24 +1,37 @@
-import { Modal } from 'antd';
+import { App } from 'antd';
 
-export function showUnpublishedModal() {
-  Modal.info({
-    title: 'Class unavailable',
-    content:
-      'This class has been unpublished by the owner. Please contact your instructor for details.',
-    okText: 'Got it',
-  });
-}
+/**
+ * Hook returning theme-aware modal openers for classroom status events.
+ *
+ * Uses antd's <App> context (mounted in root.tsx) so the modal inherits the
+ * ConfigProvider theme — static Modal.info bypasses ConfigProvider and renders
+ * with antd's default light tokens regardless of dark mode.
+ */
+export function useClassroomStatusModals() {
+  const { modal } = App.useApp();
 
-export function showLockedModal() {
-  Modal.info({
-    title: 'Read-only mode',
-    content:
-      'This class is in read-only mode. The owner has locked changes — you can view everything but cannot make edits.',
-    okText: 'Got it',
-  });
-}
+  const showUnpublished = () => {
+    modal.info({
+      title: 'Class unavailable',
+      content:
+        'This class has been unpublished by the owner. Please contact your instructor for details.',
+      okText: 'Got it',
+    });
+  };
 
-export function showStatusErrorFromResponse(data: { error?: string } | undefined | null) {
-  if (data?.error === 'CLASSROOM_UNPUBLISHED') return showUnpublishedModal();
-  if (data?.error === 'CLASSROOM_LOCKED') return showLockedModal();
+  const showLocked = () => {
+    modal.info({
+      title: 'Read-only mode',
+      content:
+        'This class is in read-only mode. The owner has locked changes — you can view everything but cannot make edits.',
+      okText: 'Got it',
+    });
+  };
+
+  const showStatusErrorFromResponse = (data: { error?: string } | undefined | null) => {
+    if (data?.error === 'CLASSROOM_UNPUBLISHED') return showUnpublished();
+    if (data?.error === 'CLASSROOM_LOCKED') return showLocked();
+  };
+
+  return { showUnpublished, showLocked, showStatusErrorFromResponse };
 }

--- a/apps/webapp/app/utils/classroomStatusModals.ts
+++ b/apps/webapp/app/utils/classroomStatusModals.ts
@@ -1,0 +1,24 @@
+import { Modal } from 'antd';
+
+export function showUnpublishedModal() {
+  Modal.info({
+    title: 'Class unavailable',
+    content:
+      'This class has been unpublished by the owner. Please contact your instructor for details.',
+    okText: 'Got it',
+  });
+}
+
+export function showLockedModal() {
+  Modal.info({
+    title: 'Read-only mode',
+    content:
+      'This class is in read-only mode. The owner has locked changes — you can view everything but cannot make edits.',
+    okText: 'Got it',
+  });
+}
+
+export function showStatusErrorFromResponse(data: { error?: string } | undefined | null) {
+  if (data?.error === 'CLASSROOM_UNPUBLISHED') return showUnpublishedModal();
+  if (data?.error === 'CLASSROOM_LOCKED') return showLockedModal();
+}

--- a/apps/webapp/app/utils/helpers.ts
+++ b/apps/webapp/app/utils/helpers.ts
@@ -127,7 +127,11 @@ export const addAuditLog = async ({
 };
 
 // Re-export from shared auth package for backward compatibility
-export { assertClassroomAccess, requireStudentAccess } from '@classmoji/auth/server';
+export {
+  assertClassroomAccess,
+  assertClassroomMutationAllowed,
+  requireStudentAccess,
+} from '@classmoji/auth/server';
 
 // NOTE: sanitizeClassroomForClient was removed - assertClassroomAccess now sanitizes automatically.
 // For direct findBySlug calls, use ClassmojiService.classroom.getClassroomForUI()

--- a/apps/webapp/app/utils/routeAuth.server.ts
+++ b/apps/webapp/app/utils/routeAuth.server.ts
@@ -4,6 +4,7 @@
  */
 export {
   assertClassroomAccess,
+  assertClassroomMutationAllowed,
   requireClassroomAdmin,
   requireClassroomStaff,
   requireClassroomTeachingTeam,

--- a/apps/webapp/tests/owner/classroom-status.spec.ts
+++ b/apps/webapp/tests/owner/classroom-status.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect } from '../fixtures/auth.fixture';
+import { getTestPrisma, getClassroomBySlug } from '../helpers/prisma.helpers';
+import { TEST_CLASSROOM } from '../helpers/env.helpers';
+import { waitForDataLoad, waitForModal } from '../helpers/wait.helpers';
+
+/**
+ * E2E coverage for classroom status modes (ACTIVE / LOCKED / UNPUBLISHED)
+ * and archive flow.
+ *
+ * Tests mutate the existing test classroom via prisma directly and reset state
+ * in afterEach so each test is independent.
+ *
+ * NOTE: The UNPUBLISHED click-intercept-for-non-owner case is not covered here
+ * because it requires a second browser context using student storage state.
+ * Cross-role tests do not fit cleanly into this framework's per-project
+ * storageState model — see tests/fixtures/auth.fixture.ts. TODO: add a
+ * student-project spec or a multi-context owner spec that loads
+ * tests/.auth/student.json.
+ */
+
+const SETTINGS_PATH = (org: string) => `/admin/${org}/settings/general`;
+const LANDING_PATH = '/select-organization';
+
+async function resetClassroom() {
+  const prisma = getTestPrisma();
+  const classroom = await getClassroomBySlug(TEST_CLASSROOM);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (prisma as any).classroom.update({
+    where: { id: classroom.id },
+    data: { status: 'ACTIVE', is_archived: false },
+  });
+}
+
+async function setClassroomState(state: {
+  status?: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+  is_archived?: boolean;
+}) {
+  const prisma = getTestPrisma();
+  const classroom = await getClassroomBySlug(TEST_CLASSROOM);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (prisma as any).classroom.update({
+    where: { id: classroom.id },
+    data: state,
+  });
+}
+
+async function readClassroomState() {
+  const prisma = getTestPrisma();
+  const classroom = await getClassroomBySlug(TEST_CLASSROOM);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (prisma as any).classroom.findUnique({
+    where: { id: classroom.id },
+    select: { status: true, is_archived: true },
+  });
+}
+
+test.describe('Owner Classroom Status — Settings', () => {
+  test.beforeEach(async () => {
+    await resetClassroom();
+  });
+
+  test.afterEach(async () => {
+    await resetClassroom();
+  });
+
+  test('status radio reflects DB and persists changes to LOCKED', async ({
+    authenticatedPage: page,
+    testOrg,
+  }) => {
+    await page.goto(SETTINGS_PATH(testOrg));
+    await waitForDataLoad(page);
+
+    // All three radio labels should render under the "Class status" section.
+    const statusSection = page.locator('div', { has: page.getByRole('heading', { name: 'Class status' }) }).first();
+    await expect(statusSection.getByText('Active', { exact: true })).toBeVisible();
+    await expect(statusSection.getByText('Locked (read-only)', { exact: true })).toBeVisible();
+    await expect(statusSection.getByText('Unpublished', { exact: true })).toBeVisible();
+
+    // Active should be the checked option initially (reset in beforeEach).
+    const activeRadio = page
+      .locator('label', { hasText: 'Active' })
+      .filter({ hasNotText: 'Normal access' })
+      .first()
+      .or(page.locator('label').filter({ hasText: /^ActiveNormal access/ }))
+      .locator('input[type="radio"]');
+    // Fallback: select all radios and check the first is checked.
+    const radios = page.locator('label:has(.ant-radio) input[type="radio"]');
+    await expect(radios.nth(0)).toBeChecked();
+
+    // Click "Locked (read-only)" — the component reloads after PATCH.
+    const lockedLabel = page.locator('label', { hasText: 'Locked (read-only)' }).first();
+    await Promise.all([
+      page.waitForLoadState('load'),
+      lockedLabel.click(),
+    ]);
+    await waitForDataLoad(page);
+
+    // DB reflects the change.
+    const state = await readClassroomState();
+    expect(state?.status).toBe('LOCKED');
+
+    // UI radio reflects the change.
+    await expect(radios.nth(1)).toBeChecked();
+  });
+
+  test('Archive button opens antd Modal.confirm and persists', async ({
+    authenticatedPage: page,
+    testOrg,
+  }) => {
+    await page.goto(SETTINGS_PATH(testOrg));
+    await waitForDataLoad(page);
+
+    await page.getByRole('button', { name: 'Archive class' }).click();
+
+    const modal = await waitForModal(page, /Archive class\?/);
+    await expect(modal).toBeVisible();
+
+    // Confirm via the "Archive" button in the modal footer.
+    await modal.getByRole('button', { name: 'Archive', exact: true }).click();
+
+    await page.waitForLoadState('load');
+    await waitForDataLoad(page);
+
+    const state = await readClassroomState();
+    expect(state?.is_archived).toBe(true);
+  });
+
+  test('no native window.confirm fires during archive', async ({
+    authenticatedPage: page,
+    testOrg,
+  }) => {
+    await page.goto(SETTINGS_PATH(testOrg));
+    await waitForDataLoad(page);
+
+    let dialogFired = false;
+    page.on('dialog', async d => {
+      dialogFired = true;
+      await d.dismiss().catch(() => {});
+    });
+
+    await page.getByRole('button', { name: 'Archive class' }).click();
+    const modal = await waitForModal(page, /Archive class\?/);
+    await modal.getByRole('button', { name: 'Archive', exact: true }).click();
+
+    await page.waitForLoadState('load');
+    await waitForDataLoad(page);
+
+    expect(dialogFired).toBe(false);
+
+    const state = await readClassroomState();
+    expect(state?.is_archived).toBe(true);
+  });
+});
+
+test.describe('Owner Classroom Status — Landing', () => {
+  test.afterEach(async () => {
+    await resetClassroom();
+  });
+
+  test('Archived section is collapsed by default and expandable', async ({
+    authenticatedPage: page,
+  }) => {
+    await setClassroomState({ is_archived: true });
+
+    await page.goto(LANDING_PATH);
+    await waitForDataLoad(page);
+
+    // Header button shows "Archived" + count "1".
+    const archivedHeader = page.getByRole('button', { name: /Archived/ });
+    await expect(archivedHeader).toBeVisible();
+    await expect(archivedHeader).toContainText('Archived');
+    await expect(archivedHeader).toContainText('1');
+    await expect(archivedHeader).toHaveAttribute('aria-expanded', 'false');
+
+    // The classroom card for the test classroom should NOT be visible while collapsed.
+    // Use the slug fragment "@<git-org>/<classroom-slug>" — the card always renders it.
+    const cardLocator = page.locator(`text=/${TEST_CLASSROOM}`);
+    await expect(cardLocator).toHaveCount(0);
+
+    // Expand.
+    await archivedHeader.click();
+    await expect(archivedHeader).toHaveAttribute('aria-expanded', 'true');
+    await expect(cardLocator.first()).toBeVisible();
+  });
+
+  test('LOCKED card shows a Read-only badge and remains clickable for OWNER', async ({
+    authenticatedPage: page,
+    testOrg,
+  }) => {
+    await setClassroomState({ status: 'LOCKED' });
+
+    await page.goto(LANDING_PATH);
+    await waitForDataLoad(page);
+
+    // The Read-only badge should be visible on the LOCKED card.
+    const badge = page.getByText('Read-only', { exact: true }).first();
+    await expect(badge).toBeVisible();
+
+    // OWNER click should navigate into the dashboard (not be intercepted).
+    // Find the card containing the test classroom slug and click it.
+    const card = page.locator(`text=/${TEST_CLASSROOM}`).first();
+    await card.click();
+
+    await page.waitForURL(new RegExp(`/admin/${testOrg}/dashboard`), { timeout: 15000 });
+    await expect(page).toHaveURL(new RegExp(`/admin/${testOrg}/dashboard`));
+  });
+});

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -779,6 +779,11 @@ export const assertClassroomAccess = async ({
     classroom
   ) as SafeClassroomRecord;
 
+  assertClassroomEntryAllowed({
+    status: classroom.status as 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED',
+    role: membership.role as 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT',
+  });
+
   return {
     userId: authData.userId,
     classroom: safeClassroom,
@@ -881,6 +886,63 @@ export async function requireStudentAccess(
     attemptedAction: options.action || 'access',
     metadata: options.metadata,
   });
+}
+
+export type ClassroomStatusError = 'CLASSROOM_LOCKED' | 'CLASSROOM_UNPUBLISHED';
+
+const statusErrorResponse = (code: ClassroomStatusError, message: string) =>
+  new Response(JSON.stringify({ error: code, message }), {
+    status: 403,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+/**
+ * Block non-owners from entering an UNPUBLISHED classroom.
+ * Call after the role check inside loaders. LOCKED never blocks entry.
+ */
+export function assertClassroomEntryAllowed({
+  status,
+  role,
+}: {
+  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+  role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
+}): void {
+  if (status === 'UNPUBLISHED' && role !== 'OWNER') {
+    throw statusErrorResponse(
+      'CLASSROOM_UNPUBLISHED',
+      'This class has been unpublished by the owner.'
+    );
+  }
+}
+
+/** Pure predicate: can this role mutate the classroom in its current state? */
+export function canMutateClassroom({
+  status,
+  role,
+}: {
+  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+  role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
+}): boolean {
+  if (role === 'OWNER') return true;
+  return status === 'ACTIVE';
+}
+
+/** Throw 403 with typed code when the current role cannot mutate. */
+export function assertClassroomMutationAllowed(args: {
+  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+  role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
+}): void {
+  if (canMutateClassroom(args)) return;
+  if (args.status === 'LOCKED') {
+    throw statusErrorResponse(
+      'CLASSROOM_LOCKED',
+      'This class is in read-only mode. The owner has locked it.'
+    );
+  }
+  throw statusErrorResponse(
+    'CLASSROOM_UNPUBLISHED',
+    'This class has been unpublished by the owner.'
+  );
 }
 
 /**

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -2,7 +2,7 @@ import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { admin } from 'better-auth/plugins';
 import getPrisma from '@classmoji/database';
-import type { Account as PrismaAccount, Role } from '@prisma/client';
+import type { Account as PrismaAccount, Role, ClassroomStatus } from '@prisma/client';
 import { ClassmojiService } from '@classmoji/services';
 
 // Use explicit secret for consistent session signing
@@ -780,8 +780,8 @@ export const assertClassroomAccess = async ({
   ) as SafeClassroomRecord;
 
   assertClassroomEntryAllowed({
-    status: classroom.status as 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED',
-    role: membership.role as 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT',
+    status: classroom.status,
+    role: membership.role,
   });
 
   return {
@@ -890,6 +890,13 @@ export async function requireStudentAccess(
 
 export type ClassroomStatusError = 'CLASSROOM_LOCKED' | 'CLASSROOM_UNPUBLISHED';
 
+type ClassroomStatusInput = { status: ClassroomStatus; role: Role };
+
+/**
+ * Throws a 403 Response with a JSON body `{ error: ClassroomStatusError, message: string }`.
+ * This intentionally diverges from the plain-text 403s used elsewhere in this module —
+ * the typed error code lets the client map specific failure modes to in-app modals.
+ */
 const statusErrorResponse = (code: ClassroomStatusError, message: string) =>
   new Response(JSON.stringify({ error: code, message }), {
     status: 403,
@@ -903,10 +910,7 @@ const statusErrorResponse = (code: ClassroomStatusError, message: string) =>
 export function assertClassroomEntryAllowed({
   status,
   role,
-}: {
-  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
-  role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
-}): void {
+}: ClassroomStatusInput): void {
   if (status === 'UNPUBLISHED' && role !== 'OWNER') {
     throw statusErrorResponse(
       'CLASSROOM_UNPUBLISHED',
@@ -919,19 +923,13 @@ export function assertClassroomEntryAllowed({
 export function canMutateClassroom({
   status,
   role,
-}: {
-  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
-  role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
-}): boolean {
+}: ClassroomStatusInput): boolean {
   if (role === 'OWNER') return true;
   return status === 'ACTIVE';
 }
 
 /** Throw 403 with typed code when the current role cannot mutate. */
-export function assertClassroomMutationAllowed(args: {
-  status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
-  role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
-}): void {
+export function assertClassroomMutationAllowed(args: ClassroomStatusInput): void {
   if (canMutateClassroom(args)) return;
   if (args.status === 'LOCKED') {
     throw statusErrorResponse(

--- a/packages/database/migrations/20260521213818_classroom_status_modes/migration.sql
+++ b/packages/database/migrations/20260521213818_classroom_status_modes/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "ClassroomStatus" AS ENUM ('ACTIVE', 'LOCKED', 'UNPUBLISHED');
+
+-- AlterTable: add new columns with defaults
+ALTER TABLE "classrooms"
+  ADD COLUMN "status" "ClassroomStatus" NOT NULL DEFAULT 'ACTIVE',
+  ADD COLUMN "is_archived" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill: prior is_active=false ⇒ archived
+UPDATE "classrooms" SET "is_archived" = NOT "is_active";
+
+-- Drop the old column
+ALTER TABLE "classrooms" DROP COLUMN "is_active";

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -116,6 +116,12 @@ enum EventType {
   ASSESSMENT
 }
 
+enum ClassroomStatus {
+  ACTIVE
+  LOCKED
+  UNPUBLISHED
+}
+
 // ============================================================================
 // BETTERAUTH TABLES
 // ============================================================================
@@ -272,7 +278,8 @@ model Classroom {
   git_org_id        String
   name              String
   content_namespace String
-  is_active         Boolean  @default(true)
+  status            ClassroomStatus @default(ACTIVE)
+  is_archived       Boolean         @default(false)
   created_at        DateTime @default(now())
   updated_at        DateTime @default(now()) @updatedAt
 

--- a/packages/database/scripts/seed.js
+++ b/packages/database/scripts/seed.js
@@ -22,14 +22,13 @@ async function main() {
   // ── Classroom ────────────────────────────────────────────────────────────
   // Slug must match TEST_CLASSROOM env var default in test-login route
   const classroom = await prisma.classroom.upsert({
-    where: { slug: 'classmoji-dev-winter-2025' },
+    where: { git_org_id_slug: { git_org_id: org.id, slug: 'classmoji-dev-winter-2025' } },
     update: {},
     create: {
       git_org_id: org.id,
       slug: 'classmoji-dev-winter-2025',
       name: 'Dev Classroom',
-      term: 'WINTER',
-      year: 2025,
+      content_namespace: 'classmoji-dev-winter-2025',
     },
   });
 

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -112,7 +112,7 @@ export const findByUserId = async (userId: string, role: Role | null = null) => 
  */
 export const findAll = async (query: Prisma.ClassroomWhereInput = {}) => {
   return getPrisma().classroom.findMany({
-    where: { is_active: true, ...query },
+    where: { ...query },
     include: {
       git_organization: true,
       settings: true,

--- a/packages/services/src/classmoji/user.service.ts
+++ b/packages/services/src/classmoji/user.service.ts
@@ -62,7 +62,8 @@ interface UserWithMemberships {
   classroom_memberships: Array<{
     classroom: {
       slug: string;
-      is_active: boolean;
+      status: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+      is_archived: boolean;
       _count?: {
         modules?: number;
       };
@@ -280,7 +281,8 @@ export const findById = async (id: string, options: { includeMemberships?: boole
         organization: {
           ...m.classroom,
           login: m.classroom.slug, // Use slug as "login" for URL compatibility
-          is_active: m.classroom.is_active,
+          status: m.classroom.status,
+        is_archived: m.classroom.is_archived,
           assignments: { _count: m.classroom._count?.modules || 0 },
           memberships: m.classroom.memberships,
         },
@@ -325,7 +327,8 @@ export const findByLogin = async (login: string) => {
       organization: {
         ...m.classroom,
         login: m.classroom.slug, // Use slug as "login" for URL compatibility
-        is_active: m.classroom.is_active,
+        status: m.classroom.status,
+        is_archived: m.classroom.is_archived,
         assignments: { _count: m.classroom._count?.modules || 0 },
         memberships: m.classroom.memberships,
       },


### PR DESCRIPTION
## Summary

Replaces the single `Classroom.is_active` boolean with a mutually-exclusive status enum and an orthogonal archive flag, and enforces them across auth, API, and UI.

- **Active** — normal access.
- **Locked** — owner can still mutate; TAs and students get read-only with an in-class banner. Mutation attempts return a typed 403 the client surfaces in a themed modal.
- **Unpublished** — only the owner can enter; non-owners see the card on the landing page but get an in-app modal on click and a 403 at the loader.
- **Archived** — independent flag. Moves the card into a collapsed-by-default "Archived (N)" section on the landing page. No access change.

All controls move to settings (`/admin/<class>/settings/general`); the per-card archive button is gone. The one native `window.confirm` is replaced with antd `Modal.confirm`, and the status modals are theme-aware (dark mode + accent color) via `App.useApp()`.

## Schema

- New: `ClassroomStatus` enum (`ACTIVE`, `LOCKED`, `UNPUBLISHED`), `Classroom.status` (default ACTIVE), `Classroom.is_archived` (default false).
- Dropped: `Classroom.is_active`. Single migration with backfill `is_archived = NOT is_active`.

## Enforcement

Centralized in `packages/auth/src/server.ts`:
- `assertClassroomEntryAllowed` wired into `assertClassroomAccess` — blocks UNPUBLISHED for non-owners at every loader.
- `assertClassroomMutationAllowed` called from 44 class-scoped action handlers — blocks non-owner writes when LOCKED or UNPUBLISHED, returning JSON `{ error, message }` with codes `CLASSROOM_LOCKED` / `CLASSROOM_UNPUBLISHED`.
- Owner always bypasses both gates.

## API

- `PATCH /api/classrooms/:id/status` — owner-only, body `{ status }`.
- `PATCH /api/classrooms/:id/archive` — now idempotent on `{ is_archived }` (was a toggle).

## UI

- Settings: status radio group + archive button (confirmation via antd modal).
- Landing: `Read-only` / `Unpublished` badges on cards; UNPUBLISHED card click opens a modal instead of navigating for non-owners; Archived section is a collapsed disclosure with a count.
- In-class: amber `Read-only mode` banner in `CommonLayout` when LOCKED and the viewer is not the owner.
- Modals inherit theme (dark mode + accent) via antd `<App>` mounted inside `ConfigProvider`.

## Incidental

- Fixed `packages/database/scripts/seed.js`: was using the removed `slug` standalone unique and the removed `term` / `year` fields; updated to compound `git_org_id_slug` and dropped term/year.
- `apps/webapp/app/routes/test-login/route.tsx`: swapped lingering `is_active: true` filter to `is_archived: false`.

## Test plan

- [ ] Restart `npm run dev` (the running instance has a stale Prisma client from before the migration)
- [ ] Owner: change status in settings to each of Active / Locked / Unpublished, confirm the value persists after reload
- [ ] Owner: click Archive → antd confirm modal appears → confirm → class moves to the Archived section, which is collapsed by default
- [ ] As a non-owner in a LOCKED class: read-only banner shows; any mutating UI returns 403 surfaced through the themed modal
- [ ] As a non-owner of an UNPUBLISHED class: card shows the badge; clicking opens the "Class unavailable" modal; direct URL navigation returns 403
- [ ] Toggle OS dark mode and confirm both modals render with dark tokens
- [ ] Run the new Playwright spec (requires `GITHUB_PROF_TOKEN` in `.env`): `cd apps/webapp && npx playwright test owner/classroom-status.spec.ts --project=owner-tests`