### PR TITLE
feat(site): add changelog page and nav link

### DIFF
--- a/apps/site/src/components/Header.astro
+++ b/apps/site/src/components/Header.astro
@@ -15,6 +15,7 @@ import GitHubStars from './GitHubStars.astro';
     <div class="hidden md:flex items-center gap-5">
       <a href="/docs" class="text-sm font-medium text-gray-600 hover:text-gray-900">Docs</a>
       <a href="/research" class="text-sm font-medium text-gray-600 hover:text-gray-900">Research</a>
+      <a href="/changelog" class="text-sm font-medium text-gray-600 hover:text-gray-900">Changelog</a>
       <a href="mailto:pape.sow.traore@dartmouth.edu?cc=tim.tregubov@dartmouth.edu&subject=Question%20about%20Classmoji" class="text-sm font-medium text-gray-600 hover:text-gray-900">Contact</a>
       <GitHubStars />
       <a
@@ -74,6 +75,7 @@ import GitHubStars from './GitHubStars.astro';
     <div class="max-w-6xl mx-auto px-6 py-4 flex flex-col gap-4">
       <a href="/docs" class="text-sm font-medium text-gray-600 hover:text-gray-900 py-1">Docs</a>
       <a href="/research" class="text-sm font-medium text-gray-600 hover:text-gray-900 py-1">Research</a>
+      <a href="/changelog" class="text-sm font-medium text-gray-600 hover:text-gray-900 py-1">Changelog</a>
       <a href="mailto:pape.sow.traore@dartmouth.edu?cc=tim.tregubov@dartmouth.edu&subject=Question%20about%20Classmoji" class="text-sm font-medium text-gray-600 hover:text-gray-900 py-1">Contact</a>
       <a
         href="https://app.classmoji.io"

--- a/apps/site/src/pages/changelog.astro
+++ b/apps/site/src/pages/changelog.astro
@@ -1,0 +1,56 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+
+// Add releases here, newest first.
+// Example entry:
+// { version: 'v1.2.0', date: 'March 24, 2026', title: 'What changed', description: 'Short summary.', tags: ['Feature'] }
+const entries = [];
+---
+
+<Layout title="Changelog - Classmoji" description="What's new in Classmoji: features, improvements, and fixes.">
+  <Header />
+
+  <section class="px-6 pt-32 pb-20">
+    <div class="max-w-3xl mx-auto">
+      <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-3">Changelog</h1>
+      <p class="text-lg text-gray-600 mb-10">New features, improvements, and fixes.</p>
+
+      {
+        entries.length === 0 ? (
+          <div class="rounded-2xl ring-1 ring-gray-200 p-10 text-center">
+            <p class="text-base font-medium text-gray-700">Nothing here yet</p>
+            <p class="text-sm text-gray-500 mt-1">Check back soon for the latest updates.</p>
+          </div>
+        ) : (
+          <ul class="space-y-4">
+            {entries.map(entry => (
+              <li class="rounded-2xl ring-1 ring-gray-200 p-6">
+                <div class="flex items-center gap-3 mb-2">
+                  <span class="text-xs font-semibold uppercase tracking-wide text-primary">
+                    {entry.version}
+                  </span>
+                  <span class="text-sm text-gray-500">{entry.date}</span>
+                </div>
+                <h2 class="text-lg font-semibold text-gray-900">{entry.title}</h2>
+                <p class="text-sm text-gray-600 mt-1">{entry.description}</p>
+                {entry.tags && (
+                  <div class="flex flex-wrap gap-2 mt-3">
+                    {entry.tags.map(tag => (
+                      <span class="text-xs font-medium text-gray-600 bg-gray-100 rounded-full px-2.5 py-0.5">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    </div>
+  </section>
+
+  <Footer />
+</Layout>


### PR DESCRIPTION
## What changed?

Adds a standalone `/changelog` screen to the marketing site (`apps/site`), alongside `research.astro`, using the shared `Layout` / `Header` / `Footer` shell and card styling. It renders a "Nothing here yet" empty state for now, with the entry-rendering markup already wired up (an `entries` array in the page frontmatter). Also adds a **Changelog** link to the desktop and mobile nav in `Header.astro`, between Research and Contact.

## Why?

The site previously had a changelog screen (a since-deleted Docusaurus docs repo, now past GitHub's 90-day restore window and not recoverable from git or web archives). This re-adds it as a first-class screen in the current Astro/Starlight site so we have a place to publish release notes again.

## Related Issue

N/A

## Screenshots (if UI changes)

**Light mode:**

Renders like the Research screen: nav with the new Changelog item, an `h1` "Changelog" + subtitle, and an empty-state card. (The public marketing site is light-mode only, matching `index.astro` / `research.astro`, so there is no dark variant.)

## How to test

1. `npm run site:dev` (the site app is not part of the default `npm run dev` stack).
2. Open http://localhost:4000/changelog — confirm the page renders with the empty state.
3. Confirm the **Changelog** link appears in both the desktop and mobile nav and routes to `/changelog`.

## Checklist

- [ ] Tests added/updated (if applicable) — n/a (static content page)
- [x] Dark mode support added (if UI changes) — n/a (marketing site is light-mode only)
- [ ] Documentation updated (if needed)
- [x] Ready for review

### Adding entries later

Push objects into the `entries` array at the top of `changelog.astro` (newest first): `{ version, date, title, description, tags }`. Can be converted to a `changelog` content collection (like the existing `blog`) in a follow-up if we want to maintain it from markdown files.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)