### PR TITLE
ci: restrict main PR source to staging

### DIFF
--- a/.github/workflows/restrict-main-source.yml
+++ b/.github/workflows/restrict-main-source.yml
@@ -1,0 +1,27 @@
+name: Restrict main PR source
+
+# Only PRs from this repo's `staging` branch may merge into `main`.
+# GitHub cannot restrict a PR's source branch natively, so this gate runs on
+# `pull_request_target` (always evaluated from main's copy of this workflow, so a
+# PR can't tamper with it) and only reads event context (no untrusted code runs).
+# Make `enforce-staging-source` a required status check on `main` to enforce it.
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  enforce-staging-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only allow PRs from staging
+        run: |
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          HEAD_REF="${{ github.head_ref }}"
+          if [ "$HEAD_REPO" != "${{ github.repository }}" ] || [ "$HEAD_REF" != "staging" ]; then
+            echo "::error::PRs into main may only come from the 'staging' branch of ${{ github.repository }} (got '$HEAD_REPO:$HEAD_REF')."
+            exit 1
+          fi
+          echo "Source branch is staging from ${{ github.repository }}"


### PR DESCRIPTION
## Summary
Adds a CI gate so that **PRs into `main` may only come from this repo's `staging` branch**. Github can't restrict a PR's source branch natively, so this enforces it via a `pull_request_target` check that becomes a required status check on `main`.

This matches the existing flow: `auto-promote-staging.yml` already auto-opens the `staging → main` promotion PR, so the canonical path into `main` is already staging.

## How it works
- Triggers on `pull_request_target` for PRs whose **base** is `main`, so the check always runs from `main`'s own copy of the workflow. A PR branch can't tamper with it, and no untrusted code runs (it only reads event context).
- Fails unless the PR head is `staging` **and** the head repo is this repo. The head-repo assertion hardens against a fork that names a branch `staging`.
- Runs with `permissions: {}` (no token).

## Bootstrap / rollout (after this merges)
1. Merge this PR into `staging`.
2. The existing auto-promote opens (or you open) the `staging → main` PR. This workflow does **not** block that promotion, because `main` doesn't have the file yet (`pull_request_target` uses the base branch's copy).
3. Merge the promotion PR. Now `main` has the workflow and the check runs on every future PR into `main`.
4. Register `enforce-staging-source` as a **required status check** on `main` (branch protection). I can do this step once the workflow is on `main`.

## Note
This does not change branch protection by itself. The required-check registration in step 4 is what enforces the rule, and it will apply to admins too (`enforce_admins` is already enabled on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)