### PR TITLE
fix(tokens): prevent null description from breaking token grants

### DIFF
--- a/apps/webapp/app/routes/admin.$class.tokens.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.tokens.new/route.tsx
@@ -286,7 +286,8 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
           student: typeof student === 'string' ? JSON.parse(student) : student,
           classroomId: classroom.id,
           amount: parseInt(num_tokens, 10),
-          description: description || null,
+          // Omit when blank; sending null breaks the non-nullable description column.
+          description: description || undefined,
         },
         options: {
           tags: [`session_${sessionId}`],

--- a/packages/services/src/classmoji/token.service.ts
+++ b/packages/services/src/classmoji/token.service.ts
@@ -63,6 +63,10 @@ export const updateExtension = async (data: UpdateExtensionInput) => {
       data: {
         ...(data as Prisma.TokenTransactionUncheckedCreateInput),
         balance_after: newBalance,
+        // `description` is non-nullable (@default('')); coalesce a possibly-null value from
+        // the spread so it can't trigger Prisma's misleading "Argument `classroom` is
+        // missing" error (same guard as assignToStudent).
+        description: (data.description as string | null | undefined) ?? '',
       },
     });
   });
@@ -108,7 +112,10 @@ export const assignToStudent = async (data: AssignToStudentInput) => {
         balance_after: newBalance,
         student_id: data.studentId,
         classroom_id: data.classroomId,
-        description: data.description,
+        // `description` is a non-nullable column (@default('')). A null here makes
+        // Prisma's create validation fail with a misleading "Argument `classroom`
+        // is missing", so coalesce null/undefined to an empty string.
+        description: data.description ?? '',
         git_repo_assignment_id: data.repositoryAssignmentId,
       },
     });


### PR DESCRIPTION
## Summary

Fixes an intermittent `PrismaClientValidationError` in the `assign_tokens_to_student` Trigger.dev task that aborts token grants when an admin grants tokens **without** typing a description.

The production error was misleading — it read `Argument \`classroom\` is missing` — but the real cause is a **`null` value sent for the non-nullable `description` column**.

## Root cause (confirmed against production + reproduced locally)

I pulled the actual prod run payloads for task `assign_tokens_to_student` on worker `v20260701.1`. Same task, same worker version, same student/classroom/amount — the **only** differing field decides success:

| `description` in payload | Result |
| --- | --- |
| `"Starting tokens"` (admin typed one) | ✅ created |
| `null` (admin left it blank) | ❌ `PrismaClientValidationError: Argument \`classroom\` is missing` |

`token_transactions.description` is `String @default("")` — **non-nullable**. Passing `null` to a non-nullable field breaks Prisma's `XOR<CreateInput, UncheckedCreateInput>` input disambiguation, and Prisma reports the confusing *"Argument `classroom` is missing"* instead of a clear "description cannot be null".

Reproduced locally on the exact client (Prisma **6.19.2**) against a live DB:
- `description: null` → throws the exact prod error
- `description: ''` and `description: undefined` → validation passes

**Origin of the null:** `apps/webapp/app/routes/admin.$class.tokens.new/route.tsx` built the payload with `description: description || null`, so a blank form field became `null`, which flowed through the task → `assignToStudent` → `tokenTransaction.create()`.

## The fix

Defense-in-depth at the two natural choke points:

1. **Service boundary** (`packages/services/src/classmoji/token.service.ts`, `assignToStudent`) — coalesce to a valid string so no caller can ever send `null` into the non-nullable column:
   ```diff
   -        description: data.description,
   +        description: data.description ?? '',
   ```
2. **Source** (`admin.$class.tokens.new/route.tsx`) — stop manufacturing `null`; omit blank descriptions so the DB default applies:
   ```diff
   -          description: description || null,
   +          description: description || undefined,
   ```
3. **Sibling create site** (`token.service.ts`, `updateExtension`) — same file spreads raw caller data into `create()`; added the same coalesce guard so the two token-transaction create sites can't drift into the identical bug (latent today — all current callers pass a non-null string — but hardened defensively):
   ```diff
   +        description: (data.description as string | null | undefined) ?? '',
   ```

Either of the first two edits alone fixes the reported crash; together they fix the root, harden the service boundary, and close the latent twin.

## Review

Reviewed with a multi-agent adversarial pass (correctness / completeness / regression / Prisma-semantics + adjudication). Verdict: **ship** — fix confirmed correct and complete for the incident, `?? ''` correctly covers both `null` and `undefined`, no regressions. The `updateExtension` hardening (edit 3) was the one substantive suggestion and is included here.

## Verification

- **Reproduced + fixed** on Prisma 6.19.2 against a live DB (see table above): the fixed values (`''`, omitted) pass validation.
- **Typecheck**: `@classmoji/services` `tsc --noEmit` passes.
- Audited the other `tokenTransaction.create` sites (`registration`, `exampleClassroom.service.ts`, seed) — they omit `description` entirely and rely on `@default("")`, so they were never affected.

## Deploy / monitoring

Merging to `staging` retriggers the `deploy-trigger` GitHub Actions job (the change touches `packages/services/**` and `packages/tasks` is bundled), which redeploys the Trigger.dev **staging** worker with the fix. After deploy I'll confirm new `assign_tokens_to_student` runs with a blank description succeed.

## Test plan

- [ ] Admin grants tokens to a student **with no description** → task completes, transaction row created with `description = ''`.
- [ ] Admin grants tokens **with** a description → unchanged (description stored).
