### PR TITLE
feat(mcp): mirror the full read resource surface as tools

### DIFF
--- a/apps/mcp/src/resources/grading.ts
+++ b/apps/mcp/src/resources/grading.ts
@@ -32,8 +32,12 @@ import {
   type SubmissionLike,
 } from './shape.ts';
 
-/** Compact queue row: identity narrowed, no token/transaction internals. */
-function queueRow(s: SubmissionLike, org: string | null) {
+/**
+ * Compact queue row: identity narrowed, no token/transaction internals.
+ * Exported so the `list_submissions` tool (tools/reads.ts) renders the SAME
+ * per-submission shape as the grading-queue resource — the two must never drift.
+ */
+export function queueRow(s: SubmissionLike, org: string | null) {
   return {
     id: s.id,
     status: s.status,
@@ -56,6 +60,71 @@ function queueRow(s: SubmissionLike, org: string | null) {
   };
 }
 
+export interface EmojiScaleRow {
+  emoji: string;
+  grade: number;
+  extra_tokens: number;
+  description: string;
+}
+
+/**
+ * Shared load for the grading-queue read surface: every submission
+ * (GitRepoAssignment) in the classroom plus the classroom emoji scale.
+ *
+ * Factored out of gradingQueueResource so the `list_submissions` tool builds on
+ * exactly the same query + emoji-scale shaping (the tool then filters the raw
+ * rows in-memory and maps them through `queueRow`). Returns RAW SubmissionLike
+ * rows so callers can filter before shaping.
+ */
+export async function loadGradingQueueData(
+  classroomId: string
+): Promise<{ emoji_scale: EmojiScaleRow[]; all: SubmissionLike[] }> {
+  const [all, emojiMappings] = await Promise.all([
+    ClassmojiService.gitRepoAssignment.findByClassroomId(classroomId) as unknown as Promise<
+      SubmissionLike[]
+    >,
+    // includeExtraTokens=true returns the full mapping rows (the default
+    // shape is a bare emoji→grade record).
+    ClassmojiService.emojiMapping.findByClassroomId(classroomId, true) as Promise<EmojiScaleRow[]>,
+  ]);
+  return {
+    emoji_scale: emojiMappings.map(m => ({
+      emoji: m.emoji,
+      grade: m.grade,
+      extra_tokens: m.extra_tokens,
+      description: m.description,
+    })),
+    all,
+  };
+}
+
+/**
+ * Shared leaderboard computation with the twin-classroom guard (S1).
+ *
+ * helper.calculateClassLeaderboard resolves by BARE slug (findBySlug), but
+ * slugs are only unique per git org. Guard: if the bare slug resolves to a
+ * different classroom than the org/slug the caller was authorized for, refuse
+ * rather than leak another classroom's leaderboard. Both the leaderboard
+ * resource and the `get_leaderboard` tool call this so the guard never drifts.
+ */
+export async function computeLeaderboard(
+  slug: string,
+  classroomId: string
+): Promise<{
+  count: number;
+  leaderboard: Awaited<ReturnType<typeof ClassmojiService.helper.calculateClassLeaderboard>>;
+}> {
+  const bySlug = await ClassmojiService.classroom.findBySlug(slug);
+  if (!bySlug || bySlug.id !== classroomId) {
+    throw new ToolError(
+      'internal',
+      `Classroom slug '${slug}' is ambiguous across git orgs — leaderboard unavailable for this classroom`
+    );
+  }
+  const leaderboard = await ClassmojiService.helper.calculateClassLeaderboard(slug);
+  return { count: leaderboard.length, leaderboard };
+}
+
 export const gradingQueueResource: ResourceDefinition = {
   name: 'grading-queue',
   uriTemplate: 'classmoji://{org}/{slug}/grading-queue',
@@ -69,29 +138,19 @@ export const gradingQueueResource: ResourceDefinition = {
   handler: async (_vars, ctx) => {
     const { classroomId } = classroomCtx(ctx);
     const org = orgLogin(ctx);
-    const [assignedToMe, all, emojiMappings] = await Promise.all([
+    const [assignedToMe, { emoji_scale, all }] = await Promise.all([
       // Rows are GitRepoAssignmentGrader records wrapping the submission.
       ClassmojiService.gitRepoAssignmentGrader.findAssignedByGrader(
         ctx.viewer.userId,
         classroomId
       ) as unknown as Promise<Array<{ git_repo_assignment: SubmissionLike }>>,
-      ClassmojiService.gitRepoAssignment.findByClassroomId(classroomId) as unknown as Promise<
-        SubmissionLike[]
-      >,
-      // includeExtraTokens=true returns the full mapping rows (the default
-      // shape is a bare emoji→grade record).
-      ClassmojiService.emojiMapping.findByClassroomId(classroomId, true) as Promise<
-        Array<{ emoji: string; grade: number; extra_tokens: number; description: string }>
-      >,
+      // Shared with the list_submissions tool (tools/reads.ts) — one query +
+      // emoji-scale shaping so the two surfaces cannot drift.
+      loadGradingQueueData(classroomId),
     ]);
 
     return {
-      emoji_scale: emojiMappings.map(m => ({
-        emoji: m.emoji,
-        grade: m.grade,
-        extra_tokens: m.extra_tokens,
-        description: m.description,
-      })),
+      emoji_scale,
       assigned_to_me: assignedToMe
         .map(g => g.git_repo_assignment)
         .filter(Boolean)
@@ -151,19 +210,9 @@ export const leaderboardResource: ResourceDefinition = {
   roles: OWNER_ONLY,
   handler: async (vars, ctx) => {
     const { classroomId } = classroomCtx(ctx);
-    // helper.calculateClassLeaderboard resolves by BARE slug (findBySlug), but
-    // slugs are only unique per git org. Guard: if the bare slug resolves to a
-    // different classroom than the org/slug the caller was authorized for,
-    // refuse rather than leak another classroom's leaderboard (S1).
-    const bySlug = await ClassmojiService.classroom.findBySlug(vars.slug);
-    if (!bySlug || bySlug.id !== classroomId) {
-      throw new ToolError(
-        'internal',
-        `Classroom slug '${vars.slug}' is ambiguous across git orgs — leaderboard unavailable for this classroom`
-      );
-    }
-    const leaderboard = await ClassmojiService.helper.calculateClassLeaderboard(vars.slug);
-    return { count: leaderboard.length, leaderboard };
+    // Shared with the get_leaderboard tool (tools/reads.ts): the twin-classroom
+    // guard + computation live in one place so they cannot drift.
+    return computeLeaderboard(vars.slug, classroomId);
   },
 };
 

--- a/apps/mcp/src/tools/__tests__/reads.test.ts
+++ b/apps/mcp/src/tools/__tests__/reads.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for the mirrored read tools (tools/reads.ts).
+ *
+ * Three things are pinned here:
+ *   1. NO-DRIFT (the central requirement): a pure mirror tool and its resource
+ *      produce byte-identical payloads (get_leaderboard vs the leaderboard
+ *      resource), and list_submissions' per-submission rows are IDENTICAL to the
+ *      grading-queue resource's `all` rows (shared queueRow shaping).
+ *   2. list_submissions filters (repository_id / assignment_id / grader_id /
+ *      status) applied in-memory over the raw rows.
+ *   3. list_teaching_team aggregation: staff only, one row per user with a
+ *      `roles[]` array; STUDENT rows excluded.
+ *
+ * `@classmoji/services` is mocked (factory idiom) so the real handler logic runs
+ * against hand-built rows. Role-gating itself is enforced by the registry (not
+ * the handlers) and is covered by the integration matrix, not here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToolError } from '../../mcp/errors.ts';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  findByClassroomId: vi.fn(), // gitRepoAssignment.findByClassroomId
+  findEmojiByClassroomId: vi.fn(), // emojiMapping.findByClassroomId
+  findAssignedByGrader: vi.fn(), // gitRepoAssignmentGrader.findAssignedByGrader
+  findBySlug: vi.fn(), // classroom.findBySlug
+  calculateClassLeaderboard: vi.fn(), // helper.calculateClassLeaderboard
+  membershipsByClassroom: vi.fn(), // classroomMembership.findByClassroomId
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    gitRepoAssignment: { findByClassroomId: (...a: unknown[]) => mocks.findByClassroomId(...a) },
+    emojiMapping: { findByClassroomId: (...a: unknown[]) => mocks.findEmojiByClassroomId(...a) },
+    gitRepoAssignmentGrader: {
+      findAssignedByGrader: (...a: unknown[]) => mocks.findAssignedByGrader(...a),
+    },
+    classroom: { findBySlug: (...a: unknown[]) => mocks.findBySlug(...a) },
+    helper: {
+      calculateClassLeaderboard: (...a: unknown[]) => mocks.calculateClassLeaderboard(...a),
+    },
+    classroomMembership: {
+      findByClassroomId: (...a: unknown[]) => mocks.membershipsByClassroom(...a),
+    },
+  },
+}));
+
+const { listSubmissionsTool, getLeaderboardTool, listTeachingTeamTool } =
+  await import('../reads.ts');
+const { gradingQueueResource, leaderboardResource } = await import('../../resources/grading.ts');
+
+const CLASSROOM = 'test-org/winter-2025';
+
+/** ctx as the registry hands it to a role-gated handler. */
+function staffCtx(role: 'OWNER' | 'ASSISTANT' = 'ASSISTANT'): ToolContext {
+  return {
+    viewer: { userId: 'staff-1', clientId: 'c', scopes: new Set(['read']) },
+    classroom: {
+      classroomId: 'class-1',
+      role,
+      status: 'ACTIVE',
+      membership: { id: 'm-1', role },
+      classroom: { slug: 'winter-2025', git_organization: { login: 'test-org' }, settings: {} },
+    },
+  } as unknown as ToolContext;
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/** Two submissions with distinct repository/assignment/grader/status. */
+function seededSubmissions() {
+  return [
+    {
+      id: 'gra-open',
+      status: 'OPEN',
+      assignment: { id: 'a-1', title: 'HW1', grades_released: false },
+      git_repo: {
+        id: 'r-1',
+        repository_id: 'repo-1',
+        repository: { id: 'repo-1', title: 'Lab 1' },
+        student: { id: 'stu-1', login: 'stu1', name: 'Student One', image: null },
+        team: null,
+      },
+      grades: [{ id: 'grade-1', emoji: '🟢' }],
+      graders: [{ grader: { id: 'grader-x', name: 'Grader X' } }],
+    },
+    {
+      id: 'gra-closed',
+      status: 'CLOSED',
+      assignment: { id: 'a-2', title: 'HW2', grades_released: true },
+      git_repo: {
+        id: 'r-2',
+        repository_id: 'repo-2',
+        repository: { id: 'repo-2', title: 'Lab 2' },
+        student: null,
+        team: { id: 'team-1', name: 'Team Alpha' },
+      },
+      grades: [],
+      graders: [{ grader: { id: 'grader-y', name: 'Grader Y' } }],
+    },
+  ];
+}
+
+const EMOJI_SCALE = [{ emoji: '🟢', grade: 100, extra_tokens: 0, description: 'Great' }];
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.findByClassroomId.mockResolvedValue(seededSubmissions());
+  mocks.findEmojiByClassroomId.mockResolvedValue(EMOJI_SCALE);
+  mocks.findAssignedByGrader.mockResolvedValue([]);
+});
+
+describe('list_submissions', () => {
+  it('returns every submission with the emoji scale and no filters', async () => {
+    const payload = parse(await listSubmissionsTool.handler({ classroom: CLASSROOM }, staffCtx()));
+    expect(payload.count).toBe(2);
+    expect(payload.total_matched).toBe(2);
+    expect(payload.truncated).toBe(false);
+    expect(payload.emoji_scale).toEqual(EMOJI_SCALE);
+    expect(payload.submissions.map((s: { id: string }) => s.id)).toEqual([
+      'gra-open',
+      'gra-closed',
+    ]);
+    // The returned id is the GitRepoAssignment id (what grade_add consumes).
+    expect(payload.submissions[0].id).toBe('gra-open');
+  });
+
+  it('filters by repository_id, assignment_id, grader_id and status', async () => {
+    const byRepo = parse(
+      await listSubmissionsTool.handler(
+        { classroom: CLASSROOM, repository_id: 'repo-2' },
+        staffCtx()
+      )
+    );
+    expect(byRepo.submissions.map((s: { id: string }) => s.id)).toEqual(['gra-closed']);
+
+    const byAssignment = parse(
+      await listSubmissionsTool.handler({ classroom: CLASSROOM, assignment_id: 'a-1' }, staffCtx())
+    );
+    expect(byAssignment.submissions.map((s: { id: string }) => s.id)).toEqual(['gra-open']);
+
+    const byGrader = parse(
+      await listSubmissionsTool.handler({ classroom: CLASSROOM, grader_id: 'grader-y' }, staffCtx())
+    );
+    expect(byGrader.submissions.map((s: { id: string }) => s.id)).toEqual(['gra-closed']);
+
+    const byStatus = parse(
+      await listSubmissionsTool.handler({ classroom: CLASSROOM, status: 'OPEN' }, staffCtx())
+    );
+    expect(byStatus.submissions.map((s: { id: string }) => s.id)).toEqual(['gra-open']);
+  });
+
+  it('honors limit and reports truncation', async () => {
+    const payload = parse(
+      await listSubmissionsTool.handler({ classroom: CLASSROOM, limit: 1 }, staffCtx())
+    );
+    expect(payload.count).toBe(1);
+    expect(payload.total_matched).toBe(2);
+    expect(payload.truncated).toBe(true);
+  });
+
+  it('NO-DRIFT: per-submission rows are identical to the grading-queue resource', async () => {
+    const tool = parse(await listSubmissionsTool.handler({ classroom: CLASSROOM }, staffCtx()));
+    const resource = (await gradingQueueResource.handler(
+      { org: 'test-org', slug: 'winter-2025' },
+      staffCtx(),
+      new URL('classmoji://x')
+    )) as { all: unknown[]; emoji_scale: unknown };
+    // Same queueRow shaping + same emoji-scale shaping, by construction.
+    expect(tool.submissions).toEqual(resource.all);
+    expect(tool.emoji_scale).toEqual(resource.emoji_scale);
+  });
+});
+
+describe('get_leaderboard', () => {
+  beforeEach(() => {
+    mocks.findBySlug.mockResolvedValue({ id: 'class-1' });
+    mocks.calculateClassLeaderboard.mockResolvedValue([
+      { id: 'stu-1', name: 'Student One', login: 'stu1', grade: 88, avatar_url: null },
+    ]);
+  });
+
+  it('NO-DRIFT: the tool payload is byte-identical to the leaderboard resource', async () => {
+    const resourcePayload = await leaderboardResource.handler(
+      { org: 'test-org', slug: 'winter-2025' },
+      staffCtx('OWNER'),
+      new URL('classmoji://x')
+    );
+    const toolResult = await getLeaderboardTool.handler(
+      { classroom: CLASSROOM },
+      staffCtx('OWNER')
+    );
+    expect(toolResult.content[0].text).toBe(JSON.stringify(resourcePayload, null, 2));
+    expect(parse(toolResult).count).toBe(1);
+  });
+
+  it('preserves the twin-classroom guard (bare slug resolves elsewhere → refuse)', async () => {
+    mocks.findBySlug.mockResolvedValue({ id: 'a-different-classroom' });
+    // The handler throws; the registry (not the handler) maps it to isError, so
+    // here we assert the thrown ToolError directly (mirrors content.test.ts).
+    const err = await getLeaderboardTool
+      .handler({ classroom: CLASSROOM }, staffCtx('OWNER'))
+      .catch(e => e);
+    expect(err).toBeInstanceOf(ToolError);
+    expect((err as ToolError).kind).toBe('internal');
+    // Guard fires BEFORE any leaderboard computation.
+    expect(mocks.calculateClassLeaderboard).not.toHaveBeenCalled();
+  });
+});
+
+describe('list_teaching_team', () => {
+  it('returns staff only, one row per user with an aggregated roles[] array', async () => {
+    mocks.membershipsByClassroom.mockResolvedValue([
+      { role: 'OWNER', user: { id: 'u1', login: 'prof', name: 'Prof' } },
+      { role: 'ASSISTANT', user: { id: 'u1', login: 'prof', name: 'Prof' } }, // same user, 2nd role
+      { role: 'TEACHER', user: { id: 'u2', login: 'tt', name: 'Teach' } },
+      { role: 'STUDENT', user: { id: 'u3', login: 'stu', name: 'Student' } }, // excluded
+    ]);
+
+    const payload = parse(await listTeachingTeamTool.handler({ classroom: CLASSROOM }, staffCtx()));
+    expect(payload.count).toBe(2);
+
+    const byId = Object.fromEntries(
+      (payload.members as Array<{ id: string; roles: string[] }>).map(m => [m.id, m])
+    );
+    expect(byId.u1.roles).toEqual(['OWNER', 'ASSISTANT']);
+    expect(byId.u2.roles).toEqual(['TEACHER']);
+    expect(byId.u3).toBeUndefined(); // students are not teaching team
+    // Only id/login/name/roles — no PII (email/school_id) or avatar.
+    expect(Object.keys(byId.u1).sort()).toEqual(['id', 'login', 'name', 'roles']);
+  });
+});

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -12,6 +12,7 @@
 
 import { registerToolDefinition } from '../mcp/registry.ts';
 import { whoamiTool } from './whoami.ts';
+import { readTools } from './reads.ts';
 import { gradeAddTool, gradeRemoveTool, gradeRemoveAllTool } from './grades.ts';
 import { graderAssignTool, graderUnassignTool } from './graders.ts';
 import { emojiMappingUpsertTool, letterGradeMappingUpsertTool } from './mappings.ts';
@@ -36,6 +37,11 @@ import { repoPublishTool, repoUnpublishTool } from './repos.ts';
 export function registerAllTools(): void {
   // Identity / bootstrap
   registerToolDefinition(whoamiTool);
+
+  // Read surface mirrored as tools (tool-only clients like claude.ai cannot
+  // list/read MCP resources). Each mirror reuses its resource's handler + tier;
+  // list_submissions/list_teaching_team add filtering / staff-id resolution.
+  for (const tool of readTools) registerToolDefinition(tool);
 
   // Grading (teaching team incl. TEACHER; remove-all OWNER)
   registerToolDefinition(gradeAddTool);

--- a/apps/mcp/src/tools/reads.ts
+++ b/apps/mcp/src/tools/reads.ts
@@ -1,0 +1,444 @@
+/**
+ * Read tools — the full read surface mirrored as TOOLS.
+ *
+ * WHY: tool-only MCP clients (e.g. claude.ai) can enumerate/call `tools/*` but
+ * have NO access to `resources/list` / `resources/read`. The entire read
+ * surface already exists as MCP *resources* (apps/mcp/src/resources/**); this
+ * module re-exposes each one as a thin `scope: 'read'` tool so those clients
+ * can reach the same data. The resources are UNCHANGED.
+ *
+ * NO-DRIFT GUARANTEE (the central requirement): every mirror tool calls the
+ * resource's OWN handler with an identically-resolved `ClassroomContext`. The
+ * registry resolves `ctx.classroom` from the tool's `roles` (which equal the
+ * resource's `roles`) exactly as it does for the resource's URI, so every
+ * in-handler guard — the leaderboard twin-guard, roster's OWNER-only field
+ * split, the quizzes triple-gate, grades_released, PII-stripping — fires
+ * identically. The tool then wraps the resource payload with `ok()`, which
+ * serializes it with the same `JSON.stringify(payload, null, 2)` the resource
+ * read uses. Resource and tool are therefore byte-identical by construction.
+ *
+ * Two tools are NOT pure mirrors:
+ *   - list_submissions   adds server-side filters over the grading-queue data
+ *     (shares loadGradingQueueData + queueRow with the grading-queue resource).
+ *   - list_teaching_team is a NEW capability (no resource lists staff-with-ids)
+ *     that resolves the grader_id an agent needs for grader_assign.
+ */
+
+import { UriTemplate } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
+import { ClassmojiService } from '@classmoji/services';
+import { IssueStatus, type Role } from '@prisma/client';
+import { z, type ZodRawShape } from 'zod';
+import type { ResourceDefinition, ToolDefinition } from '../mcp/registry.ts';
+import { parseClassroomRef } from '../authz/pure.ts';
+import { ok, requireClassroomCtx, TEACHING_TEAM } from './shared.ts';
+import { orgLogin, type SubmissionLike } from '../resources/shape.ts';
+import { meResource } from '../resources/me.ts';
+import { classroomInfoResource } from '../resources/classroomInfo.ts';
+import { rosterResource, teamsResource } from '../resources/roster.ts';
+import { reposResource, gradesMineResource } from '../resources/repos.ts';
+import {
+  loadGradingQueueData,
+  queueRow,
+  leaderboardResource,
+  submissionResource,
+  regradeQueueResource,
+  regradeMineResource,
+} from '../resources/grading.ts';
+import {
+  quizzesResource,
+  pagesResource,
+  modulesResource,
+  calendarResource,
+  calendarRangeResource,
+} from '../resources/content.ts';
+import { tokensResource } from '../resources/tokens.ts';
+
+// ─── Generic resource→tool adapter (the no-drift bridge) ────────────────────
+
+interface MirrorConfig {
+  /** The resource whose handler + role tier this tool reuses verbatim. */
+  resource: ResourceDefinition;
+  name: string;
+  title: string;
+  description: string;
+  /** Zod inputs beyond `classroom` (e.g. submission_id, calendar start/end). */
+  extraInput?: ZodRawShape;
+  /** Map validated args → the resource's non-org/slug URI-template variables. */
+  buildVars?: (args: Record<string, unknown>) => Record<string, string>;
+}
+
+/**
+ * Wrap a ResourceDefinition as a read tool. The tool inherits the resource's
+ * exact role tier and calls the resource's handler with the same ctx + vars.
+ */
+function mirrorResourceTool(config: MirrorConfig): ToolDefinition {
+  const { resource, name, title, description, extraInput = {}, buildVars } = config;
+  const classroomScoped = resource.roles !== null;
+  const template = new UriTemplate(resource.uriTemplate);
+
+  const inputSchema: ZodRawShape = {
+    ...(classroomScoped
+      ? { classroom: z.string().describe("Classroom reference as 'org/slug'") }
+      : {}),
+    ...extraInput,
+  };
+
+  return {
+    name,
+    title,
+    description,
+    scope: 'read',
+    roles: resource.roles,
+    inputSchema,
+    handler: async (args: Record<string, unknown>, ctx) => {
+      let vars: Record<string, string> = {};
+      if (classroomScoped) {
+        // The registry already validated `classroom` while resolving
+        // ctx.classroom; re-parse to get the raw org/slug the resource's URI
+        // handler would see (twin-guards key off vars.slug).
+        const { org, slug } = parseClassroomRef(args.classroom);
+        vars = { org, slug, ...(buildVars ? buildVars(args) : {}) };
+      } else if (buildVars) {
+        vars = buildVars(args);
+      }
+      const uri = new URL(
+        UriTemplate.isTemplate(resource.uriTemplate) ? template.expand(vars) : resource.uriTemplate
+      );
+      const payload = await resource.handler(vars, ctx, uri);
+      return ok(payload);
+    },
+  };
+}
+
+// ─── Pure mirrors (one per read resource) ───────────────────────────────────
+
+export const myClassroomsTool = mirrorResourceTool({
+  resource: meResource,
+  name: 'my_classrooms',
+  title: 'My identity & classrooms',
+  description:
+    'Returns the authenticated user (id, login, name), granted scopes, and every classroom ' +
+    "membership as 'org/slug' with role, status, and archive flags. Call this first to discover " +
+    "the 'org/slug' classroom reference every other tool needs. Takes no arguments.",
+});
+
+export const getClassroomInfoTool = mirrorResourceTool({
+  resource: classroomInfoResource,
+  name: 'get_classroom_info',
+  title: 'Get classroom info',
+  description:
+    'Classroom name, status, archive flag, sanitized settings (feature flags, model choices, ' +
+    'has_anthropic_key/has_openai_key booleans — never raw keys), and your role in it. Any member.',
+});
+
+export const getRosterTool = mirrorResourceTool({
+  resource: rosterResource,
+  name: 'get_roster',
+  title: 'Get student roster',
+  description:
+    'Students enrolled in the classroom (teaching team only). OWNER additionally sees contact ' +
+    'fields (email, school_id) and per-student letter_grade/comment overrides; other staff see ' +
+    'identity + grader/invite flags only.',
+});
+
+export const listTeamsTool = mirrorResourceTool({
+  resource: teamsResource,
+  name: 'list_teams',
+  title: 'List teams',
+  description:
+    'Teams in the classroom with member identities (id, name, login — no contact PII). Students ' +
+    'see visible teams and any team they belong to; staff see all teams.',
+});
+
+export const listReposTool = mirrorResourceTool({
+  resource: reposResource,
+  name: 'list_repos',
+  title: 'List assignment containers (repos)',
+  description:
+    'Assignment containers ("repos") with their due-dated assignments. Staff see all incl. ' +
+    'unpublished; students see published-only containers they have a git repo for, with their own ' +
+    'submission status per assignment (grades only after release). Any member.',
+});
+
+export const myGradesTool = mirrorResourceTool({
+  resource: gradesMineResource,
+  name: 'my_grades',
+  title: 'My released grades',
+  description:
+    'Your own graded submissions in this classroom — only assignments whose grades have been ' +
+    'released (Assignment.grades_released). Students only.',
+});
+
+export const getSubmissionTool = mirrorResourceTool({
+  resource: submissionResource,
+  name: 'get_submission',
+  title: 'Get submission detail',
+  description:
+    'One submission (a GitRepoAssignment) with its grades, graders, and analytics snapshot if ' +
+    'present. Teaching team only. `submission_id` comes from list_submissions; it is also the ' +
+    'id that grade_add, grade_remove, and grader_assign consume.',
+  extraInput: {
+    submission_id: z.string().uuid().describe('Submission (GitRepoAssignment) id'),
+  },
+  buildVars: args => ({ submissionId: String(args.submission_id) }),
+});
+
+export const getLeaderboardTool = mirrorResourceTool({
+  resource: leaderboardResource,
+  name: 'get_leaderboard',
+  title: 'Get class leaderboard',
+  description:
+    'Computed final-grade leaderboard for every student (id, name, login, grade), sorted ' +
+    'ascending by grade. OWNER only.',
+});
+
+export const listRegradeRequestsTool = mirrorResourceTool({
+  resource: regradeQueueResource,
+  name: 'list_regrade_requests',
+  title: 'List regrade requests',
+  description:
+    'All regrade requests in the classroom with student + grader comments and the affected ' +
+    'submission. Teaching team only. Resolve them with regrade_resolve.',
+});
+
+export const myRegradeRequestsTool = mirrorResourceTool({
+  resource: regradeMineResource,
+  name: 'my_regrade_requests',
+  title: 'My regrade requests',
+  description:
+    'Your own regrade requests in this classroom (status, your comment, the affected submission). ' +
+    'Students only; grader comments are not included.',
+});
+
+export const listQuizzesTool = mirrorResourceTool({
+  resource: quizzesResource,
+  name: 'list_quizzes',
+  title: 'List quizzes',
+  description:
+    'AI-graded quizzes. Staff (OWNER/ASSISTANT) see all quizzes incl. drafts and prompts; students ' +
+    'see published quizzes with their own attempt summary. Requires a Pro subscription and ' +
+    'quizzes_enabled. TEACHER is excluded (matches the web routes).',
+});
+
+export const listPagesTool = mirrorResourceTool({
+  resource: pagesResource,
+  name: 'list_pages',
+  title: 'List pages',
+  description:
+    'Course pages. OWNER/TEACHER see every page incl. drafts; assistants and students see the ' +
+    'published student-menu list. Any member.',
+});
+
+export const listModulesTool = mirrorResourceTool({
+  resource: modulesResource,
+  name: 'list_modules',
+  title: 'List modules',
+  description:
+    'Ordered curriculum modules with their content items (pages, repos, quizzes, slides). Students ' +
+    'see published modules/items only; staff also see unpublished. Returns {enabled:false} when ' +
+    'the classroom hides modules. Any member.',
+});
+
+export const listCalendarTool = mirrorResourceTool({
+  resource: calendarResource,
+  name: 'list_calendar',
+  title: 'List calendar (current month)',
+  description:
+    'Calendar events for the current month — recurring events expanded, assignment deadlines ' +
+    'merged in. Use list_calendar_range for another window. Any member.',
+});
+
+export const listCalendarRangeTool = mirrorResourceTool({
+  resource: calendarRangeResource,
+  name: 'list_calendar_range',
+  title: 'List calendar (date range)',
+  description:
+    'Calendar events for an explicit date range. `start` and `end` are ISO dates ' +
+    '(YYYY-MM-DD, e.g. 2026-07-01 / 2026-08-31), start before end. Recurring events expanded, ' +
+    'deadlines merged. Any member.',
+  extraInput: {
+    start: z.string().describe('Range start, ISO date YYYY-MM-DD'),
+    end: z.string().describe('Range end, ISO date YYYY-MM-DD (must be after start)'),
+  },
+  buildVars: args => ({ start: String(args.start), end: String(args.end) }),
+});
+
+export const myTokensTool = mirrorResourceTool({
+  resource: tokensResource,
+  name: 'my_tokens',
+  title: 'My token ledger',
+  description:
+    'Your token balance and transaction history in this classroom (grants, purchases, refunds, ' +
+    'removals). Students only.',
+});
+
+// ─── list_submissions (grading-queue data + server-side filters) ────────────
+
+const LIST_SUBMISSIONS_LIMIT_DEFAULT = 100;
+const LIST_SUBMISSIONS_LIMIT_MAX = 500;
+
+interface ListSubmissionsArgs {
+  classroom: string;
+  repository_id?: string;
+  assignment_id?: string;
+  grader_id?: string;
+  status?: IssueStatus;
+  limit?: number;
+}
+
+export const listSubmissionsTool: ToolDefinition<ListSubmissionsArgs> = {
+  name: 'list_submissions',
+  title: 'List submissions',
+  description:
+    'All submissions (GitRepoAssignments) in the classroom with grade emojis, grader assignments, ' +
+    'student/team, and the classroom emoji scale — the same per-submission shape as the ' +
+    'grading-queue. Optional filters: repository_id, assignment_id, grader_id, status (OPEN|CLOSED). ' +
+    'The returned `id` is the submission id that grade_add, grade_remove, and grader_assign ' +
+    'consume. Teaching team only.',
+  scope: 'read',
+  roles: TEACHING_TEAM,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    repository_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('Filter to one assignment container (Repository) id'),
+    assignment_id: z.string().uuid().optional().describe('Filter to one Assignment id'),
+    grader_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('Filter to submissions this grader (user id) is assigned to'),
+    status: z
+      .nativeEnum(IssueStatus)
+      .optional()
+      .describe('Filter by submission status: OPEN or CLOSED'),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(LIST_SUBMISSIONS_LIMIT_MAX)
+      .optional()
+      .describe(`Max submissions to return (default ${LIST_SUBMISSIONS_LIMIT_DEFAULT})`),
+  },
+  handler: async (args, ctx) => {
+    const { classroomId } = requireClassroomCtx(ctx);
+    const org = orgLogin(ctx);
+    // Shared with the grading-queue resource: one query + emoji-scale shaping.
+    const { emoji_scale, all } = await loadGradingQueueData(classroomId);
+
+    // The service method has no filter params (gitRepoAssignment.findByClassroomId
+    // takes only classroomId), so the filters are applied in-memory over the raw
+    // rows before shaping. Each is derived from DB columns, never request data.
+    let filtered: SubmissionLike[] = all;
+    if (args.repository_id) {
+      filtered = filtered.filter(s => s.git_repo?.repository_id === args.repository_id);
+    }
+    if (args.assignment_id) {
+      filtered = filtered.filter(s => s.assignment?.id === args.assignment_id);
+    }
+    if (args.grader_id) {
+      filtered = filtered.filter(s => (s.graders ?? []).some(g => g.grader?.id === args.grader_id));
+    }
+    if (args.status) {
+      filtered = filtered.filter(s => s.status === args.status);
+    }
+
+    const limit = Math.min(
+      args.limit ?? LIST_SUBMISSIONS_LIMIT_DEFAULT,
+      LIST_SUBMISSIONS_LIMIT_MAX
+    );
+    const page = filtered.slice(0, limit);
+
+    return ok({
+      count: page.length,
+      total_matched: filtered.length,
+      truncated: filtered.length > page.length,
+      emoji_scale,
+      submissions: page.map(s => queueRow(s, org)),
+    });
+  },
+};
+
+// ─── list_teaching_team (NEW — resolves grader_id for grader_assign) ────────
+
+interface ListTeachingTeamArgs {
+  classroom: string;
+}
+
+interface TeachingMembershipRow {
+  role: Role;
+  user?: { id: string; login?: string | null; name?: string | null } | null;
+}
+
+const TEACHING_ROLE_SET: ReadonlySet<Role> = new Set(TEACHING_TEAM);
+
+export const listTeachingTeamTool: ToolDefinition<ListTeachingTeamArgs> = {
+  name: 'list_teaching_team',
+  title: 'List teaching team',
+  description:
+    "The classroom's staff — OWNER, TEACHER, and ASSISTANT members — each with { id, login, name, " +
+    'roles[] }. Use a member id as the `grader_id` for grader_assign / grader_unassign. One person ' +
+    'may hold several roles; those are returned in their `roles` array. Teaching team only.',
+  scope: 'read',
+  roles: TEACHING_TEAM,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+  },
+  handler: async (_args, ctx) => {
+    const { classroomId } = requireClassroomCtx(ctx);
+    // One query for all memberships (includes STUDENT, filtered out below).
+    // ClassroomMembership is unique on (classroom_id, user_id, role), so a
+    // multi-role person appears as multiple rows — aggregate to one row per
+    // user with a `roles` array (cleaner for resolving a single grader_id).
+    const memberships = (await ClassmojiService.classroomMembership.findByClassroomId(
+      classroomId
+    )) as TeachingMembershipRow[];
+
+    const byUser = new Map<
+      string,
+      { id: string; login: string | null; name: string | null; roles: Role[] }
+    >();
+    for (const m of memberships) {
+      if (!TEACHING_ROLE_SET.has(m.role) || !m.user) continue;
+      const existing = byUser.get(m.user.id);
+      if (existing) {
+        if (!existing.roles.includes(m.role)) existing.roles.push(m.role);
+      } else {
+        byUser.set(m.user.id, {
+          id: m.user.id,
+          login: m.user.login ?? null,
+          name: m.user.name ?? null,
+          roles: [m.role],
+        });
+      }
+    }
+
+    const members = [...byUser.values()];
+    return ok({ count: members.length, members });
+  },
+};
+
+// ─── Manifest (registration + listing order) ────────────────────────────────
+
+export const readTools: ToolDefinition<never>[] = [
+  myClassroomsTool,
+  getClassroomInfoTool,
+  getRosterTool,
+  listTeamsTool,
+  listReposTool,
+  myGradesTool,
+  listSubmissionsTool,
+  getSubmissionTool,
+  getLeaderboardTool,
+  listRegradeRequestsTool,
+  myRegradeRequestsTool,
+  listTeachingTeamTool,
+  listQuizzesTool,
+  listPagesTool,
+  listModulesTool,
+  listCalendarTool,
+  listCalendarRangeTool,
+  myTokensTool,
+];

--- a/apps/mcp/tests/phase2-read-tools.integration.test.ts
+++ b/apps/mcp/tests/phase2-read-tools.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Integration coverage for the read tools (tools/reads.ts) — the tool mirror of
+ * the MCP read-resource surface, plus the two non-mirror tools
+ * (list_submissions filters, list_teaching_team staff-id resolution).
+ *
+ * Scope (representative slice, per the task): one allow + one deny at the
+ * adjacent role boundary for each distinct tier —
+ *   teaching-team (list_submissions, list_teaching_team, get_roster),
+ *   OWNER-only   (get_leaderboard),
+ *   member       (get_classroom_info),
+ *   STUDENT-self (my_tokens),
+ * one gated case (roster OWNER-field split), and — the central requirement — a
+ * live NO-DRIFT check: the mirror tool payload equals its resource payload.
+ *
+ * Identity discipline (S10): timofei7 holds OWNER+ASSISTANT+STUDENT and is used
+ * ONLY for OWNER-allow paths. Every denial uses a single-role identity
+ * (fake-teacher / fake-ta / fake-student-1 / fake-other-owner). Reads only — no
+ * fixtures created, no cleanup beyond minted tokens.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  callTool,
+  deleteMintedTokens,
+  DEV_REF,
+  expectForbidden,
+  getPrisma,
+  loadFixtures,
+  mintToken,
+  readResource,
+  startServer,
+  type Fixtures,
+  type MintedToken,
+  type ServerHandle,
+} from './helpers.ts';
+
+const prisma = getPrisma();
+
+let server: ServerHandle;
+let fx: Fixtures;
+
+let ownerMint: MintedToken; // timofei7 — OWNER-allow paths ONLY
+let teacherMint: MintedToken; // fake-teacher — TEACHER (single role)
+let taMint: MintedToken; // fake-ta — ASSISTANT (single role)
+let student1Mint: MintedToken; // fake-student-1 — STUDENT (single role)
+let otherOwnerMint: MintedToken; // fake-other-owner — not a dev-classroom member
+
+let owner: string;
+let teacher: string;
+let ta: string;
+let student1: string;
+let otherOwner: string;
+
+beforeAll(async () => {
+  fx = await loadFixtures();
+  server = await startServer();
+
+  [ownerMint, teacherMint, taMint, student1Mint, otherOwnerMint] = await Promise.all([
+    mintToken({ login: 'timofei7' }),
+    mintToken({ login: 'fake-teacher' }),
+    mintToken({ login: 'fake-ta' }),
+    mintToken({ login: 'fake-student-1' }),
+    mintToken({ login: 'fake-other-owner' }),
+  ]);
+  owner = ownerMint.access_token;
+  teacher = teacherMint.access_token;
+  ta = taMint.access_token;
+  student1 = student1Mint.access_token;
+  otherOwner = otherOwnerMint.access_token;
+}, 300_000);
+
+afterAll(async () => {
+  try {
+    await deleteMintedTokens();
+  } finally {
+    await server?.stop();
+    await prisma.$disconnect();
+  }
+}, 120_000);
+
+// ─── teaching-team tier ──────────────────────────────────────────────────────
+
+describe('list_submissions (teaching team)', () => {
+  it('returns submissions with ids for teaching team; STUDENT denied', async () => {
+    const allowed = await callTool(ta, 'list_submissions', { classroom: DEV_REF });
+    expect(allowed.isError).toBe(false);
+    const submissions = allowed.payload.submissions as Array<{ id: string }>;
+    expect(submissions.length).toBeGreaterThan(0);
+    // The team submission fixture is present and its id (what grade_add consumes).
+    expect(submissions.some(s => s.id === fx.teamGra.id)).toBe(true);
+    expect(Array.isArray(allowed.payload.emoji_scale)).toBe(true);
+
+    expectForbidden(
+      await callTool(student1, 'list_submissions', { classroom: DEV_REF }),
+      'list_submissions as student',
+      'INSUFFICIENT_ROLE'
+    );
+  });
+
+  it('filters by assignment_id server-side', async () => {
+    const filtered = await callTool(ta, 'list_submissions', {
+      classroom: DEV_REF,
+      assignment_id: fx.releasedAssignment.id,
+    });
+    expect(filtered.isError).toBe(false);
+    const rows = filtered.payload.submissions as Array<{ assignment: { id: string } | null }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) expect(r.assignment?.id).toBe(fx.releasedAssignment.id);
+  });
+});
+
+describe('list_teaching_team (teaching team; NEW capability)', () => {
+  it('lists staff with ids for teaching team; STUDENT denied', async () => {
+    const allowed = await callTool(ta, 'list_teaching_team', { classroom: DEV_REF });
+    expect(allowed.isError).toBe(false);
+    const members = allowed.payload.members as Array<{ id: string; roles: string[] }>;
+    // fake-ta is resolvable as a grader_id for grader_assign.
+    const taRow = members.find(m => m.id === fx.users['fake-ta'].id);
+    expect(taRow).toBeDefined();
+    expect(taRow!.roles).toContain('ASSISTANT');
+    // No STUDENT appears in the teaching-team listing.
+    const studentRow = members.find(m => m.id === fx.users['fake-student-1'].id);
+    expect(studentRow).toBeUndefined();
+
+    expectForbidden(
+      await callTool(student1, 'list_teaching_team', { classroom: DEV_REF }),
+      'list_teaching_team as student',
+      'INSUFFICIENT_ROLE'
+    );
+  });
+});
+
+// ─── OWNER-only tier ─────────────────────────────────────────────────────────
+
+describe('get_leaderboard (OWNER only)', () => {
+  it('OWNER allowed; TEACHER (adjacent) denied', async () => {
+    const allowed = await callTool(owner, 'get_leaderboard', { classroom: DEV_REF });
+    expect(allowed.isError).toBe(false);
+    expect(typeof allowed.payload.count).toBe('number');
+    expect(Array.isArray(allowed.payload.leaderboard)).toBe(true);
+
+    expectForbidden(
+      await callTool(teacher, 'get_leaderboard', { classroom: DEV_REF }),
+      'get_leaderboard as teacher',
+      'INSUFFICIENT_ROLE'
+    );
+  });
+});
+
+// ─── member tier ─────────────────────────────────────────────────────────────
+
+describe('get_classroom_info (any member)', () => {
+  it('member allowed; non-member denied', async () => {
+    const allowed = await callTool(student1, 'get_classroom_info', { classroom: DEV_REF });
+    expect(allowed.isError).toBe(false);
+    expect(allowed.payload.id).toBe(fx.dev.id);
+    expect(allowed.payload.viewer_role).toBe('STUDENT');
+    // Sanitized: no raw keys ever.
+    expect(JSON.stringify(allowed.payload)).not.toMatch(/anthropic_api_key|openai_api_key/);
+
+    expectForbidden(
+      await callTool(otherOwner, 'get_classroom_info', { classroom: DEV_REF }),
+      'get_classroom_info as non-member',
+      'NOT_A_MEMBER'
+    );
+  });
+});
+
+// ─── STUDENT-self tier ───────────────────────────────────────────────────────
+
+describe('my_tokens (STUDENT self)', () => {
+  it('STUDENT allowed; teaching team denied', async () => {
+    const allowed = await callTool(student1, 'my_tokens', { classroom: DEV_REF });
+    expect(allowed.isError).toBe(false);
+    expect(typeof allowed.payload.balance).toBe('number');
+    expect(Array.isArray(allowed.payload.transactions)).toBe(true);
+
+    expectForbidden(
+      await callTool(ta, 'my_tokens', { classroom: DEV_REF }),
+      'my_tokens as assistant',
+      'INSUFFICIENT_ROLE'
+    );
+  });
+});
+
+// ─── gated case: roster OWNER-only field split ──────────────────────────────
+
+describe('get_roster (teaching team; OWNER-only field split)', () => {
+  it('TA sees identity-only; OWNER additionally sees contact + grade fields; STUDENT denied', async () => {
+    const taRoster = await callTool(ta, 'get_roster', { classroom: DEV_REF });
+    expect(taRoster.isError).toBe(false);
+    const taStudents = taRoster.payload.students as Array<Record<string, unknown>>;
+    expect(taStudents.length).toBeGreaterThan(0);
+    for (const s of taStudents) {
+      expect(s).toHaveProperty('login');
+      expect(s).not.toHaveProperty('email');
+      expect(s).not.toHaveProperty('school_id');
+      expect(s).not.toHaveProperty('letter_grade');
+    }
+
+    // timofei7 (OWNER) sees the OWNER-only fields — proves the tool preserves
+    // the resource's role-conditional field split.
+    const ownerRoster = await callTool(owner, 'get_roster', { classroom: DEV_REF });
+    expect(ownerRoster.isError).toBe(false);
+    const ownerStudents = ownerRoster.payload.students as Array<Record<string, unknown>>;
+    expect(ownerStudents[0]).toHaveProperty('email');
+    expect(ownerStudents[0]).toHaveProperty('school_id');
+    expect(ownerStudents[0]).toHaveProperty('letter_grade');
+
+    expectForbidden(
+      await callTool(student1, 'get_roster', { classroom: DEV_REF }),
+      'get_roster as student',
+      'INSUFFICIENT_ROLE'
+    );
+  });
+});
+
+// ─── live NO-DRIFT: mirror tool payload == resource payload ─────────────────
+
+describe('no-drift: tool payloads equal their resource payloads', () => {
+  it('get_leaderboard tool == leaderboard resource (OWNER)', async () => {
+    const tool = await callTool(owner, 'get_leaderboard', { classroom: DEV_REF });
+    const resource = await readResource(owner, `classmoji://${DEV_REF}/leaderboard`);
+    expect(resource.error).toBeUndefined();
+    expect(tool.payload).toEqual(resource.payload);
+  });
+
+  it('list_submissions rows == grading-queue resource `all` rows (teaching team)', async () => {
+    const tool = await callTool(ta, 'list_submissions', { classroom: DEV_REF });
+    const resource = await readResource(ta, `classmoji://${DEV_REF}/grading-queue`);
+    expect(resource.error).toBeUndefined();
+    // The per-submission shape (queueRow) and emoji_scale are shared code.
+    expect(tool.payload.submissions).toEqual(resource.payload!.all);
+    expect(tool.payload.emoji_scale).toEqual(resource.payload!.emoji_scale);
+  });
+});


### PR DESCRIPTION
Tool-only MCP clients (claude.ai chief among them) can call `tools/*` but have **no access to `resources/list`/`resources/read`** — so the entire MCP read surface (exposed as resources) was invisible there, leaving the server effectively write-only for those users. Surfaced by a claude.ai agent that couldn't answer a grading question because it could only see the 25 mutation tools.

This mirrors every read resource as a thin `scope: 'read'` tool (the resources are unchanged), so the read surface works on tool-only clients.

### What's added — 18 read tools (`apps/mcp/src/tools/reads.ts`)
- **16 pure mirrors:** `my_classrooms`, `get_classroom_info`, `get_roster`, `list_teams`, `list_repos`, `my_grades`, `get_submission`, `get_leaderboard`, `list_regrade_requests`, `my_regrade_requests`, `list_quizzes`, `list_pages`, `list_modules`, `list_calendar`, `list_calendar_range`, `my_tokens`.
- **`list_submissions`** (teaching-team): the grading-queue feed + optional `repository_id`/`assignment_id`/`grader_id`/`status`/`limit` filters. The returned `id` is the `git_repo_assignment_id` that `grade_add`/`grade_remove`/`grader_assign` consume.
- **`list_teaching_team`** (teaching-team, NEW): staff with their user IDs — resolves the `grader_id` `grader_assign` needs (previously only available in the web UI).

### No-drift by construction
Each mirror tool inherits its resource's exact role tier and **calls the resource's own handler** with an identically-resolved context, then serializes identically. Every guard (leaderboard twin-guard, roster OWNER-field split, quizzes triple-gate, `grades_released`, PII-stripping) fires from the same code — resource and tool are byte-identical. Tests assert this (`.toEqual`).

### Tests
Unit 136 pass (7 new, incl. no-drift assertions); integration 9 pass live (allow/deny per tier — member / STUDENT-self / teaching-team / OWNER-only — roster field-split, and live no-drift). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)