### PR TITLE
Make repo/assignment creation idempotent + repos UI polish

### DIFF
--- a/apps/webapp/app/routes/admin.$class.repos/AssignmentsTable.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos/AssignmentsTable.tsx
@@ -224,23 +224,17 @@ const AssignmentTable = ({ assignments: repositories }: AssignmentTableProps) =>
       onOk: () => deleteRepository(id),
     });
 
+  // The primary action (Publish / Sync) is surfaced as an inline button; the
+  // overflow menu keeps only secondary + destructive actions.
   const repoMenuItems = (r: RepositoryRow): MenuProps['items'] => [
     ...(r.is_published
-      ? [
-          { key: 'sync', label: 'Sync', icon: <IconRefresh size={15} /> },
-          { key: 'unpublish', label: 'Unpublish', icon: <IconEyeOff size={15} /> },
-        ]
-      : [{ key: 'publish', label: 'Publish', icon: <IconCloudUpload size={15} /> }]),
-    { type: 'divider' },
+      ? [{ key: 'unpublish', label: 'Unpublish', icon: <IconEyeOff size={15} /> }, { type: 'divider' as const }]
+      : []),
     { key: 'delete', label: 'Delete', danger: true, icon: <IconTrash size={15} /> },
   ];
 
   const onRepoMenuClick = (r: RepositoryRow, key: string) => {
     switch (key) {
-      case 'sync':
-        return confirmSync(r.id);
-      case 'publish':
-        return confirmPublish(r.id);
       case 'unpublish':
         return confirmUnpublish(r.id);
       case 'delete':
@@ -396,6 +390,17 @@ const AssignmentTable = ({ assignments: repositories }: AssignmentTableProps) =>
             <div className="flex items-center gap-x-4 whitespace-nowrap">
               <ActionLink onClick={() => viewRepository(r)}>View</ActionLink>
               <ActionLink onClick={() => editRepository(r)}>Edit</ActionLink>
+              {r.is_published ? (
+                <ActionLink className="inline-flex items-center gap-x-1" onClick={() => confirmSync(r.id)}>
+                  <IconRefresh size={15} />
+                  Sync
+                </ActionLink>
+              ) : (
+                <ActionLink className="inline-flex items-center gap-x-1" onClick={() => confirmPublish(r.id)}>
+                  <IconCloudUpload size={15} />
+                  Publish
+                </ActionLink>
+              )}
               <Dropdown
                 trigger={['click']}
                 placement="bottomRight"

--- a/apps/webapp/tests/owner/assignments/publish-lifecycle.spec.ts
+++ b/apps/webapp/tests/owner/assignments/publish-lifecycle.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../fixtures/auth.fixture';
+import type { Locator, Page } from '@playwright/test';
 import { waitForDataLoad } from '../../helpers/wait.helpers';
 import { TEST_CLASSROOM } from '../../helpers/env.helpers';
 import {
@@ -18,9 +19,24 @@ import { repositoryRow } from '../../helpers/repos.helpers';
  * exists for the repository; otherwise it enqueues a Trigger.dev task. Every spec
  * here seeds the repository with a backing GitRepo so publish takes the
  * deterministic flag-flip branch.
+ *
+ * UI shape (AssignmentsTable): the primary action is an inline button — "Publish"
+ * for drafts, "Sync" for published. Secondary/destructive actions (Unpublish,
+ * Delete) live in the row's "⋯" overflow menu. Each action opens an antd
+ * `modal.confirm` dialog whose primary button text matches the action.
  */
 
 const REPOS_PATH = (org: string) => `/admin/${org}/repos`;
+
+/** Open a repository row's "⋯" overflow menu. */
+async function openRowMenu(row: Locator) {
+  await row.getByRole('button', { name: 'More actions' }).click();
+}
+
+/** Click the confirm (okText) button in the open modal.confirm dialog. */
+async function confirmDialog(page: Page, name: string) {
+  await page.locator('.ant-modal-confirm').getByRole('button', { name, exact: true }).click();
+}
 
 /** Attach a GitRepo to a seeded repository so publish() takes the flag-flip path. */
 async function attachGitRepo(classroomId: string, repositoryId: string, suffix: string) {
@@ -102,12 +118,13 @@ test.describe('Owner publishes and unpublishes an assignment', () => {
       await expect(row).toBeVisible();
       await expect(row.getByText('Published')).toBeVisible();
 
-      await row.getByText('Unpublish', { exact: true }).click();
+      await openRowMenu(row);
+      await page.getByRole('menuitem', { name: 'Unpublish', exact: true }).click();
 
       await expect(
         page.getByText('hides the repository from students')
       ).toBeVisible();
-      await page.locator('.ant-popconfirm, .ant-popover').getByRole('button', { name: 'Unpublish', exact: true }).click();
+      await confirmDialog(page, 'Unpublish');
 
       await expect(row.getByText('Draft')).toBeVisible();
 
@@ -134,13 +151,14 @@ test.describe('Owner publishes and unpublishes an assignment', () => {
       await expect(row).toBeVisible();
       await expect(row.getByText('Draft')).toBeVisible();
 
+      // Publish is an inline action for drafts; Unpublish is not offered.
       await expect(row.getByText('Unpublish', { exact: true })).toHaveCount(0);
-      await row.getByText('Publish', { exact: true }).click();
+      await row.getByRole('button', { name: 'Publish', exact: true }).click();
 
       await expect(
         page.getByText('makes the repository available to all students')
       ).toBeVisible();
-      await page.locator('.ant-popconfirm, .ant-popover').getByRole('button', { name: 'Publish', exact: true }).click();
+      await confirmDialog(page, 'Publish');
 
       await expect(row.getByText('Published')).toBeVisible();
 
@@ -166,15 +184,18 @@ test.describe('Owner publishes and unpublishes an assignment', () => {
       const row = repositoryRow(page, title);
       await expect(row).toBeVisible();
 
-      await row.getByText('Unpublish', { exact: true }).click();
-      await page.locator('.ant-popconfirm, .ant-popover').getByRole('button', { name: 'Unpublish', exact: true }).click();
+      // Unpublish via the overflow menu -> Draft.
+      await openRowMenu(row);
+      await page.getByRole('menuitem', { name: 'Unpublish', exact: true }).click();
+      await confirmDialog(page, 'Unpublish');
       await expect(row.getByText('Draft')).toBeVisible();
       await expect
         .poll(async () => getRepositoryPublishedState(seeded.repositoryId))
         .toBe(false);
 
-      await row.getByText('Publish', { exact: true }).click();
-      await page.locator('.ant-popconfirm, .ant-popover').getByRole('button', { name: 'Publish', exact: true }).click();
+      // Re-publish via the inline action -> Published.
+      await row.getByRole('button', { name: 'Publish', exact: true }).click();
+      await confirmDialog(page, 'Publish');
       await expect(row.getByText('Published')).toBeVisible();
       await expect
         .poll(async () => getRepositoryPublishedState(seeded.repositoryId))
@@ -198,8 +219,13 @@ test.describe('Owner publishes and unpublishes an assignment', () => {
       const row = repositoryRow(page, title);
       await expect(row).toBeVisible();
       await expect(row.getByText('Draft', { exact: true })).toBeVisible();
-      await expect(row.getByText('Publish', { exact: true })).toBeVisible();
-      await expect(row.getByText('Unpublish', { exact: true })).toHaveCount(0);
+      // Publish is offered inline for a draft.
+      await expect(row.getByRole('button', { name: 'Publish', exact: true })).toBeVisible();
+
+      // The overflow menu offers Delete but never Unpublish for a draft.
+      await openRowMenu(row);
+      await expect(page.getByRole('menuitem', { name: 'Delete', exact: true })).toBeVisible();
+      await expect(page.getByRole('menuitem', { name: 'Unpublish', exact: true })).toHaveCount(0);
 
       const dbRow = await getRepositoryByTitle(seeded.classroomId, title);
       expect(dbRow?.is_published).toBe(false);

--- a/packages/services/src/classmoji/gitRepo.service.ts
+++ b/packages/services/src/classmoji/gitRepo.service.ts
@@ -12,17 +12,26 @@ interface RepositoryCreatePayload {
 
 export const create = async (payload: RepositoryCreatePayload) => {
   const { repositoryId, classroom, repoName, student, team, providerId } = payload;
+  const provider = classroom.git_organization.provider as GitProvider;
 
-  return getPrisma().gitRepo.create({
-    data: {
-      name: repoName,
-      classroom_id: classroom.id,
-      repository_id: repositoryId,
-      team_id: team?.id,
-      student_id: student?.id,
-      provider: classroom.git_organization.provider as GitProvider,
-      provider_id: providerId,
-    },
+  // Upsert (not create) keyed on the @@unique([provider, provider_id]) constraint so
+  // re-runs heal the row instead of crashing. The GitHub side of repo creation is already
+  // idempotent (existing repos are detected and reused / Sync routes them back through), so
+  // a repo can exist before this row does — e.g. a retry, a Sync, or a run cancelled after
+  // the repo was created but before this insert. A plain create() collides in those cases
+  // with "Unique constraint failed on the fields: (provider, provider_id)".
+  const mutableFields = {
+    name: repoName,
+    classroom_id: classroom.id,
+    repository_id: repositoryId,
+    team_id: team?.id ?? null,
+    student_id: student?.id ?? null,
+  };
+
+  return getPrisma().gitRepo.upsert({
+    where: { provider_provider_id: { provider, provider_id: providerId } },
+    create: { ...mutableFields, provider, provider_id: providerId },
+    update: mutableFields,
   });
 };
 

--- a/packages/tasks/src/workflows/gitRepo.ts
+++ b/packages/tasks/src/workflows/gitRepo.ts
@@ -406,6 +406,18 @@ export const createProjectForRepoTask = task({
         throw new Error(`Missing project configuration for ${repoName}`);
       }
 
+      // Idempotency guard: copyProjectFromTemplate is not idempotent — a re-run would create
+      // a second GitHub Project and overwrite the first id below, orphaning it. Skip if this
+      // repo already has a project.
+      const existingRepo = await ClassmojiService.gitRepo.find({ id: repoId });
+      if (existingRepo?.project_id) {
+        logger.info(`Repo ${repoName} already has a project — skipping project creation`, {
+          repoId,
+          projectId: existingRepo.project_id,
+        });
+        return null;
+      }
+
       const orgNodeId = await gitProvider.getOrganizationNodeId(org);
       const projectTitle = repoName;
       const project = await gitProvider.copyProjectFromTemplate(

--- a/packages/tasks/src/workflows/gitRepoAssignment.ts
+++ b/packages/tasks/src/workflows/gitRepoAssignment.ts
@@ -134,6 +134,24 @@ export const createGithubRepositoryAssignmentTask = task({
       );
     }
 
+    // Idempotency guard: skip if this repo already has this assignment. createIssue mints a
+    // NEW GitHub issue every run, so a re-trigger (Sync, manual re-run, webhook redelivery)
+    // would otherwise create duplicate issues + rows. Centralizing the guard here protects
+    // every caller (gh-create_git_repo, daily_git_repo_assignments_release, and the
+    // already-guarded release_git_repo_assignments_now).
+    const existingAssignment = await ClassmojiService.gitRepoAssignment.findFirst({
+      assignment_id: assignment.id,
+      git_repo_id: studentRepo.id,
+    });
+    if (existingAssignment) {
+      logger.info('Assignment issue already exists for this repo — skipping', {
+        repoName,
+        assignmentId: assignment.id,
+        gitRepoId: studentRepo.id,
+      });
+      return;
+    }
+
     const gitProvider = getGitProvider(organization);
     const { id, number: issueNumber } = await gitProvider.createIssue(
       organization.login,

--- a/packages/ui-components/src/Callout/CalloutSlot.tsx
+++ b/packages/ui-components/src/Callout/CalloutSlot.tsx
@@ -40,7 +40,7 @@ export function CalloutSlot({ id = DEFAULT_CALLOUT_SLOT_ID, className }: Callout
   };
 
   const baseClass =
-    'pointer-events-none fixed top-4 left-1/2 w-full max-w-2xl -translate-x-1/2 px-4';
+    'pointer-events-none fixed top-20 left-1/2 w-full max-w-2xl -translate-x-1/2 px-4';
   const wrapperClass = className ? `${baseClass} ${className}` : baseClass;
 
   return (


### PR DESCRIPTION
## Context

This started from a "spam" scare in prod: a student generated a stream of repeated `create_git_repos` runs that were later bulk-cancelled. Investigation via the Trigger.dev dashboard showed it was **not** spam and **not** automatic retries (the global retry default is `maxAttempts: 1`, and every run had `attempt_count = 1`). The student kept re-triggering because repo creation was failing on a non-idempotent DB insert. This PR makes the repo/assignment creation tasks safe to re-run, plus a couple of small UI changes.

## What's included

**Idempotency (`fix(tasks)`)**
- `gitRepo.create` now upserts on `(provider, provider_id)` so a re-run (admin Sync, student re-click, webhook redelivery) heals the existing row instead of failing with `Unique constraint failed on the fields: (provider, provider_id)`. A repo's `provider_id` is stable across runs, so upsert is correct.
- `createGithubRepositoryAssignmentTask` skips when the repo already has the assignment, so a re-run does not mint duplicate Github issues + rows. The issue id changes every run, so a pre-existence guard (not an upsert) is the right fix. Centralized in the task so all callers are protected.
- `createProjectForRepoTask` skips when the repo already has a `project_id`, avoiding duplicate Github Projects that orphan the first.

**Repos UI (`feat(repos)`, `fix(ui)`)**
- Surface the primary action (Publish for drafts, Sync for published) as an inline button next to View/Edit. The overflow menu keeps only secondary/destructive actions (Unpublish, Delete).
- Offset the callout slot below the fixed header.

**Tests (`test(repos)`)**
- Update `publish-lifecycle.spec.ts` to match the current UI (inline buttons, overflow menu, `modal.confirm`).

## Testing

- `packages/services` typecheck + unit tests (82) pass.
- `packages/tasks` typecheck + eslint pass.
- The Playwright spec transpiles cleanly. Full e2e was not runnable locally because auth bootstrap needs `GITHUB_PROF_TOKEN`.

## Follow-ups (not in this PR)

- Tier 2 idempotency (token double-award in `assign_tokens_to_student`, duplicate regrade requests in `request_regrade`) needs a DB migration or guard.
- The `apps/ai-agent` submodule has an unrelated `fly.toml` change that was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)