### PR TITLE
fix(auth): link existing users on GitHub sign-in

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -386,13 +386,70 @@ export const auth = betterAuth({
       clientId: process.env.GITHUB_CLIENT_ID as string,
       clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
       scope: [], // scopes are ignored for GitHub App auth; permissions come from App config
-      mapProfileToUser: profile => {
+      mapProfileToUser: async profile => {
         // GitHub profile includes: login, id, name, email, avatar_url, etc.
-        // Map these to our custom User fields during OAuth sign-in
+        const githubId = String(profile.id);
+        const login = profile.login;
+
+        // ── Link existing users instead of colliding on the unique `login` ──────
+        // Users can already exist in our DB without a linked GitHub account:
+        //  - pre-provisioned by username via ClassmojiService.user.create (login
+        //    set, no provider_id / no account row), e.g. roster/assistant invites
+        //  - a prior login whose account row was removed
+        // This hook runs BEFORE BetterAuth's findOAuthUser lookup. If we link the
+        // account here, findOAuthUser finds it and takes the (non-destructive) link
+        // path — instead of falling through to createOAuthUser, which would throw
+        // `unable to create user` on the `login`/`provider` unique constraints.
+        try {
+          const existing = await getPrisma().user.findFirst({
+            where: {
+              OR: [{ provider: 'GITHUB', provider_id: githubId }, { login }],
+            },
+            include: {
+              accounts: { where: { provider_id: 'github' }, select: { id: true } },
+            },
+          });
+
+          if (existing && existing.accounts.length === 0) {
+            // Backfill provider linkage on the existing record (login-only invites
+            // have a null provider_id) so the (provider, provider_id) unique key and
+            // future lookups resolve correctly.
+            await getPrisma().user.update({
+              where: { id: existing.id },
+              data: {
+                provider: 'GITHUB',
+                provider_id: githubId,
+                login: existing.login ?? login,
+              },
+            });
+
+            // Create the account link BetterAuth looks up by (provider_id, account_id).
+            // Tokens are intentionally left null — BetterAuth fills them on this same
+            // sign-in once it resolves the linked account.
+            await getPrisma().account.upsert({
+              where: {
+                provider_id_account_id: { provider_id: 'github', account_id: githubId },
+              },
+              update: {},
+              create: {
+                user_id: existing.id,
+                provider_id: 'github',
+                account_id: githubId,
+              },
+            });
+          }
+        } catch (error: unknown) {
+          // Never block sign-in on the linking attempt; if it fails, BetterAuth
+          // proceeds with its default behavior and we surface its error as before.
+          console.error('[auth] mapProfileToUser account-link failed', error);
+        }
+
+        // Map these to our custom User fields (used when BetterAuth creates a
+        // genuinely new user — i.e. no existing record was linked above).
         return {
-          login: profile.login, // GitHub username
+          login, // GitHub username
           provider: 'GITHUB',
-          provider_id: String(profile.id), // GitHub user ID as string
+          provider_id: githubId, // GitHub user ID as string
         };
       },
     },


### PR DESCRIPTION
## Problem
Users that already exist in the DB by GitHub username but have **no linked `accounts` row** cannot log in — they get redirected to `/?error=unable_to_create_user`.

This affects everyone **pre-provisioned by GitHub username** (students/assistants added via `ClassmojiService.user.create`, which upserts by `login` with no `email`/`provider_id`/account), plus any user whose account link was lost.

### Root cause
On the GitHub OAuth callback, BetterAuth's `findOAuthUser(email, accountId, 'github')` finds nobody (no account link, and the GitHub email doesn't match the pre-provisioned record), so it falls through to `createOAuthUser`, which inserts a user with the same `login` → violates the `login @unique` / `@@unique([provider, provider_id])` constraints → `unable to create user`.

## Fix
Make `mapProfileToUser` (in `packages/auth/src/server.ts`) **async and self-linking**. It runs *before* `findOAuthUser`, so it's the correct interception point:

- Look up an existing user by `provider_id` **or** `login` that has no linked GitHub account.
- If found, backfill `provider`/`provider_id` and create the `accounts` link row (upsert on `@@unique([provider_id, account_id])`).
- BetterAuth's `findOAuthUser` then resolves the linked account and takes the non-destructive **link path** (refreshes tokens, creates session) — no duplicate, no collision.

Best-effort and idempotent: already-linked users skip it, truly-new users fall through to normal creation, and a failure never blocks sign-in.

No behavior change to the email gate (`select-organization` still sends users without a school email to `/registration`).

## Testing
- `packages/auth` typecheck clean.
- Reproduced the failure live on the dev environment (`unable_to_create_user`); confirmed manually creating the `accounts` link resolves login.
- Recreated the broken login-only state on the dev DB and ran the hook's exact Prisma operations: it backfills `provider_id` and creates the account link (idempotent), landing in the proven-working linked state.