### PR TITLE
feat(mcp): tool annotations + role-tailored whoami suggestions

### DIFF
--- a/apps/mcp/src/__tests__/suggestions.test.ts
+++ b/apps/mcp/src/__tests__/suggestions.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { Role } from '@prisma/client';
+import { buildSuggestions, FACULTY_SUGGESTIONS, STUDENT_SUGGESTIONS } from '../suggestions.ts';
+
+describe('buildSuggestions', () => {
+  it('returns only faculty prompts for a staff-only user', () => {
+    const s = buildSuggestions(['OWNER'] as Role[]);
+    expect(s.faculty).toEqual([...FACULTY_SUGGESTIONS]);
+    expect(s.student).toBeUndefined();
+  });
+
+  it('returns only student prompts for a student-only user', () => {
+    const s = buildSuggestions(['STUDENT'] as Role[]);
+    expect(s.student).toEqual([...STUDENT_SUGGESTIONS]);
+    expect(s.faculty).toBeUndefined();
+  });
+
+  it('returns both for a user who is staff in one class and a student in another', () => {
+    const s = buildSuggestions(['ASSISTANT', 'STUDENT'] as Role[]);
+    expect(s.faculty).toBeDefined();
+    expect(s.student).toBeDefined();
+  });
+
+  it('treats every staff role (OWNER/TEACHER/ASSISTANT) as faculty', () => {
+    for (const role of ['OWNER', 'TEACHER', 'ASSISTANT'] as Role[]) {
+      const s = buildSuggestions([role]);
+      expect(s.faculty).toBeDefined();
+      expect(s.student).toBeUndefined();
+    }
+  });
+
+  it('returns an empty object for a user with no memberships', () => {
+    expect(buildSuggestions([])).toEqual({});
+  });
+
+  it('returns fresh array copies (callers cannot mutate the shared constants)', () => {
+    const faculty = buildSuggestions(['OWNER'] as Role[]).faculty ?? [];
+    faculty.push('mutated');
+    expect(FACULTY_SUGGESTIONS).not.toContain('mutated');
+  });
+});

--- a/apps/mcp/src/mcp/__tests__/registry.test.ts
+++ b/apps/mcp/src/mcp/__tests__/registry.test.ts
@@ -34,8 +34,16 @@ vi.mock('@classmoji/services', () => ({
   },
 }));
 
-const { buildMcpServer, registerToolDefinition } = await import('../registry.ts');
+const { buildMcpServer, registerToolDefinition, toolAnnotations } = await import('../registry.ts');
 const { resetRateLimits } = await import('../rateLimit.ts');
+
+/** Minimal def stub — toolAnnotations only reads `.scope` and `.annotations`. */
+function annotationsOf(
+  scope: 'read' | 'write',
+  annotations?: { destructive?: boolean; idempotent?: boolean; openWorld?: boolean }
+) {
+  return toolAnnotations({ scope, annotations } as Parameters<typeof toolAnnotations>[0]);
+}
 
 // ─── Fake tools ──────────────────────────────────────────────────────────────
 
@@ -423,6 +431,64 @@ describe('mutation gate on write tools', () => {
     const result = await callTool(client, 't_write_classroom', { classroom: REF });
     expect(result.isError).toBeFalsy();
     expect(writeHandlerCalls).toBe(1);
+  });
+});
+
+// ─── Tool annotations (behavioral hints surfaced to clients) ────────────────
+
+describe('toolAnnotations mapping', () => {
+  it('marks reads read-only and omits the write-only hints', () => {
+    const a = annotationsOf('read');
+    expect(a.readOnlyHint).toBe(true);
+    expect(a.openWorldHint).toBe(false);
+    // destructive/idempotent are "meaningful only when readOnlyHint is false".
+    expect('destructiveHint' in a).toBe(false);
+    expect('idempotentHint' in a).toBe(false);
+  });
+
+  it('defaults an unannotated write to destructive (safety-biased)', () => {
+    const a = annotationsOf('write');
+    expect(a).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+  });
+
+  it('passes through a destructive, external-reaching write', () => {
+    expect(annotationsOf('write', { destructive: true, openWorld: true })).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
+  });
+
+  it('passes through an additive idempotent write (upsert)', () => {
+    expect(annotationsOf('write', { destructive: false, idempotent: true })).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+});
+
+describe('annotations reach the wire (tools/list)', () => {
+  it('advertises readOnlyHint on reads and destructiveHint on writes', async () => {
+    const client = await connectClient(makeViewer(['read', 'write']));
+    const tools = (await client.listTools()).tools;
+    const byName = new Map(tools.map(t => [t.name, t.annotations]));
+
+    // t_read_plain is a read tool → read-only, no destructive hint.
+    expect(byName.get('t_read_plain')).toMatchObject({ readOnlyHint: true });
+    // t_write_plain is a write tool with no declared annotations → default
+    // destructive:true (a client should confirm before running it).
+    expect(byName.get('t_write_plain')).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
   });
 });
 

--- a/apps/mcp/src/mcp/registry.ts
+++ b/apps/mcp/src/mcp/registry.ts
@@ -74,6 +74,25 @@ export interface ToolDefinition<Args = Record<string, unknown>> {
   roles: readonly Role[] | null;
   /** Zod raw shape (v1.x SDK registerTool style). */
   inputSchema: ZodRawShape;
+  /**
+   * MCP behavioral hints surfaced to clients (tools/list `annotations`).
+   * `readOnlyHint` is derived from `scope` automatically — do NOT set it here.
+   * These fields describe the WRITE surface so a client can decide whether to
+   * run a call silently or pause for human confirmation:
+   *   - `destructive`: the call deletes/removes data or access (a client should
+   *     double-check before running). Deletes/removes → true; pure creates/
+   *     updates/upserts → false. Defaults to `true` when omitted on a write, so
+   *     an unclassified new tool errs toward "make the human confirm".
+   *   - `idempotent`: repeating the call with the same args has no additional
+   *     effect (e.g. upserts). Meaningful only for writes; defaults false.
+   *   - `openWorld`: the call ripples to an external system (GitHub) rather than
+   *     just our own database. Defaults false (closed classroom domain).
+   */
+  annotations?: {
+    destructive?: boolean;
+    idempotent?: boolean;
+    openWorld?: boolean;
+  };
   /** Optional per-tool override of the default rate limit (S6). */
   rateLimit?: RateLimitConfig;
   handler: (args: Args, ctx: ToolContext) => Promise<ToolResult>;
@@ -361,6 +380,33 @@ function makeListCallback(
 }
 
 /**
+ * Translate a tool's declared scope + `annotations` into the MCP
+ * `ToolAnnotations` hint block (readOnlyHint/destructiveHint/idempotentHint/
+ * openWorldHint). `readOnlyHint` comes straight from `scope`, so the read/write
+ * split we already enforce is the single source of truth for the hint too.
+ * destructiveHint/idempotentHint are only meaningful for writes (per the MCP
+ * spec) and are omitted for reads. destructiveHint defaults to `true` for a
+ * write that declares no annotation — the safety-biased default.
+ */
+export function toolAnnotations(def: ToolDefinition<never>): {
+  readOnlyHint: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint: boolean;
+} {
+  const openWorldHint = def.annotations?.openWorld ?? false;
+  if (def.scope === 'read') {
+    return { readOnlyHint: true, openWorldHint };
+  }
+  return {
+    readOnlyHint: false,
+    destructiveHint: def.annotations?.destructive ?? true,
+    idempotentHint: def.annotations?.idempotent ?? false,
+    openWorldHint,
+  };
+}
+
+/**
  * Build a per-request McpServer bound to the authenticated viewer
  * (locked decision 3: stateless — new server + transport per request).
  * Tools/resources whose scope the token was not granted are not registered at
@@ -377,6 +423,7 @@ export function buildMcpServer(viewer: Viewer): McpServer {
         title: def.title,
         description: def.description,
         inputSchema: def.inputSchema,
+        annotations: { title: def.title, ...toolAnnotations(def) },
       },
       wrapHandler(def, viewer) as never
     );

--- a/apps/mcp/src/resources/me.ts
+++ b/apps/mcp/src/resources/me.ts
@@ -10,15 +10,16 @@
 
 import { ClassmojiService } from '@classmoji/services';
 import type { ResourceDefinition } from '../mcp/registry.ts';
+import { buildSuggestions } from '../suggestions.ts';
 
 export const meResource: ResourceDefinition = {
   name: 'me',
   uriTemplate: 'classmoji://me',
   title: 'My identity & classrooms',
   description:
-    'The authenticated user (id, login, name), granted scopes, and every classroom membership ' +
-    "(one row per role) with status and archive flags. Classrooms are addressed as 'org/slug' " +
-    'in all other resource URIs.',
+    'The authenticated user (id, login, name), granted scopes, every classroom membership ' +
+    '(one row per role) with status and archive flags, and role-tailored example questions to ' +
+    "offer the user. Classrooms are addressed as 'org/slug' in all other resource URIs.",
   scope: 'read',
   roles: null,
   handler: async (_vars, { viewer }) => {
@@ -38,6 +39,8 @@ export const meResource: ResourceDefinition = {
         status: c.status,
         is_archived: c.is_archived,
       })),
+      // Role-tailored conversation starters (cosmetic; from the roles held).
+      suggestions: buildSuggestions(classrooms.map(c => c.membership.role)),
     };
   },
 };

--- a/apps/mcp/src/suggestions.ts
+++ b/apps/mcp/src/suggestions.ts
@@ -1,0 +1,56 @@
+/**
+ * Role-tailored conversation starters returned by the identity surface
+ * (`whoami` tool + `me` resource / `my_classrooms` mirror). These are advisory
+ * example prompts an assistant can offer the user — they map to capabilities
+ * the read/write tools already expose, tailored to the roles the caller
+ * actually holds somewhere (staff vs student). Purely cosmetic: they gate
+ * nothing and grant nothing.
+ */
+
+import type { Role } from '@prisma/client';
+
+export interface Suggestions {
+  /** Present iff the caller holds OWNER/TEACHER/ASSISTANT in any classroom. */
+  faculty?: string[];
+  /** Present iff the caller holds STUDENT in any classroom. */
+  student?: string[];
+}
+
+const STAFF_ROLES: ReadonlySet<Role> = new Set<Role>(['OWNER', 'TEACHER', 'ASSISTANT']);
+
+/** Staff-facing starters (grading, at-risk students, queue, regrades, deadlines). */
+export const FACULTY_SUGGESTIONS: readonly string[] = [
+  'Show me the grade distribution for one of my classes.',
+  'Which students are struggling or falling behind?',
+  "What's in my grading queue — any submissions still ungraded?",
+  'Are there any open regrade requests I need to resolve?',
+  'What assignments are due this week?',
+];
+
+/** Student-facing starters (upcoming work, grades, tokens, regrades). */
+export const STUDENT_SUGGESTIONS: readonly string[] = [
+  'What assignments do I have coming up, and when are they due?',
+  'How am I doing — what are my current released grades?',
+  'How many tokens do I have, and can I buy a deadline extension?',
+  'Do I have any pending regrade requests?',
+];
+
+/**
+ * Build the suggestion block from the caller's membership roles. A key is
+ * included only when the caller holds a matching role somewhere, so a
+ * staff-only user never sees student prompts and vice versa; a user who is both
+ * (e.g. a TA taking another course) gets both.
+ */
+export function buildSuggestions(roles: Iterable<Role>): Suggestions {
+  let isStaff = false;
+  let isStudent = false;
+  for (const role of roles) {
+    if (STAFF_ROLES.has(role)) isStaff = true;
+    else if (role === 'STUDENT') isStudent = true;
+  }
+
+  const suggestions: Suggestions = {};
+  if (isStaff) suggestions.faculty = [...FACULTY_SUGGESTIONS];
+  if (isStudent) suggestions.student = [...STUDENT_SUGGESTIONS];
+  return suggestions;
+}

--- a/apps/mcp/src/tools/assignments.ts
+++ b/apps/mcp/src/tools/assignments.ts
@@ -37,6 +37,7 @@ const TEACHER_ALLOWED_FIELDS = new Set(['grades_released', 'student_deadline']);
 
 export const assignmentUpdateTool: ToolDefinition<AssignmentUpdateArgs> = {
   name: 'assignment_update',
+  annotations: { destructive: false },
   title: 'Update an assignment',
   description:
     'Updates an assignment (a due-dated, gradeable slice of a repo/lab): student deadline, ' +

--- a/apps/mcp/src/tools/calendar.ts
+++ b/apps/mcp/src/tools/calendar.ts
@@ -95,6 +95,7 @@ function resolveScope(
 
 export const calendarEventCreateTool: ToolDefinition<CalendarEventCreateArgs> = {
   name: 'calendar_event_create',
+  annotations: { destructive: false },
   title: 'Create a calendar event',
   description:
     'Creates a classroom calendar event (lecture, lab, office hours, or assessment). For a ' +
@@ -176,6 +177,7 @@ interface CalendarEventUpdateArgs {
 
 export const calendarEventUpdateTool: ToolDefinition<CalendarEventUpdateArgs> = {
   name: 'calendar_event_update',
+  annotations: { destructive: false },
   title: 'Update a calendar event',
   description:
     'Updates a calendar event. Assistants can only update events they created. For recurring ' +
@@ -267,6 +269,7 @@ interface CalendarEventDeleteArgs {
 
 export const calendarEventDeleteTool: ToolDefinition<CalendarEventDeleteArgs> = {
   name: 'calendar_event_delete',
+  annotations: { destructive: true },
   title: 'Delete a calendar event',
   description:
     'Deletes a calendar event. Assistants can only delete events they created. For recurring ' +

--- a/apps/mcp/src/tools/extensions.ts
+++ b/apps/mcp/src/tools/extensions.ts
@@ -54,6 +54,7 @@ interface ExtensionPurchaseArgs {
 
 export const extensionPurchaseTool: ToolDefinition<ExtensionPurchaseArgs> = {
   name: 'extension_purchase',
+  annotations: { destructive: false },
   title: 'Purchase late-hour extension',
   description:
     'Spends YOUR tokens to buy late hours on one of YOUR OWN overdue assignments (students ' +

--- a/apps/mcp/src/tools/graders.ts
+++ b/apps/mcp/src/tools/graders.ts
@@ -55,6 +55,7 @@ async function loadGitOrganization(classroomId: string) {
 
 export const graderAssignTool: ToolDefinition<GraderArgs> = {
   name: 'grader_assign',
+  annotations: { destructive: false, openWorld: true },
   title: 'Assign a grader',
   description:
     'Assigns a teaching-team member as grader on a submission. Mirrors the grader to the ' +
@@ -109,6 +110,7 @@ export const graderAssignTool: ToolDefinition<GraderArgs> = {
 
 export const graderUnassignTool: ToolDefinition<GraderArgs> = {
   name: 'grader_unassign',
+  annotations: { destructive: true, openWorld: true },
   title: 'Unassign a grader',
   description:
     'Removes a grader from a submission and from the GitHub issue assignees. Owner only.',

--- a/apps/mcp/src/tools/grades.ts
+++ b/apps/mcp/src/tools/grades.ts
@@ -59,6 +59,7 @@ async function assertEmojiInScale(classroomId: string, emoji: string): Promise<v
 
 export const gradeAddTool: ToolDefinition<GradeAddArgs> = {
   name: 'grade_add',
+  annotations: { destructive: false },
   title: 'Add a grade',
   description:
     'Adds an emoji grade to a submission (a GitRepoAssignment — one assignment on one ' +
@@ -121,6 +122,7 @@ interface GradeRemoveArgs {
 
 export const gradeRemoveTool: ToolDefinition<GradeRemoveArgs> = {
   name: 'grade_remove',
+  annotations: { destructive: true },
   title: 'Remove a grade',
   description:
     'Removes one emoji grade from a submission and reverses any token reward it minted. ' +
@@ -171,6 +173,7 @@ interface GradeRemoveAllArgs {
 
 export const gradeRemoveAllTool: ToolDefinition<GradeRemoveAllArgs> = {
   name: 'grade_remove_all',
+  annotations: { destructive: true },
   title: 'Remove all grades from a submission',
   description:
     'Removes every emoji grade from a submission and reverses their token rewards. Owner only.',

--- a/apps/mcp/src/tools/mappings.ts
+++ b/apps/mcp/src/tools/mappings.ts
@@ -24,6 +24,7 @@ interface EmojiMappingArgs {
 
 export const emojiMappingUpsertTool: ToolDefinition<EmojiMappingArgs> = {
   name: 'emoji_mapping_upsert',
+  annotations: { destructive: false, idempotent: true },
   title: 'Create or update an emoji grade mapping',
   description:
     "Creates or updates one emoji in the classroom's grading scale: its numeric grade value, " +
@@ -81,6 +82,7 @@ interface LetterGradeMappingArgs {
 
 export const letterGradeMappingUpsertTool: ToolDefinition<LetterGradeMappingArgs> = {
   name: 'letter_grade_mapping_upsert',
+  annotations: { destructive: false, idempotent: true },
   title: 'Create or update a letter grade mapping',
   description:
     'Creates or updates one letter-grade threshold (e.g. A = min 90) in the classroom. Owner only.',

--- a/apps/mcp/src/tools/modules.ts
+++ b/apps/mcp/src/tools/modules.ts
@@ -54,6 +54,7 @@ interface ModuleCreateArgs {
 
 export const moduleCreateTool: ToolDefinition<ModuleCreateArgs> = {
   name: 'module_create',
+  annotations: { destructive: false },
   title: 'Create a module',
   description:
     'Creates a curriculum module — an ordered list of content (pages, repos/labs, quizzes, ' +
@@ -104,6 +105,7 @@ interface ModuleUpdateArgs {
 
 export const moduleUpdateTool: ToolDefinition<ModuleUpdateArgs> = {
   name: 'module_update',
+  annotations: { destructive: false },
   title: 'Update a module',
   description: "Updates a module's title and/or description (the slug never changes). Owner only.",
   scope: 'write',
@@ -148,6 +150,7 @@ interface ModulePublishArgs {
 
 export const modulePublishTool: ToolDefinition<ModulePublishArgs> = {
   name: 'module_publish',
+  annotations: { destructive: false },
   title: 'Publish or unpublish a module',
   description:
     'Sets whether a curriculum module is visible to students. Items whose underlying content ' +
@@ -194,6 +197,7 @@ interface ModuleItemAddArgs {
 
 export const moduleItemAddTool: ToolDefinition<ModuleItemAddArgs> = {
   name: 'module_item_add',
+  annotations: { destructive: false },
   title: 'Add an item to a module',
   description:
     'Appends a content item to a module: a page, a repo/lab (REPOSITORY links the assignment ' +

--- a/apps/mcp/src/tools/pages.ts
+++ b/apps/mcp/src/tools/pages.ts
@@ -63,6 +63,7 @@ interface PageCreateArgs {
 
 export const pageCreateTool: ToolDefinition<PageCreateArgs> = {
   name: 'page_create',
+  annotations: { destructive: false, openWorld: true },
   title: 'Create a page',
   description:
     "Creates a new course page: a folder with an index.html in the classroom's shared content " +
@@ -136,6 +137,7 @@ interface PageUpdateArgs {
 
 export const pageUpdateTool: ToolDefinition<PageUpdateArgs> = {
   name: 'page_update',
+  annotations: { destructive: false, openWorld: true },
   title: 'Update a page',
   description:
     "Updates a course page's metadata: title, layout width, draft/published state (publishing " +
@@ -216,6 +218,7 @@ interface PageDeleteArgs {
 
 export const pageDeleteTool: ToolDefinition<PageDeleteArgs> = {
   name: 'page_delete',
+  annotations: { destructive: true, openWorld: true },
   title: 'Delete a page',
   description:
     "Permanently deletes a course page: removes its folder from the classroom's content repo " +

--- a/apps/mcp/src/tools/regrades.ts
+++ b/apps/mcp/src/tools/regrades.ts
@@ -88,6 +88,7 @@ interface RegradeCreateArgs {
 
 export const regradeCreateTool: ToolDefinition<RegradeCreateArgs> = {
   name: 'regrade_create',
+  annotations: { destructive: false },
   title: 'Request a regrade',
   description:
     'Submits a regrade (resubmit) request for one of YOUR OWN graded submissions. Students ' +
@@ -195,6 +196,7 @@ interface RegradeResolveArgs {
 
 export const regradeResolveTool: ToolDefinition<RegradeResolveArgs> = {
   name: 'regrade_resolve',
+  annotations: { destructive: false },
   title: 'Resolve a regrade request',
   description:
     'Approves or denies a pending regrade request and emails the student. After approving, add ' +

--- a/apps/mcp/src/tools/repos.ts
+++ b/apps/mcp/src/tools/repos.ts
@@ -90,6 +90,7 @@ interface RepoPublishArgs {
 
 export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
   name: 'repo_publish',
+  annotations: { destructive: false, openWorld: true },
   title: 'Publish a repo',
   description:
     'Publishes a repo (assignment container) to students and provisions their git repositories ' +
@@ -210,6 +211,9 @@ interface RepoUnpublishArgs {
 
 export const repoUnpublishTool: ToolDefinition<RepoUnpublishArgs> = {
   name: 'repo_unpublish',
+  // Reversible visibility flip in our DB (setPublished(false)); no rows removed,
+  // no GitHub call — repo_publish flips it back. Not destructive, closed-world.
+  annotations: { destructive: false },
   title: 'Unpublish a repo',
   description:
     'Hides a repo (assignment container) from students. Owner only. Existing git repositories ' +

--- a/apps/mcp/src/tools/tokens.ts
+++ b/apps/mcp/src/tools/tokens.ts
@@ -27,6 +27,7 @@ interface TokenGrantArgs {
 
 export const tokenGrantTool: ToolDefinition<TokenGrantArgs> = {
   name: 'token_grant',
+  annotations: { destructive: false },
   title: 'Grant tokens to a student',
   description:
     'Grants extension/reward tokens to one student in the classroom. Owner only. The student ' +

--- a/apps/mcp/src/tools/whoami.ts
+++ b/apps/mcp/src/tools/whoami.ts
@@ -7,6 +7,7 @@
 
 import { ClassmojiService } from '@classmoji/services';
 import type { ToolDefinition } from '../mcp/registry.ts';
+import { buildSuggestions } from '../suggestions.ts';
 
 interface MembershipSummary {
   classroom: string;
@@ -20,9 +21,9 @@ export const whoamiTool: ToolDefinition<Record<string, never>> = {
   name: 'whoami',
   title: 'Who am I',
   description:
-    'Returns the authenticated user (id, login, name), the scopes granted to this token, and a ' +
-    "summary of classroom memberships. Classrooms are addressed as 'org/slug' — use those " +
-    'references with other tools.',
+    'Returns the authenticated user (id, login, name), the scopes granted to this token, a ' +
+    'summary of classroom memberships, and role-tailored example questions to offer the user. ' +
+    "Classrooms are addressed as 'org/slug' — use those references with other tools.",
   scope: 'read',
   roles: null,
   inputSchema: {},
@@ -45,6 +46,8 @@ export const whoamiTool: ToolDefinition<Record<string, never>> = {
       name: user?.name ?? null,
       scopes: [...viewer.scopes],
       memberships,
+      // Role-tailored conversation starters (cosmetic; from the roles held).
+      suggestions: buildSuggestions(classrooms.map(c => c.membership.role)),
     };
 
     return {


### PR DESCRIPTION
## What

Two MCP-server improvements for the classmoji MCP.

### 1. Proper tool hints (MCP ToolAnnotations)
Every tool now advertises behavioral hints so clients can distinguish safe reads from writes that warrant confirmation:
- **readOnlyHint** — derived from each tool's declared `scope` (single source of truth; no drift).
- **destructiveHint: true** on the 5 delete/remove tools — `grade_remove`, `grade_remove_all`, `grader_unassign`, `calendar_event_delete`, `page_delete`. An unclassified write **defaults to destructive** (safety-biased: a future tool that forgets to classify itself errs toward "confirm first").
- **idempotentHint** on the emoji/letter upserts; **openWorldHint** on the GitHub-touching tools (`grader_*`, `page_*`, `repo_publish`).

Hints are advisory — they don't touch server-side enforcement (scope → rate-limit → role → mutation gate); they let clients auto-run reads and prompt on destructive writes.

### 2. Role-tailored whoami suggestions
`whoami` and the `me` resource / `my_classrooms` tool now return role-tailored example prompts (faculty vs student) so assistants can offer useful starters — grade distribution, at-risk students, upcoming assignments. A user who is staff in one class and a student in another gets both.

## Tests
- MCP unit suite **147 passed**, typecheck + lint clean.
- New: annotation mapping (read/write/default/passthrough) + a `tools/list` wire check; `buildSuggestions` role logic.
- Verified against the real registered tool set: 19 reads read-only, 5 destructive flagged, upserts idempotent, GitHub tools open-world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)