### PR TITLE
fix(webapp): prevent stale cached results in template repo search

### DIFF
--- a/apps/webapp/app/routes/api.github-repos/route.ts
+++ b/apps/webapp/app/routes/api.github-repos/route.ts
@@ -81,7 +81,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
       const repoList = await searchTemplateRepos(octokit, query, gitOrg.login, excluded);
       return new Response(JSON.stringify(repoList), {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
       });
     }
 


### PR DESCRIPTION
Adds `Cache-Control: no-store` to the template search response (`/api/github-repos?q=...`) so the picker always shows fresh results. Without it the browser could serve a cached list (e.g. one captured before the student-repo exclusion from #148 landed), making generated student repos appear to still show up.

One line; search path only.