### PR TITLE
fix(memberships): scope role removal

### DIFF
--- a/apps/webapp/app/routes/admin.$class.assistants/action.ts
+++ b/apps/webapp/app/routes/admin.$class.assistants/action.ts
@@ -76,6 +76,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
             user: data.user,
             gitOrganization: classroom.git_organization,
             classroom: classroom,
+            role: 'ASSISTANT',
           },
         });
 

--- a/apps/webapp/app/routes/admin.$class.students/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/route.tsx
@@ -119,6 +119,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
           payload: {
             user: data.user,
             organization: classroom,
+            role: 'STUDENT',
           },
         });
 

--- a/packages/services/src/classmoji/__tests__/classroomMembership.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroomMembership.service.test.ts
@@ -65,6 +65,49 @@ describe('remove', () => {
     expect(countMock).not.toHaveBeenCalled();
     expect(deleteManyMock).toHaveBeenCalledTimes(1);
   });
+
+  it('removes only the requested non-owner role when the user has multiple roles', async () => {
+    await membershipService.remove('c1', 'u1', 'STUDENT');
+
+    expect(findFirstMock).not.toHaveBeenCalled();
+    expect(countMock).not.toHaveBeenCalled();
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: { classroom_id: 'c1', user_id: 'u1', role: 'STUDENT' },
+    });
+  });
+
+  it('still protects a targeted owner removal', async () => {
+    findFirstMock.mockResolvedValue({ id: 'm1', role: 'OWNER' });
+    countMock.mockResolvedValue(1);
+
+    await expect(membershipService.remove('c1', 'u1', 'OWNER')).rejects.toThrow(LAST_OWNER_ERROR);
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldRemoveFromGitOrg', () => {
+  it('keeps the user in the organization when another role remains in the classroom', async () => {
+    countMock.mockResolvedValue(1);
+
+    await expect(
+      membershipService.shouldRemoveFromGitOrg('g1', 'u1', 'c1', 'STUDENT')
+    ).resolves.toBe(false);
+    expect(countMock).toHaveBeenCalledWith({
+      where: {
+        user_id: 'u1',
+        classroom: { git_org_id: 'g1' },
+        NOT: { classroom_id: 'c1', role: 'STUDENT' },
+      },
+    });
+  });
+
+  it('removes the user from the organization when no other role remains', async () => {
+    countMock.mockResolvedValue(0);
+
+    await expect(
+      membershipService.shouldRemoveFromGitOrg('g1', 'u1', 'c1', 'ASSISTANT')
+    ).resolves.toBe(true);
+  });
 });
 
 describe('removeById', () => {

--- a/packages/services/src/classmoji/classroomMembership.service.ts
+++ b/packages/services/src/classmoji/classroomMembership.service.ts
@@ -263,18 +263,21 @@ export const updateById = async (id: string, updates: Prisma.ClassroomMembership
  * Delete a membership
  * @param {string} classroomId - UUID of the Classroom
  * @param {string} userId - UUID of the User
+ * @param {Role} [role] - Optional role to remove; omit to remove every role
  * @returns {Promise<Object>}
  */
-export const remove = async (classroomId: string, userId: string) => {
-  const ownerMembership = await getPrisma().classroomMembership.findFirst({
-    where: { classroom_id: classroomId, user_id: userId, role: 'OWNER' },
-  });
-  if (ownerMembership) {
-    await assertNotLastOwner(classroomId);
+export const remove = async (classroomId: string, userId: string, role?: Role) => {
+  if (!role || role === 'OWNER') {
+    const ownerMembership = await getPrisma().classroomMembership.findFirst({
+      where: { classroom_id: classroomId, user_id: userId, role: 'OWNER' },
+    });
+    if (ownerMembership) {
+      await assertNotLastOwner(classroomId);
+    }
   }
 
   return getPrisma().classroomMembership.deleteMany({
-    where: { classroom_id: classroomId, user_id: userId },
+    where: { classroom_id: classroomId, user_id: userId, ...(role ? { role } : {}) },
   });
 };
 
@@ -300,12 +303,14 @@ export const removeById = async (id: string) => {
  * @param {string} gitOrgId - UUID of the GitOrganization
  * @param {string} userId - UUID of the User
  * @param {string} [excludeClassroomId] - Optional classroom to exclude from count
+ * @param {Role} [excludeRole] - Optional role to exclude within the classroom
  * @returns {Promise<number>}
  */
 export const countUserMembershipsInGitOrg = async (
   gitOrgId: string,
   userId: string,
-  excludeClassroomId: string | null = null
+  excludeClassroomId: string | null = null,
+  excludeRole?: Role
 ) => {
   const where: Prisma.ClassroomMembershipWhereInput = {
     user_id: userId,
@@ -314,7 +319,9 @@ export const countUserMembershipsInGitOrg = async (
     },
   };
 
-  if (excludeClassroomId) {
+  if (excludeClassroomId && excludeRole) {
+    where.NOT = { classroom_id: excludeClassroomId, role: excludeRole };
+  } else if (excludeClassroomId) {
     where.classroom_id = { not: excludeClassroomId };
   }
 
@@ -327,14 +334,16 @@ export const countUserMembershipsInGitOrg = async (
  * @param {string} gitOrgId - UUID of the GitOrganization
  * @param {string} userId - UUID of the User
  * @param {string} classroomId - UUID of the classroom being removed from
+ * @param {Role} [role] - Optional role being removed within the classroom
  * @returns {Promise<boolean>}
  */
 export const shouldRemoveFromGitOrg = async (
   gitOrgId: string,
   userId: string,
-  classroomId: string
+  classroomId: string,
+  role?: Role
 ) => {
-  const otherMemberships = await countUserMembershipsInGitOrg(gitOrgId, userId, classroomId);
+  const otherMemberships = await countUserMembershipsInGitOrg(gitOrgId, userId, classroomId, role);
   return otherMemberships === 0;
 };
 

--- a/packages/tasks/src/workflows/organization.ts
+++ b/packages/tasks/src/workflows/organization.ts
@@ -24,7 +24,7 @@ interface RemoveUserPayload {
   gitOrganization?: GitOrgData;
   classroom?: { id: string; slug: string };
   organization?: { id: string; slug: string; git_organization?: GitOrgData };
-  role?: string;
+  role?: 'OWNER' | 'TEACHER' | 'STUDENT' | 'ASSISTANT';
   payload?: RemoveUserPayload;
 }
 
@@ -199,7 +199,8 @@ export const removeUserFromOrganizationTask = task({
       const shouldRemoveFromOrg = await ClassmojiService.classroomMembership.shouldRemoveFromGitOrg(
         gitOrgData.id,
         user.id,
-        classroomData.id
+        classroomData.id,
+        userRole
       );
 
       // Step 3: Only remove from GitHub org if no other classroom memberships
@@ -212,6 +213,10 @@ export const removeUserFromOrganizationTask = task({
       }
     }
 
-    return ClassmojiService.classroomMembership.remove(classroomData.id, user.id);
+    return ClassmojiService.classroomMembership.remove(
+      classroomData.id,
+      user.id,
+      role || 'STUDENT'
+    );
   },
 });


### PR DESCRIPTION
## Root cause

Classroom memberships support multiple roles per user, but `remove_user_from_organization` deleted every membership for a user/classroom. After the last-owner safeguard shipped, removing a `STUDENT` or `ASSISTANT` role from a user who also owns the classroom attempted to delete the owner row and failed with `Cannot remove the last owner of a classroom`. The Git organization check also excluded the entire classroom, so it could remove a multi-role user from GitHub even though another role remained.

## Fix

- Pass the intended role from the student and assistant actions.
- Remove only that role from the classroom.
- Exclude only that role when checking for remaining Git organization memberships.
- Preserve the last-owner guard for actual owner removals.
- Add regression coverage for multi-role users.

## Verification

- `npm test --workspace=@classmoji/services -- --run src/classmoji/__tests__/classroomMembership.service.test.ts` (15 passed)
- Services typecheck passed.
- Trigger tasks typecheck passed.
- Webapp typecheck passed.
- Targeted ESLint passed with no new errors (existing warnings only).
- Prettier and `git diff --check` passed.

This PR targets `staging` only.