### PR TITLE
fix: close regrade/token-extension authz holes and data-linkage bugs

### DIFF
--- a/apps/webapp/app/routes/api.$operation/route.ts
+++ b/apps/webapp/app/routes/api.$operation/route.ts
@@ -93,9 +93,55 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
 
   return namedAction(request, {
     async updateRegradeRequest() {
+      // Authorization is derived from the RegradeRequest record itself, never
+      // from ids in the request body. Load the request, resolve its classroom,
+      // then require the teaching team — assistants resolve regrades from their
+      // queue, so ASSISTANT is included alongside OWNER/TEACHER.
+      const requestId = body?.request?.id;
+      if (typeof requestId !== 'string' || !requestId) {
+        return data({ error: 'request.id is required' }, { status: 400 });
+      }
+
+      const [regradeRequest] = await ClassmojiService.regradeRequest.findMany({
+        id: requestId,
+      });
+
+      if (!regradeRequest) {
+        return data({ error: 'Regrade request not found' }, { status: 404 });
+      }
+
+      const classroom = await ClassmojiService.classroom.findById(regradeRequest.classroom_id);
+
+      if (!classroom) {
+        return data({ error: 'Classroom not found' }, { status: 404 });
+      }
+
+      await assertClassroomAccess({
+        request,
+        classroomSlug: classroom.slug,
+        allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
+        resourceType: 'REGRADE_REQUEST',
+        attemptedAction: 'update_regrade_request',
+        metadata: {
+          regrade_request_id: regradeRequest.id,
+        },
+      });
+
       try {
+        // Re-derive the task payload from the DB record so the status update and
+        // the resolution email use trusted values, not client-supplied ones.
         const run = await tasks.trigger('update_regrade_request', {
-          request: body.request,
+          request: {
+            id: regradeRequest.id,
+            student: {
+              email: regradeRequest.student?.email,
+            },
+            git_repo_assignment: {
+              assignment: {
+                title: regradeRequest.git_repo_assignment?.assignment?.title,
+              },
+            },
+          },
           data: {
             status: body.status,
           },

--- a/apps/webapp/app/routes/api.extension.$class/route.ts
+++ b/apps/webapp/app/routes/api.extension.$class/route.ts
@@ -1,9 +1,16 @@
 import { namedAction } from 'remix-utils/named-action';
 import { tasks } from '@trigger.dev/sdk';
 
+import { ClassmojiService } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import { assertClassroomAccess, waitForRunCompletion, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
+
+// TokenTransaction has no `status` column; this endpoint's status is only used
+// to label the notification email. Bound it to a known, closed set (mirrors the
+// RegradeRequestStatus workflow) so the request body cannot inject arbitrary
+// text into the email that is sent to the student.
+const ALLOWED_EXTENSION_STATUSES = ['IN_REVIEW', 'APPROVED', 'DENIED'];
 
 export const loader = async () => {
   return null;
@@ -15,20 +22,69 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async createExtension() {
+      const repositoryAssignmentId = data.repositoryAssignmentId ?? data.git_repo_assignment_id;
+
       const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
         resourceType: 'EXTENSION',
         attemptedAction: 'create_extension',
-        metadata: { student_id: data.student_id, hours: data.hours },
+        metadata: { repository_assignment_id: repositoryAssignmentId, hours: data.hours },
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
+      // Treat the request body as ids only. Price, target student, and classroom
+      // are all re-derived from the DB so a crafted body cannot mint tokens,
+      // set its own price, or write into another classroom.
+      if (typeof repositoryAssignmentId !== 'string' || !repositoryAssignmentId) {
+        return {
+          action: ActionTypes.REQUEST_EXTENSION,
+          error: 'Missing repository assignment ID.',
+        };
+      }
+
+      const hours = Number(data.hours);
+      if (!Number.isInteger(hours) || hours <= 0) {
+        return {
+          action: ActionTypes.REQUEST_EXTENSION,
+          error: 'Invalid hours: must be a positive whole number.',
+        };
+      }
+
+      const repoAssignment = await ClassmojiService.gitRepoAssignment.findById(repositoryAssignmentId);
+      if (!repoAssignment || repoAssignment.git_repo?.classroom_id !== classroom.id) {
+        return {
+          action: ActionTypes.REQUEST_EXTENSION,
+          error: 'Repository assignment not found.',
+        };
+      }
+
+      // Token transactions are per-student; team repositories have no single
+      // owner to charge, so extensions are only valid on individual repos.
+      const studentId = repoAssignment.git_repo?.student_id;
+      if (!studentId) {
+        return {
+          action: ActionTypes.REQUEST_EXTENSION,
+          error: 'Extensions can only be granted on individual student repositories.',
+        };
+      }
+
+      const tokensPerHour = repoAssignment.assignment?.tokens_per_hour ?? 0;
+      if (tokensPerHour <= 0) {
+        return {
+          action: ActionTypes.REQUEST_EXTENSION,
+          error: 'Token cost is not configured for this assignment.',
+        };
+      }
+
       try {
         const run = await tasks.trigger('request_extension', {
-          classroom,
-          ...data,
+          classroomId: classroom.id,
+          studentId,
+          repositoryAssignmentId: repoAssignment.id,
+          hours,
+          tokensPerHour,
         });
 
         await waitForRunCompletion(run.id);
@@ -47,19 +103,57 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async updateExtension() {
+      const transactionId = data.transactionId ?? data.transaction_id;
+
       const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
         resourceType: 'EXTENSION',
         attemptedAction: 'update_extension',
-        metadata: { extension_id: data.extension_id },
+        metadata: { transaction_id: transactionId },
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
+      if (typeof transactionId !== 'string' || !transactionId) {
+        return {
+          action: ActionTypes.UPDATE_EXTENSION,
+          error: 'Missing transaction ID.',
+        };
+      }
+
+      const status = typeof data.status === 'string' ? data.status.toUpperCase() : '';
+      if (!ALLOWED_EXTENSION_STATUSES.includes(status)) {
+        return {
+          action: ActionTypes.UPDATE_EXTENSION,
+          error: 'Invalid extension status.',
+        };
+      }
+
+      // Load the transaction and confirm it belongs to the authorized classroom
+      // before mutating it. The notification email fields are read from trusted
+      // DB records, never from the request body.
+      const [transaction] = await ClassmojiService.token.findTransactions({ id: transactionId });
+      if (!transaction || transaction.classroom_id !== classroom.id) {
+        return {
+          action: ActionTypes.UPDATE_EXTENSION,
+          error: 'Extension transaction not found.',
+        };
+      }
+
       try {
         const run = await tasks.trigger('update_extension', {
-          ...data,
+          transactionId: transaction.id,
+          status,
+          student: {
+            login: transaction.student?.login ?? '',
+            email: transaction.student?.email ?? undefined,
+          },
+          gitRepoAssignment: {
+            assignment: {
+              title: transaction.git_repo_assignment?.assignment?.title,
+            },
+          },
         });
 
         await waitForRunCompletion(run.id);

--- a/apps/webapp/app/routes/student.$class.assignments/route.tsx
+++ b/apps/webapp/app/routes/student.$class.assignments/route.tsx
@@ -199,11 +199,9 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
-      if (!data.hours_purchased || data.hours_purchased <= 0) {
-        throw new Error('Invalid hours: Must be a positive number.');
-      }
-      if (!data.amount || data.amount >= 0) {
-        throw new Error('Invalid amount: Token spending amount must be negative.');
+      const hoursPurchased = Number(data.hours_purchased);
+      if (!Number.isInteger(hoursPurchased) || hoursPurchased <= 0) {
+        throw new Error('Invalid hours: Must be a positive whole number.');
       }
       if (!data.git_repo_assignment_id) {
         throw new Error('Missing repository assignment ID.');
@@ -212,7 +210,68 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         throw new Error('Invalid classroom ID.');
       }
 
-      await ClassmojiService.token.updateExtension(data);
+      // Load the assignment from the DB. Price and eligibility are recomputed
+      // server-side -- the client-supplied `amount` is never trusted, and the
+      // deadline / late-hour / override gates from the popover are re-enforced
+      // here so they cannot be bypassed by posting a crafted request body.
+      const repoAssignment = await ClassmojiService.gitRepoAssignment.findById(
+        data.git_repo_assignment_id
+      );
+      if (!repoAssignment || repoAssignment.git_repo?.classroom_id !== classroom.id) {
+        throw new Error('Repository assignment not found.');
+      }
+      if (repoAssignment.is_late_override) {
+        throw new Error('Extensions are unavailable: a late override is in effect.');
+      }
+
+      const tokensPerHour = repoAssignment.assignment?.tokens_per_hour ?? 0;
+      if (tokensPerHour <= 0) {
+        throw new Error('Token cost not configured for this assignment.');
+      }
+
+      const deadlineMs = repoAssignment.assignment?.student_deadline
+        ? new Date(repoAssignment.assignment.student_deadline).getTime()
+        : null;
+      if (deadlineMs === null || deadlineMs >= Date.now()) {
+        throw new Error('The deadline for this assignment has not passed yet.');
+      }
+
+      // Mirror the popover's num_late_hours cap: hours past the deadline minus
+      // hours already purchased. Only OPEN submissions can accrue late hours.
+      const purchaseTransactions = await ClassmojiService.token.findTransactions({
+        git_repo_assignment_id: repoAssignment.id,
+        student_id: data.student_id,
+        type: 'PURCHASE',
+      });
+      const alreadyPurchasedHours = purchaseTransactions.reduce(
+        (sum, t) => sum + (t.hours_purchased ?? 0),
+        0
+      );
+      const hoursPastDeadline = Math.max(0, Math.ceil((Date.now() - deadlineMs) / 3_600_000));
+      const numLateHours =
+        repoAssignment.status === 'OPEN'
+          ? Math.max(0, hoursPastDeadline - alreadyPurchasedHours)
+          : 0;
+
+      if (numLateHours <= 0) {
+        throw new Error('No purchasable late hours remain for this assignment.');
+      }
+      if (hoursPurchased > numLateHours) {
+        throw new Error(
+          `You can purchase at most ${numLateHours} more late hour(s) for this assignment.`
+        );
+      }
+
+      // Recompute the price; the balance check still runs inside updateExtension.
+      await ClassmojiService.token.updateExtension({
+        classroom_id: classroom.id,
+        student_id: data.student_id,
+        git_repo_assignment_id: repoAssignment.id,
+        amount: -(tokensPerHour * hoursPurchased),
+        hours_purchased: hoursPurchased,
+        type: 'PURCHASE',
+        description: `Purchase of ${hoursPurchased} hour(s).`,
+      });
       return {
         action: 'PURCHASE_EXTENSION_HOURS',
         success: 'Successfully purchased hour(s).',

--- a/packages/services/src/classmoji/__tests__/classroomMembership.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroomMembership.service.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The membership mutation paths (remove/removeById/update/updateById) must never
+// leave a classroom with zero OWNERs. We mock the Prisma client so we can drive
+// the owner count and assert the guard fires (or stays out of the way) exactly
+// when it should.
+const findFirstMock = vi.fn();
+const findUniqueMock = vi.fn();
+const countMock = vi.fn();
+const updateMock = vi.fn();
+const deleteManyMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    classroomMembership: {
+      findFirst: (...args: unknown[]) => findFirstMock(...args),
+      findUnique: (...args: unknown[]) => findUniqueMock(...args),
+      count: (...args: unknown[]) => countMock(...args),
+      update: (...args: unknown[]) => updateMock(...args),
+      deleteMany: (...args: unknown[]) => deleteManyMock(...args),
+      delete: (...args: unknown[]) => deleteMock(...args),
+    },
+  }),
+}));
+
+const LAST_OWNER_ERROR = 'Cannot remove the last owner of a classroom';
+
+const membershipService = await import('../classroomMembership.service.ts');
+
+beforeEach(() => {
+  findFirstMock.mockReset();
+  findUniqueMock.mockReset();
+  countMock.mockReset();
+  updateMock.mockReset();
+  deleteManyMock.mockReset();
+  deleteMock.mockReset();
+
+  updateMock.mockResolvedValue({ id: 'm1' });
+  deleteManyMock.mockResolvedValue({ count: 1 });
+  deleteMock.mockResolvedValue({ id: 'm1' });
+});
+
+describe('remove', () => {
+  it('throws when removing the last owner', async () => {
+    findFirstMock.mockResolvedValue({ id: 'm1', role: 'OWNER' });
+    countMock.mockResolvedValue(1);
+
+    await expect(membershipService.remove('c1', 'u1')).rejects.toThrow(LAST_OWNER_ERROR);
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it('allows removing an owner when another owner remains', async () => {
+    findFirstMock.mockResolvedValue({ id: 'm1', role: 'OWNER' });
+    countMock.mockResolvedValue(2);
+
+    await membershipService.remove('c1', 'u1');
+    expect(deleteManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows removing a non-owner without counting owners', async () => {
+    findFirstMock.mockResolvedValue(null);
+
+    await membershipService.remove('c1', 'u1');
+    expect(countMock).not.toHaveBeenCalled();
+    expect(deleteManyMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('removeById', () => {
+  it('throws when removing the last owner', async () => {
+    findUniqueMock.mockResolvedValue({ id: 'm1', role: 'OWNER', classroom_id: 'c1' });
+    countMock.mockResolvedValue(1);
+
+    await expect(membershipService.removeById('m1')).rejects.toThrow(LAST_OWNER_ERROR);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('allows removing a non-owner without counting owners', async () => {
+    findUniqueMock.mockResolvedValue({ id: 'm1', role: 'STUDENT', classroom_id: 'c1' });
+
+    await membershipService.removeById('m1');
+    expect(countMock).not.toHaveBeenCalled();
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('update', () => {
+  it('throws when demoting the last owner', async () => {
+    findFirstMock.mockResolvedValue({ id: 'm1', role: 'OWNER' });
+    countMock.mockResolvedValue(1);
+
+    await expect(membershipService.update('c1', 'u1', { role: 'ASSISTANT' })).rejects.toThrow(
+      LAST_OWNER_ERROR
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('allows a non-role update on the last owner', async () => {
+    findFirstMock.mockResolvedValue({ id: 'm1', role: 'OWNER' });
+
+    await membershipService.update('c1', 'u1', { is_grader: true });
+    expect(countMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the membership does not exist', async () => {
+    findFirstMock.mockResolvedValue(null);
+
+    const result = await membershipService.update('c1', 'u1', { role: 'ASSISTANT' });
+    expect(result).toBeNull();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateById', () => {
+  it('throws when demoting the last owner', async () => {
+    findUniqueMock.mockResolvedValue({ id: 'm1', role: 'OWNER', classroom_id: 'c1' });
+    countMock.mockResolvedValue(1);
+
+    await expect(membershipService.updateById('m1', { role: 'TEACHER' })).rejects.toThrow(
+      LAST_OWNER_ERROR
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('handles the { set } role update form', async () => {
+    findUniqueMock.mockResolvedValue({ id: 'm1', role: 'OWNER', classroom_id: 'c1' });
+    countMock.mockResolvedValue(1);
+
+    await expect(
+      membershipService.updateById('m1', { role: { set: 'ASSISTANT' } })
+    ).rejects.toThrow(LAST_OWNER_ERROR);
+  });
+
+  it('allows a comment-only update without touching the owner guard', async () => {
+    await membershipService.updateById('m1', { comment: 'hello' });
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(countMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/helper.tokens.test.ts
+++ b/packages/services/src/classmoji/__tests__/helper.tokens.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// When a grade carries extra tokens, HelperService.assignTokensToStudent mints a
+// reward via token.assignToStudent. token.service reads `repositoryAssignmentId`
+// (mapping it to git_repo_assignment_id), so the helper must pass that exact key
+// -- a stale `gitRepoAssignmentId` key silently dropped the linkage and left
+// grade-minted transactions unattached to the assignment.
+const updateGradeMock = vi.fn();
+const assignToStudentMock = vi.fn();
+const findEmojiMappingsMock = vi.fn();
+
+vi.mock('../index.ts', () => ({
+  default: {
+    assignmentGrade: {
+      update: (...args: unknown[]) => updateGradeMock(...args),
+    },
+    token: {
+      assignToStudent: (...args: unknown[]) => assignToStudentMock(...args),
+    },
+    emojiMapping: {
+      findByClassroomId: (...args: unknown[]) => findEmojiMappingsMock(...args),
+    },
+  },
+}));
+
+// helper imports the git provider transitively; it is never exercised here.
+vi.mock('../../git/index.ts', () => ({ getGitProvider: () => ({}) }));
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+
+const { default: HelperService } = await import('../../helper/index.ts');
+
+const gitRepoAssignment = { id: 'gra-1', studentId: 'student-1', teamId: null };
+
+describe('assignTokensToStudent token linkage', () => {
+  beforeEach(() => {
+    updateGradeMock.mockReset();
+    assignToStudentMock.mockReset();
+    findEmojiMappingsMock.mockReset();
+
+    assignToStudentMock.mockResolvedValue({ id: 'tx-1' });
+    findEmojiMappingsMock.mockResolvedValue([{ emoji: '✅', extra_tokens: 5 }]);
+  });
+
+  it('passes repositoryAssignmentId so the transaction links to the assignment', async () => {
+    await HelperService.assignTokensToStudent(
+      {
+        organization: { id: 'class-1' },
+        gitRepoAssignment,
+        grade: '✅',
+        studentId: 'student-1',
+      },
+      { id: 'grade-1' }
+    );
+
+    expect(assignToStudentMock).toHaveBeenCalledTimes(1);
+    const payload = assignToStudentMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.repositoryAssignmentId).toBe('gra-1');
+    // The stale key that silently dropped the linkage must not reappear.
+    expect(payload.gitRepoAssignmentId).toBeUndefined();
+    // The grade row is linked back to the minted transaction.
+    expect(updateGradeMock).toHaveBeenCalledWith('grade-1', { token_transaction_id: 'tx-1' });
+  });
+
+  it('does not mint tokens when the grade carries no extra tokens', async () => {
+    findEmojiMappingsMock.mockResolvedValue([{ emoji: '✅', extra_tokens: 0 }]);
+
+    await HelperService.assignTokensToStudent(
+      {
+        organization: { id: 'class-1' },
+        gitRepoAssignment,
+        grade: '✅',
+        studentId: 'student-1',
+      },
+      { id: 'grade-1' }
+    );
+
+    expect(assignToStudentMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/token.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/token.service.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// token.assignToStudent mints the TokenTransaction rows that reward students for
+// grades. It must persist the git_repo_assignment_id so those rewards stay
+// linked to the submission that earned them. We mock the Prisma client so we can
+// assert exactly what row gets written.
+const createMock = vi.fn();
+const findFirstMock = vi.fn();
+
+vi.mock('@classmoji/database', () => {
+  const tokenTransaction = {
+    findFirst: (...args: unknown[]) => findFirstMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
+  };
+  return {
+    default: () => ({
+      tokenTransaction,
+      $transaction: (fn: (tx: { tokenTransaction: typeof tokenTransaction }) => unknown) =>
+        fn({ tokenTransaction }),
+    }),
+  };
+});
+
+const { assignToStudent } = await import('../token.service.ts');
+
+describe('token.assignToStudent', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    findFirstMock.mockReset();
+    findFirstMock.mockResolvedValue({ balance_after: 10 });
+    createMock.mockImplementation((args: { data: Record<string, unknown> }) => ({
+      id: 'tx-1',
+      ...args.data,
+    }));
+  });
+
+  it('persists git_repo_assignment_id from repositoryAssignmentId', async () => {
+    await assignToStudent({
+      classroomId: 'class-1',
+      studentId: 'student-1',
+      amount: 5,
+      description: 'Tokens for getting a ✅.',
+      repositoryAssignmentId: 'gra-1',
+    });
+
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const createArg = createMock.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createArg.data.git_repo_assignment_id).toBe('gra-1');
+    expect(createArg.data.balance_after).toBe(15);
+  });
+
+  it('leaves git_repo_assignment_id unset when no assignment id is provided', async () => {
+    await assignToStudent({
+      classroomId: 'class-1',
+      studentId: 'student-1',
+      amount: 5,
+    });
+
+    const createArg = createMock.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(createArg.data.git_repo_assignment_id).toBeUndefined();
+  });
+});

--- a/packages/services/src/classmoji/classroomMembership.service.ts
+++ b/packages/services/src/classmoji/classroomMembership.service.ts
@@ -9,6 +9,37 @@ interface ClassroomMembershipUpsertData {
   comment?: string | null;
 }
 
+const LAST_OWNER_ERROR = 'Cannot remove the last owner of a classroom';
+
+/**
+ * Resolve the target role from a Prisma update input, which may be a bare enum
+ * value or a `{ set }` wrapper. Returns undefined when the update leaves role
+ * untouched.
+ */
+const resolveRoleUpdate = (
+  roleInput: Prisma.ClassroomMembershipUpdateInput['role']
+): Role | undefined => {
+  if (typeof roleInput === 'string') return roleInput as Role;
+  if (roleInput && typeof roleInput === 'object' && 'set' in roleInput) {
+    return (roleInput as { set?: Role }).set ?? undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Guard against orphaning a classroom: throw when it would be left with zero
+ * OWNER memberships. Call before removing an OWNER membership or demoting one.
+ * @param {string} classroomId - UUID of the Classroom
+ */
+const assertNotLastOwner = async (classroomId: string): Promise<void> => {
+  const ownerCount = await getPrisma().classroomMembership.count({
+    where: { classroom_id: classroomId, role: 'OWNER' },
+  });
+  if (ownerCount <= 1) {
+    throw new Error(LAST_OWNER_ERROR);
+  }
+};
+
 /**
  * Find a membership by classroom and user
  * @param {string} classroomId - UUID of the Classroom
@@ -187,6 +218,12 @@ export const update = async (
     where: { classroom_id: classroomId, user_id: userId },
   });
   if (!membership) return null;
+
+  const newRole = resolveRoleUpdate(updates.role);
+  if (membership.role === 'OWNER' && newRole && newRole !== 'OWNER') {
+    await assertNotLastOwner(classroomId);
+  }
+
   return getPrisma().classroomMembership.update({
     where: { id: membership.id },
     data: updates,
@@ -204,6 +241,14 @@ export const update = async (
  * @returns {Promise<Object>}
  */
 export const updateById = async (id: string, updates: Prisma.ClassroomMembershipUpdateInput) => {
+  const newRole = resolveRoleUpdate(updates.role);
+  if (newRole && newRole !== 'OWNER') {
+    const membership = await getPrisma().classroomMembership.findUnique({ where: { id } });
+    if (membership?.role === 'OWNER') {
+      await assertNotLastOwner(membership.classroom_id);
+    }
+  }
+
   return getPrisma().classroomMembership.update({
     where: { id },
     data: updates,
@@ -221,6 +266,13 @@ export const updateById = async (id: string, updates: Prisma.ClassroomMembership
  * @returns {Promise<Object>}
  */
 export const remove = async (classroomId: string, userId: string) => {
+  const ownerMembership = await getPrisma().classroomMembership.findFirst({
+    where: { classroom_id: classroomId, user_id: userId, role: 'OWNER' },
+  });
+  if (ownerMembership) {
+    await assertNotLastOwner(classroomId);
+  }
+
   return getPrisma().classroomMembership.deleteMany({
     where: { classroom_id: classroomId, user_id: userId },
   });
@@ -232,6 +284,11 @@ export const remove = async (classroomId: string, userId: string) => {
  * @returns {Promise<Object>}
  */
 export const removeById = async (id: string) => {
+  const membership = await getPrisma().classroomMembership.findUnique({ where: { id } });
+  if (membership?.role === 'OWNER') {
+    await assertNotLastOwner(membership.classroom_id);
+  }
+
   return getPrisma().classroomMembership.delete({
     where: { id },
   });

--- a/packages/services/src/helper/index.ts
+++ b/packages/services/src/helper/index.ts
@@ -239,7 +239,7 @@ class HelperService {
         studentId: payload.studentId,
         amount: emoji.extra_tokens,
         description: `Tokens for getting a ${grade}.`,
-        gitRepoAssignmentId: gitRepoAssignment.id,
+        repositoryAssignmentId: gitRepoAssignment.id,
       };
 
       const tokenTransaction = await ClassmojiService.token.assignToStudent(data);
@@ -276,7 +276,7 @@ class HelperService {
           studentId: membership.user_id,
           amount: emoji.extra_tokens,
           description: `Tokens for getting a ${grade}.`,
-          gitRepoAssignmentId: gitRepoAssignment.id,
+          repositoryAssignmentId: gitRepoAssignment.id,
         };
 
         const tokenTransaction = await ClassmojiService.token.assignToStudent(data);
@@ -310,7 +310,7 @@ class HelperService {
         studentId,
         amount: grade.token_transaction.amount * -1,
         description: `Removing ${grade.emoji}.`,
-        gitRepoAssignmentId: gitRepoAssignment.id,
+        repositoryAssignmentId: gitRepoAssignment.id,
         type: 'REMOVAL',
       };
 
@@ -325,7 +325,7 @@ class HelperService {
           studentId: membership.user_id,
           amount: grade.token_transaction.amount * -1,
           description: `Removing ${grade.emoji}.`,
-          gitRepoAssignmentId: gitRepoAssignment.id,
+          repositoryAssignmentId: gitRepoAssignment.id,
           type: 'REMOVAL',
         };
 


### PR DESCRIPTION
## Context

These five bugs were surfaced during an MCP-server plan audit of the codebase and confirmed with file:line evidence. Each is fixed as its own commit. Three are critical authorization/financial holes; two are data-integrity issues. All service changes ship with unit tests; the full `packages/services` suite passes (103 tests).

## Fixes

### 1. Regrade approve/deny had no role check — CRITICAL (auth)
`apps/webapp/app/routes/api.$operation/route.ts`

`updateRegradeRequest` was gated only by `checkAuth` (any authenticated user), so **any logged-in user — including the student who filed the request — could approve/deny any regrade request in any classroom.** Now the action loads the `RegradeRequest` from the DB, resolves its classroom, and authorizes via `assertClassroomAccess({ allowedRoles: ['OWNER','TEACHER','ASSISTANT'] })` (teaching-team tier — assistants resolve regrades from their queue, matching the assistant view route's `requireClassroomTeachingTeam`). Authorization is derived from the DB record, never from ids in the request body; a missing/cross-classroom/nonexistent id now returns 400/404. The Trigger.dev task payload is rebuilt from trusted DB values (which also repairs the resolution email, whose `student.email`/`assignment.title` were previously undefined because the client body never carried them).

### 2. Token extension purchase trusted client-supplied price — CRITICAL (financial)
`apps/webapp/app/routes/student.$class.assignments/route.tsx`

`purchaseExtensionHours` passed the client-supplied `amount` straight to `token.updateExtension`, and the deadline/late-hours/override gates lived **only** in `TokenExtensionPopover.tsx`. A student could POST `hours_purchased: 100, amount: -1` to buy 100 hours for 1 token. The action now:
- loads the assignment via `gitRepoAssignment.findById` and recomputes `amount = -(tokens_per_hour × hours_purchased)`, ignoring the client amount;
- re-enforces the popover's eligibility server-side: deadline must have passed, `is_late_override` rejects, and `hours_purchased` may not exceed the remaining purchasable late hours (`num_late_hours` = hours past deadline − already-purchased hours, OPEN only);
- verifies the assignment belongs to the authorized classroom;
- keeps the existing self-access + classroom checks; the negative-balance check still runs inside `updateExtension`.

### 3. Teacher-side extension endpoint trusted the request body — CRITICAL (financial + email forgery)
`apps/webapp/app/routes/api.extension.$class/route.ts`

The staff-path counterpart to #2. `createExtension` and `updateExtension` were authorized for the URL's classroom (`assertClassroomAccess({ allowedRoles: ['OWNER','TEACHER'] })`) but then forwarded the raw request body to the `request_extension` / `update_extension` Trigger.dev tasks (`{ classroom, ...data }` / `{ ...data }`). A crafted body could:
- set its own `tokensPerHour`, mispricing the extension;
- name any `classroomId` / `studentId` / `repositoryAssignmentId`, writing token transactions into another classroom or to another student;
- pass negative `hours`, which mints tokens instead of charging them;
- flip the `status` of any `transactionId` with no classroom check; and
- drive `update_extension`'s success email — a client-supplied `student.email` plus client strings interpolated into the HTML body — an email-forgery primitive.

Both actions now treat the body as ids only and re-derive everything from the DB:
- **createExtension** loads the `GitRepoAssignment` (`gitRepoAssignment.findById`), verifies its repo's `classroom_id === classroom.id`, requires a positive integer `hours`, derives `tokensPerHour` from the assignment and `studentId` from the repo (rejecting team repos, which have no single owner to charge), and builds the task payload explicitly — no `...data` spread.
- **updateExtension** loads the `TokenTransaction` (`token.findTransactions`), verifies its `classroom_id === classroom.id`, bounds `status` to a closed set, and derives the notification email's login/email/assignment title from DB records rather than the body.

### 4. Grade-token transactions lost assignment linkage — data integrity
`packages/services/src/helper/index.ts`

`HelperService` passed `gitRepoAssignmentId` in the token payload, but `token.assignToStudent` reads `repositoryAssignmentId` to populate `git_repo_assignment_id` — so every grade-minted `TokenTransaction` was written with `git_repo_assignment_id = null`. Aligned the helper's four payloads on `repositoryAssignmentId` (the key the service reads, and the name already declared on `AssignToStudentInput`). The only other caller, `packages/tasks/src/workflows/token.ts` (`assign_tokens_to_student`), passes no assignment id and is unaffected — so fixing the helper is the minimal-churn alignment. Added `token.service.test.ts` (service persists the id) and `helper.tokens.test.ts` (grade path passes the right key).

### 5. No last-OWNER protection — data integrity
`packages/services/src/classmoji/classroomMembership.service.ts`

`remove`/`removeById`/`update`/`updateById` were bare Prisma calls; nothing prevented deleting or demoting a classroom's only OWNER and orphaning it. Added a service-layer guard (`assertNotLastOwner`) that counts remaining OWNER memberships and throws `Cannot remove the last owner of a classroom` when the mutation would leave zero. Removals load the membership first to learn its role; role updates only trigger the check on an `OWNER → non-OWNER` demotion (handling both the bare-enum and `{ set }` update forms), so `comment`/`letter_grade`/`is_grader`/`has_accepted_invite` updates — the only role-less updates the current callers make (`admin.$class.assistants`, `admin.$class.grades`, `organization.ts`) — are unaffected. A thrown service error surfaces as a 400/500 in the callers, which is acceptable; no new UI. Added `classroomMembership.service.test.ts` (11 cases across all four paths).

## Test steps
- `cd packages/services && npx vitest run` — 103 passed (19 files), including the 3 new/extended specs above.
- `packages/services`: `tsc --noEmit` clean; `eslint` clean on all touched files.
- `apps/webapp`: touched route files produce no type errors and no new lint/prettier violations (pre-existing repo-wide prettier drift and `+types/route` module errors on unrelated lines left untouched to keep the diff focused).
- Not run: Playwright e2e; no DB migrations/seeds; no `npm install` / lockfile changes.

## Audit notes
- **Other `api.$operation` actions were audited and are correctly gated.** `cancelTokenTransaction` and `deleteRepositories` already gate via `assertClassroomAccess` (deriving the classroom from the DB record), and the loader's `get-org-subscription`/`get-user-by-id` enforce OWNER. `updateRegradeRequest` was the only ungated action — fixed in #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxqHNYzhSo6mpFwfcPY988
