### PR TITLE
fix(tasks): repo creation fails when template default branch isn't main; guard force-push (dev)

### DIFF
--- a/packages/tasks/src/helpers/createRepository.ts
+++ b/packages/tasks/src/helpers/createRepository.ts
@@ -72,6 +72,21 @@ export const createRepository = async (payload: CreateRepositoryPayload): Promis
     await repoGit.removeRemote('origin');
     await repoGit.addRemote('origin', studentRepoUrl);
 
+    // Safety guard: only initialize a repo that is still empty. A repo can
+    // exist on GitHub without a DB row (a previous run failed partway), and
+    // Sync will route it back through here — but if it already has branches it
+    // may contain student work, and the force-push below would destroy it.
+    // Skip template initialization and let the rest of the workflow heal the
+    // DB row / collaborators instead.
+    const remoteHeads = await repoGit.listRemote(['--heads', 'origin']);
+    if (remoteHeads.trim().length > 0) {
+      logger.warn(
+        `${gitOrgLogin}/${repoName} already has branches — skipping template initialization to avoid overwriting existing work`,
+        { remoteHeads }
+      );
+      return repoId;
+    }
+
     // Templates may use any default branch (e.g. `master` on older repos). The
     // clone checks out the template's default branch, but every step below — and
     // the feedback PR / branch protection / CLASSMOJI flow — assumes `main`, so

--- a/packages/tasks/src/helpers/createRepository.ts
+++ b/packages/tasks/src/helpers/createRepository.ts
@@ -72,6 +72,13 @@ export const createRepository = async (payload: CreateRepositoryPayload): Promis
     await repoGit.removeRemote('origin');
     await repoGit.addRemote('origin', studentRepoUrl);
 
+    // Templates may use any default branch (e.g. `master` on older repos). The
+    // clone checks out the template's default branch, but every step below — and
+    // the feedback PR / branch protection / CLASSMOJI flow — assumes `main`, so
+    // force-rename whatever was checked out to `main` before the first push.
+    // Without this, `push origin main` fails with "src refspec main does not match any".
+    await repoGit.branch(['-M', 'main']);
+
     await repoGit.push('origin', 'main', ['--force']);
     await repoGit.checkoutLocalBranch('feedback');
     await repoGit.push('origin', 'feedback', ['--set-upstream']);

--- a/packages/tasks/src/helpers/updateRepository.ts
+++ b/packages/tasks/src/helpers/updateRepository.ts
@@ -71,7 +71,16 @@ export const updateRepository = async (
       await studentGit.remote(['set-url', 'template', templateRepoUrl]);
     }
 
-    await studentGit.pull('template', 'main', ['-X', 'theirs', '--no-edit']);
+    // Templates may use any default branch (e.g. `master` on older repos) and we
+    // can't rename the instructor's repo, so resolve which branch the template's
+    // HEAD points at instead of assuming `main`. Student repos are normalized to
+    // `main` at creation; pulling template/<master> into the student's `updates`
+    // branch is a normal cross-name merge.
+    const templateSymref = await studentGit.listRemote(['--symref', 'template', 'HEAD']);
+    const templateDefaultBranch =
+      templateSymref.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m)?.[1] ?? 'main';
+
+    await studentGit.pull('template', templateDefaultBranch, ['-X', 'theirs', '--no-edit']);
     await studentGit.push('origin', 'updates', ['--force']);
 
     const { data: repoMeta } = await octokit.rest.repos.get({


### PR DESCRIPTION
Cherry-pick of #116 onto `dev` (main and dev have diverged, so this lands the same fix on both lines). Same two commits, applied cleanly — on dev the consuming workflow is `gitRepo.ts` / `gh-create_git_repo`, but the fix lives entirely in the shared `helpers/createRepository.ts`, which is unchanged between the branches at the edit site.

See **#116** for the full write-up. Summary:

1. **Bug fix:** `git clone` checks out the *template's* default branch; a `master`-default template leaves no local `main`, so `push origin main` fails with `src refspec main does not match any` (10 failed prod runs, e.g. Onslow `13swe`). Fix: `branch -M main` after clone — no-op when the template already uses `main`.
2. **Safety guard:** before the `push --force`, check `git ls-remote --heads origin`; if the student repo already has *any* branches, skip template initialization entirely (warn + return repo id so collaborators/DB row still heal). Prevents Sync from ever force-pushing over student work.

3. **Template-update flow:** `updateRepository` hardcoded `pull('template', 'main')` — the prof pushing template updates would fail the same way. Now resolves the template's actual default branch via `git ls-remote --symref template HEAD`.

Verified against local bare remotes (master-default template → full init; repo with student commits → untouched). Typecheck delta vs `origin/dev`: zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)