### PR TITLE
fix(services): scope student-repos query by classroom_id not slug

### DIFF
--- a/packages/services/src/classmoji/__tests__/user.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/user.service.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// findRepositoriesPerStudent builds two user.findMany queries. The isolation
+// invariant under test: the STUDENT query must scope by classroom_id, NOT slug.
+// Classroom.slug is unique only per git org (@@unique([git_org_id, slug])), so a
+// slug filter would match same-slug twin classrooms across DIFFERENT orgs and
+// leak another org's students + grades. We mock prisma and assert the where
+// clause the query is built with.
+const findManyMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({ user: { findMany: (...args: unknown[]) => findManyMock(...args) } }),
+}));
+
+const { findRepositoriesPerStudent } = await import('../user.service.ts');
+
+describe('findRepositoriesPerStudent — cross-org isolation', () => {
+  beforeEach(() => {
+    findManyMock.mockReset();
+    findManyMock.mockResolvedValue([]);
+  });
+
+  it('scopes the student query by classroom_id, not slug (no same-slug twin leak)', async () => {
+    const classroom = { id: 'classroom-A-id', slug: 'cs101-fall' };
+
+    await findRepositoriesPerStudent(classroom);
+
+    // First call = the student-repos query.
+    const studentQuery = findManyMock.mock.calls[0][0];
+    const membershipFilter = studentQuery.where.classroom_memberships.some;
+
+    // MUST filter by the resolved id...
+    expect(membershipFilter.classroom_id).toBe('classroom-A-id');
+    expect(membershipFilter.role).toBe('STUDENT');
+    // ...and MUST NOT reach across orgs via a bare slug.
+    expect(membershipFilter).not.toHaveProperty('classroom');
+    expect(JSON.stringify(studentQuery.where)).not.toContain('cs101-fall');
+  });
+});

--- a/packages/services/src/classmoji/user.service.ts
+++ b/packages/services/src/classmoji/user.service.ts
@@ -158,10 +158,15 @@ export const findRepositoriesPerStudent = async (classroom: StudentRepositoryCla
   };
 
   // 1. find student repos
+  // Scope by classroom_id, NOT slug: Classroom.slug is unique only per git org
+  // (@@unique([git_org_id, slug])), so a slug filter matches same-slug twin
+  // classrooms across DIFFERENT orgs and would leak another org's students +
+  // grades (cross-org isolation break). The team query below already scopes by
+  // classroom_id — keep both consistent.
   const studentWithRepos = await getPrisma().user.findMany({
     where: {
       classroom_memberships: {
-        some: { classroom: { slug: classroom.slug }, role: 'STUDENT' },
+        some: { classroom_id: classroom.id, role: 'STUDENT' },
       },
     },
     include: includeRepos,


### PR DESCRIPTION
`findRepositoriesPerStudent` filtered the student query by `classroom.slug`, while the sibling team query already scoped by `classroom.id`. Since `Classroom.slug` is unique only per git org (`@@unique([git_org_id, slug])`), the slug filter matched same-slug classrooms across different orgs — surfacing the wrong org's students in the class leaderboard (admin dashboard + MCP leaderboard resource) and the grades table.

Scopes the student query by `classroom_id` for correctness and consistency with the team query directly below it. Behavior is identical for classrooms with unique slugs; it only changes the same-slug-across-orgs case.

- Adds a regression test pinning the `classroom_id` scoping.
- Services suite 124 green; webapp typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)