### PR TITLE
Promote: MCP CRUD tools + polish fixes

### DIFF
--- a/apps/mcp/src/__tests__/config.test.ts
+++ b/apps/mcp/src/__tests__/config.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for MCP_PUBLIC_URL boot-time validation.
+ *
+ * The resource identifier advertised in RFC 9728 metadata and WWW-Authenticate
+ * challenges must be an absolute http(s) origin; a schemeless value would
+ * silently produce broken metadata. config.ts validates at module eval, so
+ * each case re-imports the module with a fresh env under vi.resetModules().
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ORIGINAL = process.env.MCP_PUBLIC_URL;
+
+async function loadConfig() {
+  vi.resetModules();
+  return import('../config.ts');
+}
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.MCP_PUBLIC_URL;
+  else process.env.MCP_PUBLIC_URL = ORIGINAL;
+  vi.resetModules();
+});
+
+describe('MCP_PUBLIC_URL validation', () => {
+  it('throws at boot on a schemeless value', async () => {
+    process.env.MCP_PUBLIC_URL = 'mcp.example.com';
+    await expect(loadConfig()).rejects.toThrow(/must be an absolute http/);
+  });
+
+  it('throws at boot on a non-http(s) scheme', async () => {
+    process.env.MCP_PUBLIC_URL = 'ftp://mcp.example.com';
+    await expect(loadConfig()).rejects.toThrow(/must use http/);
+  });
+
+  it('accepts a valid https URL and strips the trailing slash', async () => {
+    process.env.MCP_PUBLIC_URL = 'https://mcp.example.com/';
+    const cfg = await loadConfig();
+    expect(cfg.MCP_PUBLIC_URL).toBe('https://mcp.example.com');
+  });
+
+  it('falls back to the localhost default when unset', async () => {
+    delete process.env.MCP_PUBLIC_URL;
+    const cfg = await loadConfig();
+    expect(cfg.MCP_PUBLIC_URL).toMatch(/^http:\/\/localhost:\d+$/);
+  });
+});

--- a/apps/mcp/src/config.ts
+++ b/apps/mcp/src/config.ts
@@ -8,6 +8,26 @@
 
 const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
 
+/**
+ * Validate an absolute http(s) URL, throwing at boot on a schemeless or
+ * malformed value. The resource identifier advertised in RFC 9728
+ * protected-resource metadata and WWW-Authenticate challenges MUST be an
+ * absolute origin; a schemeless value ('mcp.example.com', 'localhost:8100')
+ * silently produces broken metadata clients cannot resolve.
+ */
+const requireHttpUrl = (value: string, varName: string): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`[mcp] ${varName} must be an absolute http(s) URL, got: ${value}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`[mcp] ${varName} must use http:// or https://, got: ${value}`);
+  }
+  return stripTrailingSlash(value);
+};
+
 export const MCP_PORT = Number(process.env.MCP_PORT) || 8100;
 
 /**
@@ -15,8 +35,9 @@ export const MCP_PORT = Number(process.env.MCP_PORT) || 8100;
  * RFC 9728 protected-resource metadata and referenced from WWW-Authenticate
  * challenges. Must be the externally reachable URL in production.
  */
-export const MCP_PUBLIC_URL = stripTrailingSlash(
-  process.env.MCP_PUBLIC_URL || `http://localhost:${MCP_PORT}`
+export const MCP_PUBLIC_URL = requireHttpUrl(
+  process.env.MCP_PUBLIC_URL || `http://localhost:${MCP_PORT}`,
+  'MCP_PUBLIC_URL'
 );
 
 /**

--- a/apps/mcp/src/tools/__tests__/assignments.test.ts
+++ b/apps/mcp/src/tools/__tests__/assignments.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for assignment_create / assignment_delete (Phase: assignment
+ * lifecycle). Both fire ZERO external effects (pure DB — no GitHub, no
+ * Trigger.dev, no email), so only the service boundary is mocked.
+ *
+ * The security-critical assertions: create re-verifies the PARENT container's
+ * classroom (S1) and NEVER trusts a request classroom_id; delete re-verifies
+ * the assignment's own classroom; both refuse cross-classroom targets with the
+ * uniform scopedNotFound.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  repositoryFindById: vi.fn(),
+  assignmentFindById: vi.fn(),
+  assignmentCreate: vi.fn(),
+  assignmentDeleteById: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    repository: { findById: (...a: unknown[]) => mocks.repositoryFindById(...a) },
+    assignment: {
+      findById: (...a: unknown[]) => mocks.assignmentFindById(...a),
+      create: (...a: unknown[]) => mocks.assignmentCreate(...a),
+      deleteById: (...a: unknown[]) => mocks.assignmentDeleteById(...a),
+    },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+  },
+}));
+
+const { assignmentCreateTool, assignmentDeleteTool } = await import('../assignments.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+});
+
+describe('assignment_create', () => {
+  const ARGS = {
+    classroom: 'org/winter-2025',
+    repository_id: 'repo-1',
+    title: 'Lab 3',
+    weight: 50,
+    student_deadline: '2026-07-20T23:59:00-04:00',
+  };
+
+  it('creates under a verified parent container and audits CREATE', async () => {
+    mocks.repositoryFindById.mockResolvedValue({ id: 'repo-1', classroom_id: 'class-1' });
+    mocks.assignmentCreate.mockResolvedValue({
+      id: 'asg-new',
+      title: 'Lab 3',
+      repository_id: 'repo-1',
+      weight: 50,
+      is_published: false,
+      student_deadline: new Date('2026-07-20T23:59:00-04:00'),
+    });
+
+    const payload = parse(await assignmentCreateTool.handler(ARGS, CTX));
+    expect(payload.success).toBe(true);
+    expect(payload.assignment.id).toBe('asg-new');
+
+    // repository_id passed to create is the VERIFIED parent's id.
+    const data = mocks.assignmentCreate.mock.calls[0][0] as {
+      repository_id: string;
+      title: string;
+    };
+    expect(data.repository_id).toBe('repo-1');
+    expect(data.title).toBe('Lab 3');
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    expect((mocks.auditCreate.mock.calls[0][0] as { action: string }).action).toBe('CREATE');
+  });
+
+  it('refuses a parent container in another classroom (S1) and never creates', async () => {
+    mocks.repositoryFindById.mockResolvedValue({ id: 'repo-1', classroom_id: 'OTHER-class' });
+
+    await expect(assignmentCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+    expect(mocks.assignmentCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown parent container (S1)', async () => {
+    mocks.repositoryFindById.mockResolvedValue(null);
+    await expect(assignmentCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+    expect(mocks.assignmentCreate).not.toHaveBeenCalled();
+  });
+
+  it('maps a duplicate-title P2002 to invalid_params', async () => {
+    mocks.repositoryFindById.mockResolvedValue({ id: 'repo-1', classroom_id: 'class-1' });
+    mocks.assignmentCreate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
+
+    await expect(assignmentCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('assignment_delete', () => {
+  const ARGS = { classroom: 'org/winter-2025', assignment_id: 'asg-1' };
+
+  it('deletes an in-classroom assignment and audits DELETE with a blast count', async () => {
+    mocks.assignmentFindById.mockResolvedValue({
+      id: 'asg-1',
+      title: 'Lab 3',
+      repository: { classroom_id: 'class-1' },
+      git_repo_assignments: [{ id: 's1' }, { id: 's2' }, { id: 's3' }],
+    });
+
+    const payload = parse(await assignmentDeleteTool.handler(ARGS, CTX));
+    expect(payload.success).toBe(true);
+    expect(payload.submissions_deleted).toBe(3);
+    expect(mocks.assignmentDeleteById).toHaveBeenCalledWith('asg-1');
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      data: { submissions_deleted: number };
+    };
+    expect(audit.action).toBe('DELETE');
+    expect(audit.data.submissions_deleted).toBe(3);
+  });
+
+  it('refuses an assignment in another classroom (S1) and never deletes', async () => {
+    mocks.assignmentFindById.mockResolvedValue({
+      id: 'asg-1',
+      title: 'Lab 3',
+      repository: { classroom_id: 'OTHER-class' },
+      git_repo_assignments: [],
+    });
+
+    await expect(assignmentDeleteTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+    expect(mocks.assignmentDeleteById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/src/tools/__tests__/calendar.test.ts
+++ b/apps/mcp/src/tools/__tests__/calendar.test.ts
@@ -17,6 +17,7 @@ import type { ToolContext } from '../../mcp/registry.ts';
 
 const mocks = vi.hoisted(() => ({
   getEventById: vi.fn(),
+  createEvent: vi.fn(),
   updateEvent: vi.fn(),
   updateEventWithScope: vi.fn(),
   auditCreate: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock('@classmoji/services', () => ({
   ClassmojiService: {
     calendar: {
       getEventById: (...a: unknown[]) => mocks.getEventById(...a),
+      createEvent: (...a: unknown[]) => mocks.createEvent(...a),
       updateEvent: (...a: unknown[]) => mocks.updateEvent(...a),
       updateEventWithScope: (...a: unknown[]) => mocks.updateEventWithScope(...a),
     },
@@ -33,7 +35,7 @@ vi.mock('@classmoji/services', () => ({
   },
 }));
 
-const { calendarEventUpdateTool } = await import('../calendar.ts');
+const { calendarEventCreateTool, calendarEventUpdateTool } = await import('../calendar.ts');
 
 /** OWNER context (skips the assistant own-events sub-gate cleanly). */
 const CTX: ToolContext = {
@@ -67,6 +69,134 @@ beforeEach(() => {
   mocks.getEventById.mockResolvedValue(RECURRING_EVENT);
   mocks.updateEventWithScope.mockResolvedValue(RECURRING_EVENT);
   mocks.auditCreate.mockResolvedValue(undefined);
+});
+
+// ─── F5: end_time must be after start_time ──────────────────────────────────
+
+/** Non-recurring event with concrete Date bounds (for single-edge update). */
+const TIMED_EVENT = {
+  id: 'event-2',
+  classroom_id: 'class-1',
+  created_by: 'owner-1',
+  title: 'Office Hours',
+  is_recurring: false,
+  recurrence_rule: null,
+  start_time: new Date('2026-07-20T10:00:00-04:00'),
+  end_time: new Date('2026-07-20T11:00:00-04:00'),
+};
+
+const CREATE_BASE = {
+  classroom: 'org/winter-2025',
+  title: 'Lab',
+  event_type: 'LAB' as const,
+};
+
+async function expectInvalidParams(p: Promise<unknown>) {
+  await expect(p).rejects.toMatchObject({ kind: 'invalid_params' });
+}
+
+describe('calendar end_time > start_time (F5)', () => {
+  it('rejects create when end_time <= start_time (before createEvent)', async () => {
+    await expectInvalidParams(
+      calendarEventCreateTool.handler(
+        {
+          ...CREATE_BASE,
+          start_time: '2026-07-20T11:00:00-04:00',
+          end_time: '2026-07-20T10:00:00-04:00',
+        },
+        CTX
+      )
+    );
+    // Zero-length range also rejected (strict >).
+    await expectInvalidParams(
+      calendarEventCreateTool.handler(
+        {
+          ...CREATE_BASE,
+          start_time: '2026-07-20T10:00:00-04:00',
+          end_time: '2026-07-20T10:00:00-04:00',
+        },
+        CTX
+      )
+    );
+    expect(mocks.createEvent).not.toHaveBeenCalled();
+  });
+
+  it('allows a valid create', async () => {
+    mocks.createEvent.mockResolvedValue({
+      ...TIMED_EVENT,
+      event_type: 'LAB',
+    });
+    await calendarEventCreateTool.handler(
+      {
+        ...CREATE_BASE,
+        start_time: '2026-07-20T10:00:00-04:00',
+        end_time: '2026-07-20T11:00:00-04:00',
+      },
+      CTX
+    );
+    expect(mocks.createEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a single-edge update that inverts against the stored bound', async () => {
+    mocks.getEventById.mockResolvedValue(TIMED_EVENT);
+    // Move only start_time to AFTER the stored end (11:00) → invalid.
+    await expectInvalidParams(
+      calendarEventUpdateTool.handler(
+        {
+          classroom: 'org/winter-2025',
+          event_id: 'event-2',
+          start_time: '2026-07-20T12:00:00-04:00',
+        },
+        CTX
+      )
+    );
+    expect(mocks.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it('allows a valid single-edge update (extend the end)', async () => {
+    mocks.getEventById.mockResolvedValue(TIMED_EVENT);
+    mocks.updateEvent.mockResolvedValue(TIMED_EVENT);
+    await calendarEventUpdateTool.handler(
+      { classroom: 'org/winter-2025', event_id: 'event-2', end_time: '2026-07-20T12:30:00-04:00' },
+      CTX
+    );
+    expect(mocks.updateEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT reject a recurring single-edge (this_only) override vs the template bound', async () => {
+    // RECURRING_EVENT's stored bounds are the SERIES TEMPLATE's absolute
+    // datetimes, not the edited occurrence's — a start-only override must not be
+    // validated against them (that was the false-rejection bug). getEventById
+    // defaults to RECURRING_EVENT.
+    await calendarEventUpdateTool.handler(
+      {
+        classroom: 'org/winter-2025',
+        event_id: 'event-1',
+        start_time: '2026-02-02T12:00:00-04:00',
+        edit_scope: 'this_only',
+        occurrence_date: '2026-02-02T10:00:00-04:00',
+      },
+      CTX
+    );
+    expect(mocks.updateEventWithScope).toHaveBeenCalledTimes(1);
+  });
+
+  it('still validates both-edges override on a recurring event', async () => {
+    await expectInvalidParams(
+      calendarEventUpdateTool.handler(
+        {
+          classroom: 'org/winter-2025',
+          event_id: 'event-1',
+          start_time: '2026-02-02T12:00:00-04:00',
+          end_time: '2026-02-02T11:00:00-04:00',
+          edit_scope: 'this_only',
+          occurrence_date: '2026-02-02T10:00:00-04:00',
+        },
+        CTX
+      )
+    );
+    expect(mocks.updateEventWithScope).not.toHaveBeenCalled();
+  });
 });
 
 describe('calendar_event_update recurrence preservation (U2)', () => {

--- a/apps/mcp/src/tools/__tests__/grades.test.ts
+++ b/apps/mcp/src/tools/__tests__/grades.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   findByClassroomId: vi.fn(),
   findByAssignmentId: vi.fn(),
   addGradeToGitRepoAssignment: vi.fn(),
+  removeGradeFromGitRepoAssignment: vi.fn(),
   auditCreate: vi.fn(),
 }));
 
@@ -33,10 +34,12 @@ vi.mock('@classmoji/services', () => ({
   },
   HelperService: {
     addGradeToGitRepoAssignment: (...a: unknown[]) => mocks.addGradeToGitRepoAssignment(...a),
+    removeGradeFromGitRepoAssignment: (...a: unknown[]) =>
+      mocks.removeGradeFromGitRepoAssignment(...a),
   },
 }));
 
-const { gradeAddTool } = await import('../grades.ts');
+const { gradeAddTool, gradeRemoveAllTool } = await import('../grades.ts');
 
 const CTX: ToolContext = {
   viewer: { userId: 'ta-1', clientId: 'c', scopes: new Set(['read', 'write']) },
@@ -104,5 +107,51 @@ describe('grade_add deduplicated flag (U4)', () => {
 
     const payload = parse(await gradeAddTool.handler(ARGS, CTX));
     expect(payload.deduplicated).toBe(false);
+  });
+});
+
+// ─── U9: grade_remove_all audits every completed removal ─────────────────────
+
+describe('grade_remove_all per-grade audit (U9)', () => {
+  const REMOVE_ARGS = { classroom: 'org/winter-2025', git_repo_assignment_id: 'gra-1' };
+
+  beforeEach(() => {
+    mocks.findById.mockResolvedValue(gra([]));
+  });
+
+  it('writes one audit row per grade and returns the removed count', async () => {
+    mocks.findByAssignmentId.mockResolvedValue([
+      { id: 'g1', emoji: '🟢' },
+      { id: 'g2', emoji: '🔴' },
+      { id: 'g3', emoji: '🟡' },
+    ]);
+    mocks.removeGradeFromGitRepoAssignment.mockResolvedValue(undefined);
+
+    const payload = parse(await gradeRemoveAllTool.handler(REMOVE_ARGS, CTX));
+    expect(payload.removed_count).toBe(3);
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(3);
+    // Each audit row carries the specific grade id it removed.
+    const auditedGradeIds = mocks.auditCreate.mock.calls.map(
+      c => (c[0] as { data: { grade_id: string } }).data.grade_id
+    );
+    expect(auditedGradeIds).toEqual(['g1', 'g2', 'g3']);
+  });
+
+  it('still audits the completed removals when the loop throws partway', async () => {
+    mocks.findByAssignmentId.mockResolvedValue([
+      { id: 'g1', emoji: '🟢' },
+      { id: 'g2', emoji: '🔴' },
+    ]);
+    // First removal succeeds and is audited; the second throws.
+    mocks.removeGradeFromGitRepoAssignment
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('boom'));
+
+    await expect(gradeRemoveAllTool.handler(REMOVE_ARGS, CTX)).rejects.toThrow('boom');
+    // The completed first removal was audited before the failure — not stranded.
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    expect(
+      (mocks.auditCreate.mock.calls[0][0] as { data: { grade_id: string } }).data.grade_id
+    ).toBe('g1');
   });
 });

--- a/apps/mcp/src/tools/__tests__/regrades.test.ts
+++ b/apps/mcp/src/tools/__tests__/regrades.test.ts
@@ -39,7 +39,7 @@ vi.mock('@trigger.dev/sdk', () => ({
   runs: { retrieve: (...a: unknown[]) => mocks.retrieve(...a) },
 }));
 
-const { regradeCreateTool } = await import('../regrades.ts');
+const { regradeCreateTool, regradeResolveTool } = await import('../regrades.ts');
 
 const CTX: ToolContext = {
   viewer: { userId: 'student-1', clientId: 'c', scopes: new Set(['read', 'write']) },
@@ -116,5 +116,51 @@ describe('regrade_create idempotency (F1)', () => {
       })
     );
     expect(payload.regrade_request.id).toBe('rr-new');
+  });
+});
+
+// ─── U11: regrade_resolve idempotency (no duplicate resolution email) ────────
+
+describe('regrade_resolve idempotency (U11)', () => {
+  const RESOLVE_ARGS = {
+    classroom: 'org/winter-2025',
+    regrade_request_id: 'rr-1',
+    resolution: 'APPROVED' as const,
+  };
+
+  /** loadRegradeRequestInClassroom reads findMany()[0]; classroom_id must match. */
+  function requestWithStatus(status: string) {
+    return [
+      {
+        id: 'rr-1',
+        classroom_id: 'class-1',
+        status,
+        student: { email: 's@example.com' },
+        git_repo_assignment: { assignment: { title: 'Lab 1' } },
+      },
+    ];
+  }
+
+  it('returns the recorded resolution WITHOUT re-triggering when already terminal', async () => {
+    mocks.findMany.mockResolvedValue(requestWithStatus('APPROVED'));
+
+    const payload = parse(await regradeResolveTool.handler(RESOLVE_ARGS, CTX));
+    expect(payload.already_resolved).toBe(true);
+    expect(payload.regrade_request.status).toBe('APPROVED');
+    // The whole point of U11: no second task run, so no duplicate email.
+    expect(mocks.trigger).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('triggers the resolution task once for an IN_REVIEW request', async () => {
+    mocks.findMany.mockResolvedValue(requestWithStatus('IN_REVIEW'));
+    mocks.trigger.mockResolvedValue({ id: 'run-1' });
+    mocks.retrieve.mockResolvedValue({ status: 'COMPLETED', output: {} });
+
+    const payload = parse(await regradeResolveTool.handler(RESOLVE_ARGS, CTX));
+    expect(mocks.trigger).toHaveBeenCalledTimes(1);
+    expect(mocks.trigger).toHaveBeenCalledWith('update_regrade_request', expect.any(Object));
+    expect(payload.regrade_request.status).toBe('APPROVED');
+    expect(payload.already_resolved).toBeUndefined();
   });
 });

--- a/apps/mcp/src/tools/__tests__/repos.test.ts
+++ b/apps/mcp/src/tools/__tests__/repos.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for repo_create (container create). The tool must:
+ *   - write classroom_id from ctx, never from input;
+ *   - refresh the content manifest but NEVER trigger repo provisioning
+ *     (provisioning is repo_publish's job — a create must not touch GitHub repos);
+ *   - validate a supplied tag belongs to the classroom (S1);
+ *   - enforce the GROUP+INSTRUCTOR-needs-tag rule and map P2002 to invalid_params.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  repositoryCreate: vi.fn(),
+  findByClassroomId: vi.fn(),
+  saveManifest: vi.fn(),
+  auditCreate: vi.fn(),
+  createRepositoriesTrigger: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    repository: { create: (...a: unknown[]) => mocks.repositoryCreate(...a) },
+    organizationTag: { findByClassroomId: (...a: unknown[]) => mocks.findByClassroomId(...a) },
+    contentManifest: { saveManifest: (...a: unknown[]) => mocks.saveManifest(...a) },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+  },
+}));
+
+vi.mock('@classmoji/tasks', () => ({
+  default: {
+    createRepositoriesTask: {
+      trigger: (...a: unknown[]) => mocks.createRepositoriesTrigger(...a),
+    },
+  },
+}));
+
+const { repoCreateTool } = await import('../repos.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    slug: 'cs1-w26',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {}, slug: 'cs1-w26' },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.saveManifest.mockResolvedValue(undefined);
+  mocks.auditCreate.mockResolvedValue(undefined);
+  mocks.repositoryCreate.mockResolvedValue({
+    id: 'repo-new',
+    title: 'Lab 1',
+    slug: 'lab-1',
+    type: 'INDIVIDUAL',
+    is_published: false,
+    weight: 100,
+  });
+});
+
+describe('repo_create', () => {
+  const BASE = { classroom: 'org/cs1-w26', title: 'Lab 1', template: 'lab1-template' };
+
+  it('creates an unpublished container from ctx classroom, refreshes manifest, NO provisioning', async () => {
+    const payload = parse(await repoCreateTool.handler(BASE, CTX));
+
+    expect(payload.repository.id).toBe('repo-new');
+    expect(payload.repository.is_published).toBe(false);
+
+    const data = mocks.repositoryCreate.mock.calls[0][0] as { classroom_id: string; type: string };
+    expect(data.classroom_id).toBe('class-1'); // from ctx, not input
+    expect(data.type).toBe('INDIVIDUAL');
+
+    expect(mocks.saveManifest).toHaveBeenCalledWith('class-1');
+    // The key isolation guarantee: creating a container must NOT provision repos.
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+    expect((mocks.auditCreate.mock.calls[0][0] as { action: string }).action).toBe('CREATE');
+  });
+
+  it('rejects a GROUP + instructor-assigned container with no tag_id', async () => {
+    await expect(repoCreateTool.handler({ ...BASE, type: 'GROUP' }, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+    expect(mocks.repositoryCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a tag_id that belongs to another classroom (S1)', async () => {
+    mocks.findByClassroomId.mockResolvedValue([{ id: 'tag-a' }, { id: 'tag-b' }]);
+    await expect(
+      repoCreateTool.handler(
+        { ...BASE, type: 'GROUP', tag_id: '11111111-1111-1111-1111-111111111111' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'not_found' });
+    expect(mocks.repositoryCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a GROUP container when the tag_id belongs to the classroom', async () => {
+    mocks.findByClassroomId.mockResolvedValue([{ id: 'tag-a' }]);
+    mocks.repositoryCreate.mockResolvedValue({
+      id: 'repo-g',
+      title: 'Group Lab',
+      slug: 'group-lab',
+      type: 'GROUP',
+      is_published: false,
+      weight: 100,
+    });
+
+    await repoCreateTool.handler(
+      { ...BASE, title: 'Group Lab', type: 'GROUP', tag_id: 'tag-a' },
+      CTX
+    );
+    const data = mocks.repositoryCreate.mock.calls[0][0] as {
+      type: string;
+      tag_id: string;
+      team_formation_mode: string;
+    };
+    expect(data.type).toBe('GROUP');
+    expect(data.tag_id).toBe('tag-a');
+    expect(data.team_formation_mode).toBe('INSTRUCTOR');
+  });
+
+  it('maps a duplicate-title P2002 to invalid_params', async () => {
+    mocks.repositoryCreate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
+    await expect(repoCreateTool.handler(BASE, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+    expect(mocks.saveManifest).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/src/tools/__tests__/roster.test.ts
+++ b/apps/mcp/src/tools/__tests__/roster.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for roster_add_student / roster_remove_student.
+ *
+ * Security focus: add never trusts a request classroom_id (uses ctx); remove
+ * resolves the target from the DB and builds the removal-task payload ENTIRELY
+ * server-side (closing the web route's client-supplied `data.user` hole), and
+ * refuses unknown / cross-classroom / non-student targets with scopedNotFound.
+ * @classmoji/tasks and @trigger.dev/sdk are mocked — no real emails or GitHub.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  addStudents: vi.fn(),
+  findByLogin: vi.fn(),
+  findByClassroomAndUser: vi.fn(),
+  classroomFindById: vi.fn(),
+  auditCreate: vi.fn(),
+  batchTrigger: vi.fn(),
+  taskTrigger: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    roster: { addStudents: (...a: unknown[]) => mocks.addStudents(...a) },
+    user: { findByLogin: (...a: unknown[]) => mocks.findByLogin(...a) },
+    classroomMembership: {
+      findByClassroomAndUser: (...a: unknown[]) => mocks.findByClassroomAndUser(...a),
+    },
+    classroom: { findById: (...a: unknown[]) => mocks.classroomFindById(...a) },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+  },
+}));
+
+vi.mock('@classmoji/tasks', () => ({
+  default: { sendEmailTask: { batchTrigger: (...a: unknown[]) => mocks.batchTrigger(...a) } },
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  tasks: { trigger: (...a: unknown[]) => mocks.taskTrigger(...a) },
+}));
+
+const { rosterAddStudentTool, rosterRemoveStudentTool } = await import('../roster.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+  mocks.taskTrigger.mockResolvedValue({ id: 'run-1' });
+  mocks.batchTrigger.mockResolvedValue(undefined);
+});
+
+describe('roster_add_student', () => {
+  const ARGS = {
+    classroom: 'org/w26',
+    students: [{ email: 'a@x.edu', name: 'A' }, { email: 'b@x.edu' }],
+  };
+
+  it('adds via the service using ctx classroomId and triggers the returned emails', async () => {
+    mocks.addStudents.mockResolvedValue({
+      addedExistingUsers: 1,
+      invitedNewUsers: 1,
+      emails: [{ payload: { to: 'a@x.edu', subject: 's', html: 'h' } }],
+    });
+
+    const payload = parse(await rosterAddStudentTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ added: 1, invited: 1, total: 2 });
+
+    // classroomId comes from ctx, never from args.
+    expect(mocks.addStudents).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      students: ARGS.students,
+    });
+    expect(mocks.batchTrigger).toHaveBeenCalledTimes(1);
+    expect((mocks.auditCreate.mock.calls[0][0] as { action: string }).action).toBe('CREATE');
+  });
+
+  it('does not batch-trigger when the service returns no emails', async () => {
+    mocks.addStudents.mockResolvedValue({ addedExistingUsers: 0, invitedNewUsers: 0, emails: [] });
+    await rosterAddStudentTool.handler(ARGS, CTX);
+    expect(mocks.batchTrigger).not.toHaveBeenCalled();
+  });
+
+  it('audits the mutation even if the email trigger fails afterwards', async () => {
+    mocks.addStudents.mockResolvedValue({
+      addedExistingUsers: 1,
+      invitedNewUsers: 0,
+      emails: [{ payload: { to: 'a@x.edu', subject: 's', html: 'h' } }],
+    });
+    mocks.batchTrigger.mockRejectedValue(new Error('trigger down'));
+
+    await expect(rosterAddStudentTool.handler(ARGS, CTX)).rejects.toThrow('trigger down');
+    // The audit was written BEFORE the failing email send — mutation not stranded.
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('roster_remove_student', () => {
+  const ARGS = { classroom: 'org/w26', student_login: 'alice', confirm: true as const };
+
+  beforeEach(() => {
+    mocks.classroomFindById.mockResolvedValue({
+      id: 'class-1',
+      git_organization: { id: 'gorg-1', login: 'myorg' },
+    });
+  });
+
+  it('builds the removal payload from DB records (not client input) and fires the task', async () => {
+    mocks.findByLogin.mockResolvedValue({ id: 'stu-1', login: 'alice' });
+    mocks.findByClassroomAndUser.mockResolvedValue({
+      has_accepted_invite: true,
+      user: { id: 'stu-1', login: 'alice', name: 'Alice' },
+    });
+
+    const payload = parse(await rosterRemoveStudentTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ success: true, queued: true, login: 'alice' });
+
+    // S1 membership lookup scoped to the ctx classroom + STUDENT role.
+    expect(mocks.findByClassroomAndUser).toHaveBeenCalledWith('class-1', 'stu-1', 'STUDENT');
+
+    // The task payload is built entirely server-side.
+    const arg = mocks.taskTrigger.mock.calls[0] as [string, { payload: Record<string, unknown> }];
+    expect(arg[0]).toBe('remove_user_from_organization');
+    expect(arg[1].payload).toMatchObject({
+      user: { id: 'stu-1', login: 'alice', has_accepted_invite: true },
+      role: 'STUDENT',
+    });
+    // organization carries the loaded classroom (with git org) for the task.
+    expect((arg[1].payload.organization as { id: string }).id).toBe('class-1');
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as { action: string; data: { login: string } };
+    expect(audit.action).toBe('DELETE');
+    expect(audit.data.login).toBe('alice');
+  });
+
+  it('refuses an unknown login (scopedNotFound) and never fires the task', async () => {
+    mocks.findByLogin.mockResolvedValue(null);
+    await expect(rosterRemoveStudentTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+    expect(mocks.taskTrigger).not.toHaveBeenCalled();
+  });
+
+  it('refuses a user who is not a STUDENT in this classroom (S1) and never fires', async () => {
+    mocks.findByLogin.mockResolvedValue({ id: 'stu-1', login: 'alice' });
+    mocks.findByClassroomAndUser.mockResolvedValue(null); // not a member here
+    await expect(rosterRemoveStudentTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+    expect(mocks.taskTrigger).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('requires student_login or user_id', async () => {
+    await expect(
+      rosterRemoveStudentTool.handler({ classroom: 'org/w26', confirm: true }, CTX)
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+  });
+});

--- a/apps/mcp/src/tools/assignments.ts
+++ b/apps/mcp/src/tools/assignments.ts
@@ -22,7 +22,20 @@ import type { Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolDefinition } from '../mcp/registry.ts';
-import { holdsRole, loadAssignmentInClassroom, ok, OWNER_TEACHER, writeAudit } from './shared.ts';
+import {
+  holdsRole,
+  loadAssignmentInClassroom,
+  loadRepositoryInClassroom,
+  ok,
+  OWNER_ONLY,
+  OWNER_TEACHER,
+  writeAudit,
+} from './shared.ts';
+
+/** Prisma unique-violation (P2002) — Assignment is @@unique([repository_id, title]). */
+function isUniqueTitleViolation(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error as { code?: string }).code === 'P2002';
+}
 
 interface AssignmentUpdateArgs {
   classroom: string;
@@ -106,6 +119,168 @@ export const assignmentUpdateTool: ToolDefinition<AssignmentUpdateArgs> = {
         weight: updated.weight,
         grades_released: updated.grades_released,
       },
+    });
+  },
+};
+
+interface AssignmentCreateArgs {
+  classroom: string;
+  repository_id: string;
+  title: string;
+  weight?: number;
+  description?: string;
+  student_deadline?: string;
+  grader_deadline?: string;
+  tokens_per_hour?: number;
+  release_at?: string;
+  is_published?: boolean;
+}
+
+export const assignmentCreateTool: ToolDefinition<AssignmentCreateArgs> = {
+  name: 'assignment_create',
+  annotations: { destructive: false },
+  title: 'Create an assignment',
+  description:
+    'Creates an assignment (a due-dated, gradeable slice of a repo/lab) under an existing ' +
+    'repository (assignment container). Owner only. Creating it does NOT provision anything on ' +
+    'GitHub — the assignment reaches students only when its repo is published (repo_publish) or ' +
+    'the next release runs. Created as a draft unless is_published is set.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    repository_id: z.string().uuid().describe('Parent repo (assignment container) id'),
+    title: z.string().min(1).max(200).describe('Assignment title (unique per repository)'),
+    weight: z
+      .number()
+      .int()
+      .positive()
+      .max(10000)
+      .optional()
+      .describe('Grading weight (default 100)'),
+    description: z.string().max(10000).optional(),
+    student_deadline: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe('Student due date (ISO 8601, e.g. 2026-07-20T23:59:00-04:00)'),
+    grader_deadline: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe('Grader due date (ISO 8601)'),
+    tokens_per_hour: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Extension token cost per late hour (default 0)'),
+    release_at: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe('Auto-release date (ISO 8601)'),
+    is_published: z.boolean().optional().describe('Publish immediately (default false = draft)'),
+  },
+  handler: async (args, ctx) => {
+    // S1: the assignment row does not exist yet, so re-verify ownership of the
+    // PARENT container. classroom_id on the new row derives from the verified
+    // parent's repository_id — never from request input.
+    const repository = await loadRepositoryInClassroom(args.repository_id, ctx);
+
+    const data: Prisma.AssignmentUncheckedCreateInput = {
+      repository_id: repository.id,
+      title: args.title,
+      ...(args.weight !== undefined ? { weight: args.weight } : {}),
+      ...(args.description !== undefined ? { description: args.description } : {}),
+      ...(args.student_deadline !== undefined
+        ? { student_deadline: new Date(args.student_deadline) }
+        : {}),
+      ...(args.grader_deadline !== undefined
+        ? { grader_deadline: new Date(args.grader_deadline) }
+        : {}),
+      ...(args.tokens_per_hour !== undefined ? { tokens_per_hour: args.tokens_per_hour } : {}),
+      ...(args.release_at !== undefined ? { release_at: new Date(args.release_at) } : {}),
+      ...(args.is_published !== undefined ? { is_published: args.is_published } : {}),
+    };
+
+    let created;
+    try {
+      created = await ClassmojiService.assignment.create(data);
+    } catch (error) {
+      if (isUniqueTitleViolation(error)) {
+        throw new ToolError(
+          'invalid_params',
+          'An assignment with this title already exists in this repository.'
+        );
+      }
+      throw error;
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'ASSIGNMENT',
+      resource_id: created.id,
+      action: 'CREATE',
+      data: { tool: 'assignment_create', repository_id: repository.id, title: args.title },
+    });
+
+    return ok({
+      success: true,
+      assignment: {
+        id: created.id,
+        title: created.title,
+        repository_id: created.repository_id,
+        weight: created.weight,
+        is_published: created.is_published,
+        student_deadline: created.student_deadline?.toISOString() ?? null,
+      },
+    });
+  },
+};
+
+interface AssignmentDeleteArgs {
+  classroom: string;
+  assignment_id: string;
+}
+
+export const assignmentDeleteTool: ToolDefinition<AssignmentDeleteArgs> = {
+  name: 'assignment_delete',
+  annotations: { destructive: true },
+  title: 'Delete an assignment',
+  description:
+    'Permanently deletes an assignment. Owner only. THIS CANNOT BE UNDONE and cascades: it ' +
+    'deletes every student/team submission for this assignment along with all their grades, ' +
+    'grader assignments, regrade requests, token transactions, and analytics, plus its ' +
+    'page/slide/calendar links. It does NOT remove the GitHub issues already created in student ' +
+    'repos (they are orphaned), and it does NOT reconcile student token balances.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    assignment_id: z.string().uuid().describe('Assignment id'),
+  },
+  handler: async (args, ctx) => {
+    const assignment = await loadAssignmentInClassroom(args.assignment_id, ctx);
+    // Blast-radius count for the audit trail (findById includes the submissions).
+    const submissionsDeleted = assignment.git_repo_assignments?.length ?? 0;
+
+    await ClassmojiService.assignment.deleteById(assignment.id);
+
+    await writeAudit(ctx, {
+      resource_type: 'ASSIGNMENT',
+      resource_id: assignment.id,
+      action: 'DELETE',
+      data: {
+        tool: 'assignment_delete',
+        title: assignment.title,
+        submissions_deleted: submissionsDeleted,
+      },
+    });
+
+    return ok({
+      success: true,
+      deleted_assignment_id: assignment.id,
+      submissions_deleted: submissionsDeleted,
     });
   },
 };

--- a/apps/mcp/src/tools/calendar.ts
+++ b/apps/mcp/src/tools/calendar.ts
@@ -93,6 +93,21 @@ function resolveScope(
   return null;
 }
 
+/**
+ * An event must end strictly after it starts (mirrors the web calendar form).
+ * A zero-length (end == start) or inverted range is rejected. The NaN guards
+ * are defensive — Zod already enforces valid ISO-with-offset strings.
+ */
+function assertEndAfterStart(start: Date, end: Date): void {
+  if (
+    Number.isNaN(start.getTime()) ||
+    Number.isNaN(end.getTime()) ||
+    end.getTime() <= start.getTime()
+  ) {
+    throw new ToolError('invalid_params', 'end_time must be after start_time');
+  }
+}
+
 export const calendarEventCreateTool: ToolDefinition<CalendarEventCreateArgs> = {
   name: 'calendar_event_create',
   annotations: { destructive: false },
@@ -123,6 +138,7 @@ export const calendarEventCreateTool: ToolDefinition<CalendarEventCreateArgs> = 
     if (args.is_recurring && !args.recurrence_rule) {
       throw new ToolError('invalid_params', 'recurrence_rule is required when is_recurring');
     }
+    assertEndAfterStart(new Date(args.start_time), new Date(args.end_time));
 
     const event = await ClassmojiService.calendar.createEvent(
       classroom.classroomId,
@@ -217,6 +233,28 @@ export const calendarEventUpdateTool: ToolDefinition<CalendarEventUpdateArgs> = 
     };
     if (Object.keys(updates).length === 0) {
       throw new ToolError('invalid_params', 'Provide at least one field to update');
+    }
+
+    // end_time must be after start_time. When BOTH edges are supplied we can
+    // compare them directly (recurrence-independent). When only one edge moves,
+    // we can only validate against the stored bound for a NON-recurring event —
+    // for a recurring occurrence override (this_only / this_and_future) the
+    // stored event.start_time/end_time are the SERIES TEMPLATE's absolute
+    // datetimes (dated at the series start), not this occurrence's, so comparing
+    // a single new edge against them is meaningless (it would reject valid
+    // edits). A start-only recurring override is always valid anyway (the
+    // service derives end = start + template duration); a both-edges override is
+    // still fully validated by the first branch.
+    if (args.start_time !== undefined && args.end_time !== undefined) {
+      assertEndAfterStart(new Date(args.start_time), new Date(args.end_time));
+    } else if (
+      !event.is_recurring &&
+      (args.start_time !== undefined || args.end_time !== undefined)
+    ) {
+      const effectiveStart =
+        args.start_time !== undefined ? new Date(args.start_time) : event.start_time;
+      const effectiveEnd = args.end_time !== undefined ? new Date(args.end_time) : event.end_time;
+      assertEndAfterStart(effectiveStart, effectiveEnd);
     }
 
     const scoped = resolveScope(event.is_recurring, args.edit_scope, args.occurrence_date);

--- a/apps/mcp/src/tools/grades.ts
+++ b/apps/mcp/src/tools/grades.ts
@@ -191,6 +191,7 @@ export const gradeRemoveAllTool: ToolDefinition<GradeRemoveAllArgs> = {
     // orchestrated removal to reverse tokens. A bare
     // assignmentGrade.removeAllGrades would delete rows but strand tokens.
     const grades = await ClassmojiService.assignmentGrade.findByAssignmentId(gra.id);
+    let removedCount = 0;
     for (const grade of grades) {
       await HelperService.removeGradeFromGitRepoAssignment({
         classroom: { id: classroom.classroomId },
@@ -201,15 +202,18 @@ export const gradeRemoveAllTool: ToolDefinition<GradeRemoveAllArgs> = {
         },
         grade,
       });
+      // U9: audit each removal as it lands, not once at the end — a mid-loop
+      // failure must still leave every completed removal audited. Per-grade
+      // rows match grade_remove's audit shape (emoji + grade_id).
+      await writeAudit(ctx, {
+        resource_type: 'GIT_REPO_ASSIGNMENT',
+        resource_id: gra.id,
+        action: 'DELETE',
+        data: { tool: 'grade_remove_all', emoji: grade.emoji, grade_id: grade.id },
+      });
+      removedCount += 1;
     }
 
-    await writeAudit(ctx, {
-      resource_type: 'GIT_REPO_ASSIGNMENT',
-      resource_id: gra.id,
-      action: 'DELETE',
-      data: { tool: 'grade_remove_all', removed_count: grades.length },
-    });
-
-    return ok({ success: true, removed_count: grades.length });
+    return ok({ success: true, removed_count: removedCount });
   },
 };

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -16,7 +16,7 @@ import { readTools } from './reads.ts';
 import { gradeAddTool, gradeRemoveTool, gradeRemoveAllTool } from './grades.ts';
 import { graderAssignTool, graderUnassignTool } from './graders.ts';
 import { emojiMappingUpsertTool, letterGradeMappingUpsertTool } from './mappings.ts';
-import { assignmentUpdateTool } from './assignments.ts';
+import { assignmentCreateTool, assignmentUpdateTool, assignmentDeleteTool } from './assignments.ts';
 import { regradeCreateTool, regradeResolveTool } from './regrades.ts';
 import {
   moduleCreateTool,
@@ -32,7 +32,8 @@ import {
 import { pageCreateTool, pageUpdateTool, pageDeleteTool } from './pages.ts';
 import { tokenGrantTool } from './tokens.ts';
 import { extensionPurchaseTool } from './extensions.ts';
-import { repoPublishTool, repoUnpublishTool } from './repos.ts';
+import { repoCreateTool, repoPublishTool, repoUnpublishTool } from './repos.ts';
+import { rosterAddStudentTool, rosterRemoveStudentTool } from './roster.ts';
 
 export function registerAllTools(): void {
   // Identity / bootstrap
@@ -56,8 +57,10 @@ export function registerAllTools(): void {
   registerToolDefinition(emojiMappingUpsertTool);
   registerToolDefinition(letterGradeMappingUpsertTool);
 
-  // Assignments (OWNER+TEACHER with per-field tiering)
+  // Assignments (create/delete OWNER-only; update OWNER+TEACHER with per-field tiering)
+  registerToolDefinition(assignmentCreateTool);
   registerToolDefinition(assignmentUpdateTool);
+  registerToolDefinition(assignmentDeleteTool);
 
   // Regrades (student self-create; teaching-team resolve)
   registerToolDefinition(regradeCreateTool);
@@ -82,10 +85,15 @@ export function registerAllTools(): void {
   // Tokens (OWNER)
   registerToolDefinition(tokenGrantTool);
 
+  // Roster (OWNER — add sends real emails; remove is destructive, confirm-gated)
+  registerToolDefinition(rosterAddStudentTool);
+  registerToolDefinition(rosterRemoveStudentTool);
+
   // Extensions (STUDENT self)
   registerToolDefinition(extensionPurchaseTool);
 
-  // Repos: publish/unpublish + provisioning (OWNER — route-derived)
+  // Repos: create container + publish/unpublish + provisioning (OWNER)
+  registerToolDefinition(repoCreateTool);
   registerToolDefinition(repoPublishTool);
   registerToolDefinition(repoUnpublishTool);
 }

--- a/apps/mcp/src/tools/regrades.ts
+++ b/apps/mcp/src/tools/regrades.ts
@@ -212,6 +212,20 @@ export const regradeResolveTool: ToolDefinition<RegradeResolveArgs> = {
   handler: async (args, ctx) => {
     const request = await loadRegradeRequestInClassroom(args.regrade_request_id, ctx);
 
+    // Idempotency (U11): waitForRunCompletion below is a 60s client-side
+    // timeout, not a cancel — the update_regrade_request run can flip the row
+    // and email the student AFTER the MCP request has timed out. A client retry
+    // would re-trigger the task and send a SECOND resolution email. Once the
+    // request leaves IN_REVIEW it is terminal, so return its recorded
+    // resolution without re-triggering. (Mirrors regrade_create's F1 guard.)
+    if (request.status !== 'IN_REVIEW') {
+      return ok({
+        success: true,
+        regrade_request: { id: request.id, status: request.status },
+        already_resolved: true,
+      });
+    }
+
     // Same task + payload as api.$operation updateRegradeRequest: the status
     // update and the resolution email use values re-derived from the DB
     // record, never the request body. onSuccess emails the student.

--- a/apps/mcp/src/tools/repos.ts
+++ b/apps/mcp/src/tools/repos.ts
@@ -31,19 +31,18 @@ import Tasks from '@classmoji/tasks';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolDefinition, ToolContext } from '../mcp/registry.ts';
-import { ok, OWNER_ONLY, requireClassroomCtx, scopedNotFound, writeAudit } from './shared.ts';
+import {
+  loadRepositoryInClassroom,
+  ok,
+  OWNER_ONLY,
+  requireClassroomCtx,
+  scopedNotFound,
+  writeAudit,
+} from './shared.ts';
 
-type RepositoryRecord = NonNullable<
-  Awaited<ReturnType<typeof ClassmojiService.repository.findById>>
->;
-
-/** Load a Repository (an assignment container) and verify its classroom_id. */
-async function loadRepositoryInClassroom(id: string, ctx: ToolContext): Promise<RepositoryRecord> {
-  const record = await ClassmojiService.repository.findById(id);
-  if (!record || record.classroom_id !== requireClassroomCtx(ctx).classroomId) {
-    throw scopedNotFound('Repo');
-  }
-  return record;
+/** Prisma unique-violation (P2002) — Repository is @@unique([classroom_id, title]). */
+function isUniqueTitleViolation(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error as { code?: string }).code === 'P2002';
 }
 
 /** The classroom slug drives the task payload + concurrency key (route parity). */
@@ -237,5 +236,164 @@ export const repoUnpublishTool: ToolDefinition<RepoUnpublishArgs> = {
     });
 
     return ok({ success: true, is_published: false, message: 'Repository unpublished' });
+  },
+};
+
+interface RepoCreateArgs {
+  classroom: string;
+  title: string;
+  template: string;
+  type?: 'INDIVIDUAL' | 'GROUP';
+  weight?: number;
+  description?: string;
+  is_extra_credit?: boolean;
+  drop_lowest_count?: number;
+  tag_id?: string;
+  team_formation_mode?: 'INSTRUCTOR' | 'SELF_FORMED';
+  team_formation_deadline?: string;
+  max_team_size?: number;
+  project_template_id?: string;
+  project_template_title?: string;
+}
+
+export const repoCreateTool: ToolDefinition<RepoCreateArgs> = {
+  name: 'repo_create',
+  // Commits a content-manifest refresh to the GitHub content repo (best-effort,
+  // failure-tolerant) → openWorld. No student repos are provisioned here (that
+  // is repo_publish), and nothing is removed → not destructive.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Create an assignment container (repo)',
+  description:
+    'Creates an UNPUBLISHED assignment container (a "repo"/lab) in the classroom. Owner only. No ' +
+    'student git repos are created — the container starts empty and hidden; add assignments with ' +
+    'assignment_create, then provision student repos with repo_publish. For a GROUP repo with ' +
+    'instructor-assigned teams, pass tag_id (a team tag in this classroom). Refreshes the ' +
+    "classroom's content manifest on GitHub (best-effort).",
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    title: z.string().min(1).max(200).describe('Repo/lab title (unique per classroom)'),
+    template: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('GitHub template repo name students are provisioned from at publish'),
+    type: z
+      .enum(['INDIVIDUAL', 'GROUP'])
+      .optional()
+      .describe('Individual or group repo (default INDIVIDUAL)'),
+    weight: z.number().int().min(0).max(10000).optional().describe('Grading weight (default 100)'),
+    description: z.string().max(2000).optional(),
+    is_extra_credit: z.boolean().optional().describe('default false'),
+    drop_lowest_count: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Drop the N lowest assignments (default 0)'),
+    tag_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('Team tag id (GROUP with instructor-assigned teams)'),
+    team_formation_mode: z
+      .enum(['INSTRUCTOR', 'SELF_FORMED'])
+      .optional()
+      .describe('GROUP only (default INSTRUCTOR)'),
+    team_formation_deadline: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe('GROUP only (ISO 8601)'),
+    max_team_size: z.number().int().positive().optional().describe('GROUP only'),
+    project_template_id: z.string().optional().describe('GitHub Projects V2 template node_id'),
+    project_template_title: z.string().optional().describe('Human-readable project template name'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+    const type = args.type ?? 'INDIVIDUAL';
+    const teamMode = args.team_formation_mode ?? 'INSTRUCTOR';
+
+    // S1 for the one cross-record reference: a supplied tag must belong to THIS
+    // classroom (Tag has no findById — validate via the classroom-scoped list).
+    if (args.tag_id) {
+      const tags = await ClassmojiService.organizationTag.findByClassroomId(classroom.classroomId);
+      if (!tags.some(t => t.id === args.tag_id)) {
+        throw scopedNotFound('Tag');
+      }
+    }
+
+    // Mirror the web superRefine: instructor-assigned GROUP teams need a tag.
+    if (type === 'GROUP' && teamMode === 'INSTRUCTOR' && !args.tag_id) {
+      throw new ToolError(
+        'invalid_params',
+        'A GROUP repo with instructor-assigned teams requires tag_id'
+      );
+    }
+
+    let created;
+    try {
+      created = await ClassmojiService.repository.create({
+        // classroom_id is ALWAYS the authorized classroom, never request input.
+        classroom_id: classroom.classroomId,
+        title: args.title,
+        template: args.template,
+        type,
+        ...(args.weight !== undefined ? { weight: args.weight } : {}),
+        ...(args.description !== undefined ? { description: args.description } : {}),
+        ...(args.is_extra_credit !== undefined ? { is_extra_credit: args.is_extra_credit } : {}),
+        ...(args.drop_lowest_count !== undefined
+          ? { drop_lowest_count: args.drop_lowest_count }
+          : {}),
+        ...(args.tag_id !== undefined ? { tag_id: args.tag_id } : {}),
+        ...(type === 'GROUP'
+          ? {
+              team_formation_mode: teamMode,
+              ...(args.team_formation_deadline !== undefined
+                ? { team_formation_deadline: new Date(args.team_formation_deadline) }
+                : {}),
+              ...(args.max_team_size !== undefined ? { max_team_size: args.max_team_size } : {}),
+            }
+          : {}),
+        ...(args.project_template_id !== undefined
+          ? { project_template_id: args.project_template_id }
+          : {}),
+        ...(args.project_template_title !== undefined
+          ? { project_template_title: args.project_template_title }
+          : {}),
+      });
+    } catch (error) {
+      if (isUniqueTitleViolation(error)) {
+        throw new ToolError(
+          'invalid_params',
+          'A repo with this title already exists in this classroom.'
+        );
+      }
+      throw error;
+    }
+
+    // Mirror the web create flow: refresh the content manifest (best-effort —
+    // saveManifest swallows GitHub errors internally, so this never throws).
+    await ClassmojiService.contentManifest.saveManifest(classroom.classroomId);
+
+    await writeAudit(ctx, {
+      resource_type: 'REPOSITORIES',
+      resource_id: created.id,
+      action: 'CREATE',
+      data: { tool: 'repo_create', title: args.title, type },
+    });
+
+    return ok({
+      success: true,
+      repository: {
+        id: created.id,
+        title: created.title,
+        slug: created.slug,
+        type: created.type,
+        is_published: created.is_published,
+        weight: created.weight,
+      },
+    });
   },
 };

--- a/apps/mcp/src/tools/roster.ts
+++ b/apps/mcp/src/tools/roster.ts
@@ -1,0 +1,203 @@
+/**
+ * Roster tools — roster_add_student / roster_remove_student (plan §5.2 gap 5).
+ *
+ * Tier: OWNER only (requireClassroomAdmin → ['OWNER'] on both web routes,
+ * admin.$class.students add/remove).
+ *
+ * ADD mirrors admin.$class.students.add: the DB split + email composition are
+ * shared via ClassmojiService.roster.addStudents (extracted so route + tool
+ * take one path); this tool triggers the returned emails. It sends REAL emails
+ * and is NOT idempotent (calling twice emails twice — the DB writes are
+ * skipDuplicates, the emails are not). It does NOT touch GitHub — activation
+ * stays student-driven.
+ *
+ * REMOVE triggers the single-source-of-truth remove_user_from_organization
+ * task (never reimplemented). Unlike the web action — which forwards a
+ * client-supplied `data.user` straight into the task (an S1 hole) — this tool
+ * resolves the target from the DB by (classroom, login/user_id) and builds the
+ * task payload ENTIRELY server-side. It is destructive and requires confirm:
+ * true, because when the student belongs to no other class in the GitHub org
+ * the task removes them from the org (revoking access and deleting their
+ * private forks). Fire-and-forget: a dropped job leaves the student in place
+ * (fails safe) and there is no wait-timeout window for a retry to re-fire.
+ */
+
+import { ClassmojiService } from '@classmoji/services';
+import Tasks from '@classmoji/tasks';
+import { tasks } from '@trigger.dev/sdk';
+import { z } from 'zod';
+import { ToolError } from '../mcp/errors.ts';
+import type { ToolDefinition } from '../mcp/registry.ts';
+import { ok, OWNER_ONLY, requireClassroomCtx, scopedNotFound, writeAudit } from './shared.ts';
+
+interface RosterAddStudentArgs {
+  classroom: string;
+  students: Array<{ email: string; name?: string }>;
+}
+
+export const rosterAddStudentTool: ToolDefinition<RosterAddStudentArgs> = {
+  name: 'roster_add_student',
+  // Sends real invitation emails (openWorld). Adds rows only — nothing removed.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Add students to the roster',
+  description:
+    'Adds students to the classroom roster by email (bulk). Owner only. Existing Classmoji users ' +
+    'are enrolled immediately (still pending their GitHub org invite); unknown emails get an ' +
+    'invitation row. Sends a real email to every student — NOT idempotent, calling twice emails ' +
+    'twice. Does not touch GitHub or create repos; students get their org invite + repos when ' +
+    'they first sign in and join.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    students: z
+      .array(
+        z.object({
+          email: z.string().email().describe('Student email'),
+          name: z.string().min(1).max(200).optional().describe('Student name'),
+        })
+      )
+      .min(1)
+      .max(200)
+      .describe('Students to add (1–200)'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // classroomId is ALWAYS the authorized classroom, never request input.
+    const result = await ClassmojiService.roster.addStudents({
+      classroomId: classroom.classroomId,
+      students: args.students,
+    });
+
+    // Audit BEFORE sending emails: addStudents has already committed the
+    // memberships/invites, so a transient email-service failure must not leave
+    // that mutation un-audited (plan §5.1 — every mutation writes an audit row).
+    await writeAudit(ctx, {
+      resource_type: 'STUDENT_ROSTER',
+      action: 'CREATE',
+      data: {
+        tool: 'roster_add_student',
+        added: result.addedExistingUsers,
+        invited: result.invitedNewUsers,
+      },
+    });
+
+    if (result.emails.length > 0) {
+      await Tasks.sendEmailTask.batchTrigger(result.emails);
+    }
+
+    return ok({
+      success: true,
+      added: result.addedExistingUsers,
+      invited: result.invitedNewUsers,
+      total: args.students.length,
+    });
+  },
+};
+
+interface RosterRemoveStudentArgs {
+  classroom: string;
+  student_login?: string;
+  user_id?: string;
+  confirm: true;
+}
+
+export const rosterRemoveStudentTool: ToolDefinition<RosterRemoveStudentArgs> = {
+  name: 'roster_remove_student',
+  // Can remove the student from the GitHub org (deleting their private forks) →
+  // destructive + openWorld. Requires confirm:true (enforced by the schema).
+  annotations: { destructive: true, openWorld: true },
+  title: 'Remove a student from the classroom',
+  description:
+    'Removes a student from the classroom. Owner only, destructive, requires confirm:true. ' +
+    'Identify the student by student_login or user_id. Triggers the standard removal workflow: ' +
+    'it removes them from the classroom GitHub team and, IF they are in no other class in that ' +
+    'GitHub org, removes them from the org entirely (revoking access and DELETING their private ' +
+    'forks) — this is not cleanly reversible. Deletes the classroom membership. Runs in the ' +
+    'background; does not delete their assignment repos, but org removal revokes access.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    student_login: z.string().min(1).optional().describe('The student GitHub login'),
+    user_id: z.string().uuid().optional().describe('The student user id (alternative to login)'),
+    confirm: z
+      .literal(true)
+      .describe('Must be true — acknowledges this can remove the student from the GitHub org'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // Resolve the target user id server-side (login → user, or a supplied id).
+    let userId = args.user_id;
+    if (!userId) {
+      if (!args.student_login) {
+        throw new ToolError('invalid_params', 'Provide student_login or user_id');
+      }
+      const user = await ClassmojiService.user.findByLogin(args.student_login);
+      if (!user) throw scopedNotFound('Student');
+      userId = user.id;
+    }
+
+    // S1: the target must be a STUDENT in THIS classroom. Missing and
+    // cross-classroom both return the same not_found (no existence leak).
+    const membership = await ClassmojiService.classroomMembership.findByClassroomAndUser(
+      classroom.classroomId,
+      userId,
+      'STUDENT'
+    );
+    if (!membership?.user) throw scopedNotFound('Student');
+    const target = membership.user;
+    // has_accepted_invite is a MEMBERSHIP field (the web UI merges it onto its
+    // client-side user object); the removal task reads it as user.has_accepted_invite.
+    const hasAcceptedInvite = membership.has_accepted_invite;
+
+    // Classroom-with-git-organization for the task payload (legacy shape the
+    // web route uses: task derives gitOrg from organization.git_organization).
+    const classroomRecord = await ClassmojiService.classroom.findById(classroom.classroomId);
+    if (!classroomRecord) throw new ToolError('internal', 'Classroom record unavailable');
+
+    // Audit the intent BEFORE firing the async removal.
+    await writeAudit(ctx, {
+      resource_type: 'STUDENT_ROSTER',
+      resource_id: target.id,
+      action: 'DELETE',
+      data: {
+        tool: 'roster_remove_student',
+        user_id: target.id,
+        login: target.login,
+        had_accepted_invite: hasAcceptedInvite,
+      },
+    });
+
+    // Trigger the single-source-of-truth removal task with a payload built
+    // ENTIRELY from resolved DB records — never from client input. Fire-and-
+    // forget: a dropped job fails safe (student stays), and there is no wait
+    // window for a client retry to re-fire a destructive GitHub op.
+    void tasks
+      .trigger('remove_user_from_organization', {
+        payload: {
+          user: {
+            id: target.id,
+            login: target.login,
+            has_accepted_invite: hasAcceptedInvite,
+          },
+          organization: classroomRecord,
+          role: 'STUDENT',
+        },
+      })
+      .catch((error: unknown) => {
+        console.error('[mcp] remove_user_from_organization trigger failed:', error);
+      });
+
+    return ok({
+      success: true,
+      queued: true,
+      user_id: target.id,
+      login: target.login,
+      message:
+        'Student removal queued — removing GitHub team/org access and the membership in the background.',
+    });
+  },
+};

--- a/apps/mcp/src/tools/shared.ts
+++ b/apps/mcp/src/tools/shared.ts
@@ -183,6 +183,27 @@ export async function loadRegradeRequestInClassroom(
   return record;
 }
 
+type RepositoryRecord = NonNullable<
+  Awaited<ReturnType<typeof ClassmojiService.repository.findById>>
+>;
+
+/**
+ * Load a Repository (an assignment container) and verify its classroom_id.
+ * Used as the parent-container S1 check by repo_publish/repo_unpublish and by
+ * assignment_create (whose target row does not exist yet, so ownership is
+ * re-verified against the parent container instead).
+ */
+export async function loadRepositoryInClassroom(
+  id: string,
+  ctx: ToolContext
+): Promise<RepositoryRecord> {
+  const record = await ClassmojiService.repository.findById(id);
+  if (!record || record.classroom_id !== requireClassroomCtx(ctx).classroomId) {
+    throw scopedNotFound('Repo');
+  }
+  return record;
+}
+
 // ─── Misc shared utilities ───────────────────────────────────────────────────
 
 /**

--- a/apps/webapp/app/routes/admin.$class.students.add/action.ts
+++ b/apps/webapp/app/routes/admin.$class.students.add/action.ts
@@ -1,89 +1,32 @@
 import { ClassmojiService } from '@classmoji/services';
 import Tasks from '@classmoji/tasks';
-import getPrisma from '@classmoji/database';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
-  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(request, classSlug, {
+  const {
+    classroom,
+    userId: _userId,
+    membership,
+  } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'STUDENT_ROSTER',
     action: 'bulk_add_students',
   });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = (await request.json()) as { students: Array<{ email: string; name?: string }> };
-  const emails = data.students.map(s => s.email.toLowerCase());
 
-  // Find users who already exist on the platform
-  const existingUsers = await getPrisma().user.findMany({
-    where: { email: { in: emails } },
-    select: { id: true, email: true, name: true },
+  // Shared with the MCP roster_add_student tool: the DB split + email
+  // composition live in the service; the route triggers the returned emails.
+  const result = await ClassmojiService.roster.addStudents({
+    classroomId: classroom.id,
+    students: data.students,
   });
-  const existingEmailSet = new Set(existingUsers.map(u => u!.email!.toLowerCase()));
 
-  // Split students into existing users vs new invites
-  const studentsToInvite = [];
-  const studentsToAddDirectly = [];
-
-  for (const student of data.students) {
-    const emailLower = student.email.toLowerCase();
-    if (existingEmailSet.has(emailLower)) {
-      const user = existingUsers.find(u => u!.email!.toLowerCase() === emailLower);
-      studentsToAddDirectly.push({ ...student, userId: user!.id, userName: user!.name });
-    } else {
-      studentsToInvite.push(student);
-    }
-  }
-
-  // Create classroom memberships for existing users
-  if (studentsToAddDirectly.length > 0) {
-    const memberships = studentsToAddDirectly.map(student => ({
-      classroom_id: classroom.id,
-      user_id: student.userId,
-      role: 'STUDENT' as const,
-      has_accepted_invite: false, // They still need to accept GitHub org invite
-    }));
-
-    await ClassmojiService.classroomMembership.createMany(memberships);
-
-    // Send notification emails to existing users
-    const existingUserEmails = studentsToAddDirectly.map(student => ({
-      payload: {
-        to: student.email,
-        subject: `[Classmoji] You've been added to ${classroom.name}`,
-        html: `<p>Hi ${student.userName || student.name}!</p>
-          <p>You have been added to <b>${classroom.name}</b> on Classmoji.</p>
-          <p>Click the following link to access your classroom: <a href="${process.env.WEBAPP_URL}">${process.env.WEBAPP_URL}</a></p>`,
-      },
-    }));
-
-    await Tasks.sendEmailTask.batchTrigger(existingUserEmails);
-  }
-
-  // Create invites for new users
-  if (studentsToInvite.length > 0) {
-    const invites = studentsToInvite.map(student => ({
-      school_email: student.email,
-      classroom_id: classroom.id,
-      student_name: student.name,
-    }));
-
-    await ClassmojiService.classroomInvite.createManyInvites(invites);
-
-    // Send email invitations to new students
-    const newUserEmails = studentsToInvite.map(student => ({
-      payload: {
-        to: student.email,
-        subject: `[Classmoji] You're invited to join ${classroom.name}`,
-        html: `<p>Hi ${student.name}!</p>
-          <p>You have been invited to join <b>${classroom.name}</b> on Classmoji.</p>
-          <p>Click the following link to login: <a href="${process.env.WEBAPP_URL}">${process.env.WEBAPP_URL}</a></p>`,
-      },
-    }));
-
-    await Tasks.sendEmailTask.batchTrigger(newUserEmails);
+  if (result.emails.length > 0) {
+    await Tasks.sendEmailTask.batchTrigger(result.emails);
   }
 
   return {

--- a/packages/services/src/classmoji/__tests__/roster.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/roster.service.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for roster.addStudents — the extracted bulk-add logic shared by
+ * the web "Add Students" action and the MCP roster_add_student tool. Prisma and
+ * the sibling services are mocked; the test pins the existing-vs-invite split,
+ * case-insensitive email matching, and that composed emails are RETURNED (the
+ * service never triggers them — the caller does).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const userFindMany = vi.fn();
+vi.mock('@classmoji/database', () => ({
+  default: () => ({ user: { findMany: (...a: unknown[]) => userFindMany(...a) } }),
+}));
+
+const classroomFindById = vi.fn();
+vi.mock('../classroom.service.ts', () => ({
+  findById: (...a: unknown[]) => classroomFindById(...a),
+}));
+
+const createMany = vi.fn();
+vi.mock('../classroomMembership.service.ts', () => ({
+  createMany: (...a: unknown[]) => createMany(...a),
+}));
+
+const createManyInvites = vi.fn();
+vi.mock('../classroomInvite.service.ts', () => ({
+  createManyInvites: (...a: unknown[]) => createManyInvites(...a),
+}));
+
+const roster = await import('../roster.service.ts');
+
+beforeEach(() => {
+  userFindMany.mockReset();
+  classroomFindById.mockReset();
+  createMany.mockReset();
+  createManyInvites.mockReset();
+  classroomFindById.mockResolvedValue({ id: 'class-1', name: 'CS1' });
+  createMany.mockResolvedValue({ count: 1 });
+  createManyInvites.mockResolvedValue({ count: 1 });
+});
+
+describe('roster.addStudents', () => {
+  it('enrolls existing users, invites unknown emails, and returns both email sets', async () => {
+    userFindMany.mockResolvedValue([{ id: 'u-existing', email: 'known@x.edu', name: 'Known' }]);
+
+    const result = await roster.addStudents({
+      classroomId: 'class-1',
+      students: [
+        { email: 'known@x.edu', name: 'K' },
+        { email: 'new@x.edu', name: 'New' },
+      ],
+    });
+
+    expect(result.addedExistingUsers).toBe(1);
+    expect(result.invitedNewUsers).toBe(1);
+
+    // Existing user → membership with has_accepted_invite:false.
+    expect(createMany).toHaveBeenCalledWith([
+      {
+        classroom_id: 'class-1',
+        user_id: 'u-existing',
+        role: 'STUDENT',
+        has_accepted_invite: false,
+      },
+    ]);
+    // Unknown email → invite row.
+    expect(createManyInvites).toHaveBeenCalledWith([
+      { school_email: 'new@x.edu', classroom_id: 'class-1', student_name: 'New' },
+    ]);
+
+    expect(result.emails).toHaveLength(2);
+    expect(result.emails[0].payload.subject).toContain('added to CS1');
+    expect(result.emails[1].payload.subject).toContain('invited to join CS1');
+  });
+
+  it('matches existing users case-insensitively', async () => {
+    userFindMany.mockResolvedValue([{ id: 'u1', email: 'a@x.edu', name: 'A' }]);
+
+    const result = await roster.addStudents({
+      classroomId: 'class-1',
+      students: [{ email: 'A@X.edu' }],
+    });
+
+    expect(result.addedExistingUsers).toBe(1);
+    expect(result.invitedNewUsers).toBe(0);
+    expect(createManyInvites).not.toHaveBeenCalled();
+  });
+
+  it('throws when the classroom does not exist', async () => {
+    classroomFindById.mockResolvedValue(null);
+    await expect(
+      roster.addStudents({ classroomId: 'nope', students: [{ email: 'a@x.edu' }] })
+    ).rejects.toThrow(/classroom/);
+  });
+});

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -2,6 +2,7 @@
 import * as gitOrganizationService from './gitOrganization.service.ts';
 import * as classroomService from './classroom.service.ts';
 import * as classroomMembershipService from './classroomMembership.service.ts';
+import * as rosterService from './roster.service.ts';
 import * as moduleService from './module.service.ts';
 import * as repositoryService from './repository.service.ts';
 import * as autogradingTestService from './autogradingTest.service.ts';
@@ -47,6 +48,7 @@ const ClassmojiService = {
   gitOrganization: gitOrganizationService,
   classroom: classroomService,
   classroomMembership: classroomMembershipService,
+  roster: rosterService,
   module: moduleService,
   repository: repositoryService,
   autogradingTest: autogradingTestService,

--- a/packages/services/src/classmoji/roster.service.ts
+++ b/packages/services/src/classmoji/roster.service.ts
@@ -1,0 +1,119 @@
+import getPrisma from '@classmoji/database';
+import * as classroomService from './classroom.service.ts';
+import * as classroomMembershipService from './classroomMembership.service.ts';
+import * as classroomInviteService from './classroomInvite.service.ts';
+
+export interface RosterStudentInput {
+  email: string;
+  name?: string;
+}
+
+export interface RosterEmail {
+  payload: { to: string; subject: string; html: string };
+}
+
+export interface AddStudentsResult {
+  addedExistingUsers: number;
+  invitedNewUsers: number;
+  /**
+   * Composed notification emails for the CALLER to send. Services must not
+   * import @classmoji/tasks (tasks already depends on services — importing it
+   * here would be circular), so email composition lives here but the trigger
+   * stays with the caller (web route / MCP tool).
+   */
+  emails: RosterEmail[];
+}
+
+/**
+ * Add students to a classroom roster by email (bulk). Existing platform users
+ * are enrolled directly (a STUDENT membership with has_accepted_invite=false,
+ * pending their GitHub org invite); unknown emails get a ClassroomInvite row.
+ * Shared by the web "Add Students" action and the MCP roster_add_student tool
+ * so both take one code path.
+ *
+ * Does NOT touch GitHub or provision repos — activation stays student-driven
+ * (self-join / member_added webhook → activate_membership).
+ */
+export const addStudents = async ({
+  classroomId,
+  students,
+}: {
+  classroomId: string;
+  students: RosterStudentInput[];
+}): Promise<AddStudentsResult> => {
+  const classroom = await classroomService.findById(classroomId);
+  if (!classroom) {
+    throw new Error(`[roster] classroom ${classroomId} not found`);
+  }
+
+  const emails = students.map(s => s.email.toLowerCase());
+  const existingUsers = await getPrisma().user.findMany({
+    where: { email: { in: emails } },
+    select: { id: true, email: true, name: true },
+  });
+  const existingByEmail = new Map(existingUsers.map(u => [(u.email ?? '').toLowerCase(), u]));
+
+  const toAddDirectly: Array<RosterStudentInput & { userId: string; userName: string | null }> = [];
+  const toInvite: RosterStudentInput[] = [];
+  for (const student of students) {
+    const existing = existingByEmail.get(student.email.toLowerCase());
+    if (existing) {
+      toAddDirectly.push({ ...student, userId: existing.id, userName: existing.name });
+    } else {
+      toInvite.push(student);
+    }
+  }
+
+  const emailsOut: RosterEmail[] = [];
+
+  // Enroll existing users directly (they still need to accept the GitHub org invite).
+  if (toAddDirectly.length > 0) {
+    const memberships = toAddDirectly.map(student => ({
+      classroom_id: classroomId,
+      user_id: student.userId,
+      role: 'STUDENT' as const,
+      has_accepted_invite: false,
+    }));
+    await classroomMembershipService.createMany(memberships);
+
+    for (const student of toAddDirectly) {
+      emailsOut.push({
+        payload: {
+          to: student.email,
+          subject: `[Classmoji] You've been added to ${classroom.name}`,
+          html: `<p>Hi ${student.userName || student.name}!</p>
+          <p>You have been added to <b>${classroom.name}</b> on Classmoji.</p>
+          <p>Click the following link to access your classroom: <a href="${process.env.WEBAPP_URL}">${process.env.WEBAPP_URL}</a></p>`,
+        },
+      });
+    }
+  }
+
+  // Invite unknown emails (claimed when they register).
+  if (toInvite.length > 0) {
+    const invites = toInvite.map(student => ({
+      school_email: student.email,
+      classroom_id: classroomId,
+      student_name: student.name,
+    }));
+    await classroomInviteService.createManyInvites(invites);
+
+    for (const student of toInvite) {
+      emailsOut.push({
+        payload: {
+          to: student.email,
+          subject: `[Classmoji] You're invited to join ${classroom.name}`,
+          html: `<p>Hi ${student.name}!</p>
+          <p>You have been invited to join <b>${classroom.name}</b> on Classmoji.</p>
+          <p>Click the following link to login: <a href="${process.env.WEBAPP_URL}">${process.env.WEBAPP_URL}</a></p>`,
+        },
+      });
+    }
+  }
+
+  return {
+    addedExistingUsers: toAddDirectly.length,
+    invitedNewUsers: toInvite.length,
+    emails: emailsOut,
+  };
+};


### PR DESCRIPTION
Promote staging → main (prod). Only this change is ahead of main:

- **feat(mcp): assignment/container/roster write tools + polish fixes** (#178)
  - New OWNER-only tools: assignment_create/delete, repo_create, roster_add_student/remove_student (extracts ClassmojiService.roster.addStudents; web action rewired to share it).
  - Polish: calendar end>start, grade_remove_all per-grade audit, regrade_resolve idempotency, roster audit-before-email, MCP_PUBLIC_URL boot validation.

Adversarial review: no isolation findings; 2 confirmed correctness bugs fixed. 179 MCP + 3 service tests green; typecheck + lint clean; no lockfile change. No DB migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)