### PR TITLE
Import publish + student nav fixes (follow-up to #124)

### DIFF
--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -190,8 +190,10 @@ const CommonLayout = ({
     if (item.link === '/modules' && role !== 'OWNER' && !showModules) return null;
     if (item.link === '/repos' && role !== 'OWNER' && !showRepos) return null;
 
-    // Students see the repositories section framed as "Modules".
-    const displayLabel = item.link === '/repos' && role === 'STUDENT' ? 'Modules' : item.label;
+    // Repos keeps its own label now that students have a real Modules tab.
+    // (Previously the repos section was framed as "Modules" for students, which
+    // now collides with the actual Modules tab.)
+    const displayLabel = item.label;
 
     return (
       <RequireRole roles={item.roles} key={key}>

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -425,7 +425,9 @@ const CommonLayout = ({
               {category.label}
             </div>
           )}
-          <div className="space-y-0.5">{categoryItems}</div>
+          {/* Lean nav is a flat, short list with no section labels, so give the
+              items more breathing room; the grouped full nav stays tight. */}
+          <div className={leanNav ? 'space-y-1.5' : 'space-y-0.5'}>{categoryItems}</div>
         </div>
       );
     }),
@@ -522,7 +524,7 @@ const CommonLayout = ({
         {/* Navigation — the bordered class selector above already separates this
             zone, so no top divider here (the footer keeps its divider). */}
         <nav className="flex-1 overflow-y-auto overflow-x-hidden py-0.5 no-scrollbar">
-          <div className="space-y-0.5">{tabs}</div>
+          <div className={leanNav ? 'space-y-1.5' : 'space-y-0.5'}>{tabs}</div>
         </nav>
 
         {/* Bottom row: profile + GitHub + collapse */}

--- a/packages/services/src/classmoji/githubClassroomImport.service.ts
+++ b/packages/services/src/classmoji/githubClassroomImport.service.ts
@@ -300,7 +300,10 @@ export async function importGithubClassroom(
             slug: a.slug || null,
             template: a.starterRepoFullName,
             type,
-            is_published: false,
+            // Imported assignments are published on arrival: the student repos
+            // already exist on Github, so there is nothing to provision and no
+            // reason to hide them as drafts.
+            is_published: true,
             // Imported assignments start unweighted; the teacher sets grading
             // weights when they configure the gradebook.
             weight: 0,
@@ -318,7 +321,8 @@ export async function importGithubClassroom(
             title: a.title,
             slug: a.slug || null,
             student_deadline: a.deadline ? new Date(a.deadline) : null,
-            is_published: false,
+            // Published on arrival, same as the repository above (repos exist).
+            is_published: true,
           },
           update: {},
         });


### PR DESCRIPTION
## Summary

Follow-up fixes on top of #124 (merged). Two commits, both small.

### Publish imported repos + de-duplicate student Modules nav (`772547a`)
- **Imported repositories arrive published.** Github Classroom import now creates repositories and assignments with `is_published: true` instead of as drafts. The student repos already exist on Github, so there is nothing to provision and no reason to hide them. Applies to the `create` branch of the upsert, so re-import still will not clobber teacher edits.
- **Fixed the duplicate "Modules" entry in the student sidebar.** The `/repos` tab used to relabel itself to "Modules" for students, a hack that predated the real Modules tab. With Modules now on by default (#124), that produced two "Modules" entries. Repos now shows its own "Repositories" label.

### More spacing in the lean owner nav (`e09c4a0`)
- In the owner's collapsed feature set (lean nav, a flat list with no section labels), items used a tight `space-y-0.5` that read as cramped. Lean mode now uses `space-y-1.5`; the grouped full nav stays tight.

## Migration
None.

## Test notes
- `packages/services` and `apps/webapp` both typecheck clean.
- Import a classroom: repositories come in published, not draft. The student sidebar shows a single "Modules" tab plus a separate "Repositories" tab.
- As an owner, toggle off "Show all features" to see the roomier lean-nav spacing.

## Notes
- `apps/ai-agent` submodule intentionally excluded; `package-lock.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)