### PR TITLE
fix(tasks): repo creation fails when template default branch isn't main; guard force-push

### DIFF
--- a/packages/tasks/src/helpers/createRepository.ts
+++ b/packages/tasks/src/helpers/createRepository.ts
@@ -72,6 +72,21 @@ export const createRepository = async (payload: CreateRepositoryPayload): Promis
     await repoGit.removeRemote('origin');
     await repoGit.addRemote('origin', studentRepoUrl);
 
+    // Safety guard: only initialize a repo that is still empty. A repo can
+    // exist on GitHub without a DB row (a previous run failed partway), and
+    // Sync will route it back through here — but if it already has branches it
+    // may contain student work, and the force-push below would destroy it.
+    // Skip template initialization and let the rest of the workflow heal the
+    // DB row / collaborators instead.
+    const remoteHeads = await repoGit.listRemote(['--heads', 'origin']);
+    if (remoteHeads.trim().length > 0) {
+      logger.warn(
+        `${gitOrgLogin}/${repoName} already has branches — skipping template initialization to avoid overwriting existing work`,
+        { remoteHeads }
+      );
+      return repoId;
+    }
+
     // Templates may use any default branch (e.g. `master` on older repos). The
     // clone checks out the template's default branch, but every step below — and
     // the feedback PR / branch protection / CLASSMOJI flow — assumes `main`, so

--- a/packages/tasks/src/helpers/createRepository.ts
+++ b/packages/tasks/src/helpers/createRepository.ts
@@ -72,6 +72,13 @@ export const createRepository = async (payload: CreateRepositoryPayload): Promis
     await repoGit.removeRemote('origin');
     await repoGit.addRemote('origin', studentRepoUrl);
 
+    // Templates may use any default branch (e.g. `master` on older repos). The
+    // clone checks out the template's default branch, but every step below — and
+    // the feedback PR / branch protection / CLASSMOJI flow — assumes `main`, so
+    // force-rename whatever was checked out to `main` before the first push.
+    // Without this, `push origin main` fails with "src refspec main does not match any".
+    await repoGit.branch(['-M', 'main']);
+
     await repoGit.push('origin', 'main', ['--force']);
     await repoGit.checkoutLocalBranch('feedback');
     await repoGit.push('origin', 'feedback', ['--set-upstream']);

--- a/packages/tasks/src/helpers/updateRepository.ts
+++ b/packages/tasks/src/helpers/updateRepository.ts
@@ -71,7 +71,16 @@ export const updateRepository = async (
       await studentGit.remote(['set-url', 'template', templateRepoUrl]);
     }
 
-    await studentGit.pull('template', 'main', ['-X', 'theirs', '--no-edit']);
+    // Templates may use any default branch (e.g. `master` on older repos) and we
+    // can't rename the instructor's repo, so resolve which branch the template's
+    // HEAD points at instead of assuming `main`. Student repos are normalized to
+    // `main` at creation; pulling template/<master> into the student's `updates`
+    // branch is a normal cross-name merge.
+    const templateSymref = await studentGit.listRemote(['--symref', 'template', 'HEAD']);
+    const templateDefaultBranch =
+      templateSymref.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m)?.[1] ?? 'main';
+
+    await studentGit.pull('template', templateDefaultBranch, ['-X', 'theirs', '--no-edit']);
     await studentGit.push('origin', 'updates', ['--force']);
 
     const { data: repoMeta } = await octokit.rest.repos.get({


### PR DESCRIPTION
## Problem

`gh-create_repository` fails for any classroom whose **template repo's default branch isn't `main`**:

```
error: src refspec main does not match any
error: failed to push some refs to 'https://github.com/OnslowCollege2026/13swe-project-management-2026-...'
```

`createRepository()` clones the template and immediately runs `git push origin main --force` — but `git clone` checks out the *template's* default branch, so a `master`-default template leaves no local `main` ref to push. 10 failed prod runs over the last 30 days (`13swe-software-engineering-26x`, `kval-2026-26x`, `cspc-349-...`), mostly from students forming self-formed teams. Affected state: the GitHub repo gets created but stays **empty** — no branches, no collaborators, no DB row, so students never see it.

## Fix (commit 1)

Force-rename the cloned branch to `main` before the first push:

```ts
await repoGit.branch(['-M', 'main']);
```

Normalizing (rather than preserving the template's branch name) is correct because everything downstream — both `main` pushes, the Feedback PR base, branch protection, the "push to main" student messaging — assumes `main`. Exact no-op when the template already uses `main` (the common case).

## Safety guard (commit 2)

Recovery for the failed repos is module **Sync**, which re-routes DB-row-less students through this same code — ending in `push origin main --force` against a repo that already exists on GitHub. If a previous run ever failed *between* adding collaborators and writing the DB row, a student could have pushed work that the force-push would silently destroy.

Guard the initialization with a ref-advertisement check:

```ts
const remoteHeads = await repoGit.listRemote(['--heads', 'origin']);
if (remoteHeads.trim().length > 0) {
  logger.warn(`${gitOrgLogin}/${repoName} already has branches — skipping template initialization…`);
  return repoId;
}
```

- **No refs** (fresh repo, or the failed-run state) → initialize as before.
- **Any refs** → never push; log a warning and return the repo id so the rest of the workflow still heals collaborators / DB row / assignments around the untouched content.

This makes repo creation idempotent at the GitHub layer (Sync was already idempotent at the DB layer), so Sync is safe to click any number of times.

Known trade-off: a repo left *partially* initialized by a mid-init crash (has `main` but no feedback PR) now trips the guard on re-Sync instead of being force-push-redone — strictly safer; the warn log names the repo for manual completion. Rare given `maxAttempts: 1`.

## Verification

- Reproduced against local bare remotes via the project's own `simple-git`: `master`-default template + empty repo → full init (`main`/`feedback`/`updates` + CLASSMOJI commit); repo containing a student commit → guard trips, `main` untouched.
- `git branch -v -M main` (the exact command simple-git emits) verified for both `master→main` and already-`main` (no-op).
- Confirmed the existing 422 "name already exists" heal path matches octokit 9.x error messages (`toErrorMessage` appends the `errors` array), so Sync picks up the orphaned empty repos.
- `tsc --noEmit` clean on `packages/tasks`.

## Rollout

1. Merge → deploy `packages/tasks` to prod Trigger.
2. Click **Sync** on the affected modules (Onslow `13swe-software-engineering-26x` project-management module, plus the failed modules in `kval-2026-26x` / `cspc-349-web-front-end-engineering-26x`). Sync re-creates exactly the missing repos; students do nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)