### PR TITLE
fix(grades): scope student-repo grade computation to the classroom

### DIFF
--- a/apps/webapp/app/routes/admin.$class.grades/columns/studentGradeColumns.tsx
+++ b/apps/webapp/app/routes/admin.$class.grades/columns/studentGradeColumns.tsx
@@ -48,7 +48,9 @@ const createGradeColumn = ({
   ...(sorter && { sorter }),
   render: (student: StudentRecord) => {
     const grade = calculateGrade(student);
-    if (grade < 0) return null;
+    // `!(grade >= 0)` (not `grade < 0`) so a non-finite grade blanks the cell
+    // instead of falling through to a false `F` from calculateLetterGrade(NaN).
+    if (!(grade >= 0)) return null;
     return renderGrade(grade);
   },
 });

--- a/packages/services/src/classmoji/user.service.ts
+++ b/packages/services/src/classmoji/user.service.ts
@@ -144,6 +144,16 @@ export const deleteByLogin = async (login: string) => {
 export const findRepositoriesPerStudent = async (classroom: StudentRepositoryClassroomContext) => {
   const includeRepos = {
     git_repos: {
+      // Scope to THIS classroom. A user's `git_repos` relation spans every
+      // classroom they belong to (each student also has an auto-provisioned
+      // `example-<login>` course), so without this filter a student's repos
+      // from another classroom bleed into this classroom's grade computation —
+      // and that other classroom's grade emojis (e.g. the example course's ⭐)
+      // aren't in THIS classroom's EmojiMapping, so convertEmojiToNumber
+      // returns undefined and NaN-poisons the student's entire final grade
+      // (surfaces as a false `F` on the grades table / `null` on leaderboards).
+      // Applies to both the student-owned query and the team query below.
+      where: { classroom_id: classroom.id },
       include: {
         repository: true,
         assignments: {

--- a/packages/utils/src/__tests__/grades.test.ts
+++ b/packages/utils/src/__tests__/grades.test.ts
@@ -67,6 +67,13 @@ describe('calculateNumericGrade', () => {
   it('averages emoji grades', () => {
     expect(calculateNumericGrade(['heart', 'eyes'], EMOJI_MAP)).toBe(90);
   });
+
+  it('ignores emojis not in the scale instead of producing NaN', () => {
+    // '⭐' belongs to a different classroom's scale (regression: a foreign repo
+    // bled in and NaN-poisoned the whole grade). It must be dropped, not averaged.
+    expect(calculateNumericGrade(['⭐'], EMOJI_MAP)).toBe(0);
+    expect(calculateNumericGrade(['heart', '⭐'], EMOJI_MAP)).toBe(100);
+  });
 });
 
 describe('applyLatePenalty', () => {
@@ -186,6 +193,21 @@ describe('calculateStudentFinalGrade', () => {
     ];
     // base 80 + extra (100 * 5/100) = 80 + 5 = 85
     expect(calculateStudentFinalGrade(repos, EMOJI_MAP, NO_PENALTY, true)).toBe(85);
+  });
+
+  it('does not let an unrecognized emoji NaN-poison the whole final grade', () => {
+    // Regression: a repo whose grade uses an emoji from ANOTHER classroom's
+    // scale ('⭐') must not turn a finite grade into NaN (which serialized to
+    // `null` on leaderboards and rendered as a false `F` on the grades table).
+    const repos: GitRepo[] = [
+      repo([ra({ grades: [{ emoji: 'heart' }] })], mod({ weight: 50 })),
+      repo([ra({ id: 'foreign', grades: [{ emoji: '⭐' }] })], mod({ weight: 50 })),
+    ];
+    const grade = calculateStudentFinalGrade(repos, EMOJI_MAP, NO_PENALTY);
+    expect(Number.isFinite(grade)).toBe(true);
+    expect(Number.isNaN(grade)).toBe(false);
+    // heart=100 (weight 50) + foreign-repo-drops-to-0 (weight 50) = 50
+    expect(grade).toBe(50);
   });
 });
 

--- a/packages/utils/src/grades.ts
+++ b/packages/utils/src/grades.ts
@@ -92,9 +92,14 @@ export const calculateStudentFinalGrade = (
 
   if (totalWeight == 0) return -1;
 
-  return (
-    Math.round((finalGrade / totalWeight) * 100 * 10) / 10 + (includeLatePenalty ? extraCredit : 0)
-  );
+  const result =
+    Math.round((finalGrade / totalWeight) * 100 * 10) / 10 + (includeLatePenalty ? extraCredit : 0);
+
+  // Never hand back a non-finite grade: it serializes to `null` over JSON and
+  // renders as a false `F` (NaN >= min_grade is false for every band). Fall
+  // back to the same "no computable grade" sentinel used above so callers'
+  // existing `< 0` / `>= 0` guards handle it uniformly.
+  return Number.isFinite(result) ? result : -1;
 };
 
 /**
@@ -214,14 +219,18 @@ export const calculateNumericGrade = (
   emojis: string[],
   emojiToNumberMap: Record<string, number>
 ): number => {
-  if (emojis.length === 0) {
+  // Ignore emojis that don't resolve to a finite value in this classroom's
+  // scale rather than letting a single unrecognized emoji turn the whole
+  // average (and, downstream, the student's entire final grade) into NaN.
+  const values = emojis
+    .map(emoji => convertEmojiToNumber(emoji, emojiToNumberMap))
+    .filter((value): value is number => Number.isFinite(value));
+
+  if (values.length === 0) {
     return 0;
   }
 
-  return (
-    emojis.reduce((acc, emoji) => acc + convertEmojiToNumber(emoji, emojiToNumberMap), 0) /
-    emojis.length
-  );
+  return values.reduce((acc, value) => acc + value, 0) / values.length;
 };
 
 /**


### PR DESCRIPTION
`findRepositoriesPerStudent` included a student's `git_repos` across **all** classrooms they belong to, not just the one being graded. Since every user also has an auto-provisioned `example-<login>` course, that course's repos entered a real course's grade computation — and its grade emojis (e.g. the example scale's `⭐`) aren't in the real course's `EmojiMapping`, so `convertEmojiToNumber` returned `undefined` and NaN-poisoned the student's entire final grade. It surfaced as a false `F` on the grades table and `null` on leaderboards, for any student enrolled in 2+ courses with different emoji scales.

### Changes
- **Root fix:** scope the `git_repos` include to `classroom_id` in `findRepositoriesPerStudent` (covers both the student-owned and team queries).
- **Defense-in-depth** in `@classmoji/utils`: `calculateNumericGrade` ignores emojis that don't resolve to a finite value instead of averaging in `undefined`; `calculateStudentFinalGrade` returns the existing `-1` sentinel for any non-finite result.
- **Grades table** render guard uses `!(grade >= 0)` so a non-finite grade blanks the cell rather than falling through to a false `F`.
- Regression tests pin the unrecognized-emoji case.

Affects the admin dashboard leaderboard, the admin grades table, and the MCP leaderboard resource (all share this computation). Behavior is unchanged for any student in a single classroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)