### PR TITLE
fix(tasks): skip empty assignment batch in daily release

### DIFF
--- a/packages/tasks/src/workflows/gitRepoAssignment.ts
+++ b/packages/tasks/src/workflows/gitRepoAssignment.ts
@@ -485,7 +485,9 @@ export const dailyRepositoryAssignmentsReleaseTask = schedules.task({
               };
             });
 
-            await createGithubRepositoryAssignmentTask.batchTriggerAndWait(payloads);
+            if (payloads.length > 0) {
+              await createGithubRepositoryAssignmentTask.batchTriggerAndWait(payloads);
+            }
             await ClassmojiService.assignment.update(assignment.id, {
               is_published: true,
             });


### PR DESCRIPTION
## Problem

The daily assignment release task (`dailyRepositoryAssignmentsReleaseTask`) crashed with:

> BatchTriggerError: Failed to create batch with 0 items: Validation error: Number must be greater than 0 at "runCount"

When an already-published repository has no enrolled recipients — no students for an `INDIVIDUAL` repo, or no teams for a tagged repo — `recipients`, and therefore `payloads`, is empty, and `createGithubRepositoryAssignmentTask.batchTriggerAndWait([])` throws because Trigger.dev rejects 0-item batches. Since it threw inside the per-assignment loop, it aborted the **entire** daily release for every repository, not just the empty one.

## Fix

Guard the batch call with `if (payloads.length > 0)` while still marking the assignment `is_published: true`. This mirrors the pattern already used by the on-demand `releaseAssignmentsNowTask` (`packages/tasks/src/workflows/gitRepoAssignment.ts`), so the assignment still releases on schedule (later joiners are backfilled) — there is simply no empty GitHub batch to trigger.