### PR TITLE
fix(webapp): scope gitRepoAssignment actions to the authorized classroom

### DIFF
--- a/apps/webapp/app/routes/api.gitRepoAssignment.$class/route.ts
+++ b/apps/webapp/app/routes/api.gitRepoAssignment.$class/route.ts
@@ -1,3 +1,4 @@
+import { data as errorResponse } from 'react-router';
 import { namedAction } from 'remix-utils/named-action';
 
 import { tasks } from '@trigger.dev/sdk';
@@ -11,29 +12,62 @@ import {
 } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
+/**
+ * Load a GitRepoAssignment by id and confirm it belongs to `classroomId`.
+ *
+ * SECURITY: the request body is trusted only for the id — the record (and the
+ * classroom it belongs to) is derived from the DB. A caller authorized for one
+ * classroom must never be able to reach another classroom's submission by
+ * posting its id/object. Returns `null` on a missing id, a missing record, or a
+ * classroom mismatch so callers can respond with a 404.
+ */
+async function loadClassroomScopedGitRepoAssignment(id: unknown, classroomId: string) {
+  if (typeof id !== 'string' || !id) return null;
+  const record = await ClassmojiService.gitRepoAssignment.findById(id);
+  if (!record || record.git_repo?.classroom_id !== classroomId) return null;
+  return record;
+}
+
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
   const data = await request.json();
 
   return namedAction(request, {
     async autograde() {
-      const {
-        userId: _userId,
-        classroom,
-        membership,
-      } = await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
         resourceType: 'GIT_REPO_ASSIGNMENT',
         attemptedAction: 'autograde',
-        metadata: { workflowName: data.workflowName },
+        metadata: { repositoryId: data.repositoryId },
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
+      // Verify the repository the task will act on belongs to this classroom
+      // before triggering, and rebuild the payload explicitly — never spread the
+      // raw body into the task (which would let a caller target another
+      // classroom's repo or override the classroom slug).
+      const repositoryId = data.repositoryId;
+      const repository =
+        typeof repositoryId === 'string' && repositoryId
+          ? await ClassmojiService.repository.findById(repositoryId)
+          : null;
+
+      if (!repository || repository.classroom_id !== classroom.id) {
+        return errorResponse(
+          {
+            action: 'AUTOGRADE_GIT_REPO_ASSIGNMENT',
+            error: 'Repository not found for this classroom.',
+          },
+          { status: 404 }
+        );
+      }
+
       try {
         const run = await tasks.trigger('dispatch_autograde_workflow', {
-          ...data,
+          repositoryId,
+          classroomSlug: classSlug,
         });
 
         await waitForRunCompletion(run.id);
@@ -53,29 +87,49 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async addGrade() {
-      const {
-        userId: _userId,
-        classroom,
-        membership,
-      } = await assertClassroomAccess({
+      const { userId, classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
         resourceType: 'GIT_REPO_ASSIGNMENT',
         attemptedAction: 'add_grade',
-        metadata: { assignment_id: data.gitRepoAssignment?.assignment_id },
+        metadata: { git_repo_assignment_id: data.gitRepoAssignment?.id },
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
-      const { gitRepoAssignment, graderId, grade, studentId, teamId } = data;
+      const grade = data.grade;
+      if (typeof grade !== 'string' || grade.trim().length === 0) {
+        return errorResponse(
+          { action: ActionTypes.ADD_GRADE_TO_GIT_REPO_ASSIGNMENT, error: 'A grade is required.' },
+          { status: 400 }
+        );
+      }
+
+      // Trust only the id from the body; derive the record, its classroom, and
+      // the token recipient (student/team) from the DB.
+      const gitRepoAssignment = await loadClassroomScopedGitRepoAssignment(
+        data.gitRepoAssignment?.id,
+        classroom.id
+      );
+      if (!gitRepoAssignment) {
+        return errorResponse(
+          {
+            action: ActionTypes.ADD_GRADE_TO_GIT_REPO_ASSIGNMENT,
+            error: 'Submission not found for this classroom.',
+          },
+          { status: 404 }
+        );
+      }
 
       await HelperService.addGradeToGitRepoAssignment({
         classroom,
-        gitRepoAssignment,
-        graderId,
+        gitRepoAssignment: { id: gitRepoAssignment.id },
+        // The UI always grades as the signed-in user; use the authenticated id
+        // rather than a client-supplied graderId.
+        graderId: userId,
         grade,
-        studentId,
-        teamId,
+        studentId: gitRepoAssignment.git_repo.student_id ?? undefined,
+        teamId: gitRepoAssignment.git_repo.team_id ?? undefined,
       });
 
       return {
@@ -85,26 +139,62 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async removeGrade() {
-      const {
-        userId: _userId2,
-        classroom,
-        membership,
-      } = await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
         resourceType: 'GIT_REPO_ASSIGNMENT',
         attemptedAction: 'remove_grade',
-        metadata: { assignment_id: data.gitRepoAssignment?.assignment_id },
+        metadata: { git_repo_assignment_id: data.gitRepoAssignment?.id },
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
-      const { grade, gitRepoAssignment } = data;
+      const gitRepoAssignment = await loadClassroomScopedGitRepoAssignment(
+        data.gitRepoAssignment?.id,
+        classroom.id
+      );
+      if (!gitRepoAssignment) {
+        return errorResponse(
+          {
+            action: ActionTypes.REMOVE_GRADE_FROM_GIT_REPO_ASSIGNMENT,
+            error: 'Submission not found for this classroom.',
+          },
+          { status: 404 }
+        );
+      }
+
+      // Load the grade by id and confirm it belongs to the (classroom-verified)
+      // submission before deleting it / reversing tokens.
+      const gradeId = data.grade?.id;
+      if (typeof gradeId !== 'string' || !gradeId) {
+        return errorResponse(
+          {
+            action: ActionTypes.REMOVE_GRADE_FROM_GIT_REPO_ASSIGNMENT,
+            error: 'A grade is required.',
+          },
+          { status: 400 }
+        );
+      }
+
+      const gradeRecord = await ClassmojiService.assignmentGrade.findById(gradeId);
+      if (!gradeRecord || gradeRecord.git_repo_assignment_id !== gitRepoAssignment.id) {
+        return errorResponse(
+          {
+            action: ActionTypes.REMOVE_GRADE_FROM_GIT_REPO_ASSIGNMENT,
+            error: 'Grade not found for this submission.',
+          },
+          { status: 404 }
+        );
+      }
 
       await HelperService.removeGradeFromGitRepoAssignment({
         classroom,
-        gitRepoAssignment,
-        grade,
+        gitRepoAssignment: {
+          id: gitRepoAssignment.id,
+          studentId: gitRepoAssignment.git_repo.student_id ?? undefined,
+          teamId: gitRepoAssignment.git_repo.team_id ?? undefined,
+        },
+        grade: gradeRecord,
       });
 
       return {
@@ -114,11 +204,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
 
     async updateLateOverride() {
-      const {
-        userId: _userId3,
-        classroom,
-        membership,
-      } = await assertClassroomAccess({
+      const { classroom, membership } = await assertClassroomAccess({
         request,
         classroomSlug: classSlug,
         allowedRoles: ['OWNER', 'TEACHER'],
@@ -128,11 +214,26 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
       });
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
-      const { git_repo_assignment_id, is_late_override } = data;
+      const { is_late_override } = data;
+
+      const gitRepoAssignment = await loadClassroomScopedGitRepoAssignment(
+        data.git_repo_assignment_id,
+        classroom.id
+      );
+      if (!gitRepoAssignment) {
+        return errorResponse(
+          {
+            action: ActionTypes.UPDATE_LATE_OVERRIDE,
+            error: 'Submission not found for this classroom.',
+          },
+          { status: 404 }
+        );
+      }
+
       const message = is_late_override ? 'Added override' : 'Removed override';
 
-      await ClassmojiService.gitRepoAssignment.update(git_repo_assignment_id, {
-        is_late_override,
+      await ClassmojiService.gitRepoAssignment.update(gitRepoAssignment.id, {
+        is_late_override: Boolean(is_late_override),
       });
 
       return {
@@ -153,12 +254,30 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
       assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const { assignment_id, grades_released } = data;
+
+      // Load the assignment and verify it belongs to this classroom (via its
+      // repository) before flipping the release flag.
+      const assignment =
+        typeof assignment_id === 'string' && assignment_id
+          ? await ClassmojiService.assignment.findById(assignment_id)
+          : null;
+
+      if (!assignment || assignment.repository?.classroom_id !== classroom.id) {
+        return errorResponse(
+          {
+            action: ActionTypes.UPDATE_GRADE_RELEASE,
+            error: 'Assignment not found for this classroom.',
+          },
+          { status: 404 }
+        );
+      }
+
       const message = grades_released
         ? 'Grades released to students'
         : 'Grades hidden from students';
 
-      await ClassmojiService.assignment.update(assignment_id, {
-        grades_released,
+      await ClassmojiService.assignment.update(assignment.id, {
+        grades_released: Boolean(grades_released),
       });
 
       return {


### PR DESCRIPTION
## Summary

Found during the MCP-server plan audit (same series as #157).

`apps/webapp/app/routes/api.gitRepoAssignment.$class/route.ts` authorized the caller for the classroom named in the URL (`assertClassroomAccess` on the slug) but then trusted ids/objects taken straight from the request body. Because the handlers passed those body values into the services without ever checking they belong to the authorized classroom, a teaching-team member of classroom A could operate on classroom B's data by posting B's ids/objects. All five named actions were affected:

- **addGrade** (OWNER/TEACHER/ASSISTANT): passed the client-supplied `gitRepoAssignment` object + client `graderId`/`studentId`/`teamId` straight to `HelperService.addGradeToGitRepoAssignment`, which grades by `gitRepoAssignment.id` and mints bonus tokens to the client-named `studentId`/`teamId`. Cross-classroom grade insertion + token minting to an arbitrary user.
- **removeGrade** (same roles): passed client `gitRepoAssignment` + a client `grade` object to `HelperService.removeGradeFromGitRepoAssignment`, which deletes by `grade.id` and reverses tokens. Cross-classroom grade deletion + token reversal.
- **updateLateOverride** (OWNER/TEACHER): `gitRepoAssignment.update(git_repo_assignment_id, …)` on an unscoped body id.
- **updateGradeRelease** (OWNER/TEACHER): `assignment.update(assignment_id, { grades_released })` on an unscoped body id — release/hide grades on any classroom's assignment.
- **autograde** (OWNER/TEACHER): spread the raw body into `tasks.trigger('dispatch_autograde_workflow', { ...data })`, so a client could pass another classroom's `repositoryId` (and override `classroomSlug`).

## Fix pattern: derive from DB, verify classroom, never trust the body

Each action now uses the body only for ids, loads the target record from the DB with enough relations to reach its `classroom_id`, compares against the `classroom.id` returned by `assertClassroomAccess`, and returns a 404 on mismatch/not-found before any write. The services are still called with their existing signatures, now populated from DB-loaded records.

- **addGrade** — loads the `GitRepoAssignment` (`ClassmojiService.gitRepoAssignment.findById`, which includes `git_repo`), verifies `git_repo.classroom_id === classroom.id`, derives `studentId`/`teamId` from the DB `git_repo` (not the client), requires a non-empty emoji `grade`, and grades as the **authenticated `userId`** rather than a client `graderId`.
- **removeGrade** — verifies the `GitRepoAssignment`'s classroom, then loads the `AssignmentGrade` by id and confirms `git_repo_assignment_id` matches the verified submission before deleting / reversing tokens. Token recipient derived from the DB `git_repo`.
- **updateLateOverride** / **updateGradeRelease** — load + classroom-verify the `GitRepoAssignment` / `Assignment` (via its `repository.classroom_id`), then update by the verified id; booleans coerced with `Boolean(...)`.
- **autograde** — verifies `repositoryId` belongs to the classroom (`repository.classroom_id === classroom.id`) and rebuilds the task payload explicitly as `{ repositoryId, classroomSlug: classSlug }` — no `...data` spread, and the classroom slug comes from the authorized URL, not the body.

### graderId
The only caller of addGrade/removeGrade is `apps/webapp/app/components/features/grading/EmojiGrader.tsx`, which always sends `graderId: user!.id` (the signed-in user). The UI never grades on behalf of another grader, so the route now ignores the body value and uses the authenticated `userId`. (The separate "assign grader" feature — `admin.$class.repos_.$title/action.ts` `addGrader`/`removeGrader` — is a different endpoint and is untouched.)

## Scope / compatibility

- Changes are confined to the route layer, so this does **not** conflict with #157 (which touches `packages/services/src/helper/index.ts`). `HelperService` call signatures are unchanged.
- No new `tsc --noEmit` errors introduced in `apps/webapp` for the touched file (verified against the pre-change baseline).
- No schema/service changes; existing scoped lookups (`gitRepoAssignment.findById`, `assignmentGrade.findById`, `assignment.findById`, `repository.findById`) are reused.

## Test steps

1. As a teaching-team member of classroom A, attempt each action against classroom A's own submissions/assignments/repos — grades, late overrides, grade release, and autograde all work as before.
2. Craft a request to `/api/gitRepoAssignment/<A-slug>?action=…` carrying a `gitRepoAssignment`/`assignment_id`/`repositoryId`/`grade.id` that belongs to classroom B — each action now returns 404 ("… not found for this classroom") and performs no write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxqHNYzhSo6mpFwfcPY988