### PR TITLE
chore(webapp): remove non-functional show grades toggle

### DIFF
--- a/apps/webapp/app/routes/admin.$class.settings.grades/GradingSettingsOptions.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.grades/GradingSettingsOptions.tsx
@@ -1,11 +1,9 @@
-import { useState } from 'react';
-import { Form, InputNumber, Button, Switch } from 'antd';
+import { Form, InputNumber, Button } from 'antd';
 
 import { useGlobalFetcher } from '~/hooks';
 import { SettingSection } from '~/components';
 
 interface GradingSettings {
-  show_grades_to_students: boolean;
   late_penalty_points_per_hour: number;
 }
 
@@ -15,15 +13,11 @@ interface GradingSettingsOptionsProps {
 
 const GradingSettingsOptions = ({ settings }: GradingSettingsOptionsProps) => {
   const { fetcher } = useGlobalFetcher();
-  const [showGradesToStudents, setShowGradesToStudents] = useState(
-    settings.show_grades_to_students
-  );
 
   const onFinish = (values: { late_penalty_points_per_hour: number }) => {
     fetcher!.submit(
       {
         late_penalty_points_per_hour: values.late_penalty_points_per_hour,
-        show_grades_to_students: showGradesToStudents,
       },
       {
         action: '?/saveGradingSettings',
@@ -48,15 +42,6 @@ const GradingSettingsOptions = ({ settings }: GradingSettingsOptionsProps) => {
       >
         <Form.Item label="Late penalty points per hour" name="late_penalty_points_per_hour">
           <InputNumber className="w-full" min={0} />
-        </Form.Item>
-
-        <Form.Item label="Show grades to students" name="show_grades_to_students">
-          <Switch
-            checked={showGradesToStudents}
-            onChange={value => {
-              setShowGradesToStudents(value);
-            }}
-          />
         </Form.Item>
 
         <Form.Item label={null}>


### PR DESCRIPTION
## Summary
- The "Show grades to students" toggle on the classroom grading settings page saved `show_grades_to_students`, but no student-facing code ever reads that flag (verified by repo-wide grep) — the toggle was decorative.
- Grade visibility is governed solely by per-assignment `grades_released`.
- Removed the dead Switch form item, the `showGradesToStudents` state, the field from the submitted payload, and the field from the `GradingSettings` interface in `GradingSettingsOptions.tsx`. The late-penalty field is untouched.
- The route's action generically persists whatever payload it receives (`ClassmojiService.classroom.updateSettings(classroom.id, data)`) — it does not explicitly whitelist `show_grades_to_students`, so no changes were needed there.
- The `show_grades_to_students` schema column is intentionally left in place; column removal is deferred to a future migration.

## Test plan
- [x] `npx tsc --noEmit` in `apps/webapp` — no errors introduced by this change (pre-existing `+types/route` module errors exist repo-wide, unrelated to this diff)
- [x] Confirmed no remaining references to `show_grades_to_students` / `showGradesToStudents` anywhere under `apps/webapp/`
- [ ] Manually verify the grading settings page renders correctly with the toggle removed and the late-penalty field still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxqHNYzhSo6mpFwfcPY988