### PR TITLE
feat(webapp): allow private org repos as assignment templates

### DIFF
--- a/apps/webapp/app/routes/admin.$class.repos_.form/AsyncAutocomplete.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.form/AsyncAutocomplete.tsx
@@ -1,39 +1,46 @@
 import { useState, useEffect } from 'react';
-import { Octokit } from '@octokit/rest';
 import type { Control, FieldValues } from 'react-hook-form';
 import { FormItem } from 'react-hook-form-antd';
-import { Select, Input, Spin } from 'antd';
+import { Select, Input, Spin, Tag } from 'antd';
 import { useDebounce } from '@uidotdev/usehooks';
 
-const getAsyncData = async (query: string, token: string) => {
+interface TemplateRepository {
+  name: string;
+  full_name: string;
+  description: string | null;
+  updated_at: string | null;
+  private: boolean;
+  language: string | null;
+  stargazers_count: number;
+}
+
+// Search the classroom org's repos (public + private) plus global public repos
+// via the server endpoint, which uses the org installation token. The
+// installation token is never exposed to the browser.
+const getAsyncData = async (query: string, classSlug: string): Promise<TemplateRepository[]> => {
   try {
-    // Search for public template repositories using GitHub's search API
-    const octokit = new Octokit({ auth: token });
+    const params = new URLSearchParams({ classroomSlug: classSlug, q: query });
+    const response = await fetch(`/api/github-repos?${params.toString()}`);
 
-    const searchQuery = query + ' in:name is:public';
+    if (!response.ok) {
+      console.error('Error searching templates:', response.status);
+      return [];
+    }
 
-    const response = await octokit.rest.search.repos({
-      q: searchQuery,
-      sort: 'updated',
-      order: 'desc',
-      per_page: 50,
-    });
-
-    return response.data.items;
+    const data = (await response.json()) as TemplateRepository[] | { error: string };
+    return Array.isArray(data) ? data : [];
   } catch (error: unknown) {
-    console.error('Error searching public templates:', error);
+    console.error('Error searching templates:', error);
     return [];
   }
 };
-
-type PublicTemplateRepository = Awaited<ReturnType<typeof getAsyncData>>[number];
 
 interface AsyncAutocompleteProps {
   template: string;
   isPublished: boolean;
   setTemplate: (template: string) => void;
   control: Control<FieldValues>;
-  token: string;
+  classSlug: string;
 }
 
 const AsyncAutocomplete = ({
@@ -41,10 +48,10 @@ const AsyncAutocomplete = ({
   isPublished,
   setTemplate,
   control,
-  token,
+  classSlug,
 }: AsyncAutocompleteProps) => {
   const [loading, setLoading] = useState(false);
-  const [data, setData] = useState<PublicTemplateRepository[] | null>(null);
+  const [data, setData] = useState<TemplateRepository[] | null>(null);
   const [query, setQuery] = useState('');
   const [value, setValue] = useState(template);
 
@@ -62,7 +69,7 @@ const AsyncAutocomplete = ({
   const fetchOptions = async (q: string) => {
     setLoading(true);
     try {
-      const result = await getAsyncData(q, token);
+      const result = await getAsyncData(q, classSlug);
       setData(result);
     } catch (error: unknown) {
       console.error('Error fetching repositories:', error);
@@ -79,13 +86,13 @@ const AsyncAutocomplete = ({
         <div className="flex gap-2">
           <FormItem
             name="template"
-            label="Search Public Template Repositories"
+            label="Search template repositories"
             className="w-full"
             control={control}
           >
             <Select
               className="w-full"
-              placeholder="Type to search public template repositories..."
+              placeholder="Type to search template repositories..."
               loading={loading}
               value={value}
               onSelect={v => {
@@ -98,21 +105,25 @@ const AsyncAutocomplete = ({
               notFoundContent={
                 loading ? (
                   <div className="text-center py-4">
-                    <Spin size="small" />{' '}
-                    <span className="ml-2">Searching public templates...</span>
+                    <Spin size="small" /> <span className="ml-2">Searching templates...</span>
                   </div>
                 ) : query ? (
                   'No template repositories found'
                 ) : (
-                  'Type to search for public template repositories'
+                  'Type to search for template repositories'
                 )
               }
               options={(data || []).map(d => ({
                 value: d.full_name,
                 label: (
                   <div className="flex items-center justify-between">
-                    <div>
-                      <div className="font-medium">{d.full_name}</div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{d.full_name}</span>
+                      {d.private && (
+                        <Tag color="gold" className="m-0">
+                          Private
+                        </Tag>
+                      )}
                     </div>
                     <div className="flex items-center gap-2 text-xs text-gray-400">
                       {Number(d.stargazers_count) > 0 && (

--- a/apps/webapp/app/routes/admin.$class.repos_.form/FormModule.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.form/FormModule.tsx
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import { useEffect, useState } from 'react';
-import { Octokit } from '@octokit/rest';
 
 import { useRevalidator } from 'react-router';
 import { useCallout } from '@classmoji/ui-components';
@@ -94,7 +93,6 @@ interface ModuleData {
 }
 
 interface FormModuleProps {
-  token: string;
   isNew: boolean;
   repository: ModuleData | null;
   close: () => void;
@@ -106,7 +104,6 @@ interface FormModuleProps {
 }
 
 const FormModule = ({
-  token,
   isNew,
   repository,
   close,
@@ -271,29 +268,43 @@ const FormModule = ({
 
   useEffect(() => {
     const fetchTemplateRepoIssues = async () => {
-      const ocktokit = new Octokit({ auth: token });
       if (!template) return;
       const [owner, repo] = template.split('/');
+      if (!owner || !repo) return;
 
-      const { data } = await ocktokit.issues.listForRepo({
-        owner,
-        repo,
-      });
-
-      const promises = data.map(async ({ title, body }) => {
-        const data = await fetch('/api/parser', {
-          method: 'POST',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ markdown: body }),
+      // Fetch the template's issues through the server endpoint, which uses the
+      // org installation token. This works for private templates that the
+      // instructor's personal token can't read. Best-effort: a failure just
+      // means assignment titles won't prefill, so never break the form.
+      try {
+        const params = new URLSearchParams({
+          classroomSlug: classroom.slug,
+          owner,
+          repo,
         });
-        const res = await data.json();
-        return { title: title, body: res.html };
-      });
+        const res = await fetch(`/api/github-repo-issues?${params.toString()}`);
+        if (!res.ok) return;
+        const issues = (await res.json()) as Array<{ title: string; body: string | null }>;
+        if (!Array.isArray(issues)) return;
 
-      Promise.all(promises).then(assignments => setTemplateAssignments(assignments));
+        const promises = issues.map(async ({ title, body }) => {
+          const data = await fetch('/api/parser', {
+            method: 'POST',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ markdown: body }),
+          });
+          const parsed = await data.json();
+          return { title, body: parsed.html };
+        });
+
+        const assignments = await Promise.all(promises);
+        setTemplateAssignments(assignments);
+      } catch (error: unknown) {
+        console.error('Error fetching template repo issues:', error);
+      }
     };
 
     if (template || repository?.template) {
@@ -584,7 +595,7 @@ const FormModule = ({
               template={repository?.template || ''}
               isPublished={repository?.is_published || false}
               setTemplate={setTemplate}
-              token={token}
+              classSlug={classroom.slug}
             />
           </Card>
 

--- a/apps/webapp/app/routes/admin.$class.repos_.form/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.form/route.tsx
@@ -2,7 +2,6 @@ import { namedAction } from 'remix-utils/named-action';
 import { useNavigate, useParams } from 'react-router';
 import { IconChevronLeft, IconFolder } from '@tabler/icons-react';
 
-import { getAuthSession } from '@classmoji/auth/server';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import FormModule from './FormModule';
 import { ClassmojiService } from '@classmoji/services';
@@ -18,7 +17,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'view_module_form',
   });
 
-  const authData = await getAuthSession(request);
   const url = new URL(request.url);
   const moduleTitle = url.searchParams.get('title');
   const tags = await ClassmojiService.organizationTag.findByClassroomId(classroom.id);
@@ -64,7 +62,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   });
 
   return {
-    token: authData?.token,
     repository,
     isNew: !repository,
     tags,
@@ -76,8 +73,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 };
 
 const ModuleForm = ({ loaderData }: Route.ComponentProps) => {
-  const { token, repository, isNew, tags, classroom, pages, slides, hasReposWithProjects } =
-    loaderData;
+  const { repository, isNew, tags, classroom, pages, slides, hasReposWithProjects } = loaderData;
   const navigate = useNavigate();
   const { class: classSlug } = useParams();
   const goToRepos = () => navigate(`/admin/${classSlug}/repos`);
@@ -107,7 +103,6 @@ const ModuleForm = ({ loaderData }: Route.ComponentProps) => {
       </div>
 
       <FormModule
-        token={token!}
         repository={repository as Parameters<typeof FormModule>[0]['repository']}
         isNew={isNew}
         close={close}

--- a/apps/webapp/app/routes/api.github-repo-issues/route.ts
+++ b/apps/webapp/app/routes/api.github-repo-issues/route.ts
@@ -1,0 +1,69 @@
+/**
+ * GitHub Repo Issues API - Lists open issues for a template repository.
+ *
+ * Used by the assignment form to prefill assignment titles from a template's
+ * GitHub issues. Authenticated with the classroom org installation token, so it
+ * works for private templates the instructor's personal token can't read.
+ *
+ * Only OWNER and ASSISTANT roles can access this endpoint.
+ */
+import { Octokit } from '@octokit/rest';
+import { assertClassroomAccess } from '~/utils/helpers';
+import { getInstallationToken } from '~/routes/student.$class.quizzes/helpers.server';
+import type { Route } from './+types/route';
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const classroomSlug = url.searchParams.get('classroomSlug');
+  const owner = url.searchParams.get('owner');
+  const repo = url.searchParams.get('repo');
+
+  if (!classroomSlug || !owner || !repo) {
+    return new Response(JSON.stringify({ error: 'classroomSlug, owner and repo are required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Verify user is OWNER or ASSISTANT
+  const { classroom } = await assertClassroomAccess({
+    request,
+    classroomSlug,
+    allowedRoles: ['OWNER', 'ASSISTANT'],
+    resourceType: 'GITHUB_REPOS',
+    attemptedAction: 'list_issues',
+  });
+
+  if (!classroom.git_organization) {
+    return new Response(
+      JSON.stringify({ error: 'No GitHub organization configured for this classroom' }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  try {
+    const token = await getInstallationToken(classroom.git_organization);
+    const octokit = new Octokit({ auth: token });
+
+    const { data } = await octokit.issues.listForRepo({ owner, repo });
+
+    // Drop pull requests (the issues endpoint includes them) and return only
+    // what the form needs.
+    const issues = data
+      .filter(issue => !issue.pull_request)
+      .map(issue => ({ title: issue.title, body: issue.body ?? '' }));
+
+    return new Response(JSON.stringify(issues), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error: unknown) {
+    console.error('[api.github-repo-issues] Error fetching issues:', error);
+    return new Response(JSON.stringify({ error: 'Failed to fetch repository issues' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/apps/webapp/app/routes/api.github-repos/route.ts
+++ b/apps/webapp/app/routes/api.github-repos/route.ts
@@ -1,7 +1,15 @@
 /**
  * GitHub Repos API - Lists repositories in a classroom's GitHub organization
  *
- * Used by instructors to select a test repository for code-aware quiz preview.
+ * Two modes (both authenticated with the org installation token, so private org
+ * repos are visible without exposing the token to the browser):
+ *  - No `q`: lists the org's repos (most recently updated). Used by the
+ *    code-aware quiz preview repo picker.
+ *  - With `q`: template search. Merges global public results with the
+ *    classroom org's repos (public + private) so instructors can pick a private
+ *    template that lives in their org, while still finding public templates
+ *    hosted anywhere. Used by the assignment template picker.
+ *
  * Only OWNER and ASSISTANT roles can access this endpoint.
  */
 import { Octokit } from '@octokit/rest';
@@ -9,9 +17,22 @@ import { assertClassroomAccess } from '~/utils/helpers';
 import { getInstallationToken } from '~/routes/student.$class.quizzes/helpers.server';
 import type { Route } from './+types/route';
 
+const SEARCH_LIMIT = 50;
+
+interface RepoSearchItem {
+  name: string;
+  full_name: string;
+  description: string | null;
+  updated_at: string | null | undefined;
+  private: boolean;
+  language: string | null;
+  stargazers_count: number;
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const classroomSlug = url.searchParams.get('classroomSlug');
+  const query = url.searchParams.get('q')?.trim() ?? '';
 
   if (!classroomSlug) {
     return new Response(JSON.stringify({ error: 'classroomSlug is required' }), {
@@ -45,6 +66,16 @@ export async function loader({ request }: Route.LoaderArgs) {
     const token = await getInstallationToken(gitOrg);
     const octokit = new Octokit({ auth: token });
 
+    // Template search mode: merge global public results with the org's repos
+    // (which include private). Returns a richer shape so the picker can badge
+    // private repos.
+    if (query.length >= 2) {
+      const repoList = await searchTemplateRepos(octokit, query, gitOrg.login);
+      return new Response(JSON.stringify(repoList), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     // List repos in the organization, sorted by most recently updated
     const { data: repos } = await octokit.repos.listForOrg({
       org: gitOrg.login,
@@ -71,4 +102,54 @@ export async function loader({ request }: Route.LoaderArgs) {
       headers: { 'Content-Type': 'application/json' },
     });
   }
+}
+
+/**
+ * Run two name searches and merge them: any public repo on GitHub, plus repos
+ * in the classroom org (public + private, visible to the installation token).
+ * Deduped by full_name (the org's public repos match both queries).
+ */
+async function searchTemplateRepos(
+  octokit: Octokit,
+  query: string,
+  orgLogin: string
+): Promise<RepoSearchItem[]> {
+  const [publicResult, orgResult] = await Promise.allSettled([
+    octokit.rest.search.repos({
+      q: `${query} in:name is:public`,
+      sort: 'updated',
+      order: 'desc',
+      per_page: SEARCH_LIMIT,
+    }),
+    octokit.rest.search.repos({
+      q: `${query} in:name org:${orgLogin}`,
+      sort: 'updated',
+      order: 'desc',
+      per_page: SEARCH_LIMIT,
+    }),
+  ]);
+
+  const merged = new Map<string, RepoSearchItem>();
+
+  // Org results first so private repos win the dedupe and surface at the top.
+  for (const result of [orgResult, publicResult]) {
+    if (result.status !== 'fulfilled') {
+      console.error('[api.github-repos] Template search query failed:', result.reason);
+      continue;
+    }
+    for (const r of result.value.data.items) {
+      if (merged.has(r.full_name)) continue;
+      merged.set(r.full_name, {
+        name: r.name,
+        full_name: r.full_name,
+        description: r.description,
+        updated_at: r.updated_at,
+        private: r.private,
+        language: r.language ?? null,
+        stargazers_count: r.stargazers_count ?? 0,
+      });
+    }
+  }
+
+  return Array.from(merged.values()).slice(0, SEARCH_LIMIT);
 }


### PR DESCRIPTION
Lets instructors pick a **private** repo from the classroom org as an assignment template (previously public repos only).

- **`api.github-repos`**: optional `q` param searches with the org installation token, merging global public + the org's repos (incl. private), deduped, with a `private` flag. Without `q`, unchanged (`listForOrg`).
- **`api.github-repo-issues`** (new): lists a template's issues via the installation token so private templates can prefill assignment titles.
- **`AsyncAutocomplete`**: fetches the endpoint with `classSlug` instead of the personal token; badges private results.
- **`FormModule` / `route`**: issue prefetch goes through the new endpoint (non-fatal); drops the now-unused personal token plumbing.
- Excludes Classmoji-generated student/team repos from the template search so they don't clutter the picker.

No schema change. Private templates must live in the classroom's own org (installation token is org-scoped).