### PR TITLE
Sync main into staging

### DIFF
--- a/packages/tasks/src/workflows/gitRepo.ts
+++ b/packages/tasks/src/workflows/gitRepo.ts
@@ -430,6 +430,9 @@ export const createProjectForRepoTask = task({
     const { classroom, repository, repoName, repoId, team } = payload;
 
     try {
+      // Idempotency guard: copyProjectFromTemplate is not idempotent — a re-run would create
+      // a second GitHub Project and overwrite the first id below, orphaning it. Skip if this
+      // repo already has a project.
       const existingRepo = await ClassmojiService.gitRepo.find({ id: repoId });
       if (existingRepo?.project_id) {
         logger.info(`Repo ${repoName} already has a project; skipping project copy`, {
@@ -448,18 +451,6 @@ export const createProjectForRepoTask = task({
 
       if (!org || !repository.project_template_id) {
         throw new Error(`Missing project configuration for ${repoName}`);
-      }
-
-      // Idempotency guard: copyProjectFromTemplate is not idempotent — a re-run would create
-      // a second GitHub Project and overwrite the first id below, orphaning it. Skip if this
-      // repo already has a project.
-      const existingRepo = await ClassmojiService.gitRepo.find({ id: repoId });
-      if (existingRepo?.project_id) {
-        logger.info(`Repo ${repoName} already has a project — skipping project creation`, {
-          repoId,
-          projectId: existingRepo.project_id,
-        });
-        return null;
       }
 
       const orgNodeId = await gitProvider.getOrganizationNodeId(org);

--- a/packages/tasks/src/workflows/gitRepoAssignment.ts
+++ b/packages/tasks/src/workflows/gitRepoAssignment.ts
@@ -219,22 +219,6 @@ export const createGithubRepositoryAssignmentTask = task({
     }
 
     const gitProvider = getGitProvider(organization);
-    const existingAssignment = await ClassmojiService.gitRepoAssignment.findFirst({
-      assignment_id: assignment.id,
-      git_repo_id: studentRepo.id,
-    });
-
-    if (existingAssignment) {
-      logger.info('GitHub assignment issue already exists; skipping creation', {
-        organization: organization.login,
-        repoName,
-        assignmentId: assignment.id,
-        assignmentTitle: assignment.title,
-        studentRepoId: studentRepo.id,
-        gitRepoAssignmentId: existingAssignment.id,
-      });
-      return existingAssignment;
-    }
 
     let issue: { id: string; number: number };
 


### PR DESCRIPTION
## Summary
Syncs the latest `main` changes into `staging`. This replaces #136 (which was opened from a fork) by hosting the branch directly on this repo.

Carries over everything from #136:
- repo analytics commit bounding from #135
- Github assignment issue error context
- idempotent Git provisioning persistence for repos and repo assignments
- dedupes and validates repo-creation recipients before fan-out
- scheduled and manual assignment release now provision only missing repos after partial runs
- adopts an existing same-title Github issue before creating a new assignment issue, preventing duplicate issues after DB-write retries
- avoids duplicate Github Project copies when a repo already has project metadata

## Conflict resolution
- `packages/services/src/classmoji/gitRepo.service.ts`: kept staging's documented idempotent upsert (extracted `mutableFields`, explicit `?? null`) and aligned the inbound `gitRepo.service` test to expect `null` instead of `undefined` for `team_id`.

## Build fix
Both `main` and `staging` had independently added idempotency guards to the project- and assignment-creation tasks, each declaring `existingRepo` / `existingAssignment` in the same scope. The merge stacked both copies, so esbuild failed the SSR build with "symbol has already been declared". Removed the redundant second guard in each task, keeping the first one (it runs first, carries the rationale comment, and its return value matches the success path).

## Tests
- `npm run web:build` passes (client + SSR bundles)
- `npm --workspace @classmoji/services test` for the touched suites: gitRepo, gitRepoAssignment, repoAnalytics, GitHubProvider findIssueByTitle / listCommits all green
- eslint clean on the resolved service file, its test, and both workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)