### PR TITLE
Repository provisioning hardening + Modules tab on by default

### DIFF
--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -124,11 +124,11 @@ const CommonLayout = ({
 
   // Effective student-nav visibility: prefer the fresh value from the layout
   // loader (navVisibility), fall back to the store. Defaults match the schema
-  // (modules off, pages/repos on).
+  // (modules, pages, repos all on).
   const storeSettings = classroom?.settings as
     | { show_modules?: boolean; show_pages?: boolean; show_repos?: boolean }
     | undefined;
-  const showModules = navVisibility?.showModules ?? storeSettings?.show_modules ?? false;
+  const showModules = navVisibility?.showModules ?? storeSettings?.show_modules ?? true;
   const showPages = navVisibility?.showPages ?? storeSettings?.show_pages ?? true;
   const showRepos = navVisibility?.showRepos ?? storeSettings?.show_repos ?? true;
 
@@ -289,9 +289,13 @@ const CommonLayout = ({
     });
 
     return (
-      <div key="menu-pages" className={collapsed ? 'pt-3' : 'pt-4'}>
-        <hr className="mx-4 mb-3 border-t border-gray-200 dark:border-gray-700" />
-        <div className="space-y-1.5">{menuPageItems}</div>
+      <div key="menu-pages" className={collapsed ? 'pt-3' : 'pt-5'}>
+        {!collapsed && (
+          <div className="px-3.5 mb-1 text-[11px] font-semibold uppercase tracking-wider text-ink-4 select-none">
+            Pages
+          </div>
+        )}
+        <div className="space-y-0.5">{menuPageItems}</div>
       </div>
     );
   };
@@ -359,7 +363,6 @@ const CommonLayout = ({
 
     return (
       <div key="show-all-toggle" className={leanNav ? '' : collapsed ? 'pt-3' : 'pt-4'}>
-        {!leanNav && <hr className="mx-4 mb-3 border-t border-gray-200 dark:border-gray-700" />}
         <button
           type="button"
           onClick={() => setShowAllNav(!showAllNav)}
@@ -408,12 +411,19 @@ const CommonLayout = ({
         renderNavItem(item, `${categoryKey}-${index}`)
       );
 
-      // Lean nav is a short, flat list — skip the category dividers/spacing that
-      // only make sense when the full set is grouped into sections.
+      // Lean nav is a short, flat list — skip the section labels/spacing that
+      // only make sense when the full set is grouped into sections. Expanded nav
+      // groups each category under a small muted label (no full-width rule);
+      // collapsed (icon-only) mode has no room for a label, so the extra top
+      // spacing alone carries the grouping.
       return (
-        <div key={categoryKey} className={leanNav ? '' : collapsed ? 'pt-3' : 'pt-4'}>
-          {!leanNav && <hr className="mx-4 mb-3 border-t border-gray-200 dark:border-gray-700" />}
-          <div className="space-y-1.5">{categoryItems}</div>
+        <div key={categoryKey} className={leanNav ? '' : collapsed ? 'pt-3' : 'pt-5'}>
+          {!leanNav && !collapsed && (
+            <div className="px-3.5 mb-1 text-[11px] font-semibold uppercase tracking-wider text-ink-4 select-none">
+              {category.label}
+            </div>
+          )}
+          <div className="space-y-0.5">{categoryItems}</div>
         </div>
       );
     }),
@@ -510,7 +520,7 @@ const CommonLayout = ({
         {/* Navigation — the bordered class selector above already separates this
             zone, so no top divider here (the footer keeps its divider). */}
         <nav className="flex-1 overflow-y-auto overflow-x-hidden py-0.5 no-scrollbar">
-          <div className="space-y-1.5">{tabs}</div>
+          <div className="space-y-0.5">{tabs}</div>
         </nav>
 
         {/* Bottom row: profile + GitHub + collapse */}

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -363,6 +363,23 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     classroom,
     'STUDENT'
   );
+  // If the student is ALREADY a member of the GitHub org (common when migrating
+  // from GitHub Classroom), GitHub rejects a fresh org invitation with a 422,
+  // which used to error the whole join. In that case skip the invite and add them
+  // straight to the class team — they're already in the org.
+  const alreadyMember = await gitProvider.isUserMemberOfOrganization(
+    classroom.git_organization.login,
+    student_login
+  );
+
+  if (alreadyMember) {
+    await gitProvider.addTeamMember(classroom.git_organization.login, team.slug, student_login);
+    return {
+      success: 'Already in the organization — added you to the class.',
+      action: ActionTypes.SEND_INVITATION,
+    };
+  }
+
   const githubUser = await gitProvider.getUserByLogin(student_login);
   await gitProvider.inviteToOrganization(classroom.git_organization.login, String(githubUser.id), [
     team.id,

--- a/apps/webapp/app/routes/admin.$class.repos/helpers.ts
+++ b/apps/webapp/app/routes/admin.$class.repos/helpers.ts
@@ -62,6 +62,14 @@ export const publishAssignment = async (
         },
         { concurrencyKey: classroomSlug }
       );
+
+      // Publish = "make available to students" — flip visibility immediately so
+      // the repository shows up for students as soon as the instructor clicks
+      // Publish. Per-student GitHub repos provision in the background above; if
+      // that job is slow or partially fails, the repository is still visible
+      // (instructors can re-run Sync to fill in missing repos). Mirrors the
+      // SELF_FORMED branch below, which already publishes up front.
+      await ClassmojiService.repository.setPublished(repositoryId, true);
     } else if (repository.team_formation_mode === 'SELF_FORMED') {
       // For self-formed teams, just mark repository as published
       // Teams and repos will be created when students form their teams
@@ -95,6 +103,11 @@ export const publishAssignment = async (
         },
         { concurrencyKey: classroomSlug }
       );
+
+      // Publish = "make available to students" — flip visibility immediately
+      // (see the INDIVIDUAL branch above). Team repos provision in the
+      // background; the repository stays visible regardless.
+      await ClassmojiService.repository.setPublished(repositoryId, true);
     }
 
     const accessToken = await auth.createPublicToken({

--- a/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
@@ -114,7 +114,7 @@ const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
         <Form layout="vertical" className="w-3/4">
           <Form.Item label="Show Modules">
             <Switch
-              checked={settings.show_modules ?? false}
+              checked={settings.show_modules ?? true}
               onChange={handleNavToggle('show_modules')}
             />
           </Form.Item>

--- a/apps/webapp/app/routes/student.$class.modules/route.tsx
+++ b/apps/webapp/app/routes/student.$class.modules/route.tsx
@@ -50,7 +50,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     attemptedAction: 'view_modules',
   });
 
-  const showModules = Boolean(classroom.settings?.show_modules);
+  const showModules = classroom.settings?.show_modules !== false;
   // Staff may preview drafts; students only see published modules and items.
   const isStaff = !!membership && membership.role !== 'STUDENT';
 

--- a/apps/webapp/app/utils/navVisibility.ts
+++ b/apps/webapp/app/utils/navVisibility.ts
@@ -1,8 +1,8 @@
 /**
  * Student-navigation visibility flags, derived from classroom settings and
  * shared by the role layout loaders (admin/student/assistant) so the nav reads
- * a single, fresh source. Defaults match the Prisma schema: modules off,
- * pages/repos on.
+ * a single, fresh source. Defaults match the Prisma schema: modules, pages,
+ * and repos all on.
  */
 export interface NavVisibility {
   showModules: boolean;
@@ -11,7 +11,7 @@ export interface NavVisibility {
 }
 
 export const DEFAULT_NAV_VISIBILITY: NavVisibility = {
-  showModules: false,
+  showModules: true,
   showPages: true,
   showRepos: true,
 };
@@ -21,7 +21,7 @@ export const DEFAULT_NAV_VISIBILITY: NavVisibility = {
 export const navVisibilityFromSettings = (
   settings?: { show_modules?: unknown; show_pages?: unknown; show_repos?: unknown } | null
 ): NavVisibility => ({
-  showModules: settings?.show_modules === true,
+  showModules: settings?.show_modules !== false,
   showPages: settings?.show_pages !== false,
   showRepos: settings?.show_repos !== false,
 });

--- a/packages/database/migrations/20260620030000_modules_on_by_default/migration.sql
+++ b/packages/database/migrations/20260620030000_modules_on_by_default/migration.sql
@@ -1,0 +1,8 @@
+-- Modules tab now shows by default, matching pages and repos.
+-- Flip the column default for new classrooms...
+ALTER TABLE "classroom_settings" ALTER COLUMN "show_modules" SET DEFAULT true;
+
+-- ...and turn it on for existing classrooms (the feature shipped off-by-default,
+-- so every row is currently false; none were deliberately disabled). Owners can
+-- still hide it from Settings → Content.
+UPDATE "classroom_settings" SET "show_modules" = true WHERE "show_modules" = false;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -325,7 +325,7 @@ model ClassroomSettings {
   slides_enabled               Boolean  @default(false)
   syllabus_bot_enabled         Boolean  @default(false)
   recent_viewers_enabled       Boolean  @default(true)
-  show_modules                 Boolean  @default(false)
+  show_modules                 Boolean  @default(true)
   show_pages                   Boolean  @default(true)
   show_repos                   Boolean  @default(true)
   syllabus_bot_model           String?

--- a/packages/tasks/src/helpers/createRepository.ts
+++ b/packages/tasks/src/helpers/createRepository.ts
@@ -5,6 +5,15 @@ import fs from 'fs';
 
 import { getGitProvider } from '@classmoji/services';
 
+// Public fallback template used when an instructor's configured template repo has
+// no commits. An empty repo can't seed a student/team repo (the clone lands on an
+// unborn branch and every push fails with "src refspec main does not match any"),
+// so we seed from this shared repo instead. It must stay PUBLIC — the clone runs
+// with the instructor's org installation token, which can't read classmoji-org
+// private repos.
+const FALLBACK_TEMPLATE_REPO = 'classmoji/empty-template';
+const FALLBACK_TEMPLATE_URL = `https://github.com/${FALLBACK_TEMPLATE_REPO}.git`;
+
 type GitOrganizationLike = Parameters<typeof getGitProvider>[0] & { login: string | null };
 
 interface ClassroomForRepositoryCreation {
@@ -87,12 +96,38 @@ export const createRepository = async (payload: CreateRepositoryPayload): Promis
       return repoId;
     }
 
-    // Templates may use any default branch (e.g. `master` on older repos). The
-    // clone checks out the template's default branch, but every step below — and
-    // the feedback PR / branch protection / CLASSMOJI flow — assumes `main`, so
-    // force-rename whatever was checked out to `main` before the first push.
-    // Without this, `push origin main` fails with "src refspec main does not match any".
-    await repoGit.branch(['-M', 'main']);
+    // Does the cloned template have any commits? An *empty* template (no commits
+    // at all — e.g. a freshly created "BlankProject") leaves the clone on an
+    // unborn branch, so `git branch -M main` / `git push origin main` below would
+    // fail with "src refspec main does not match any" and the student/team repo
+    // would be created empty and broken.
+    let templateHasCommits = true;
+    try {
+      await repoGit.raw(['rev-parse', '--verify', 'HEAD']);
+    } catch {
+      templateHasCommits = false;
+    }
+
+    if (templateHasCommits) {
+      // Templates may use any default branch (e.g. `master` on older repos). The
+      // clone checks out the template's default branch, but every step below — and
+      // the feedback PR / branch protection / CLASSMOJI flow — assumes `main`, so
+      // force-rename whatever was checked out to `main` before the first push.
+      await repoGit.branch(['-M', 'main']);
+    } else {
+      // Empty template (no commits — e.g. a freshly created "BlankProject"). Seed
+      // from Classmoji's shared, public empty-template repo (which ships a README)
+      // so the student/team repo gets a real `main` with content instead of an
+      // empty-tree commit. The CLASSMOJI.md commit further down still adds the
+      // welcome file on top.
+      logger.warn(
+        `Template ${templateOwner}/${templateRepo} has no commits; seeding from ${FALLBACK_TEMPLATE_REPO}`
+      );
+      await repoGit.addRemote('seed', FALLBACK_TEMPLATE_URL);
+      await repoGit.fetch('seed', 'main');
+      await repoGit.checkout(['-B', 'main', 'seed/main']);
+      await repoGit.removeRemote('seed');
+    }
 
     await repoGit.push('origin', 'main', ['--force']);
     await repoGit.checkoutLocalBranch('feedback');

--- a/packages/tasks/src/helpers/updateRepository.ts
+++ b/packages/tasks/src/helpers/updateRepository.ts
@@ -77,8 +77,22 @@ export const updateRepository = async (
     // `main` at creation; pulling template/<master> into the student's `updates`
     // branch is a normal cross-name merge.
     const templateSymref = await studentGit.listRemote(['--symref', 'template', 'HEAD']);
-    const templateDefaultBranch =
-      templateSymref.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m)?.[1] ?? 'main';
+    const templateDefaultBranch = templateSymref.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m)?.[1];
+
+    // An *empty* template (no commits at all — e.g. a freshly created
+    // "BlankProject") has no HEAD ref, so there is nothing to pull. Attempting
+    // `git pull template main` here would throw "couldn't find remote ref main".
+    // Treat it as a clean no-op so a sync against an empty template doesn't error.
+    if (!templateDefaultBranch) {
+      logger.warn(
+        `Template ${templateOwner}/${templateRepo} has no commits; skipping update for ${orgLogin}/${repoName}`
+      );
+      return {
+        message: 'Template is empty — nothing to sync',
+        prUrl: '',
+        hasChanges: false,
+      };
+    }
 
     await studentGit.pull('template', templateDefaultBranch, ['-X', 'theirs', '--no-edit']);
     await studentGit.push('origin', 'updates', ['--force']);

--- a/packages/tasks/src/workflows/repoAnalytics.ts
+++ b/packages/tasks/src/workflows/repoAnalytics.ts
@@ -1,4 +1,4 @@
-import { task, schedules, logger } from '@trigger.dev/sdk';
+import { task, logger } from '@trigger.dev/sdk';
 import { ClassmojiService } from '@classmoji/services';
 
 interface RefreshRepoAnalyticsPayload {
@@ -63,23 +63,30 @@ export const refreshRepoAnalytics = task({
 
 /**
  * Cron: refresh analytics for every active gitRepo assignment every 6h.
+ *
+ * TEMPORARILY DISABLED — the 6h fan-out was churning Trigger runs against
+ * stale/fake/deleted repos. A declarative `schedules.task` cron can ONLY be
+ * turned off by removing it from code and redeploying packages/tasks (it cannot
+ * be toggled in the Trigger.dev dashboard or via the API). To re-enable: restore
+ * `schedules` to the import above, uncomment this block, and redeploy.
+ * The on-demand `refresh-repo-analytics` task is unaffected.
  */
-export const refreshAllActiveRepoAnalytics = schedules.task({
-  id: 'refresh-repo-analytics-all',
-  cron: '0 */6 * * *',
-  run: async () => {
-    const ids = await ClassmojiService.repoAnalytics.listActiveAssignmentIds();
-
-    logger.info('Refreshing active repo analytics', {
-      count: ids.length,
-      first: ids[0] ?? null,
-      last: ids[ids.length - 1] ?? null,
-    });
-
-    for (const id of ids) {
-      await refreshRepoAnalytics.trigger({ repositoryAssignmentId: id });
-    }
-
-    return { count: ids.length };
-  },
-});
+// export const refreshAllActiveRepoAnalytics = schedules.task({
+//   id: 'refresh-repo-analytics-all',
+//   cron: '0 */6 * * *',
+//   run: async () => {
+//     const ids = await ClassmojiService.repoAnalytics.listActiveAssignmentIds();
+//
+//     logger.info('Refreshing active repo analytics', {
+//       count: ids.length,
+//       first: ids[0] ?? null,
+//       last: ids[ids.length - 1] ?? null,
+//     });
+//
+//     for (const id of ids) {
+//       await refreshRepoAnalytics.trigger({ repositoryAssignmentId: id });
+//     }
+//
+//     return { count: ids.length };
+//   },
+// });


### PR DESCRIPTION
## Summary

Two changes, bundled for one deploy.

### 1. Harden repository provisioning and publish flow (`db25c81`)
- **Empty templates no longer break provisioning.** When an instructor's template repo has no commits, `createRepository` seeds the student/team repo from the public `classmoji/empty-template` repo (which ships a README) so it lands with a real `main` instead of failing with "src refspec main does not match any". `updateRepository` treats a sync from an empty template as a clean no-op.
- **Org members can join.** `select-organization` adds a student who is already in the Github org straight to the team instead of re-inviting (the org invite returns 422 for existing members).
- **Publish makes repos visible immediately.** Clicking Publish now flips repository visibility up front, so students see it while per-student repos provision in the background.
- **Disabled the 6h refresh-repo-analytics cron** (declarative schedule, must be removed in code) to stop churn against stale or deleted repos.

### 2. Show the Modules tab by default (`0d09a8a`)
- Flips `show_modules` to default-on (schema, nav defaults, settings toggle) to match Pages and Repos, with a migration that turns it on for existing classrooms. Owners can still hide it from Settings then Content.
- Restyles the student nav to group sections under small muted labels instead of full-width dividers.

## Migration
`20260620030000_modules_on_by_default`: sets the `show_modules` column default to true and backfills existing `classroom_settings` rows.

## Test notes
- `packages/tasks`: tsc clean, lint clean.
- Verify a fresh classroom shows the Modules tab by default; toggling it off in Settings then Content still hides it.
- Provisioning: publishing an assignment shows the repository to students immediately; an empty template seeds from `classmoji/empty-template`.

## Notes
- `apps/ai-agent` submodule is intentionally excluded.
- `package-lock.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)