### PR TITLE
feat: semantic merge + conflict chooser for content previews and editor saves (Phase 7 + 7.5)

### DIFF
--- a/apps/mcp/src/mcp/errors.ts
+++ b/apps/mcp/src/mcp/errors.ts
@@ -22,12 +22,19 @@ export class ToolError extends Error {
   kind: ToolErrorKind;
   /** Optional machine-readable code (e.g. CLASSROOM_LOCKED) mirroring the webapp's typed 403s. */
   code?: string;
+  /**
+   * Optional structured payload merged into the serialized error JSON
+   * (e.g. `{ ids: [...] }` from a PreviewResolutionError), so MCP clients get
+   * the same machine-readable details the web actions return.
+   */
+  data?: Record<string, unknown>;
 
-  constructor(kind: ToolErrorKind, message: string, code?: string) {
+  constructor(kind: ToolErrorKind, message: string, code?: string, data?: Record<string, unknown>) {
     super(message);
     this.name = 'ToolError';
     this.kind = kind;
     this.code = code;
+    this.data = data;
   }
 }
 

--- a/apps/mcp/src/mcp/registry.ts
+++ b/apps/mcp/src/mcp/registry.ts
@@ -199,6 +199,7 @@ function toErrorResult(error: unknown, toolName: string): ToolResult {
             error: error.kind,
             ...(error.code ? { code: error.code } : {}),
             message: error.message,
+            ...(error.data ?? {}),
           }),
         },
       ],
@@ -274,6 +275,7 @@ function toResourceError(error: unknown, resourceName: string): McpError {
     return new McpError(RESOURCE_ERROR_CODES[error.kind], error.message, {
       kind: error.kind,
       ...(error.code ? { code: error.code } : {}),
+      ...(error.data ?? {}),
     });
   }
   // Unknown failure: log server-side, return a generic message (no internals).

--- a/apps/mcp/src/tools/__tests__/deck.test.ts
+++ b/apps/mcp/src/tools/__tests__/deck.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   getDeckPreviewStatus: vi.fn(),
   ensureDeckPreviewBranch: vi.fn(),
   acceptDeckPreview: vi.fn(),
+  resolveDeckPreviewConflicts: vi.fn(),
   discardDeckPreview: vi.fn(),
   resolveSharedThemeUrls: vi.fn(),
   auditCreate: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock('@classmoji/services/slides', async () => {
     getDeckPreviewStatus: (...a: unknown[]) => mocks.getDeckPreviewStatus(...a),
     ensureDeckPreviewBranch: (...a: unknown[]) => mocks.ensureDeckPreviewBranch(...a),
     acceptDeckPreview: (...a: unknown[]) => mocks.acceptDeckPreview(...a),
+    resolveDeckPreviewConflicts: (...a: unknown[]) => mocks.resolveDeckPreviewConflicts(...a),
     discardDeckPreview: (...a: unknown[]) => mocks.discardDeckPreview(...a),
     resolveSharedThemeUrls: (...a: unknown[]) => mocks.resolveSharedThemeUrls(...a),
     slideService: {
@@ -975,6 +977,7 @@ describe('deck_preview_accept', () => {
       conflict: true,
       units,
       order_conflict: orderConflict,
+      auto_merged: 3,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });
@@ -990,11 +993,16 @@ describe('deck_preview_accept', () => {
       conflict: true,
       units,
       order_conflict: orderConflict,
+      auto_merged: 3,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });
     expect(payload.message).toMatch(/deck_get/);
     expect(payload.message).toMatch(/deck_preview_discard/);
+    // The report teaches the resolutions path and names the counts.
+    expect(payload.message).toMatch(/resolutions/);
+    expect(payload.message).toContain('3 change(s) auto-merge cleanly');
+    expect(payload.message).toContain('2 conflict(s)');
 
     const audit = mocks.auditCreate.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(audit.data).toMatchObject({
@@ -1002,9 +1010,146 @@ describe('deck_preview_accept', () => {
       outcome: 'conflict',
       conflict_unit_ids: ['aaa'],
       order_conflict: true,
+      auto_merged: 3,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });
+  });
+
+  it('a semantic auto-merge surfaces semantic + auto_merged in payload and audit', async () => {
+    mocks.getDeckPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 2 });
+    mocks.acceptDeckPreview.mockResolvedValue({
+      merged: true,
+      semantic: true,
+      auto_merged: 7,
+      sha: 'merge-sha',
+      html_regenerated: true,
+    });
+
+    const payload = parse(
+      await deckPreviewAcceptTool.handler({ classroom: 'org/x', slide_id: SLIDE_ID }, CTX)
+    );
+
+    expect(payload).toEqual({
+      success: true,
+      merged: true,
+      semantic: true,
+      auto_merged: 7,
+      new_sha: 'merge-sha',
+      html_regenerated: true,
+    });
+    const audit = mocks.auditCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(audit.data).toMatchObject({ outcome: 'merged', semantic: true, auto_merged: 7 });
+  });
+
+  it('a 409 during the semantic merge maps to CONTENT_CONFLICT', async () => {
+    mocks.getDeckPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 1 });
+    mocks.acceptDeckPreview.mockRejectedValue(
+      Object.assign(new Error('Deck changed since it was read'), { status: 409 })
+    );
+
+    await expect(
+      deckPreviewAcceptTool.handler({ classroom: 'org/x', slide_id: SLIDE_ID }, CTX)
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      code: 'CONTENT_CONFLICT',
+      message: expect.stringContaining('deck_preview_accept'),
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── deck_preview_accept — resolutions ───────────────────────────────────────
+
+describe('deck_preview_accept with resolutions', () => {
+  const RESOLUTIONS = [
+    { id: 'aaa', choose: 'ours' as const },
+    { id: '__order__', choose: 'theirs' as const },
+  ];
+
+  beforeEach(() => {
+    mocks.getDeckPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 2 });
+    mocks.resolveDeckPreviewConflicts.mockResolvedValue({
+      merged: true,
+      semantic: true,
+      html_regenerated: true,
+      auto_merged: 4,
+      resolved: RESOLUTIONS,
+      sha: 'resolved-sha',
+    });
+  });
+
+  it('routes to resolveDeckPreviewConflicts (with the theme resolver) and audits the choices', async () => {
+    const payload = parse(
+      await deckPreviewAcceptTool.handler(
+        { classroom: 'org/x', slide_id: SLIDE_ID, resolutions: RESOLUTIONS },
+        CTX
+      )
+    );
+
+    expect(payload).toEqual({
+      success: true,
+      merged: true,
+      semantic: true,
+      resolved: RESOLUTIONS,
+      auto_merged: 4,
+      new_sha: 'resolved-sha',
+      html_regenerated: true,
+    });
+
+    expect(mocks.acceptDeckPreview).not.toHaveBeenCalled();
+    expect(mocks.resolveDeckPreviewConflicts).toHaveBeenCalledTimes(1);
+    const opts = mocks.resolveDeckPreviewConflicts.mock.calls[0][1] as {
+      resolutions: unknown;
+      resolveThemeUrls: (deck: DeckJson) => Promise<unknown>;
+    };
+    expect(opts.resolutions).toEqual(RESOLUTIONS);
+    expect(opts.resolveThemeUrls).toBeTypeOf('function');
+    await opts.resolveThemeUrls(DECK());
+    expect(mocks.resolveSharedThemeUrls).toHaveBeenCalledTimes(1);
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(audit.data).toMatchObject({
+      tool: 'deck_preview_accept',
+      outcome: 'merged',
+      semantic: true,
+      resolutions: RESOLUTIONS,
+      auto_merged: 4,
+      new_sha: 'resolved-sha',
+    });
+  });
+
+  it('maps PreviewResolutionError to invalid_params naming the ids — no audit', async () => {
+    mocks.resolveDeckPreviewConflicts.mockRejectedValue(
+      Object.assign(new Error('Every conflict needs a choice — missing: bbb'), {
+        name: 'PreviewResolutionError',
+        code: 'UNRESOLVED_CONFLICTS',
+        ids: ['bbb'],
+      })
+    );
+
+    await expect(
+      deckPreviewAcceptTool.handler(
+        { classroom: 'org/x', slide_id: SLIDE_ID, resolutions: RESOLUTIONS },
+        CTX
+      )
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: expect.stringContaining('bbb'),
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('still requires a pending preview', async () => {
+    mocks.getDeckPreviewStatus.mockResolvedValue({ exists: false });
+
+    await expect(
+      deckPreviewAcceptTool.handler(
+        { classroom: 'org/x', slide_id: SLIDE_ID, resolutions: RESOLUTIONS },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.resolveDeckPreviewConflicts).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/mcp/src/tools/__tests__/deck.test.ts
+++ b/apps/mcp/src/tools/__tests__/deck.test.ts
@@ -530,6 +530,26 @@ describe('deck_apply routing + locking', () => {
     expect(mocks.discardDeckPreview).toHaveBeenCalledTimes(1);
   });
 
+  it('a 409 after THIS apply created the branch KEEPS it when a concurrent apply committed to it (S4)', async () => {
+    // Routing check sees no preview (loads from main); ensure creates the
+    // branch; a racer commits to it; our save 409s. The cleanup re-check finds
+    // the branch moved ahead of main → it must NOT be discarded (that would
+    // silently delete the racer's committed work).
+    mocks.getDeckPreviewStatus
+      .mockResolvedValueOnce({ exists: false }) // routing decision (load from main)
+      .mockResolvedValueOnce({ exists: true, commits_ahead: 1 }); // cleanup re-check
+    mocks.ensureDeckPreviewBranch.mockResolvedValue({ branch: PREVIEW_BRANCH, created: true });
+    mocks.saveDeck.mockRejectedValue(
+      Object.assign(new Error('Deck changed since it was read'), { status: 409 })
+    );
+
+    await expect(deckApplyTool.handler(APPLY_ARGS, CTX)).rejects.toMatchObject({
+      code: 'CONTENT_CONFLICT',
+    });
+    // The concurrent writer's commits survive — the branch is retained.
+    expect(mocks.discardDeckPreview).not.toHaveBeenCalled();
+  });
+
   it('a 409 while STACKING keeps the pre-existing preview branch', async () => {
     mocks.getDeckPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 1 });
     mocks.ensureDeckPreviewBranch.mockResolvedValue({ branch: PREVIEW_BRANCH, created: false });

--- a/apps/mcp/src/tools/__tests__/deck.test.ts
+++ b/apps/mcp/src/tools/__tests__/deck.test.ts
@@ -1119,7 +1119,7 @@ describe('deck_preview_accept with resolutions', () => {
     });
   });
 
-  it('maps PreviewResolutionError to invalid_params naming the ids — no audit', async () => {
+  it('maps PreviewResolutionError to invalid_params carrying its code AND ids — no audit', async () => {
     mocks.resolveDeckPreviewConflicts.mockRejectedValue(
       Object.assign(new Error('Every conflict needs a choice — missing: bbb'), {
         name: 'PreviewResolutionError',
@@ -1135,8 +1135,52 @@ describe('deck_preview_accept with resolutions', () => {
       )
     ).rejects.toMatchObject({
       kind: 'invalid_params',
+      code: 'UNRESOLVED_CONFLICTS',
+      data: { ids: ['bbb'] },
       message: expect.stringContaining('bbb'),
     });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('passes expected_ours_sha/expected_theirs_sha through to the resolve service (F3)', async () => {
+    await deckPreviewAcceptTool.handler(
+      {
+        classroom: 'org/x',
+        slide_id: SLIDE_ID,
+        resolutions: RESOLUTIONS,
+        expected_ours_sha: 'report-ours-sha',
+        expected_theirs_sha: 'report-theirs-sha',
+      },
+      CTX
+    );
+
+    expect(mocks.resolveDeckPreviewConflicts.mock.calls[0][1]).toMatchObject({
+      resolutions: RESOLUTIONS,
+      expectedOursSha: 'report-ours-sha',
+      expectedTheirsSha: 'report-theirs-sha',
+    });
+  });
+
+  it('maps a stale sha pin (CONTENT_CONFLICT PreviewResolutionError) to the CONTENT_CONFLICT code', async () => {
+    mocks.resolveDeckPreviewConflicts.mockRejectedValue(
+      Object.assign(new Error('The live deck changed since the conflict report — re-run accept'), {
+        name: 'PreviewResolutionError',
+        code: 'CONTENT_CONFLICT',
+        ids: [],
+      })
+    );
+
+    await expect(
+      deckPreviewAcceptTool.handler(
+        {
+          classroom: 'org/x',
+          slide_id: SLIDE_ID,
+          resolutions: RESOLUTIONS,
+          expected_ours_sha: 'stale',
+        },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params', code: 'CONTENT_CONFLICT' });
     expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
 

--- a/apps/mcp/src/tools/__tests__/pageContent.test.ts
+++ b/apps/mcp/src/tools/__tests__/pageContent.test.ts
@@ -965,7 +965,7 @@ describe('page_preview_accept with resolutions', () => {
     });
   });
 
-  it('maps PreviewResolutionError to invalid_params naming the ids — no audit', async () => {
+  it('maps PreviewResolutionError to invalid_params carrying its code AND ids — no audit', async () => {
     mocks.resolvePreviewConflicts.mockRejectedValue(
       Object.assign(new Error('Every conflict needs a choice — missing: p2'), {
         name: 'PreviewResolutionError',
@@ -981,8 +981,52 @@ describe('page_preview_accept with resolutions', () => {
       )
     ).rejects.toMatchObject({
       kind: 'invalid_params',
+      code: 'UNRESOLVED_CONFLICTS',
+      data: { ids: ['p2'] },
       message: expect.stringContaining('p2'),
     });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('passes expected_ours_sha/expected_theirs_sha through to the resolve service (F3)', async () => {
+    await pagePreviewAcceptTool.handler(
+      {
+        classroom: 'org/x',
+        page_id: PAGE_ID,
+        resolutions: RESOLUTIONS,
+        expected_ours_sha: 'report-ours-sha',
+        expected_theirs_sha: 'report-theirs-sha',
+      },
+      CTX
+    );
+
+    expect(mocks.resolvePreviewConflicts.mock.calls[0][1]).toEqual({
+      resolutions: RESOLUTIONS,
+      expectedOursSha: 'report-ours-sha',
+      expectedTheirsSha: 'report-theirs-sha',
+    });
+  });
+
+  it('maps a stale sha pin (CONTENT_CONFLICT PreviewResolutionError) to the CONTENT_CONFLICT code', async () => {
+    mocks.resolvePreviewConflicts.mockRejectedValue(
+      Object.assign(new Error('The live page changed since the conflict report — re-run accept'), {
+        name: 'PreviewResolutionError',
+        code: 'CONTENT_CONFLICT',
+        ids: [],
+      })
+    );
+
+    await expect(
+      pagePreviewAcceptTool.handler(
+        {
+          classroom: 'org/x',
+          page_id: PAGE_ID,
+          resolutions: RESOLUTIONS,
+          expected_ours_sha: 'stale',
+        },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params', code: 'CONTENT_CONFLICT' });
     expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
 

--- a/apps/mcp/src/tools/__tests__/pageContent.test.ts
+++ b/apps/mcp/src/tools/__tests__/pageContent.test.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   getPreviewStatus: vi.fn(),
   ensurePreviewBranch: vi.fn(),
   acceptPreview: vi.fn(),
+  resolvePreviewConflicts: vi.fn(),
   discardPreview: vi.fn(),
   auditCreate: vi.fn(),
 }));
@@ -54,6 +55,7 @@ vi.mock('@classmoji/services', async () => {
         getPreviewStatus: (...a: unknown[]) => mocks.getPreviewStatus(...a),
         ensurePreviewBranch: (...a: unknown[]) => mocks.ensurePreviewBranch(...a),
         acceptPreview: (...a: unknown[]) => mocks.acceptPreview(...a),
+        resolvePreviewConflicts: (...a: unknown[]) => mocks.resolvePreviewConflicts(...a),
         discardPreview: (...a: unknown[]) => mocks.discardPreview(...a),
       },
       audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
@@ -834,6 +836,7 @@ describe('page_preview_accept', () => {
       merged: false,
       conflict: true,
       units,
+      auto_merged: 5,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });
@@ -848,20 +851,151 @@ describe('page_preview_accept', () => {
     expect(payload).toMatchObject({
       conflict: true,
       units,
+      auto_merged: 5,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });
     expect(payload.message).toMatch(/page_content_get/);
     expect(payload.message).toMatch(/page_preview_discard/);
+    // The report teaches the resolutions path and names the counts.
+    expect(payload.message).toMatch(/resolutions/);
+    expect(payload.message).toContain('5 change(s) auto-merge cleanly');
+    expect(payload.message).toContain('1 conflict(s)');
 
     const audit = mocks.auditCreate.mock.calls[0][0] as { data: Record<string, unknown> };
     expect(audit.data).toMatchObject({
       tool: 'page_preview_accept',
       outcome: 'conflict',
       conflict_unit_ids: ['h1'],
+      auto_merged: 5,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });
+  });
+
+  it('a semantic auto-merge surfaces semantic + auto_merged in payload and audit', async () => {
+    mocks.getPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 2 });
+    mocks.acceptPreview.mockResolvedValue({
+      merged: true,
+      semantic: true,
+      auto_merged: 7,
+      sha: 'merge-sha',
+    });
+
+    const payload = parse(
+      await pagePreviewAcceptTool.handler({ classroom: 'org/x', page_id: PAGE_ID }, CTX)
+    );
+
+    expect(payload).toEqual({
+      success: true,
+      merged: true,
+      semantic: true,
+      auto_merged: 7,
+      new_sha: 'merge-sha',
+    });
+    const audit = mocks.auditCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(audit.data).toMatchObject({ outcome: 'merged', semantic: true, auto_merged: 7 });
+  });
+
+  it('a 409 during the semantic merge maps to CONTENT_CONFLICT', async () => {
+    mocks.getPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 1 });
+    mocks.acceptPreview.mockRejectedValue(
+      Object.assign(new Error('File was modified'), { status: 409 })
+    );
+
+    await expect(
+      pagePreviewAcceptTool.handler({ classroom: 'org/x', page_id: PAGE_ID }, CTX)
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      code: 'CONTENT_CONFLICT',
+      message: expect.stringContaining('page_preview_accept'),
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── page_preview_accept — resolutions ───────────────────────────────────────
+
+describe('page_preview_accept with resolutions', () => {
+  const RESOLUTIONS = [
+    { id: 'h1', choose: 'ours' as const },
+    { id: '__order__', choose: 'theirs' as const },
+  ];
+
+  beforeEach(() => {
+    mocks.getPreviewStatus.mockResolvedValue({ exists: true, commits_ahead: 2 });
+    mocks.resolvePreviewConflicts.mockResolvedValue({
+      merged: true,
+      semantic: true,
+      auto_merged: 4,
+      resolved: RESOLUTIONS,
+      sha: 'resolved-sha',
+    });
+  });
+
+  it('routes to resolvePreviewConflicts and audits the choices', async () => {
+    const payload = parse(
+      await pagePreviewAcceptTool.handler(
+        { classroom: 'org/x', page_id: PAGE_ID, resolutions: RESOLUTIONS },
+        CTX
+      )
+    );
+
+    expect(payload).toEqual({
+      success: true,
+      merged: true,
+      semantic: true,
+      resolved: RESOLUTIONS,
+      auto_merged: 4,
+      new_sha: 'resolved-sha',
+    });
+
+    expect(mocks.acceptPreview).not.toHaveBeenCalled();
+    expect(mocks.resolvePreviewConflicts).toHaveBeenCalledTimes(1);
+    expect(mocks.resolvePreviewConflicts.mock.calls[0][1]).toEqual({ resolutions: RESOLUTIONS });
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(audit.data).toMatchObject({
+      tool: 'page_preview_accept',
+      outcome: 'merged',
+      semantic: true,
+      resolutions: RESOLUTIONS,
+      auto_merged: 4,
+      new_sha: 'resolved-sha',
+    });
+  });
+
+  it('maps PreviewResolutionError to invalid_params naming the ids — no audit', async () => {
+    mocks.resolvePreviewConflicts.mockRejectedValue(
+      Object.assign(new Error('Every conflict needs a choice — missing: p2'), {
+        name: 'PreviewResolutionError',
+        code: 'UNRESOLVED_CONFLICTS',
+        ids: ['p2'],
+      })
+    );
+
+    await expect(
+      pagePreviewAcceptTool.handler(
+        { classroom: 'org/x', page_id: PAGE_ID, resolutions: RESOLUTIONS },
+        CTX
+      )
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: expect.stringContaining('p2'),
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('still requires a pending preview', async () => {
+    mocks.getPreviewStatus.mockResolvedValue({ exists: false });
+
+    await expect(
+      pagePreviewAcceptTool.handler(
+        { classroom: 'org/x', page_id: PAGE_ID, resolutions: RESOLUTIONS },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.resolvePreviewConflicts).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/mcp/src/tools/deck.ts
+++ b/apps/mcp/src/tools/deck.ts
@@ -56,6 +56,7 @@ import type { ToolDefinition } from '../mcp/registry.ts';
 import {
   assertSlideEditable,
   loadSlideInClassroom,
+  mapSemanticMergeError,
   ok,
   TEACHING_TEAM,
   writeAudit,
@@ -82,27 +83,6 @@ function contentConflict(at: 'main' | 'preview' = 'main'): ToolError {
       : 'Deck changed since you read it — call deck_get again for a fresh sha',
     'CONTENT_CONFLICT'
   );
-}
-
-/**
- * Map semantic-merge failures from accept/resolve to tool errors:
- * PreviewResolutionError (bad/incomplete resolutions) → invalid_params naming
- * the ids; a 409 (main moved while merging) → CONTENT_CONFLICT so the caller
- * simply re-runs the accept. Anything else is returned unchanged for rethrow.
- */
-function mapSemanticMergeError(error: unknown, tool: string): unknown {
-  const named = error as { name?: string; message?: string; status?: number };
-  if (named?.name === 'PreviewResolutionError') {
-    return new ToolError('invalid_params', named.message ?? 'Invalid resolutions');
-  }
-  if (named?.status === 409) {
-    return new ToolError(
-      'invalid_params',
-      `Main changed while merging — call ${tool} again`,
-      'CONTENT_CONFLICT'
-    );
-  }
-  return error;
 }
 
 /**
@@ -1003,6 +983,8 @@ interface DeckPreviewArgs {
 
 interface DeckPreviewAcceptArgs extends DeckPreviewArgs {
   resolutions?: MergeResolution[];
+  expected_ours_sha?: string;
+  expected_theirs_sha?: string;
 }
 
 export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewAcceptArgs> = {
@@ -1015,9 +997,14 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewAcceptArgs> = {
     'edits merge automatically (git first, then a per-slide semantic 3-way merge — the result ' +
     'reports semantic: true with the auto_merged count when that layer kicked in). Only genuine ' +
     'same-unit collisions stop the accept: you get a report of just those units (ours = main, ' +
-    'theirs = preview, base) plus auto_merged. To finish, either call this tool again with ' +
+    'theirs = preview, base) plus auto_merged. A top-level slide-order conflict is reported ' +
+    "separately as order_conflict — resolve it via the '__order__' id (unlike " +
+    "page_preview_accept, which lists '__order__' inside units). To finish, either call this " +
+    'tool again with ' +
     'resolutions — one {id, choose: ours|theirs} per reported conflict id (ours = keep the live ' +
-    "main version, theirs = keep the preview's) — or re-read fresh main with deck_get, re-apply " +
+    "main version, theirs = keep the preview's), passing the report's ours_sha/theirs_sha as " +
+    'expected_ours_sha/expected_theirs_sha to pin your choices to the state you reviewed — or ' +
+    're-read fresh main with deck_get, re-apply ' +
     'merged slides with deck_apply and accept again, or deck_preview_discard.',
   scope: 'write',
   roles: TEACHING_TEAM,
@@ -1042,6 +1029,23 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewAcceptArgs> = {
           "the sentinels '__order__' (slide order), '__order__:<stackId>' (a stack's child " +
           "order), and '__meta__' (theme/config). Omit to attempt a plain accept."
       ),
+    expected_ours_sha: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Pass the ours_sha from the conflict report your resolutions answer. If main's deck " +
+          'changed since that report, the accept fails with CONTENT_CONFLICT instead of ' +
+          'applying reviewed choices to unseen content. Only meaningful with resolutions.'
+      ),
+    expected_theirs_sha: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        'Pass the theirs_sha from the conflict report your resolutions answer (same staleness ' +
+          'pin for the preview side). Only meaningful with resolutions.'
+      ),
   },
   handler: async (args, ctx) => {
     const slide = await loadSlideInClassroom(args.slide_id, ctx);
@@ -1059,6 +1063,8 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewAcceptArgs> = {
         result = await resolveDeckPreviewConflicts(slide, {
           resolutions: args.resolutions,
           resolveThemeUrls: deck => resolveSharedThemeUrls(slide, deck),
+          ...(args.expected_ours_sha ? { expectedOursSha: args.expected_ours_sha } : {}),
+          ...(args.expected_theirs_sha ? { expectedTheirsSha: args.expected_theirs_sha } : {}),
         });
       } catch (error: unknown) {
         throw mapSemanticMergeError(error, 'deck_preview_accept');
@@ -1159,7 +1165,8 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewAcceptArgs> = {
         `${result.auto_merged} change(s) auto-merge cleanly; ${conflictCount} conflict(s) need ` +
         'a decision. Resolve by calling deck_preview_accept again with resolutions ' +
         "(one {id, choose: 'ours'|'theirs'} per conflict id — include '__order__' if " +
-        'order_conflict is present; ours = main, theirs = preview) — or re-read fresh main ' +
+        "order_conflict is present; ours = main, theirs = preview), passing this report's " +
+        'ours_sha/theirs_sha as expected_ours_sha/expected_theirs_sha — or re-read fresh main ' +
         'with deck_get, re-apply merged slides with deck_apply and accept again, or ' +
         'deck_preview_discard to drop the preview.',
     });

--- a/apps/mcp/src/tools/deck.ts
+++ b/apps/mcp/src/tools/deck.ts
@@ -40,12 +40,14 @@ import {
   mintSlideId,
   normalizeSlideHtml,
   previewBranchName,
+  resolveDeckPreviewConflicts,
   resolveSharedThemeUrls,
   saveDeck,
   slideService,
   type DeckJson,
   type DeckShaSource,
   type DeckSlide,
+  type MergeResolution,
 } from '@classmoji/services/slides';
 import type { Prisma } from '@prisma/client';
 import { z } from 'zod';
@@ -80,6 +82,27 @@ function contentConflict(at: 'main' | 'preview' = 'main'): ToolError {
       : 'Deck changed since you read it — call deck_get again for a fresh sha',
     'CONTENT_CONFLICT'
   );
+}
+
+/**
+ * Map semantic-merge failures from accept/resolve to tool errors:
+ * PreviewResolutionError (bad/incomplete resolutions) → invalid_params naming
+ * the ids; a 409 (main moved while merging) → CONTENT_CONFLICT so the caller
+ * simply re-runs the accept. Anything else is returned unchanged for rethrow.
+ */
+function mapSemanticMergeError(error: unknown, tool: string): unknown {
+  const named = error as { name?: string; message?: string; status?: number };
+  if (named?.name === 'PreviewResolutionError') {
+    return new ToolError('invalid_params', named.message ?? 'Invalid resolutions');
+  }
+  if (named?.status === 409) {
+    return new ToolError(
+      'invalid_params',
+      `Main changed while merging — call ${tool} again`,
+      'CONTENT_CONFLICT'
+    );
+  }
+  return error;
 }
 
 /**
@@ -688,7 +711,14 @@ function applyDeckOps(
             return container;
           }
           // The schema refine guarantees html is present on non-containers.
-          return buildLeaf(spec as { html: string; notes?: string; hidden?: boolean; attrs?: Record<string, string> });
+          return buildLeaf(
+            spec as {
+              html: string;
+              notes?: string;
+              hidden?: boolean;
+              attrs?: Record<string, string>;
+            }
+          );
         });
         insertSlidesAt(deck, inserted, op.position, 'insert');
         const entry: Record<string, unknown> = {
@@ -971,21 +1001,47 @@ interface DeckPreviewArgs {
   slide_id: string;
 }
 
-export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewArgs> = {
+interface DeckPreviewAcceptArgs extends DeckPreviewArgs {
+  resolutions?: MergeResolution[];
+}
+
+export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewAcceptArgs> = {
   name: 'deck_preview_accept',
   annotations: { destructive: false, openWorld: true },
   title: 'Accept a deck preview',
   description:
-    "Publishes a deck's pending preview: merges the preview branch into main (git auto-merges " +
-    'non-overlapping edits), regenerates the index.html artifact from the merged deck.json, ' +
-    'and deletes the branch. On a genuine same-slide conflict nothing merges — you get a ' +
-    'per-slide report (ours = main, theirs = preview, base); re-read fresh main with deck_get, ' +
-    're-apply the resolved slides, then accept again or discard.',
+    "Publishes a deck's pending preview: merges the preview branch into main, regenerates the " +
+    'index.html artifact from the merged deck.json, and deletes the branch. Non-overlapping ' +
+    'edits merge automatically (git first, then a per-slide semantic 3-way merge — the result ' +
+    'reports semantic: true with the auto_merged count when that layer kicked in). Only genuine ' +
+    'same-unit collisions stop the accept: you get a report of just those units (ours = main, ' +
+    'theirs = preview, base) plus auto_merged. To finish, either call this tool again with ' +
+    'resolutions — one {id, choose: ours|theirs} per reported conflict id (ours = keep the live ' +
+    "main version, theirs = keep the preview's) — or re-read fresh main with deck_get, re-apply " +
+    'merged slides with deck_apply and accept again, or deck_preview_discard.',
   scope: 'write',
   roles: TEACHING_TEAM,
   inputSchema: {
     classroom: z.string().describe("Classroom reference as 'org/slug'"),
     slide_id: z.string().uuid().describe('Slide deck id'),
+    resolutions: z
+      .array(
+        z
+          .object({
+            id: z.string().min(1),
+            choose: z.enum(['ours', 'theirs']),
+          })
+          .strict()
+      )
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        "Per-conflict choices from a prior conflict report: ours = keep main's (live) version, " +
+          "theirs = keep the preview's. Must cover EVERY reported conflict id — slide ids plus " +
+          "the sentinels '__order__' (slide order), '__order__:<stackId>' (a stack's child " +
+          "order), and '__meta__' (theme/config). Omit to attempt a plain accept."
+      ),
   },
   handler: async (args, ctx) => {
     const slide = await loadSlideInClassroom(args.slide_id, ctx);
@@ -996,9 +1052,53 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewArgs> = {
       throw new ToolError('invalid_params', 'No pending preview for this deck — nothing to accept');
     }
 
-    const result = await acceptDeckPreview(slide, {
-      resolveThemeUrls: deck => resolveSharedThemeUrls(slide, deck),
-    });
+    // ── Resolutions path: apply chooser decisions to the conflicted merge ──
+    if (args.resolutions?.length) {
+      let result;
+      try {
+        result = await resolveDeckPreviewConflicts(slide, {
+          resolutions: args.resolutions,
+          resolveThemeUrls: deck => resolveSharedThemeUrls(slide, deck),
+        });
+      } catch (error: unknown) {
+        throw mapSemanticMergeError(error, 'deck_preview_accept');
+      }
+
+      await writeAudit(ctx, {
+        resource_type: 'SLIDES',
+        resource_id: slide.id,
+        action: 'UPDATE',
+        data: {
+          tool: 'deck_preview_accept',
+          outcome: 'merged',
+          semantic: true,
+          resolutions: args.resolutions.map(({ id, choose }) => ({ id, choose })),
+          auto_merged: result.auto_merged,
+          new_sha: result.sha,
+          html_regenerated: result.html_regenerated,
+          ...(result.preview_kept ? { preview_kept: true, reason: result.reason } : {}),
+        } as unknown as Prisma.InputJsonValue,
+      });
+      return ok({
+        success: true,
+        merged: true,
+        semantic: true,
+        resolved: args.resolutions,
+        auto_merged: result.auto_merged,
+        new_sha: result.sha,
+        html_regenerated: result.html_regenerated,
+        ...(result.preview_kept ? { preview_kept: true, reason: result.reason } : {}),
+      });
+    }
+
+    let result;
+    try {
+      result = await acceptDeckPreview(slide, {
+        resolveThemeUrls: deck => resolveSharedThemeUrls(slide, deck),
+      });
+    } catch (error: unknown) {
+      throw mapSemanticMergeError(error, 'deck_preview_accept');
+    }
 
     if (result.merged) {
       await writeAudit(ctx, {
@@ -1010,6 +1110,7 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewArgs> = {
           outcome: 'merged',
           new_sha: result.sha,
           html_regenerated: result.html_regenerated,
+          ...(result.semantic ? { semantic: true, auto_merged: result.auto_merged } : {}),
           ...(result.preview_kept ? { preview_kept: true, reason: result.reason } : {}),
         } as Prisma.InputJsonValue,
       });
@@ -1018,6 +1119,7 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewArgs> = {
         merged: true,
         new_sha: result.sha,
         html_regenerated: result.html_regenerated,
+        ...(result.semantic ? { semantic: true, auto_merged: result.auto_merged } : {}),
         ...(result.preview_kept
           ? {
               preview_kept: true,
@@ -1039,21 +1141,27 @@ export const deckPreviewAcceptTool: ToolDefinition<DeckPreviewArgs> = {
         outcome: 'conflict',
         conflict_unit_ids: result.units.map(unit => unit.id),
         ...(result.order_conflict ? { order_conflict: true } : {}),
+        auto_merged: result.auto_merged,
         ours_sha: result.ours_sha,
         theirs_sha: result.theirs_sha,
       } as Prisma.InputJsonValue,
     });
 
+    const conflictCount = result.units.length + (result.order_conflict ? 1 : 0);
     return ok({
       conflict: true,
       units: result.units,
       ...(result.order_conflict ? { order_conflict: result.order_conflict } : {}),
+      auto_merged: result.auto_merged,
       ours_sha: result.ours_sha,
       theirs_sha: result.theirs_sha,
       message:
-        'The preview conflicts with newer changes on main. Re-read fresh main with deck_get, ' +
-        'merge each conflicted slide (ours = main, theirs = preview), re-apply with deck_apply, ' +
-        'then accept again — or deck_preview_discard to drop the preview.',
+        `${result.auto_merged} change(s) auto-merge cleanly; ${conflictCount} conflict(s) need ` +
+        'a decision. Resolve by calling deck_preview_accept again with resolutions ' +
+        "(one {id, choose: 'ours'|'theirs'} per conflict id — include '__order__' if " +
+        'order_conflict is present; ours = main, theirs = preview) — or re-read fresh main ' +
+        'with deck_get, re-apply merged slides with deck_apply and accept again, or ' +
+        'deck_preview_discard to drop the preview.',
     });
   },
 };

--- a/apps/mcp/src/tools/deck.ts
+++ b/apps/mcp/src/tools/deck.ts
@@ -29,16 +29,12 @@
  */
 
 import {
-  BUILTIN_THEMES,
   DeckParseError,
-  SlideHtmlError,
   acceptDeckPreview,
   discardDeckPreview,
   ensureDeckPreviewBranch,
   getDeckPreviewStatus,
   loadDeck,
-  mintSlideId,
-  normalizeSlideHtml,
   previewBranchName,
   resolveDeckPreviewConflicts,
   resolveSharedThemeUrls,
@@ -49,6 +45,17 @@ import {
   type DeckSlide,
   type MergeResolution,
 } from '@classmoji/services/slides';
+// The op engine is imported via its OWN subpath (not `…/slides`) so test
+// mocks of `@classmoji/services/slides` leave the real engine in place —
+// op semantics in the deck tool tests stay genuine.
+import {
+  DeckOpError,
+  SlideHtmlError,
+  applyDeckOps,
+  deckOpSchema,
+  findSlide,
+  type DeckOp,
+} from '@classmoji/services/slides/ops';
 import type { Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
@@ -232,31 +239,6 @@ function countSlides(slides: DeckSlide[]): number {
   return count;
 }
 
-/** Find a slide by id (top level or one stack level down, per Reveal). */
-function findSlide(
-  slides: DeckSlide[],
-  id: string
-): { parent: DeckSlide[]; index: number; slide: DeckSlide } | null {
-  for (let i = 0; i < slides.length; i++) {
-    if (slides[i].id === id) return { parent: slides, index: i, slide: slides[i] };
-    const children = slides[i].children;
-    if (children) {
-      for (let j = 0; j < children.length; j++) {
-        if (children[j].id === id) return { parent: children, index: j, slide: children[j] };
-      }
-    }
-  }
-  return null;
-}
-
-function collectIds(slides: DeckSlide[], out = new Set<string>()): Set<string> {
-  for (const slide of slides) {
-    out.add(slide.id);
-    if (slide.children) collectIds(slide.children, out);
-  }
-  return out;
-}
-
 // ─── deck_outline ────────────────────────────────────────────────────────────
 
 interface DeckOutlineArgs {
@@ -414,391 +396,6 @@ export const deckGetTool: ToolDefinition<DeckGetArgs> = {
 
 // ─── deck_apply ──────────────────────────────────────────────────────────────
 
-const attrsSchema = z.record(z.string());
-
-const positionSchema = z.union([
-  z.object({ after: z.string().min(1) }).strict(),
-  z.object({ at: z.enum(['start', 'end']) }).strict(),
-]);
-
-const newChildSlideSchema = z
-  .object({
-    html: z.string().max(200_000),
-    notes: z.string().max(50_000).optional(),
-    hidden: z.boolean().optional(),
-    attrs: attrsSchema.optional(),
-  })
-  .strict();
-
-const newSlideSchema = z
-  .object({
-    html: z.string().max(200_000).optional(),
-    notes: z.string().max(50_000).optional(),
-    hidden: z.boolean().optional(),
-    attrs: attrsSchema.optional(),
-    children: z
-      .array(newChildSlideSchema)
-      .min(1)
-      .max(20)
-      .optional()
-      .describe(
-        'Create a vertical stack: the slide becomes a container holding these child slides ' +
-          '(one nesting level — children cannot have children). Omit html on the container.'
-      ),
-  })
-  .strict()
-  .refine(s => (s.children?.length ? s.html === undefined : typeof s.html === 'string'), {
-    message:
-      'A new slide needs either html (regular slide) or children (vertical stack container) — ' +
-      'stack containers carry no html of their own',
-  });
-
-const opSchema = z.discriminatedUnion('op', [
-  z.object({
-    op: z.literal('update'),
-    id: z.string().min(1),
-    html: z.string().max(200_000).optional(),
-    notes: z
-      .string()
-      .max(50_000)
-      .nullable()
-      .optional()
-      .describe('Speaker notes HTML; null or empty string removes the notes'),
-    hidden: z.boolean().optional(),
-    attrs: attrsSchema
-      .nullable()
-      .optional()
-      .describe('Full replacement attrs record (null or {} clears all extra attributes)'),
-  }),
-  z.object({
-    op: z.literal('insert'),
-    slides: z.array(newSlideSchema).min(1).max(20),
-    position: positionSchema,
-  }),
-  z.object({
-    op: z.literal('move'),
-    id: z.string().min(1),
-    position: positionSchema,
-  }),
-  z.object({
-    op: z.literal('delete'),
-    id: z.string().min(1),
-  }),
-  z.object({
-    op: z.literal('reorder'),
-    order: z
-      .array(z.string().min(1))
-      .min(1)
-      .describe('The complete new top-level slide order (a permutation of current top-level ids)'),
-  }),
-  z.object({
-    op: z.literal('set_theme'),
-    theme: z.string().max(120).optional(),
-    code_theme: z
-      .string()
-      .max(50)
-      .regex(/^[\w.-]+$/)
-      .optional(),
-  }),
-]);
-
-type DeckOp = z.infer<typeof opSchema>;
-
-/** Typed error for deck op failures (unknown ids, bad positions, bad values). */
-class DeckOpError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'DeckOpError';
-  }
-}
-
-function mustFindSlide(slides: DeckSlide[], id: string, opName: string) {
-  const found = findSlide(slides, id);
-  if (!found) {
-    throw new DeckOpError(`Unknown slide id '${id}' in ${opName} op`);
-  }
-  return found;
-}
-
-function insertSlidesAt(
-  deck: DeckJson,
-  newSlides: DeckSlide[],
-  position: { after: string } | { at: 'start' | 'end' },
-  opName: string
-): void {
-  if ('after' in position) {
-    const target = mustFindSlide(deck.slides, position.after, opName);
-    target.parent.splice(target.index + 1, 0, ...newSlides);
-  } else if (position.at === 'start') {
-    deck.slides.unshift(...newSlides);
-  } else {
-    deck.slides.push(...newSlides);
-  }
-}
-
-/** shared:/custom: theme names: single path segment, no separators, no '..'. */
-const THEME_NAME_RE = /^[\w.-]+$/;
-
-/** Validate a set_theme theme value: builtin, 'custom:<file>.css', or 'shared:<name>'. */
-function assertValidTheme(theme: string): void {
-  if (theme.startsWith('shared:') || theme.startsWith('custom:')) {
-    // The suffix lands in repo paths (.slidesthemes/<name>/…) and generated
-    // link hrefs — refuse anything that could traverse ('/', '..').
-    const name = theme.slice(theme.indexOf(':') + 1);
-    if (!THEME_NAME_RE.test(name) || name.includes('..')) {
-      throw new DeckOpError(
-        `Invalid theme name '${theme}' — shared:/custom: names may only contain letters, ` +
-          "digits, '_', '-', and '.' (no path separators, no '..')"
-      );
-    }
-    return;
-  }
-  if ((BUILTIN_THEMES as readonly string[]).includes(theme)) return;
-  throw new DeckOpError(
-    `Unknown theme '${theme}' — use a builtin (${BUILTIN_THEMES.join(', ')}), ` +
-      "'custom:<file>.css', or 'shared:<name>'"
-  );
-}
-
-/**
- * Apply a sequence of deck operations. Pure — returns a new deck, input
- * untouched. Ops are applied sequentially, so later ops see earlier ops'
- * effects. Ids are matched at the top level and one stack level down.
- * EVERY incoming html/notes fragment rounds through normalizeSlideHtml
- * (SlideHtmlError propagates — stray <section> tags are rejected).
- */
-function applyDeckOps(
-  currentDeck: DeckJson,
-  ops: DeckOp[]
-): { deck: DeckJson; applied: Array<Record<string, unknown>> } {
-  const deck = structuredClone(currentDeck) as DeckJson;
-  const applied: Array<Record<string, unknown>> = [];
-
-  for (const op of ops) {
-    switch (op.op) {
-      case 'update': {
-        if (
-          op.html === undefined &&
-          op.notes === undefined &&
-          op.hidden === undefined &&
-          op.attrs === undefined
-        ) {
-          throw new DeckOpError(
-            `update op for '${op.id}' must set at least one of html, notes, hidden, attrs`
-          );
-        }
-        const target = mustFindSlide(deck.slides, op.id, 'update');
-        if (op.html !== undefined && target.slide.children?.length) {
-          throw new DeckOpError(
-            `Slide '${op.id}' is a vertical stack container and has no html — target its children`
-          );
-        }
-        if (op.html !== undefined) {
-          target.slide.html = normalizeSlideHtml(op.html);
-        }
-        if (op.notes !== undefined) {
-          if (op.notes == null || op.notes === '') {
-            delete target.slide.notes;
-          } else {
-            target.slide.notes = normalizeSlideHtml(op.notes);
-          }
-        }
-        if (op.hidden !== undefined) {
-          if (op.hidden) target.slide.hidden = true;
-          else delete target.slide.hidden;
-        }
-        if (op.attrs !== undefined) {
-          if (op.attrs == null || Object.keys(op.attrs).length === 0) {
-            delete target.slide.attrs;
-          } else {
-            target.slide.attrs = { ...op.attrs };
-          }
-        }
-        applied.push({ op: 'update', id: op.id });
-        break;
-      }
-
-      case 'insert': {
-        // Runtime mirrors of the schema rules (defense in depth — the test
-        // harness and any validation-bypassing client hit the handler direct).
-        for (const spec of op.slides) {
-          const hasChildren = Boolean(spec.children?.length);
-          if (hasChildren && spec.html !== undefined) {
-            throw new DeckOpError(
-              'A vertical stack container cannot carry html — put content on its children'
-            );
-          }
-          if (!hasChildren && typeof spec.html !== 'string') {
-            throw new DeckOpError(
-              'A new slide needs html (regular slide) or children (vertical stack container)'
-            );
-          }
-          if (
-            hasChildren &&
-            spec.children!.some(c => (c as { children?: unknown[] }).children?.length)
-          ) {
-            throw new DeckOpError(
-              'Nested stacks are not supported — child slides cannot have children'
-            );
-          }
-        }
-        // A stack container can never land inside another stack (Reveal
-        // supports one nesting level) — mirror the move-op guard BEFORE any
-        // building so the rejection is targeted.
-        if (op.slides.some(s => s.children?.length) && 'after' in op.position) {
-          const target = mustFindSlide(deck.slides, op.position.after, 'insert');
-          if (target.parent !== deck.slides) {
-            throw new DeckOpError(
-              `Cannot insert a vertical stack after '${op.position.after}' — that position is ` +
-                'inside another stack (nested stacks are not supported)'
-            );
-          }
-        }
-        const used = collectIds(deck.slides);
-        const mint = (): string => {
-          let id = mintSlideId();
-          while (used.has(id)) id = mintSlideId(); // re-mint collisions
-          used.add(id);
-          return id;
-        };
-        const buildLeaf = (spec: {
-          html: string;
-          notes?: string;
-          hidden?: boolean;
-          attrs?: Record<string, string>;
-        }): DeckSlide => {
-          const leaf: DeckSlide = { id: mint(), html: normalizeSlideHtml(spec.html) };
-          if (spec.notes != null && spec.notes !== '') {
-            leaf.notes = normalizeSlideHtml(spec.notes);
-          }
-          if (spec.hidden) leaf.hidden = true;
-          if (spec.attrs && Object.keys(spec.attrs).length > 0) leaf.attrs = { ...spec.attrs };
-          return leaf;
-        };
-        const childIdsByContainer: Record<string, string[]> = {};
-        const inserted: DeckSlide[] = op.slides.map(spec => {
-          if (spec.children?.length) {
-            const container: DeckSlide = { id: mint() };
-            container.children = spec.children.map(buildLeaf);
-            if (spec.notes != null && spec.notes !== '') {
-              container.notes = normalizeSlideHtml(spec.notes);
-            }
-            if (spec.hidden) container.hidden = true;
-            if (spec.attrs && Object.keys(spec.attrs).length > 0) {
-              container.attrs = { ...spec.attrs };
-            }
-            childIdsByContainer[container.id] = container.children.map(c => c.id);
-            return container;
-          }
-          // The schema refine guarantees html is present on non-containers.
-          return buildLeaf(
-            spec as {
-              html: string;
-              notes?: string;
-              hidden?: boolean;
-              attrs?: Record<string, string>;
-            }
-          );
-        });
-        insertSlidesAt(deck, inserted, op.position, 'insert');
-        const entry: Record<string, unknown> = {
-          op: 'insert',
-          count: inserted.length,
-          ids: inserted.map(s => s.id),
-        };
-        if (Object.keys(childIdsByContainer).length > 0) entry.children = childIdsByContainer;
-        applied.push(entry);
-        break;
-      }
-
-      case 'move': {
-        if ('after' in op.position && op.position.after === op.id) {
-          throw new DeckOpError(`Cannot move slide '${op.id}' relative to itself`);
-        }
-        const source = mustFindSlide(deck.slides, op.id, 'move');
-        // Reveal supports one level of nesting: a stack container can never
-        // land inside another container. Checked BEFORE the splice so the
-        // rejection is targeted (not a generic unknown-id error).
-        if (source.slide.children?.length && 'after' in op.position) {
-          const target = mustFindSlide(deck.slides, op.position.after, 'move');
-          if (target.parent !== deck.slides) {
-            throw new DeckOpError(
-              `Cannot move slide '${op.id}' after '${op.position.after}' — '${op.id}' is a ` +
-                'vertical stack container and that position is inside another stack ' +
-                '(nested stacks are not supported)'
-            );
-          }
-        }
-        const [moved] = source.parent.splice(source.index, 1);
-        insertSlidesAt(deck, [moved], op.position, 'move');
-        applied.push({ op: 'move', id: op.id });
-        break;
-      }
-
-      case 'delete': {
-        const target = mustFindSlide(deck.slides, op.id, 'delete');
-        if (target.parent === deck.slides && deck.slides.length === 1) {
-          throw new DeckOpError('A deck must keep at least one slide — cannot delete the last one');
-        }
-        target.parent.splice(target.index, 1);
-        applied.push({ op: 'delete', id: op.id });
-        break;
-      }
-
-      case 'reorder': {
-        const currentIds = deck.slides.map(s => s.id);
-        const sameLength = op.order.length === currentIds.length;
-        const currentSet = new Set(currentIds);
-        const isPermutation =
-          sameLength &&
-          new Set(op.order).size === op.order.length &&
-          op.order.every(id => currentSet.has(id));
-        if (!isPermutation) {
-          throw new DeckOpError(
-            'reorder order must be a permutation of the current top-level slide ids ' +
-              `(current: ${currentIds.join(', ')})`
-          );
-        }
-        const byId = new Map(deck.slides.map(s => [s.id, s]));
-        deck.slides = op.order.flatMap(id => {
-          const found = byId.get(id);
-          return found ? [found] : []; // unreachable — permutation verified above
-        });
-        applied.push({ op: 'reorder', count: op.order.length });
-        break;
-      }
-
-      case 'set_theme': {
-        if (op.theme === undefined && op.code_theme === undefined) {
-          throw new DeckOpError('set_theme op must set theme and/or code_theme');
-        }
-        if (op.theme !== undefined && op.theme !== deck.theme) {
-          assertValidTheme(op.theme);
-          deck.theme = op.theme;
-          // Mirror the editor's merge rules: an explicit theme change clears
-          // the paired dark theme and drops starter-recognized customCss.
-          delete deck.themeDark;
-          if (deck.customCss === slideService.STARTER_CUSTOM_CSS) {
-            delete deck.customCss;
-          }
-        }
-        if (op.code_theme !== undefined && op.code_theme !== deck.codeTheme) {
-          deck.codeTheme = op.code_theme;
-          delete deck.codeThemeDark;
-        }
-        applied.push({
-          op: 'set_theme',
-          ...(op.theme !== undefined ? { theme: op.theme } : {}),
-          ...(op.code_theme !== undefined ? { code_theme: op.code_theme } : {}),
-        });
-        break;
-      }
-    }
-  }
-
-  return { deck, applied };
-}
-
 interface DeckApplyArgs {
   classroom: string;
   slide_id: string;
@@ -838,7 +435,7 @@ export const deckApplyTool: ToolDefinition<DeckApplyArgs> = {
       .optional()
       .describe("Which file the sha came from, as reported by deck_get/outline (default 'deck')"),
     ops: z
-      .array(opSchema)
+      .array(deckOpSchema)
       .min(1)
       .max(25)
       .describe('Slide operations, applied sequentially (later ops see earlier effects)'),
@@ -894,7 +491,9 @@ export const deckApplyTool: ToolDefinition<DeckApplyArgs> = {
     let newDeck: DeckJson;
     let applied: Array<Record<string, unknown>>;
     try {
-      ({ deck: newDeck, applied } = applyDeckOps(loaded.deck, args.ops));
+      ({ deck: newDeck, applied } = applyDeckOps(loaded.deck, args.ops, {
+        starterCustomCss: slideService.STARTER_CUSTOM_CSS,
+      }));
     } catch (error: unknown) {
       if (error instanceof DeckOpError || error instanceof SlideHtmlError) {
         throw new ToolError('invalid_params', error.message);

--- a/apps/mcp/src/tools/deck.ts
+++ b/apps/mcp/src/tools/deck.ts
@@ -529,9 +529,25 @@ export const deckApplyTool: ToolDefinition<DeckApplyArgs> = {
         // The branch was created by THIS apply and the save failed — delete
         // the fresh (empty) branch so it doesn't strand the deck in preview
         // mode with no pending edits. Best-effort.
+        //
+        // BUT re-check first: a concurrent apply (the racer that got the 422
+        // "already exists" from ensureDeckPreviewBranch) may have committed to
+        // the branch between our creation and this failed save. Deleting it
+        // then would silently discard that writer's commits — so skip the
+        // discard when the branch moved past main (same ahead_by guard the
+        // Phase 7 accept paths use).
         if (createdPreviewBranch) {
           try {
-            await discardDeckPreview(slide);
+            const status = await getDeckPreviewStatus(slide);
+            if (status.exists && (status.commits_ahead ?? 0) > 0) {
+              console.warn(
+                `[deck_apply] Preview branch gained ${status.commits_ahead} concurrent ` +
+                  'commit(s) after creation — keeping it instead of discarding after the ' +
+                  'failed save.'
+              );
+            } else {
+              await discardDeckPreview(slide);
+            }
           } catch (cleanupError: unknown) {
             console.warn(
               '[deck_apply] Failed to clean up the freshly created preview branch:',

--- a/apps/mcp/src/tools/pageContent.ts
+++ b/apps/mcp/src/tools/pageContent.ts
@@ -27,6 +27,7 @@ import { ToolError } from '../mcp/errors.ts';
 import type { ToolDefinition } from '../mcp/registry.ts';
 import {
   loadPageWithRepoInClassroom,
+  mapSemanticMergeError,
   ok,
   OWNER_TEACHER,
   writeAudit,
@@ -630,27 +631,8 @@ interface PagePreviewArgs {
 
 interface PagePreviewAcceptArgs extends PagePreviewArgs {
   resolutions?: Array<{ id: string; choose: 'ours' | 'theirs' }>;
-}
-
-/**
- * Map semantic-merge failures from accept/resolve to tool errors:
- * PreviewResolutionError (bad/incomplete resolutions) → invalid_params naming
- * the ids; a 409 (main moved while merging) → CONTENT_CONFLICT so the caller
- * simply re-runs the accept. Anything else is returned unchanged for rethrow.
- */
-function mapSemanticMergeError(error: unknown, tool: string): unknown {
-  const named = error as { name?: string; message?: string; status?: number };
-  if (named?.name === 'PreviewResolutionError') {
-    return new ToolError('invalid_params', named.message ?? 'Invalid resolutions');
-  }
-  if (named?.status === 409) {
-    return new ToolError(
-      'invalid_params',
-      `Main changed while merging — call ${tool} again`,
-      'CONTENT_CONFLICT'
-    );
-  }
-  return error;
+  expected_ours_sha?: string;
+  expected_theirs_sha?: string;
 }
 
 export const pagePreviewAcceptTool: ToolDefinition<PagePreviewAcceptArgs> = {
@@ -662,9 +644,13 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewAcceptArgs> = {
     'branch. Non-overlapping edits merge automatically (git first, then a per-block semantic ' +
     '3-way merge — the result reports semantic: true with the auto_merged count when that ' +
     'layer kicked in). Only genuine same-block collisions stop the accept: you get a report of ' +
-    'just those blocks (ours = main, theirs = preview, base) plus auto_merged. To finish, ' +
+    'just those blocks (ours = main, theirs = preview, base) plus auto_merged. A block-order ' +
+    "conflict appears as a units entry with id '__order__' (unlike deck_preview_accept, which " +
+    'reports top-level order separately as order_conflict). To finish, ' +
     'either call this tool again with resolutions — one {id, choose: ours|theirs} per reported ' +
-    "conflict id (ours = keep the live main version, theirs = keep the preview's) — or re-read " +
+    "conflict id (ours = keep the live main version, theirs = keep the preview's), passing the " +
+    "report's ours_sha/theirs_sha as expected_ours_sha/expected_theirs_sha to pin your choices " +
+    'to the state you reviewed — or re-read ' +
     'fresh main with page_content_get, re-apply merged blocks with page_content_apply and ' +
     'accept again, or page_preview_discard.',
   scope: 'write',
@@ -690,6 +676,23 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewAcceptArgs> = {
           "the '__order__' sentinel when a block-order conflict was reported. Omit to attempt " +
           'a plain accept.'
       ),
+    expected_ours_sha: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Pass the ours_sha from the conflict report your resolutions answer. If main's " +
+          'content changed since that report, the accept fails with CONTENT_CONFLICT instead ' +
+          'of applying reviewed choices to unseen content. Only meaningful with resolutions.'
+      ),
+    expected_theirs_sha: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        'Pass the theirs_sha from the conflict report your resolutions answer (same staleness ' +
+          'pin for the preview side). Only meaningful with resolutions.'
+      ),
   },
   handler: async (args, ctx) => {
     const page = await loadPageWithRepoInClassroom(args.page_id, ctx);
@@ -705,6 +708,8 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewAcceptArgs> = {
       try {
         result = await ClassmojiService.pageContent.resolvePreviewConflicts(page, {
           resolutions: args.resolutions,
+          ...(args.expected_ours_sha ? { expectedOursSha: args.expected_ours_sha } : {}),
+          ...(args.expected_theirs_sha ? { expectedTheirsSha: args.expected_theirs_sha } : {}),
         });
       } catch (error: unknown) {
         throw mapSemanticMergeError(error, 'page_preview_accept');
@@ -796,7 +801,8 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewAcceptArgs> = {
         `${result.auto_merged} change(s) auto-merge cleanly; ${result.units.length} conflict(s) ` +
         'need a decision. Resolve by calling page_preview_accept again with resolutions ' +
         "(one {id, choose: 'ours'|'theirs'} per conflict id — '__order__' addresses a " +
-        'block-order conflict; ours = main, theirs = preview) — or re-read fresh main with ' +
+        "block-order conflict; ours = main, theirs = preview), passing this report's " +
+        'ours_sha/theirs_sha as expected_ours_sha/expected_theirs_sha — or re-read fresh main with ' +
         'page_content_get, re-apply merged blocks with page_content_apply and accept again, ' +
         'or page_preview_discard to drop the preview.',
     });

--- a/apps/mcp/src/tools/pageContent.ts
+++ b/apps/mcp/src/tools/pageContent.ts
@@ -374,38 +374,11 @@ export const pageContentGetTool: ToolDefinition<PageContentGetArgs> = {
 
 // ─── page_content_apply ──────────────────────────────────────────────────────
 
-const blockSchema = z.record(z.unknown());
-
-const positionSchema = z.union([
-  z.object({ after: z.string().min(1) }).strict(),
-  z.object({ at: z.enum(['start', 'end']) }).strict(),
-]);
-
-const opSchema = z.discriminatedUnion('op', [
-  z.object({
-    op: z.literal('update'),
-    id: z.string().min(1),
-    block: blockSchema.describe('Full replacement block (its id is preserved)'),
-  }),
-  z.object({
-    op: z.literal('insert'),
-    blocks: z.array(blockSchema).min(1).max(20),
-    position: positionSchema,
-  }),
-  z.object({
-    op: z.literal('move'),
-    id: z.string().min(1),
-    position: positionSchema,
-  }),
-  z.object({
-    op: z.literal('delete'),
-    id: z.string().min(1),
-  }),
-  z.object({
-    op: z.literal('replace_all'),
-    blocks: z.array(blockSchema),
-  }),
-]);
+// Op vocabulary is single-sourced in the service (pageBlockOpSchema) so the
+// MCP tool, the pages editor save action, and applyBlockOps validate against
+// ONE schema (plan §7 P8). This tool keeps its own tighter .max(25) total-op
+// cap below as the override.
+const opSchema = ClassmojiService.pageContent.pageBlockOpSchema;
 
 type PageContentOp = z.infer<typeof opSchema>;
 

--- a/apps/mcp/src/tools/pageContent.ts
+++ b/apps/mcp/src/tools/pageContent.ts
@@ -628,20 +628,68 @@ interface PagePreviewArgs {
   page_id: string;
 }
 
-export const pagePreviewAcceptTool: ToolDefinition<PagePreviewArgs> = {
+interface PagePreviewAcceptArgs extends PagePreviewArgs {
+  resolutions?: Array<{ id: string; choose: 'ours' | 'theirs' }>;
+}
+
+/**
+ * Map semantic-merge failures from accept/resolve to tool errors:
+ * PreviewResolutionError (bad/incomplete resolutions) → invalid_params naming
+ * the ids; a 409 (main moved while merging) → CONTENT_CONFLICT so the caller
+ * simply re-runs the accept. Anything else is returned unchanged for rethrow.
+ */
+function mapSemanticMergeError(error: unknown, tool: string): unknown {
+  const named = error as { name?: string; message?: string; status?: number };
+  if (named?.name === 'PreviewResolutionError') {
+    return new ToolError('invalid_params', named.message ?? 'Invalid resolutions');
+  }
+  if (named?.status === 409) {
+    return new ToolError(
+      'invalid_params',
+      `Main changed while merging — call ${tool} again`,
+      'CONTENT_CONFLICT'
+    );
+  }
+  return error;
+}
+
+export const pagePreviewAcceptTool: ToolDefinition<PagePreviewAcceptArgs> = {
   name: 'page_preview_accept',
   annotations: { destructive: false, openWorld: true },
   title: 'Accept a page preview',
   description:
-    "Publishes a page's pending preview: merges the preview branch into main (git auto-merges " +
-    'non-overlapping edits) and deletes the branch. On a genuine same-block conflict nothing ' +
-    'merges — you get a per-block report (ours = main, theirs = preview, base); re-read fresh ' +
-    'main with page_content_get, re-apply the resolved blocks, then accept again or discard.',
+    "Publishes a page's pending preview: merges the preview branch into main and deletes the " +
+    'branch. Non-overlapping edits merge automatically (git first, then a per-block semantic ' +
+    '3-way merge — the result reports semantic: true with the auto_merged count when that ' +
+    'layer kicked in). Only genuine same-block collisions stop the accept: you get a report of ' +
+    'just those blocks (ours = main, theirs = preview, base) plus auto_merged. To finish, ' +
+    'either call this tool again with resolutions — one {id, choose: ours|theirs} per reported ' +
+    "conflict id (ours = keep the live main version, theirs = keep the preview's) — or re-read " +
+    'fresh main with page_content_get, re-apply merged blocks with page_content_apply and ' +
+    'accept again, or page_preview_discard.',
   scope: 'write',
   roles: OWNER_TEACHER,
   inputSchema: {
     classroom: z.string().describe("Classroom reference as 'org/slug'"),
     page_id: z.string().uuid().describe('Page id'),
+    resolutions: z
+      .array(
+        z
+          .object({
+            id: z.string().min(1),
+            choose: z.enum(['ours', 'theirs']),
+          })
+          .strict()
+      )
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        "Per-conflict choices from a prior conflict report: ours = keep main's (live) version, " +
+          "theirs = keep the preview's. Must cover EVERY reported conflict id — block ids plus " +
+          "the '__order__' sentinel when a block-order conflict was reported. Omit to attempt " +
+          'a plain accept.'
+      ),
   },
   handler: async (args, ctx) => {
     const page = await loadPageWithRepoInClassroom(args.page_id, ctx);
@@ -651,7 +699,48 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewArgs> = {
       throw new ToolError('invalid_params', 'No pending preview for this page — nothing to accept');
     }
 
-    const result = await ClassmojiService.pageContent.acceptPreview(page);
+    // ── Resolutions path: apply chooser decisions to the conflicted merge ──
+    if (args.resolutions?.length) {
+      let result;
+      try {
+        result = await ClassmojiService.pageContent.resolvePreviewConflicts(page, {
+          resolutions: args.resolutions,
+        });
+      } catch (error: unknown) {
+        throw mapSemanticMergeError(error, 'page_preview_accept');
+      }
+
+      await writeAudit(ctx, {
+        resource_type: 'PAGES',
+        resource_id: page.id,
+        action: 'UPDATE',
+        data: {
+          tool: 'page_preview_accept',
+          outcome: 'merged',
+          semantic: true,
+          resolutions: args.resolutions.map(({ id, choose }) => ({ id, choose })),
+          auto_merged: result.auto_merged,
+          new_sha: result.sha,
+          ...(result.preview_kept ? { preview_kept: true, reason: result.reason } : {}),
+        } as unknown as Prisma.InputJsonValue,
+      });
+      return ok({
+        success: true,
+        merged: true,
+        semantic: true,
+        resolved: args.resolutions,
+        auto_merged: result.auto_merged,
+        new_sha: result.sha,
+        ...(result.preview_kept ? { preview_kept: true, reason: result.reason } : {}),
+      });
+    }
+
+    let result;
+    try {
+      result = await ClassmojiService.pageContent.acceptPreview(page);
+    } catch (error: unknown) {
+      throw mapSemanticMergeError(error, 'page_preview_accept');
+    }
 
     if (result.merged) {
       await writeAudit(ctx, {
@@ -662,6 +751,7 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewArgs> = {
           tool: 'page_preview_accept',
           outcome: 'merged',
           new_sha: result.sha,
+          ...(result.semantic ? { semantic: true, auto_merged: result.auto_merged } : {}),
           ...(result.preview_kept ? { preview_kept: true, reason: result.reason } : {}),
         } as Prisma.InputJsonValue,
       });
@@ -669,6 +759,7 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewArgs> = {
         success: true,
         merged: true,
         new_sha: result.sha,
+        ...(result.semantic ? { semantic: true, auto_merged: result.auto_merged } : {}),
         ...(result.preview_kept
           ? {
               preview_kept: true,
@@ -689,6 +780,7 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewArgs> = {
         tool: 'page_preview_accept',
         outcome: 'conflict',
         conflict_unit_ids: result.units.map(unit => unit.id),
+        auto_merged: result.auto_merged,
         ours_sha: result.ours_sha,
         theirs_sha: result.theirs_sha,
       } as Prisma.InputJsonValue,
@@ -697,13 +789,16 @@ export const pagePreviewAcceptTool: ToolDefinition<PagePreviewArgs> = {
     return ok({
       conflict: true,
       units: result.units,
+      auto_merged: result.auto_merged,
       ours_sha: result.ours_sha,
       theirs_sha: result.theirs_sha,
       message:
-        'The preview conflicts with newer changes on main. Re-read fresh main with ' +
-        'page_content_get, merge each conflicted unit (ours = main, theirs = preview), ' +
-        're-apply with page_content_apply, then accept again — or page_preview_discard to drop ' +
-        'the preview.',
+        `${result.auto_merged} change(s) auto-merge cleanly; ${result.units.length} conflict(s) ` +
+        'need a decision. Resolve by calling page_preview_accept again with resolutions ' +
+        "(one {id, choose: 'ours'|'theirs'} per conflict id — '__order__' addresses a " +
+        'block-order conflict; ours = main, theirs = preview) — or re-read fresh main with ' +
+        'page_content_get, re-apply merged blocks with page_content_apply and accept again, ' +
+        'or page_preview_discard to drop the preview.',
     });
   },
 };

--- a/apps/mcp/src/tools/shared.ts
+++ b/apps/mcp/src/tools/shared.ts
@@ -328,6 +328,52 @@ export async function loadRepositoryInClassroom(
   return record;
 }
 
+// ─── Semantic-merge error mapping (deck + page preview accept tools) ────────
+
+/**
+ * Map semantic-merge failures from a preview accept/resolve to tool errors:
+ * - PreviewResolutionError with code CONTENT_CONFLICT (the report the choices
+ *   were pinned to went stale) → the same CONTENT_CONFLICT tool error a plain
+ *   mid-merge 409 produces, so clients branch on one code.
+ * - Any other PreviewResolutionError (bad/incomplete resolutions, main file
+ *   deleted) → invalid_params carrying the service's `code` and offending
+ *   `ids`, so MCP clients get exactly what the web actions return.
+ * - A bare 409 (main moved while merging) → CONTENT_CONFLICT.
+ * Anything else is returned unchanged for rethrow.
+ */
+export function mapSemanticMergeError(error: unknown, tool: string): unknown {
+  const named = error as {
+    name?: string;
+    message?: string;
+    status?: number;
+    code?: string;
+    ids?: string[];
+  };
+  if (named?.name === 'PreviewResolutionError') {
+    if (named.code === 'CONTENT_CONFLICT') {
+      return new ToolError(
+        'invalid_params',
+        named.message ?? `Content changed since the conflict report — call ${tool} again`,
+        'CONTENT_CONFLICT'
+      );
+    }
+    return new ToolError(
+      'invalid_params',
+      named.message ?? 'Invalid resolutions',
+      named.code,
+      named.ids?.length ? { ids: named.ids } : undefined
+    );
+  }
+  if (named?.status === 409) {
+    return new ToolError(
+      'invalid_params',
+      `Main changed while merging — call ${tool} again`,
+      'CONTENT_CONFLICT'
+    );
+  }
+  return error;
+}
+
 // ─── Misc shared utilities ───────────────────────────────────────────────────
 
 /**

--- a/apps/pages/app/components/editor/PageEditor.tsx
+++ b/apps/pages/app/components/editor/PageEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useImperativeHandle, forwardRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useImperativeHandle, forwardRef } from 'react';
 import {
   useCreateBlockNote,
   SuggestionMenuController,
@@ -54,10 +54,18 @@ interface PageEditorProps {
   pageId: string;
   darkMode: boolean;
   onChange?: (document: unknown) => void;
+  /**
+   * Fired once after mount with the editor's NORMALIZED document
+   * (`editor.document`). The parent uses this as its diff-at-save baseline so
+   * both diff sides share BlockNote's normalization (no phantom updates).
+   */
+  onReady?: (document: unknown) => void;
+  /** When false, the editor is read-only (e.g. while a save-merge chooser is open). */
+  editable?: boolean;
 }
 
 const PageEditor = forwardRef(function PageEditor(
-  { initialContent, pageId, darkMode, onChange }: PageEditorProps,
+  { initialContent, pageId, darkMode, onChange, onReady, editable = true }: PageEditorProps,
   ref: React.Ref<{ getContent: () => unknown }>
 ) {
   // Upload handler: POSTs to the page's upload action
@@ -107,6 +115,15 @@ const PageEditor = forwardRef(function PageEditor(
     }),
     [editor]
   );
+
+  // Baseline capture (P2): hand the parent this editor's normalized document
+  // once, right after mount. Runs again for a remounted instance (the parent
+  // remounts via `key` on merged adoption), so the baseline tracks the
+  // adopted document. `editor` is stable; onReady reads refs only.
+  useEffect(() => {
+    onReady?.(editor.document);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per editor instance
+  }, [editor]);
 
   // Slash menu: default + multi-column + custom blocks
   const getAllSlashMenuItems = useMemo(() => {
@@ -261,6 +278,7 @@ const PageEditor = forwardRef(function PageEditor(
       `}</style>
       <BlockNoteView
         editor={editor}
+        editable={editable}
         theme={darkMode ? 'dark' : 'light'}
         slashMenu={false}
         formattingToolbar={false}

--- a/apps/pages/app/components/editor/blockOpsDiff.ts
+++ b/apps/pages/app/components/editor/blockOpsDiff.ts
@@ -1,0 +1,235 @@
+/**
+ * blockOpsDiff.ts — pure diff-at-save helper for the pages editor.
+ *
+ * Diffs the editor's current BlockNote document against the baseline snapshot
+ * it mounted from (loader content / merged-document adoption / last
+ * successful save) and emits the block operations the server replays against
+ * the SAME base (`theirs = applyBlockOps(base, ops)` in
+ * pageContent.service). Untouched blocks never leave the client, and
+ * concurrent saves to different blocks auto-merge by construction.
+ *
+ * The unit is the TOP-LEVEL block: nested children ride inside their
+ * top-level block, so a changed child = one update op on its top-level
+ * parent — matching the merge engine's unit.
+ *
+ * `null` = no trustworthy diff — the caller falls back to the whole-document
+ * save (the 7.5 path, which needs no baseline). Returned for:
+ * - a missing/non-array baseline or current document,
+ * - a top-level block without a usable string id,
+ * - duplicate ids anywhere in either tree (id-addressed ops would be
+ *   ambiguous server-side),
+ * - ids that change scope between the docs (top-level ⇄ nested — the op
+ *   vocabulary cannot express a cross-scope move without id churn),
+ * - reorders moving more than MAX_MOVES blocks (a whole-document save beats
+ *   a long, fragile move script).
+ *
+ * No React/BlockNote imports — the Playwright runner unit-tests this module
+ * directly (tests/unit/block-ops-diff.spec.ts) without a browser.
+ */
+
+// ── Op vocabulary (client-side twin of pageContent.service's BlockOp) ────────
+
+export type BlockPosition = { after: string } | { at: 'start' | 'end' };
+
+export type BlockOp =
+  | { op: 'update'; id: string; block: unknown }
+  | { op: 'insert'; blocks: unknown[]; position: BlockPosition }
+  | { op: 'move'; id: string; position: BlockPosition }
+  | { op: 'delete'; id: string };
+
+/** Reorders that move more than this many blocks fall back to a whole-doc save. */
+export const MAX_MOVES = 3;
+
+interface BlockNode {
+  id?: unknown;
+  children?: unknown;
+  [key: string]: unknown;
+}
+
+// ── Canonical JSON (service twin) ────────────────────────────────────────────
+
+/**
+ * Deterministic serialization with object keys sorted at every level, so two
+ * structurally identical blocks compare equal regardless of key insertion
+ * order (the baseline came from parsed file JSON, the current doc from the
+ * live editor).
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'undefined';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${canonicalJson((value as Record<string, unknown>)[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
+// ── Document analysis ────────────────────────────────────────────────────────
+
+interface DocInfo {
+  /** Top-level block ids in document order. */
+  topIds: string[];
+  /** Ids that live nested inside some block's children subtree. */
+  nested: Set<string>;
+}
+
+/**
+ * Collect a document's top-level ids and nested ids. `null` = the document
+ * can't be diffed safely: a top-level entry that isn't an object, a top-level
+ * block without a non-empty string id, or any id appearing twice in the tree.
+ * (Nested blocks without ids are fine — they ride inside their parent.)
+ */
+function analyzeDoc(doc: unknown[]): DocInfo | null {
+  const topIds: string[] = [];
+  const all = new Set<string>();
+  const nested = new Set<string>();
+  let duplicate = false;
+
+  const walkChildren = (children: unknown): void => {
+    if (duplicate || !Array.isArray(children)) return;
+    for (const child of children) {
+      if (!child || typeof child !== 'object') continue;
+      const id = (child as BlockNode).id;
+      if (typeof id === 'string' && id) {
+        if (all.has(id)) {
+          duplicate = true;
+          return;
+        }
+        all.add(id);
+        nested.add(id);
+      }
+      walkChildren((child as BlockNode).children);
+      if (duplicate) return;
+    }
+  };
+
+  for (const block of doc) {
+    if (!block || typeof block !== 'object') return null;
+    const id = (block as BlockNode).id;
+    if (typeof id !== 'string' || !id) return null;
+    if (all.has(id)) return null;
+    all.add(id);
+    topIds.push(id);
+    walkChildren((block as BlockNode).children);
+    if (duplicate) return null;
+  }
+  return { topIds, nested };
+}
+
+/** Indices of one longest strictly-increasing subsequence of `seq` (O(n²) DP). */
+function lisIndices(seq: number[]): number[] {
+  const n = seq.length;
+  if (n === 0) return [];
+  const len = new Array<number>(n).fill(1);
+  const prev = new Array<number>(n).fill(-1);
+  let best = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < i; j++) {
+      if (seq[j] < seq[i] && len[j] + 1 > len[i]) {
+        len[i] = len[j] + 1;
+        prev[i] = j;
+      }
+    }
+    if (len[i] > len[best]) best = i;
+  }
+  const out: number[] = [];
+  for (let k = best; k !== -1; k = prev[k]) out.push(k);
+  return out.reverse();
+}
+
+// ── The diff ─────────────────────────────────────────────────────────────────
+
+/**
+ * Diff `current` against `baseline` into a minimal op script, or `null` when
+ * no trustworthy diff exists (see module doc) — the caller then falls back to
+ * the whole-document save.
+ *
+ * Op order matters for server-side replay and is fixed as
+ * updates → deletes → moves → inserts:
+ * - updates address common ids in place (position-independent);
+ * - deletes leave only the survivors;
+ * - moves put the survivors in their final relative order (minimal set via
+ *   LIS: only blocks OFF the longest stable subsequence move, each placed
+ *   `{ after: <its final predecessor> }` in final order — every anchor is a
+ *   survivor already in position);
+ * - inserts splice each consecutive run of new blocks after its final
+ *   left-hand neighbor (a survivor, or a block from an earlier insert run).
+ *
+ * An empty array means the documents are canonically identical — nothing to
+ * save.
+ */
+export function diffBlockOps(baseline: unknown, current: unknown): BlockOp[] | null {
+  if (!Array.isArray(baseline) || !Array.isArray(current)) return null;
+
+  const base = analyzeDoc(baseline);
+  const cur = analyzeDoc(current);
+  if (!base || !cur) return null;
+
+  // Cross-scope ids (top-level in one doc, nested in the other): a whole-doc
+  // save lets the merge engine's cross-scope handling deal with it.
+  for (const id of cur.topIds) {
+    if (base.nested.has(id)) return null;
+  }
+  for (const id of base.topIds) {
+    if (cur.nested.has(id)) return null;
+  }
+
+  const baseSet = new Set(base.topIds);
+  const curSet = new Set(cur.topIds);
+  const ops: BlockOp[] = [];
+
+  // 1. update — common ids whose block (whole subtree) changed canonically.
+  const baseBlockById = new Map<string, unknown>();
+  base.topIds.forEach((id, index) => baseBlockById.set(id, baseline[index]));
+  cur.topIds.forEach((id, index) => {
+    if (!baseSet.has(id)) return;
+    if (canonicalJson(baseBlockById.get(id)) !== canonicalJson(current[index])) {
+      ops.push({ op: 'update', id, block: current[index] });
+    }
+  });
+
+  // 2. delete — base ids gone from current.
+  for (const id of base.topIds) {
+    if (!curSet.has(id)) ops.push({ op: 'delete', id });
+  }
+
+  // 3. move — survivors whose relative order changed (minimal set via LIS).
+  const remaining = base.topIds.filter(id => curSet.has(id));
+  const commonCur = cur.topIds.filter(id => baseSet.has(id));
+  const basePos = new Map<string, number>();
+  remaining.forEach((id, index) => basePos.set(id, index));
+  const seq = commonCur.map(id => basePos.get(id)!);
+  const stable = new Set(lisIndices(seq).map(index => commonCur[index]));
+  const movedCount = commonCur.length - stable.size;
+  if (movedCount > MAX_MOVES) return null;
+  commonCur.forEach((id, index) => {
+    if (stable.has(id)) return;
+    ops.push({
+      op: 'move',
+      id,
+      position: index === 0 ? { at: 'start' } : { after: commonCur[index - 1] },
+    });
+  });
+
+  // 4. insert — consecutive runs of new blocks, left-to-right.
+  let i = 0;
+  while (i < cur.topIds.length) {
+    if (baseSet.has(cur.topIds[i])) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < cur.topIds.length && !baseSet.has(cur.topIds[j])) j++;
+    ops.push({
+      op: 'insert',
+      blocks: current.slice(i, j),
+      position: i === 0 ? { at: 'start' } : { after: cur.topIds[i - 1] },
+    });
+    i = j;
+  }
+
+  return ops;
+}

--- a/apps/pages/app/components/editor/blockOpsDiff.ts
+++ b/apps/pages/app/components/editor/blockOpsDiff.ts
@@ -28,6 +28,13 @@
  */
 
 // ── Op vocabulary (client-side twin of pageContent.service's BlockOp) ────────
+//
+// The AUTHORITATIVE op vocabulary is the zod `pageBlockOpSchema` in
+// packages/services pageContent.service.ts — the route and the MCP tool both
+// validate against it (plan §7 P8). This is a hand-kept structural SUBSET (the
+// diff never emits `replace_all`): server code can't be imported into the
+// browser bundle, so it can't import the schema's type here. Every op this
+// module emits must stay assignable to `pageBlockOpSchema`'s inferred type.
 
 export type BlockPosition = { after: string } | { at: 'start' | 'end' };
 

--- a/apps/pages/app/components/preview/PreviewControls.tsx
+++ b/apps/pages/app/components/preview/PreviewControls.tsx
@@ -11,12 +11,14 @@ import {
   chooserCopy,
   chooserSubtitle,
   conflictIds,
+  orderDiffIds,
   reasonLabel,
   type ChooserCopy,
   type ChooserVariant,
   type ConflictUnit,
   type MergeChoice,
   type MergeResolution,
+  type UnitPreviews,
 } from './conflictChooser.ts';
 
 dayjs.extend(relativeTime);
@@ -47,6 +49,7 @@ export type { ConflictUnit };
 interface PreviewActionData {
   conflict?: boolean;
   units?: ConflictUnit[];
+  unitPreviews?: UnitPreviews | null;
   autoMerged?: number;
   oursSha?: string | null;
   theirsSha?: string | null;
@@ -90,6 +93,7 @@ function usePreviewActions() {
   };
 
   const conflictUnits = fetcher.data?.conflict ? (fetcher.data.units ?? []) : null;
+  const unitPreviews = fetcher.data?.conflict ? (fetcher.data.unitPreviews ?? null) : null;
   const autoMerged = fetcher.data?.conflict ? (fetcher.data.autoMerged ?? 0) : 0;
   const conflictOursSha = fetcher.data?.conflict ? (fetcher.data.oursSha ?? null) : null;
   const error = fetcher.data?.error ?? null;
@@ -101,6 +105,7 @@ function usePreviewActions() {
     applyResolutions,
     discard,
     conflictUnits,
+    unitPreviews,
     autoMerged,
     conflictOursSha,
     error,
@@ -196,19 +201,49 @@ const BlockPreview = ({ block }: { block: unknown }) => {
   );
 };
 
-/** Numbered id list for an ordering conflict side. */
-const OrderList = ({ ids }: { ids: string[] }) => (
+/**
+ * Numbered rows for an ordering conflict side. With the accept report's
+ * `unit_previews` each row shows the block's type/text summary (moved blocks —
+ * a different position in the two orderings — get an amber marker); without
+ * them (e.g. a save-merge report) it falls back to the raw block id.
+ */
+const OrderList = ({
+  ids,
+  previews,
+  moved,
+}: {
+  ids: string[];
+  previews?: UnitPreviews | null;
+  moved?: Set<string>;
+}) => (
   <ol className="space-y-0.5 text-xs text-gray-700 dark:text-gray-300 max-h-36 overflow-y-auto">
-    {ids.map((id, position) => (
-      <li key={`${id}-${position}`} className="flex gap-1.5">
-        <span className="w-5 shrink-0 text-right tabular-nums text-gray-400 dark:text-gray-500">
-          {position + 1}.
-        </span>
-        <span className="truncate font-mono text-[11px]">{id}</span>
-      </li>
-    ))}
+    {ids.map((id, position) => {
+      const summary = previews?.[id]?.summary;
+      const isMoved = moved?.has(id) ?? false;
+      return (
+        <li
+          key={`${id}-${position}`}
+          data-testid={`order-row-${id}`}
+          data-moved={isMoved ? 'true' : undefined}
+          className={`flex gap-1.5 rounded px-1 ${
+            isMoved ? 'bg-amber-100/70 dark:bg-amber-900/40' : ''
+          }`}
+        >
+          <span className="w-5 shrink-0 text-right tabular-nums text-gray-400 dark:text-gray-500">
+            {position + 1}.
+          </span>
+          {summary ? (
+            <span className="truncate">{summary}</span>
+          ) : (
+            <span className="truncate font-mono text-[11px]">{id}</span>
+          )}
+        </li>
+      );
+    })}
   </ol>
 );
+
+const EMPTY_MOVED: Set<string> = new Set();
 
 const cardShell =
   'rounded-lg border border-rose-200 dark:border-rose-800/70 bg-white dark:bg-neutral-900 p-3';
@@ -221,19 +256,31 @@ const ConflictCard = ({
   copy,
   choice,
   onChoose,
+  unitPreviews,
 }: {
   unit: ConflictUnit;
   copy: ChooserCopy;
   choice: MergeChoice | undefined;
   onChoose: (id: string, choice: MergeChoice) => void;
+  unitPreviews?: UnitPreviews | null;
 }) => {
   const isOrder = unit.id === ORDER_CONFLICT_ID;
   const title = isOrder ? 'Block order' : `Block ${unit.index + 1}`;
 
+  const oursIds = isOrder && Array.isArray(unit.ours) ? (unit.ours as string[]) : [];
+  const theirsIds = isOrder && Array.isArray(unit.theirs) ? (unit.theirs as string[]) : [];
+  const movedIds = isOrder ? orderDiffIds(oursIds, theirsIds) : EMPTY_MOVED;
+
   const renderSide = (side: MergeChoice) => {
     const value = side === 'ours' ? unit.ours : unit.theirs;
     if (isOrder) {
-      return <OrderList ids={Array.isArray(value) ? (value as string[]) : []} />;
+      return (
+        <OrderList
+          ids={Array.isArray(value) ? (value as string[]) : []}
+          previews={unitPreviews}
+          moved={movedIds}
+        />
+      );
     }
     if (value === undefined || value === null) {
       return <Tombstone label={copy.tombstone[side]} />;
@@ -279,6 +326,7 @@ const ConflictCard = ({
  */
 export const ConflictPanel = ({
   units,
+  unitPreviews,
   autoMerged,
   oursSha,
   busy,
@@ -287,6 +335,7 @@ export const ConflictPanel = ({
   variant = 'preview',
 }: {
   units: ConflictUnit[];
+  unitPreviews?: UnitPreviews | null;
   autoMerged: number;
   oursSha: string | null;
   busy: boolean;
@@ -314,7 +363,7 @@ export const ConflictPanel = ({
       className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/95 px-4 sm:px-6 lg:px-8 py-3 max-h-[70vh] overflow-y-auto"
     >
       {busy && (
-        <div className="-mx-4 sm:-mx-6 lg:-mx-8 -mt-3 mb-3">
+        <div className="sticky top-0 z-10 -mx-4 sm:-mx-6 lg:-mx-8 -mt-3 mb-3 shadow-sm">
           <MergeProgress label={copy.busyLabel} />
         </div>
       )}
@@ -334,6 +383,7 @@ export const ConflictPanel = ({
             copy={copy}
             choice={choices[unit.id]}
             onChoose={choose}
+            unitPreviews={unitPreviews}
           />
         ))}
       </div>
@@ -389,6 +439,7 @@ export const PreviewBar = ({
     applyResolutions,
     discard,
     conflictUnits,
+    unitPreviews,
     autoMerged,
     conflictOursSha,
     error,
@@ -449,6 +500,7 @@ export const PreviewBar = ({
       {conflictUnits && (
         <ConflictPanel
           units={conflictUnits}
+          unitPreviews={unitPreviews}
           autoMerged={autoMerged}
           oursSha={conflictOursSha}
           busy={busy}
@@ -471,6 +523,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
     applyResolutions,
     discard,
     conflictUnits,
+    unitPreviews,
     autoMerged,
     conflictOursSha,
     error,
@@ -524,6 +577,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
       {conflictUnits && (
         <ConflictPanel
           units={conflictUnits}
+          unitPreviews={unitPreviews}
           autoMerged={autoMerged}
           oursSha={conflictOursSha}
           busy={busy}

--- a/apps/pages/app/components/preview/PreviewControls.tsx
+++ b/apps/pages/app/components/preview/PreviewControls.tsx
@@ -388,7 +388,7 @@ export const PreviewBar = ({
                 rel="noopener noreferrer"
                 className={`${actionButtonBase} inline-flex items-center gap-1 text-amber-900 dark:text-amber-200 ring-1 ring-amber-300 dark:ring-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40`}
               >
-                Diff
+                GitHub diff
                 <IconExternalLink size={14} />
               </a>
             )}
@@ -406,7 +406,7 @@ export const PreviewBar = ({
               disabled={busy}
               className={`${actionButtonBase} bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400`}
             >
-              {busy && pending === 'accept' ? 'Accepting…' : 'Accept'}
+              {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
             </button>
           </div>
         </div>
@@ -471,7 +471,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
             disabled={busy}
             className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {busy && pending === 'accept' ? 'Accepting…' : 'Accept'}
+            {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
           </button>
           <button
             type="button"

--- a/apps/pages/app/components/preview/PreviewControls.tsx
+++ b/apps/pages/app/components/preview/PreviewControls.tsx
@@ -8,8 +8,12 @@ import {
   allResolved,
   blockSummary,
   buildResolutions,
+  chooserCopy,
+  chooserSubtitle,
   conflictIds,
   reasonLabel,
+  type ChooserCopy,
+  type ChooserVariant,
   type ConflictUnit,
   type MergeChoice,
   type MergeResolution,
@@ -53,7 +57,7 @@ interface PreviewActionData {
 
 function usePreviewActions() {
   const fetcher = useFetcher<PreviewActionData>();
-  const [pending, setPending] = useState<'accept' | 'discard' | null>(null);
+  const [pending, setPending] = useState<'accept' | 'resolve' | 'discard' | null>(null);
   const busy = fetcher.state !== 'idle';
 
   const accept = () => {
@@ -65,7 +69,7 @@ function usePreviewActions() {
   // The report's shas ride along so the server can refuse (CONTENT_CONFLICT)
   // if the content moved after the reviewed report (F3 pinning).
   const applyResolutions = (resolutions: MergeResolution[]) => {
-    setPending('accept');
+    setPending('resolve');
     fetcher.submit(
       {
         intent: 'preview-accept',
@@ -103,27 +107,39 @@ function usePreviewActions() {
   };
 }
 
-// ─── Conflict chooser (Phase 7) ──────────────────────────────────────────────
+// ─── Conflict chooser (Phase 7; save variant 7.5) ────────────────────────────
 
-const SIDE_TITLE: Record<MergeChoice, string> = {
-  ours: 'Live version (yours)',
-  theirs: "Preview version (agent's)",
-};
-const SIDE_ACTION: Record<MergeChoice, string> = {
-  ours: 'Keep live',
-  theirs: 'Take preview',
-};
+/**
+ * Prominent in-flight indicator for merge submissions: the accept/resolve
+ * round-trips take several seconds of GitHub calls, and a button-label change
+ * alone is easy to miss.
+ */
+export const MergeProgress = ({ label }: { label: string }) => (
+  <div
+    data-testid="merge-progress"
+    className="flex items-center gap-2.5 border-b border-amber-300 dark:border-amber-700/70 bg-amber-100/95 dark:bg-amber-900/90 px-4 sm:px-6 lg:px-8 py-2.5 text-sm font-medium text-amber-900 dark:text-amber-100"
+    role="status"
+  >
+    <span
+      className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-amber-600 dark:border-amber-300 border-t-transparent"
+      aria-hidden
+    />
+    {label}
+  </div>
+);
 
 /** One selectable side of a conflict card (radio + bounded preview). */
 const ChoiceSide = ({
   unitId,
   side,
+  copy,
   selected,
   onChoose,
   children,
 }: {
   unitId: string;
   side: MergeChoice;
+  copy: ChooserCopy;
   selected: boolean;
   onChoose: (side: MergeChoice) => void;
   children: ReactNode;
@@ -144,9 +160,9 @@ const ChoiceSide = ({
         onChange={() => onChoose(side)}
         className="accent-amber-600"
       />
-      {SIDE_TITLE[side]}
+      {copy.sideTitle[side]}
       <span className="ml-auto text-[11px] font-normal text-gray-500 dark:text-gray-400">
-        {SIDE_ACTION[side]}
+        {copy.sideAction[side]}
       </span>
     </span>
     {children}
@@ -199,13 +215,15 @@ const cardShell =
 const cardBadge =
   'rounded-full bg-rose-100 dark:bg-rose-900/60 px-2 py-0.5 text-[11px] text-rose-800 dark:text-rose-200';
 
-/** One conflict card: side-by-side live vs preview with a choice per side. */
+/** One conflict card: side-by-side ours vs theirs with a choice per side. */
 const ConflictCard = ({
   unit,
+  copy,
   choice,
   onChoose,
 }: {
   unit: ConflictUnit;
+  copy: ChooserCopy;
   choice: MergeChoice | undefined;
   onChoose: (id: string, choice: MergeChoice) => void;
 }) => {
@@ -218,11 +236,7 @@ const ConflictCard = ({
       return <OrderList ids={Array.isArray(value) ? (value as string[]) : []} />;
     }
     if (value === undefined || value === null) {
-      return (
-        <Tombstone
-          label={side === 'ours' ? 'Deleted in the live version' : 'Deleted in the preview'}
-        />
-      );
+      return <Tombstone label={copy.tombstone[side]} />;
     }
     return <BlockPreview block={value} />;
   };
@@ -239,6 +253,7 @@ const ConflictCard = ({
             key={side}
             unitId={unit.id}
             side={side}
+            copy={copy}
             selected={choice === side}
             onChoose={chosen => onChoose(unit.id, chosen)}
           >
@@ -252,17 +267,24 @@ const ConflictCard = ({
 
 /**
  * Conflict chooser panel (Phase 7): a side-by-side card per conflicted block,
- * an Apply footer that submits a resolution for EVERY listed conflict, and a
- * Discard escape. Auto-merged counts from the accept report are surfaced so
- * staff know only the true collisions are listed.
+ * an Apply footer that submits a resolution for EVERY listed conflict, and an
+ * escape hatch. Auto-merged counts from the report are surfaced so staff know
+ * only the true collisions are listed.
+ *
+ * Two variants share the machinery (7.5): `preview` (accept flow — ours = the
+ * live page, theirs = the agent's preview; escape = discard the preview) and
+ * `save` (a stale editor save — ours = what's saved on the server, theirs =
+ * the editor's unsaved version; escape = reload latest). `onDiscard` is the
+ * variant's escape action.
  */
-const ConflictPanel = ({
+export const ConflictPanel = ({
   units,
   autoMerged,
   oursSha,
   busy,
   onApply,
   onDiscard,
+  variant = 'preview',
 }: {
   units: ConflictUnit[];
   autoMerged: number;
@@ -270,6 +292,7 @@ const ConflictPanel = ({
   busy: boolean;
   onApply: (resolutions: MergeResolution[]) => void;
   onDiscard: () => void;
+  variant?: ChooserVariant;
 }) => {
   const ids = conflictIds(units);
   // Keyed on the report's ours_sha too: a re-accept after main moved can
@@ -283,27 +306,35 @@ const ConflictPanel = ({
   const choose = (id: string, choice: MergeChoice) =>
     setChoices(prev => ({ ...prev, [id]: choice }));
   const ready = allResolved(ids, choices);
+  const copy = chooserCopy(variant);
 
   return (
     <div
       data-testid="preview-conflict-panel"
       className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/95 px-4 sm:px-6 lg:px-8 py-3 max-h-[70vh] overflow-y-auto"
     >
-      <div className="text-sm font-medium text-rose-900 dark:text-rose-100">
-        Changes conflict with edits made on the live page
-      </div>
+      {busy && (
+        <div className="-mx-4 sm:-mx-6 lg:-mx-8 -mt-3 mb-3">
+          <MergeProgress label={copy.busyLabel} />
+        </div>
+      )}
+      <div className="text-sm font-medium text-rose-900 dark:text-rose-100">{copy.heading}</div>
       <div
         data-testid="conflict-auto-merged"
         className="mt-0.5 text-sm text-rose-800 dark:text-rose-200"
       >
-        {autoMerged > 0
-          ? `${autoMerged} change${autoMerged === 1 ? '' : 's'} merged automatically; these need you:`
-          : 'Choose which version to keep for each conflict:'}
+        {chooserSubtitle(variant, autoMerged)}
       </div>
 
       <div className="mt-3 space-y-3">
         {units.map(unit => (
-          <ConflictCard key={unit.id} unit={unit} choice={choices[unit.id]} onChoose={choose} />
+          <ConflictCard
+            key={unit.id}
+            unit={unit}
+            copy={copy}
+            choice={choices[unit.id]}
+            onChoose={choose}
+          />
         ))}
       </div>
 
@@ -324,13 +355,13 @@ const ConflictPanel = ({
           onClick={onDiscard}
           className={`${actionButtonBase} text-rose-800 dark:text-rose-200 ring-1 ring-rose-300 dark:ring-rose-700 hover:bg-rose-100 dark:hover:bg-rose-900/40`}
         >
-          Discard preview
+          {copy.secondaryAction}
         </button>
         <span className="text-xs text-rose-700 dark:text-rose-300">
           {ready
             ? 'Applies your choice for every conflict and publishes the merge.'
             : 'Pick a version for every conflict to enable Apply.'}{' '}
-          Or re-apply from the current version (via your agent).
+          {copy.footerNote}
         </span>
       </div>
     </div>
@@ -412,6 +443,9 @@ export const PreviewBar = ({
         </div>
         {error && <div className="mt-2 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
+      {busy && pending === 'accept' && (
+        <MergeProgress label="Merging preview into the live page — this can take a few seconds…" />
+      )}
       {conflictUnits && (
         <ConflictPanel
           units={conflictUnits}
@@ -484,6 +518,9 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
         </div>
         {error && <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
+      {busy && pending === 'accept' && (
+        <MergeProgress label="Merging preview into the live page — this can take a few seconds…" />
+      )}
       {conflictUnits && (
         <ConflictPanel
           units={conflictUnits}

--- a/apps/pages/app/components/preview/PreviewControls.tsx
+++ b/apps/pages/app/components/preview/PreviewControls.tsx
@@ -1,19 +1,32 @@
-import { useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Link, useFetcher } from 'react-router';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { IconExternalLink, IconGitBranch } from '@tabler/icons-react';
+import {
+  ORDER_CONFLICT_ID,
+  allResolved,
+  blockSummary,
+  buildResolutions,
+  conflictIds,
+  reasonLabel,
+  type ConflictUnit,
+  type MergeChoice,
+  type MergeResolution,
+} from './conflictChooser.ts';
 
 dayjs.extend(relativeTime);
 
 /**
  * Preview-branch UI (plan §3b): the persistent bar shown while rendering the
  * pending `preview/<content_path>` branch, the slim staff-only banner shown on
- * the live page when a preview exists, and the conflict panel rendered when an
- * accept hits a git merge conflict.
+ * the live page when a preview exists, and the side-by-side conflict chooser
+ * rendered when an accept hits a genuine merge conflict (Phase 7).
  *
  * All accept/discard submissions post the same JSON intents the route action
  * handles (`preview-accept` / `preview-discard`) — staff-gated server-side.
+ * The chooser re-posts `preview-accept` with a `resolutions` payload covering
+ * every listed conflict.
  */
 
 export interface PreviewInfo {
@@ -25,18 +38,15 @@ export interface PreviewInfo {
   diffUrl: string | null;
 }
 
-export interface ConflictUnit {
-  id: string;
-  index: number;
-  ours?: unknown;
-  theirs?: unknown;
-  base?: unknown;
-}
+export type { ConflictUnit };
 
 interface PreviewActionData {
   conflict?: boolean;
   units?: ConflictUnit[];
+  autoMerged?: number;
   error?: string;
+  code?: string;
+  ids?: string[];
 }
 
 function usePreviewActions() {
@@ -49,6 +59,15 @@ function usePreviewActions() {
     fetcher.submit({ intent: 'preview-accept' }, { method: 'POST', encType: 'application/json' });
   };
 
+  // Chooser submit: same intent, plus one {id, choose} per listed conflict.
+  const applyResolutions = (resolutions: MergeResolution[]) => {
+    setPending('accept');
+    fetcher.submit(
+      { intent: 'preview-accept', resolutions: JSON.stringify(resolutions) },
+      { method: 'POST', encType: 'application/json' }
+    );
+  };
+
   const discard = () => {
     if (!window.confirm('Discard the pending preview? Its changes will be permanently deleted.')) {
       return;
@@ -58,38 +77,240 @@ function usePreviewActions() {
   };
 
   const conflictUnits = fetcher.data?.conflict ? (fetcher.data.units ?? []) : null;
+  const autoMerged = fetcher.data?.conflict ? (fetcher.data.autoMerged ?? 0) : 0;
   const error = fetcher.data?.error ?? null;
 
-  return { busy, pending, accept, discard, conflictUnits, error };
+  return { busy, pending, accept, applyResolutions, discard, conflictUnits, autoMerged, error };
 }
 
-function unitLabel(unit: ConflictUnit): string {
-  if (unit.id === '__order__') return 'block ordering';
-  const type = ((unit.theirs ?? unit.ours ?? unit.base) as { type?: string } | undefined)?.type;
-  return `block ${unit.index + 1} (${unit.id}${type ? `, ${type}` : ''})`;
-}
+// ─── Conflict chooser (Phase 7) ──────────────────────────────────────────────
 
-/**
- * Conflict panel: lists the blocks that genuinely need a decision. The per-unit
- * chooser is Phase 7 — for now we name the conflicted units readably.
- */
-const ConflictPanel = ({ units }: { units: ConflictUnit[] }) => (
-  <div
-    data-testid="preview-conflict-panel"
-    className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/60 px-4 sm:px-6 lg:px-8 py-3"
+const SIDE_TITLE: Record<MergeChoice, string> = {
+  ours: 'Live version (yours)',
+  theirs: "Preview version (agent's)",
+};
+const SIDE_ACTION: Record<MergeChoice, string> = {
+  ours: 'Keep live',
+  theirs: 'Take preview',
+};
+
+/** One selectable side of a conflict card (radio + bounded preview). */
+const ChoiceSide = ({
+  unitId,
+  side,
+  selected,
+  onChoose,
+  children,
+}: {
+  unitId: string;
+  side: MergeChoice;
+  selected: boolean;
+  onChoose: (side: MergeChoice) => void;
+  children: ReactNode;
+}) => (
+  <label
+    data-testid={`conflict-choose-${side}-${unitId}`}
+    className={`flex flex-col gap-1.5 rounded-lg border p-2 cursor-pointer transition-colors ${
+      selected
+        ? 'border-amber-500 dark:border-amber-400 ring-1 ring-amber-500 dark:ring-amber-400 bg-amber-50/60 dark:bg-amber-950/40'
+        : 'border-stone-200 dark:border-neutral-700 hover:border-amber-300 dark:hover:border-amber-700'
+    }`}
   >
-    <div className="text-sm font-medium text-rose-900 dark:text-rose-100">
-      Changes conflict with edits made on the live page
-    </div>
-    <div className="mt-1 text-sm text-rose-800 dark:text-rose-200">
-      Conflicting blocks:{' '}
-      {units.length > 0 ? units.map(unit => unitLabel(unit)).join(', ') : 'none reported'}
-    </div>
-    <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">
-      Re-apply from the current version (via your agent) or discard the preview.
-    </div>
+    <span className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-200">
+      <input
+        type="radio"
+        name={`conflict-${unitId}`}
+        checked={selected}
+        onChange={() => onChoose(side)}
+        className="accent-amber-600"
+      />
+      {SIDE_TITLE[side]}
+      <span className="ml-auto text-[11px] font-normal text-gray-500 dark:text-gray-400">
+        {SIDE_ACTION[side]}
+      </span>
+    </span>
+    {children}
+  </label>
+);
+
+/** Placeholder for a side where the unit was deleted. */
+const Tombstone = ({ label }: { label: string }) => (
+  <div className="flex h-full min-h-16 items-center justify-center rounded border border-dashed border-gray-300 dark:border-neutral-600 bg-gray-50 dark:bg-neutral-800/60 px-3 py-4 text-xs italic text-gray-500 dark:text-gray-400">
+    {label}
   </div>
 );
+
+/** Readable structural preview of one block side (no BlockNote editor mounted). */
+const BlockPreview = ({ block }: { block: unknown }) => {
+  const { type, text, childCount } = blockSummary(block);
+  return (
+    <div className="rounded border border-stone-200 dark:border-neutral-700 bg-stone-50 dark:bg-neutral-800 p-2 text-xs max-h-36 overflow-y-auto">
+      <span className="inline-block rounded bg-stone-200 dark:bg-neutral-700 px-1.5 py-0.5 font-mono text-[10px] text-stone-700 dark:text-neutral-200">
+        {type}
+      </span>
+      <div className="mt-1 whitespace-pre-wrap text-gray-800 dark:text-gray-200">
+        {text || <span className="italic text-gray-400 dark:text-gray-500">(no text content)</span>}
+      </div>
+      {childCount > 0 && (
+        <div className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">
+          {childCount} nested block{childCount === 1 ? '' : 's'}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/** Numbered id list for an ordering conflict side. */
+const OrderList = ({ ids }: { ids: string[] }) => (
+  <ol className="space-y-0.5 text-xs text-gray-700 dark:text-gray-300 max-h-36 overflow-y-auto">
+    {ids.map((id, position) => (
+      <li key={`${id}-${position}`} className="flex gap-1.5">
+        <span className="w-5 shrink-0 text-right tabular-nums text-gray-400 dark:text-gray-500">
+          {position + 1}.
+        </span>
+        <span className="truncate font-mono text-[11px]">{id}</span>
+      </li>
+    ))}
+  </ol>
+);
+
+const cardShell =
+  'rounded-lg border border-rose-200 dark:border-rose-800/70 bg-white dark:bg-neutral-900 p-3';
+const cardBadge =
+  'rounded-full bg-rose-100 dark:bg-rose-900/60 px-2 py-0.5 text-[11px] text-rose-800 dark:text-rose-200';
+
+/** One conflict card: side-by-side live vs preview with a choice per side. */
+const ConflictCard = ({
+  unit,
+  choice,
+  onChoose,
+}: {
+  unit: ConflictUnit;
+  choice: MergeChoice | undefined;
+  onChoose: (id: string, choice: MergeChoice) => void;
+}) => {
+  const isOrder = unit.id === ORDER_CONFLICT_ID;
+  const title = isOrder ? 'Block order' : `Block ${unit.index + 1}`;
+
+  const renderSide = (side: MergeChoice) => {
+    const value = side === 'ours' ? unit.ours : unit.theirs;
+    if (isOrder) {
+      return <OrderList ids={Array.isArray(value) ? (value as string[]) : []} />;
+    }
+    if (value === undefined || value === null) {
+      return (
+        <Tombstone
+          label={side === 'ours' ? 'Deleted in the live version' : 'Deleted in the preview'}
+        />
+      );
+    }
+    return <BlockPreview block={value} />;
+  };
+
+  return (
+    <div data-testid={`conflict-card-${unit.id}`} className={cardShell}>
+      <div className="flex items-center gap-2 text-xs">
+        <span className="font-semibold text-gray-700 dark:text-gray-200">{title}</span>
+        <span className={cardBadge}>{reasonLabel(unit.reason)}</span>
+      </div>
+      <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {(['ours', 'theirs'] as const).map(side => (
+          <ChoiceSide
+            key={side}
+            unitId={unit.id}
+            side={side}
+            selected={choice === side}
+            onChoose={chosen => onChoose(unit.id, chosen)}
+          >
+            {renderSide(side)}
+          </ChoiceSide>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Conflict chooser panel (Phase 7): a side-by-side card per conflicted block,
+ * an Apply footer that submits a resolution for EVERY listed conflict, and a
+ * Discard escape. Auto-merged counts from the accept report are surfaced so
+ * staff know only the true collisions are listed.
+ */
+const ConflictPanel = ({
+  units,
+  autoMerged,
+  busy,
+  onApply,
+  onDiscard,
+}: {
+  units: ConflictUnit[];
+  autoMerged: number;
+  busy: boolean;
+  onApply: (resolutions: MergeResolution[]) => void;
+  onDiscard: () => void;
+}) => {
+  const ids = conflictIds(units);
+  const signature = ids.join('|');
+  const [choices, setChoices] = useState<Record<string, MergeChoice>>({});
+  // Drop stale choices when the conflict set changes (a re-accept can shrink it).
+  useEffect(() => setChoices({}), [signature]);
+
+  const choose = (id: string, choice: MergeChoice) =>
+    setChoices(prev => ({ ...prev, [id]: choice }));
+  const ready = allResolved(ids, choices);
+
+  return (
+    <div
+      data-testid="preview-conflict-panel"
+      className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/95 px-4 sm:px-6 lg:px-8 py-3 max-h-[70vh] overflow-y-auto"
+    >
+      <div className="text-sm font-medium text-rose-900 dark:text-rose-100">
+        Changes conflict with edits made on the live page
+      </div>
+      <div
+        data-testid="conflict-auto-merged"
+        className="mt-0.5 text-sm text-rose-800 dark:text-rose-200"
+      >
+        {autoMerged > 0
+          ? `${autoMerged} change${autoMerged === 1 ? '' : 's'} merged automatically; these need you:`
+          : 'Choose which version to keep for each conflict:'}
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {units.map(unit => (
+          <ConflictCard key={unit.id} unit={unit} choice={choices[unit.id]} onChoose={choose} />
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          data-testid="conflict-apply"
+          disabled={!ready || busy}
+          onClick={() => onApply(buildResolutions(ids, choices))}
+          className={`${actionButtonBase} bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400`}
+        >
+          {busy ? 'Applying…' : 'Apply choices'}
+        </button>
+        <button
+          type="button"
+          data-testid="conflict-discard"
+          disabled={busy}
+          onClick={onDiscard}
+          className={`${actionButtonBase} text-rose-800 dark:text-rose-200 ring-1 ring-rose-300 dark:ring-rose-700 hover:bg-rose-100 dark:hover:bg-rose-900/40`}
+        >
+          Discard preview
+        </button>
+        <span className="text-xs text-rose-700 dark:text-rose-300">
+          {ready
+            ? 'Applies your choice for every conflict and publishes the merge.'
+            : 'Pick a version for every conflict to enable Apply.'}{' '}
+          Or re-apply from the current version (via your agent).
+        </span>
+      </div>
+    </div>
+  );
+};
 
 const actionButtonBase =
   'rounded px-3 py-1 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
@@ -105,7 +326,8 @@ export const PreviewBar = ({
   preview: PreviewInfo;
   isEmbedded?: boolean;
 }) => {
-  const { busy, pending, accept, discard, conflictUnits, error } = usePreviewActions();
+  const { busy, pending, accept, applyResolutions, discard, conflictUnits, autoMerged, error } =
+    usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
@@ -156,7 +378,15 @@ export const PreviewBar = ({
         </div>
         {error && <div className="mt-2 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
-      {conflictUnits && <ConflictPanel units={conflictUnits} />}
+      {conflictUnits && (
+        <ConflictPanel
+          units={conflictUnits}
+          autoMerged={autoMerged}
+          busy={busy}
+          onApply={applyResolutions}
+          onDiscard={discard}
+        />
+      )}
     </div>
   );
 };
@@ -165,7 +395,8 @@ export const PreviewBar = ({
  * Slim staff-only banner on the normal (live) view when a preview branch exists.
  */
 export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
-  const { busy, pending, accept, discard, conflictUnits, error } = usePreviewActions();
+  const { busy, pending, accept, applyResolutions, discard, conflictUnits, autoMerged, error } =
+    usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
@@ -209,7 +440,15 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
         </div>
         {error && <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
-      {conflictUnits && <ConflictPanel units={conflictUnits} />}
+      {conflictUnits && (
+        <ConflictPanel
+          units={conflictUnits}
+          autoMerged={autoMerged}
+          busy={busy}
+          onApply={applyResolutions}
+          onDiscard={discard}
+        />
+      )}
     </div>
   );
 };

--- a/apps/pages/app/components/preview/PreviewControls.tsx
+++ b/apps/pages/app/components/preview/PreviewControls.tsx
@@ -44,6 +44,8 @@ interface PreviewActionData {
   conflict?: boolean;
   units?: ConflictUnit[];
   autoMerged?: number;
+  oursSha?: string | null;
+  theirsSha?: string | null;
   error?: string;
   code?: string;
   ids?: string[];
@@ -60,10 +62,17 @@ function usePreviewActions() {
   };
 
   // Chooser submit: same intent, plus one {id, choose} per listed conflict.
+  // The report's shas ride along so the server can refuse (CONTENT_CONFLICT)
+  // if the content moved after the reviewed report (F3 pinning).
   const applyResolutions = (resolutions: MergeResolution[]) => {
     setPending('accept');
     fetcher.submit(
-      { intent: 'preview-accept', resolutions: JSON.stringify(resolutions) },
+      {
+        intent: 'preview-accept',
+        resolutions: JSON.stringify(resolutions),
+        ...(fetcher.data?.oursSha ? { ours_sha: fetcher.data.oursSha } : {}),
+        ...(fetcher.data?.theirsSha ? { theirs_sha: fetcher.data.theirsSha } : {}),
+      },
       { method: 'POST', encType: 'application/json' }
     );
   };
@@ -78,9 +87,20 @@ function usePreviewActions() {
 
   const conflictUnits = fetcher.data?.conflict ? (fetcher.data.units ?? []) : null;
   const autoMerged = fetcher.data?.conflict ? (fetcher.data.autoMerged ?? 0) : 0;
+  const conflictOursSha = fetcher.data?.conflict ? (fetcher.data.oursSha ?? null) : null;
   const error = fetcher.data?.error ?? null;
 
-  return { busy, pending, accept, applyResolutions, discard, conflictUnits, autoMerged, error };
+  return {
+    busy,
+    pending,
+    accept,
+    applyResolutions,
+    discard,
+    conflictUnits,
+    autoMerged,
+    conflictOursSha,
+    error,
+  };
 }
 
 // ─── Conflict chooser (Phase 7) ──────────────────────────────────────────────
@@ -239,18 +259,23 @@ const ConflictCard = ({
 const ConflictPanel = ({
   units,
   autoMerged,
+  oursSha,
   busy,
   onApply,
   onDiscard,
 }: {
   units: ConflictUnit[];
   autoMerged: number;
+  oursSha: string | null;
   busy: boolean;
   onApply: (resolutions: MergeResolution[]) => void;
   onDiscard: () => void;
 }) => {
   const ids = conflictIds(units);
-  const signature = ids.join('|');
+  // Keyed on the report's ours_sha too: a re-accept after main moved can
+  // yield the SAME conflict ids over different content — stale choices must
+  // not survive into the new report (F3).
+  const signature = `${oursSha ?? ''}::${ids.join('|')}`;
   const [choices, setChoices] = useState<Record<string, MergeChoice>>({});
   // Drop stale choices when the conflict set changes (a re-accept can shrink it).
   useEffect(() => setChoices({}), [signature]);
@@ -326,8 +351,17 @@ export const PreviewBar = ({
   preview: PreviewInfo;
   isEmbedded?: boolean;
 }) => {
-  const { busy, pending, accept, applyResolutions, discard, conflictUnits, autoMerged, error } =
-    usePreviewActions();
+  const {
+    busy,
+    pending,
+    accept,
+    applyResolutions,
+    discard,
+    conflictUnits,
+    autoMerged,
+    conflictOursSha,
+    error,
+  } = usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
@@ -382,6 +416,7 @@ export const PreviewBar = ({
         <ConflictPanel
           units={conflictUnits}
           autoMerged={autoMerged}
+          oursSha={conflictOursSha}
           busy={busy}
           onApply={applyResolutions}
           onDiscard={discard}
@@ -395,8 +430,17 @@ export const PreviewBar = ({
  * Slim staff-only banner on the normal (live) view when a preview branch exists.
  */
 export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
-  const { busy, pending, accept, applyResolutions, discard, conflictUnits, autoMerged, error } =
-    usePreviewActions();
+  const {
+    busy,
+    pending,
+    accept,
+    applyResolutions,
+    discard,
+    conflictUnits,
+    autoMerged,
+    conflictOursSha,
+    error,
+  } = usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
@@ -444,6 +488,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
         <ConflictPanel
           units={conflictUnits}
           autoMerged={autoMerged}
+          oursSha={conflictOursSha}
           busy={busy}
           onApply={applyResolutions}
           onDiscard={discard}

--- a/apps/pages/app/components/preview/conflictChooser.ts
+++ b/apps/pages/app/components/preview/conflictChooser.ts
@@ -33,6 +33,34 @@ export interface ConflictUnit {
   base?: unknown;
 }
 
+/**
+ * A block as the order-conflict list renders it — one entry per referenced id
+ * in the accept report's `unit_previews`. In a pure ordering conflict the
+ * content is identical on both sides, so each block is summarized ONCE here and
+ * shown in both orderings (text-only; no BlockNote editor is mounted).
+ */
+export interface UnitPreview {
+  index: number;
+  summary: string;
+}
+
+/** id → order-list preview. Absent/empty ⇒ the card falls back to raw ids. */
+export type UnitPreviews = Record<string, UnitPreview>;
+
+/**
+ * The ids whose position differs between the two orderings — the moved blocks
+ * the list highlights. An id present in only one ordering counts as moved.
+ * Symmetric: both sides agree on the same moved set.
+ */
+export function orderDiffIds(ours: string[], theirs: string[]): Set<string> {
+  const oursPos = new Map(ours.map((id, i) => [id, i] as const));
+  const theirsPos = new Map(theirs.map((id, i) => [id, i] as const));
+  const moved = new Set<string>();
+  for (const [id, i] of oursPos) if (theirsPos.get(id) !== i) moved.add(id);
+  for (const [id, i] of theirsPos) if (oursPos.get(id) !== i) moved.add(id);
+  return moved;
+}
+
 const REASON_LABELS: Record<string, string> = {
   content: 'Edited in both versions',
   delete_vs_edit: 'Deleted in one version, edited in the other',

--- a/apps/pages/app/components/preview/conflictChooser.ts
+++ b/apps/pages/app/components/preview/conflictChooser.ts
@@ -1,0 +1,110 @@
+/**
+ * conflictChooser.ts — pure helpers for the side-by-side preview-conflict
+ * chooser (plan §3b Phase 7).
+ *
+ * No JSX/React imports here: PreviewControls renders these, and the Playwright
+ * runner unit-tests them directly (tests/unit/conflict-chooser.spec.ts)
+ * without a browser.
+ */
+
+/** A per-conflict choice: `ours` = the live (main) side, `theirs` = the preview side. */
+export type MergeChoice = 'ours' | 'theirs';
+
+/** One chooser decision, keyed by the conflict id from the accept report. */
+export interface MergeResolution {
+  id: string;
+  choose: MergeChoice;
+}
+
+/** Sentinel unit id for a top-level ordering conflict (service twin). */
+export const ORDER_CONFLICT_ID = '__order__';
+
+/**
+ * One conflicted unit from the accept 409 payload (the service's
+ * BlockMergeConflict shape). Absent ours/theirs = deleted on that side; the
+ * `__order__` sentinel carries id arrays instead of blocks.
+ */
+export interface ConflictUnit {
+  id: string;
+  index: number;
+  reason?: 'content' | 'delete_vs_edit' | 'both_added' | 'order' | string;
+  ours?: unknown;
+  theirs?: unknown;
+  base?: unknown;
+}
+
+const REASON_LABELS: Record<string, string> = {
+  content: 'Edited in both versions',
+  delete_vs_edit: 'Deleted in one version, edited in the other',
+  both_added: 'Added in both versions',
+  order: 'Blocks reordered differently in both versions',
+};
+
+/** Human label for a conflict reason (fallback for future reasons). */
+export function reasonLabel(reason: string | undefined): string {
+  return (reason && REASON_LABELS[reason]) || 'Changed in both versions';
+}
+
+/** Readable structural summary of a BlockNote block — never mounts an editor. */
+export interface BlockSummary {
+  type: string;
+  text: string;
+  childCount: number;
+}
+
+interface InlineNode {
+  type?: string;
+  text?: string;
+  content?: unknown;
+}
+
+/** Flatten BlockNote inline content (styled text, links, table rows) to plain text. */
+function inlineText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map(node => {
+        const inline = node as InlineNode;
+        if (typeof inline.text === 'string') return inline.text;
+        if (inline.content !== undefined) return inlineText(inline.content);
+        return '';
+      })
+      .join('');
+  }
+  // Table content: { type: 'tableContent', rows: [{ cells: [...] }] }
+  const rows = (content as { rows?: { cells?: unknown[] }[] } | null | undefined)?.rows;
+  if (Array.isArray(rows)) {
+    return rows
+      .map(row => (Array.isArray(row?.cells) ? row.cells.map(inlineText).join(' · ') : ''))
+      .join('\n');
+  }
+  return '';
+}
+
+/** Summarize a block side for the chooser card (type badge + text + child count). */
+export function blockSummary(block: unknown): BlockSummary {
+  const node = (block ?? {}) as { type?: unknown; content?: unknown; children?: unknown };
+  return {
+    type: typeof node.type === 'string' ? node.type : 'block',
+    text: inlineText(node.content).trim(),
+    childCount: Array.isArray(node.children) ? node.children.length : 0,
+  };
+}
+
+/** The conflict ids that must each carry a choice before Apply enables. */
+export function conflictIds(units: ConflictUnit[]): string[] {
+  return units.map(unit => unit.id);
+}
+
+/** true when every listed conflict id has an ours/theirs choice. */
+export function allResolved(ids: string[], choices: Record<string, MergeChoice>): boolean {
+  return ids.length > 0 && ids.every(id => choices[id] === 'ours' || choices[id] === 'theirs');
+}
+
+/** Build the resolutions payload the accept intent posts (one entry per id). */
+export function buildResolutions(
+  ids: string[],
+  choices: Record<string, MergeChoice>
+): MergeResolution[] {
+  return ids.map(id => ({ id, choose: choices[id] }));
+}

--- a/apps/pages/app/components/preview/conflictChooser.ts
+++ b/apps/pages/app/components/preview/conflictChooser.ts
@@ -91,6 +91,62 @@ export function blockSummary(block: unknown): BlockSummary {
   };
 }
 
+// ─── Chooser copy variants (preview accepts vs editor saves, Phase 7.5) ──────
+
+/**
+ * Which flow mounted the chooser. `preview` = a preview-branch accept
+ * (ours = the live page, theirs = the agent's preview). `save` = an editor
+ * save whose conflict token was stale (ours = what's saved on the server,
+ * theirs = the editor's unsaved version) — same machinery, flipped framing.
+ */
+export type ChooserVariant = 'preview' | 'save';
+
+export interface ChooserCopy {
+  heading: string;
+  sideTitle: Record<MergeChoice, string>;
+  sideAction: Record<MergeChoice, string>;
+  tombstone: Record<MergeChoice, string>;
+  /** Label of the escape-hatch button (discard the preview / reload latest). */
+  secondaryAction: string;
+  /** Trailing footer sentence after the apply hint. */
+  footerNote: string;
+  /** Progress-strip copy while the apply submit is in flight. */
+  busyLabel: string;
+}
+
+const CHOOSER_COPY: Record<ChooserVariant, ChooserCopy> = {
+  preview: {
+    heading: 'Changes conflict with edits made on the live page',
+    sideTitle: { ours: 'Live version (yours)', theirs: "Preview version (agent's)" },
+    sideAction: { ours: 'Keep live', theirs: 'Take preview' },
+    tombstone: { ours: 'Deleted in the live version', theirs: 'Deleted in the preview' },
+    secondaryAction: 'Discard preview',
+    footerNote: 'Or re-apply from the current version (via your agent).',
+    busyLabel: 'Publishing your choices — this can take a few seconds…',
+  },
+  save: {
+    heading: 'Your save collided with changes saved by someone else',
+    sideTitle: { ours: 'Saved on the server', theirs: 'Your unsaved version' },
+    sideAction: { ours: "Keep server's", theirs: 'Keep yours' },
+    tombstone: { ours: 'Deleted on the server', theirs: 'Deleted in your version' },
+    secondaryAction: 'Reload latest',
+    footerNote: 'Or reload the latest version and discard your unsaved changes.',
+    busyLabel: 'Saving the merged version — this can take a few seconds…',
+  },
+};
+
+/** The chooser's variant-dependent labels. */
+export function chooserCopy(variant: ChooserVariant): ChooserCopy {
+  return CHOOSER_COPY[variant];
+}
+
+/** The subtitle under the heading (mentions the auto-merged count when > 0). */
+export function chooserSubtitle(variant: ChooserVariant, autoMerged: number): string {
+  if (autoMerged <= 0) return 'Choose which version to keep for each conflict:';
+  const merged = `${autoMerged} change${autoMerged === 1 ? '' : 's'} merged automatically`;
+  return variant === 'save' ? `${merged}; choose per block:` : `${merged}; these need you:`;
+}
+
 /** The conflict ids that must each carry a choice before Apply enables. */
 export function conflictIds(units: ConflictUnit[]): string[] {
   return units.map(unit => unit.id);

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -287,41 +287,33 @@ export const action = async ({
     const saveOursSha =
       typeof data.ours_sha === 'string' && data.ours_sha ? data.ours_sha : undefined;
 
-    try {
-      const blocks = JSON.parse(data.content as string);
+    // Ops save: the client posts a block-op diff against the document at
+    // base_sha instead of the whole document (untouched blocks never
+    // transmit). Presence of `ops` selects the path; shape errors are 400.
+    let saveOps: unknown[] | null = null;
+    if (data.ops != null) {
+      try {
+        const parsed = typeof data.ops === 'string' ? JSON.parse(data.ops) : data.ops;
+        if (!Array.isArray(parsed)) {
+          throw new Error('ops must be an array');
+        }
+        saveOps = parsed;
+      } catch {
+        return Response.json(
+          { error: 'Malformed ops payload — expected an array of block operations' },
+          { status: 400 }
+        );
+      }
+    }
 
+    try {
       // F2 (4b parity with slides): optimistic-lock the write on the
       // content.json sha the editor loaded (loader / previous save response).
       const expectedSha =
         typeof data.content_sha === 'string' && data.content_sha ? data.content_sha : null;
 
-      if (!expectedSha) {
-        // Token-less save. Legit only when content.json doesn't exist yet
-        // (fresh or legacy-HTML page — the loader handed out a null token).
-        // If the file EXISTS, this is a stale pre-token client bundle (or the
-        // file appeared since the editor loaded, e.g. an MCP apply): reject
-        // rather than silently clobber. Fresh existence check — the 60s cache
-        // must not vouch for absence.
-        const existing = await loadPageContent(actionPage, { skipCache: true });
-        if (existing.format === 'json') {
-          return Response.json(
-            { conflict: true, message: 'This page changed since you opened it.' },
-            { status: 409 }
-          );
-        }
-      }
-
-      // Semantic save-merge (Phase 7.5): the token IS the 3-way base — a
-      // stale save merges against fresh main instead of refusing outright.
-      const runMergeSave = () =>
-        ClassmojiService.pageContent.savePageContentWithMerge(actionPage, blocks, {
-          baseSha: expectedSha as string,
-          ...(saveResolutions ? { resolutions: saveResolutions } : {}),
-          ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
-          message: `Update page: ${page.title}`,
-        });
       // Conflict report → 409 the chooser renders (the client re-submits the
-      // same content + resolutions + the report's ours_sha).
+      // same content/ops + resolutions + the report's ours_sha).
       const mergeReport = (report: { units: unknown; auto_merged: number; ours_sha: string }) =>
         Response.json(
           {
@@ -340,27 +332,89 @@ export const action = async ({
       // token over a stale document would clobber them on the NEXT save.
       let mergedDocument: unknown[] | null = null;
 
-      if (saveResolutions && expectedSha) {
-        // Resolution pass: the token is known-stale — go straight to the 3-way.
-        const mergeResult = await runMergeSave();
+      if (saveOps) {
+        // ── Ops save ──────────────────────────────────────────────────────
+        // base = the document at base_sha (the conflict token the diff was
+        // computed against); the service materializes theirs = base + ops and
+        // runs the SAME merge/report/resolutions machinery as the whole-doc
+        // path. `document` is null when the commit is exactly base + ops —
+        // no adoption/remount needed for a clean save.
+        const baseSha =
+          typeof data.base_sha === 'string' && data.base_sha ? data.base_sha : expectedSha;
+        if (!baseSha) {
+          // No base to replay against (fresh/legacy page has no token) — the
+          // OPS_BASE_MISMATCH code tells the client to fall back to one
+          // whole-document save.
+          return Response.json(
+            { error: 'An ops save requires base_sha', code: 'OPS_BASE_MISMATCH' },
+            { status: 409 }
+          );
+        }
+        const mergeResult = await ClassmojiService.pageContent.savePageContentFromOps(actionPage, {
+          ops: saveOps as Parameters<
+            typeof ClassmojiService.pageContent.savePageContentFromOps
+          >[1]['ops'],
+          baseSha,
+          ...(saveResolutions ? { resolutions: saveResolutions } : {}),
+          ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
+          message: `Update page: ${page.title}`,
+        });
         if (!mergeResult.merged) return mergeReport(mergeResult);
         sha = mergeResult.sha;
         mergedWithConcurrent = mergeResult.concurrent;
         mergedDocument = mergeResult.document;
       } else {
-        try {
-          const saved = await savePageContent(actionPage, blocks, {
-            ...(expectedSha ? { expectedSha } : {}),
+        // ── Whole-document save (7.5 path, unchanged) ─────────────────────
+        const blocks = JSON.parse(data.content as string);
+
+        if (!expectedSha) {
+          // Token-less save. Legit only when content.json doesn't exist yet
+          // (fresh or legacy-HTML page — the loader handed out a null token).
+          // If the file EXISTS, this is a stale pre-token client bundle (or the
+          // file appeared since the editor loaded, e.g. an MCP apply): reject
+          // rather than silently clobber. Fresh existence check — the 60s cache
+          // must not vouch for absence.
+          const existing = await loadPageContent(actionPage, { skipCache: true });
+          if (existing.format === 'json') {
+            return Response.json(
+              { conflict: true, message: 'This page changed since you opened it.' },
+              { status: 409 }
+            );
+          }
+        }
+
+        // Semantic save-merge (Phase 7.5): the token IS the 3-way base — a
+        // stale save merges against fresh main instead of refusing outright.
+        const runMergeSave = () =>
+          ClassmojiService.pageContent.savePageContentWithMerge(actionPage, blocks, {
+            baseSha: expectedSha as string,
+            ...(saveResolutions ? { resolutions: saveResolutions } : {}),
+            ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
+            message: `Update page: ${page.title}`,
           });
-          sha = saved.sha;
-        } catch (error: unknown) {
-          if ((error as { status?: number } | null)?.status !== 409 || !expectedSha) throw error;
-          // Stale token → the semantic 3-way merge instead of a blank refusal.
+
+        if (saveResolutions && expectedSha) {
+          // Resolution pass: the token is known-stale — go straight to the 3-way.
           const mergeResult = await runMergeSave();
           if (!mergeResult.merged) return mergeReport(mergeResult);
           sha = mergeResult.sha;
           mergedWithConcurrent = mergeResult.concurrent;
           mergedDocument = mergeResult.document;
+        } else {
+          try {
+            const saved = await savePageContent(actionPage, blocks, {
+              ...(expectedSha ? { expectedSha } : {}),
+            });
+            sha = saved.sha;
+          } catch (error: unknown) {
+            if ((error as { status?: number } | null)?.status !== 409 || !expectedSha) throw error;
+            // Stale token → the semantic 3-way merge instead of a blank refusal.
+            const mergeResult = await runMergeSave();
+            if (!mergeResult.merged) return mergeReport(mergeResult);
+            sha = mergeResult.sha;
+            mergedWithConcurrent = mergeResult.concurrent;
+            mergedDocument = mergeResult.document;
+          }
         }
       }
 
@@ -378,6 +432,14 @@ export const action = async ({
           : {}),
       });
     } catch (error: unknown) {
+      if (error instanceof ClassmojiService.pageContent.PageOpsBaseMismatchError) {
+        // The posted ops don't apply to the document at base_sha (the client
+        // diffed against something else, or sent a malformed op). The code
+        // tells the client to auto-fall-back to ONE whole-document save of
+        // its current content. Checked BEFORE the generic 409 handler — this
+        // error carries status 409 but must not render the reload banner.
+        return Response.json({ error: error.message, code: error.code }, { status: 409 });
+      }
       if (error instanceof ClassmojiService.pageContent.PreviewResolutionError) {
         // Stale resolution pin (main moved after the reviewed report) → 409;
         // bad/stale resolutions → 400 naming the ids. Either way the client

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -266,6 +266,27 @@ export const action = async ({
   const { intent } = data;
 
   if (intent === 'save') {
+    // Phase 7.5: a save-conflict chooser re-submit carries the SAME posted
+    // content plus one {id, choose} per conflict and the report's ours_sha pin.
+    let saveResolutions: { id: string; choose: 'ours' | 'theirs' }[] | null = null;
+    if (data.resolutions != null) {
+      try {
+        const parsed =
+          typeof data.resolutions === 'string' ? JSON.parse(data.resolutions) : data.resolutions;
+        if (!Array.isArray(parsed) || parsed.length === 0) {
+          throw new Error('resolutions must be a non-empty array');
+        }
+        saveResolutions = parsed;
+      } catch {
+        return Response.json(
+          { error: 'Malformed resolutions payload — expected [{id, choose}]' },
+          { status: 400 }
+        );
+      }
+    }
+    const saveOursSha =
+      typeof data.ours_sha === 'string' && data.ours_sha ? data.ours_sha : undefined;
+
     try {
       const blocks = JSON.parse(data.content as string);
 
@@ -290,18 +311,88 @@ export const action = async ({
         }
       }
 
-      const { sha } = await savePageContent(actionPage, blocks, {
-        ...(expectedSha ? { expectedSha } : {}),
-      });
+      // Semantic save-merge (Phase 7.5): the token IS the 3-way base — a
+      // stale save merges against fresh main instead of refusing outright.
+      const runMergeSave = () =>
+        ClassmojiService.pageContent.savePageContentWithMerge(actionPage, blocks, {
+          baseSha: expectedSha as string,
+          ...(saveResolutions ? { resolutions: saveResolutions } : {}),
+          ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
+          message: `Update page: ${page.title}`,
+        });
+      // Conflict report → 409 the chooser renders (the client re-submits the
+      // same content + resolutions + the report's ours_sha).
+      const mergeReport = (report: { units: unknown; auto_merged: number; ours_sha: string }) =>
+        Response.json(
+          {
+            conflict: true,
+            units: report.units,
+            autoMerged: report.auto_merged,
+            oursSha: report.ours_sha,
+          },
+          { status: 409 }
+        );
+
+      let sha: string;
+      let mergedWithConcurrent = 0;
+      // The merged blocks as committed. The editor must adopt this document —
+      // its local copy lacks the folded-in concurrent changes, and a fresh
+      // token over a stale document would clobber them on the NEXT save.
+      let mergedDocument: unknown[] | null = null;
+
+      if (saveResolutions && expectedSha) {
+        // Resolution pass: the token is known-stale — go straight to the 3-way.
+        const mergeResult = await runMergeSave();
+        if (!mergeResult.merged) return mergeReport(mergeResult);
+        sha = mergeResult.sha;
+        mergedWithConcurrent = mergeResult.concurrent;
+        mergedDocument = mergeResult.document;
+      } else {
+        try {
+          const saved = await savePageContent(actionPage, blocks, {
+            ...(expectedSha ? { expectedSha } : {}),
+          });
+          sha = saved.sha;
+        } catch (error: unknown) {
+          if ((error as { status?: number } | null)?.status !== 409 || !expectedSha) throw error;
+          // Stale token → the semantic 3-way merge instead of a blank refusal.
+          const mergeResult = await runMergeSave();
+          if (!mergeResult.merged) return mergeReport(mergeResult);
+          sha = mergeResult.sha;
+          mergedWithConcurrent = mergeResult.concurrent;
+          mergedDocument = mergeResult.document;
+        }
+      }
+
       await ClassmojiService.page.quickUpdate(pageId, {
         updated_at: new Date(),
       });
       // Return the new sha — the editor's conflict token for its next save.
-      return Response.json({ success: true, sha });
+      // A merged save also returns the committed document + the concurrent
+      // count (the editor adopts the document and toasts the count).
+      return Response.json({
+        success: true,
+        sha,
+        ...(mergedDocument
+          ? { merged_with_concurrent: mergedWithConcurrent, merged_content: mergedDocument }
+          : {}),
+      });
     } catch (error: unknown) {
+      if (error instanceof ClassmojiService.pageContent.PreviewResolutionError) {
+        // Stale resolution pin (main moved after the reviewed report) → 409;
+        // bad/stale resolutions → 400 naming the ids. Either way the client
+        // re-runs the plain save for a fresh report.
+        if (error.code === 'CONTENT_CONFLICT') {
+          return Response.json({ error: error.message, code: error.code }, { status: 409 });
+        }
+        return Response.json(
+          { error: error.message, code: error.code, ids: error.ids },
+          { status: 400 }
+        );
+      }
       if ((error as { status?: number } | null)?.status === 409) {
-        // Someone (another editor, an MCP apply) changed content.json since
-        // this editor loaded it. Nothing was written.
+        // No mergeable path (token-less over existing content, unreadable
+        // base, main's file gone, or a double CAS loss). Nothing was written.
         return Response.json(
           { conflict: true, message: 'This page changed since you opened it.' },
           { status: 409 }

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -289,21 +289,32 @@ export const action = async ({
 
     // Ops save: the client posts a block-op diff against the document at
     // base_sha instead of the whole document (untouched blocks never
-    // transmit). Presence of `ops` selects the path; shape errors are 400.
+    // transmit). Presence of `ops` selects the path. The op vocabulary is
+    // validated against the service's single-source zod schema (op cap 400) so
+    // a structurally malformed payload is a typed 400 the client recovers from
+    // by falling back to a full-document save — never a raw TypeError → 500
+    // (plan §7 P8).
     let saveOps: unknown[] | null = null;
     if (data.ops != null) {
+      let rawOps: unknown;
       try {
-        const parsed = typeof data.ops === 'string' ? JSON.parse(data.ops) : data.ops;
-        if (!Array.isArray(parsed)) {
-          throw new Error('ops must be an array');
-        }
-        saveOps = parsed;
+        rawOps = typeof data.ops === 'string' ? JSON.parse(data.ops) : data.ops;
       } catch {
+        rawOps = undefined; // invalid JSON → schema rejects → typed 400 below
+      }
+      const parsed = ClassmojiService.pageContent.pageBlockOpsPayloadSchema.safeParse(rawOps);
+      if (!parsed.success) {
+        // `code` makes the client auto-fall-back to ONE whole-document save
+        // (its code-keyed fallback effect), which needs no base to replay.
         return Response.json(
-          { error: 'Malformed ops payload — expected an array of block operations' },
+          {
+            error: 'Malformed ops payload — retrying as a full-document save',
+            code: 'OPS_MALFORMED',
+          },
           { status: 400 }
         );
       }
+      saveOps = parsed.data;
     }
 
     try {
@@ -357,7 +368,10 @@ export const action = async ({
           baseSha,
           ...(saveResolutions ? { resolutions: saveResolutions } : {}),
           ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
-          message: `Update page: ${page.title}`,
+          // No message override: a genuine fold-in or a resolution pass is
+          // recorded distinctly by the service ("(merged)" / resolution
+          // summary); a clean ops save keeps the plain message (plan
+          // "commit-message" finding).
         });
         if (!mergeResult.merged) return mergeReport(mergeResult);
         sha = mergeResult.sha;
@@ -390,7 +404,9 @@ export const action = async ({
             baseSha: expectedSha as string,
             ...(saveResolutions ? { resolutions: saveResolutions } : {}),
             ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
-            message: `Update page: ${page.title}`,
+            // No message override — the service records a merged/resolution
+            // commit distinctly; a clean save keeps the plain message (plan
+            // "commit-message" finding).
           });
 
         if (saveResolutions && expectedSha) {

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -81,6 +81,13 @@ export const loader = async ({
     canEdit && (rawNotice === 'preview-accepted' || rawNotice === 'preview-discarded')
       ? rawNotice
       : null;
+  // Semantic-merge accepts also round-trip how many changes auto-merged
+  // (Phase 7) so the success toast can mention them.
+  const rawAutoMerged = url.searchParams.get('auto_merged');
+  const noticeAutoMerged =
+    notice === 'preview-accepted' && rawAutoMerged && /^\d+$/.test(rawAutoMerged)
+      ? Number(rawAutoMerged)
+      : null;
 
   let previewStatus: {
     exists: boolean;
@@ -182,6 +189,7 @@ export const loader = async ({
     userRole,
     canEdit,
     notice,
+    noticeAutoMerged,
     // Conflict token (F2, 4b parity with slides): content.json's blob sha,
     // echoed back by the editor on every save so the action can 409 instead
     // of clobbering a concurrent write. null = no content.json yet (fresh or
@@ -312,8 +320,30 @@ export const action = async ({
   // intent). Accept merges the preview branch into main; discard deletes it.
 
   if (intent === 'preview-accept') {
+    // Chooser resolutions (Phase 7): when present, this accept is a conflict
+    // resolution pass — one {id, choose: 'ours'|'theirs'} per currently
+    // conflicted unit; the resolved merge is committed to main.
+    let resolutions: { id: string; choose: 'ours' | 'theirs' }[] | null = null;
+    if (data.resolutions != null) {
+      try {
+        const parsed =
+          typeof data.resolutions === 'string' ? JSON.parse(data.resolutions) : data.resolutions;
+        if (!Array.isArray(parsed) || parsed.length === 0) {
+          throw new Error('resolutions must be a non-empty array');
+        }
+        resolutions = parsed;
+      } catch {
+        return Response.json(
+          { error: 'Malformed resolutions payload — expected [{id, choose}]' },
+          { status: 400 }
+        );
+      }
+    }
+
     try {
-      const result = await ClassmojiService.pageContent.acceptPreview(actionPage);
+      const result = resolutions
+        ? await ClassmojiService.pageContent.resolvePreviewConflicts(actionPage, { resolutions })
+        : await ClassmojiService.pageContent.acceptPreview(actionPage);
       if (result.merged) {
         // Settle guard: GitHub's Contents API lags a merge by ~1-2s, so an
         // immediate redirect can render pre-accept content under an
@@ -328,12 +358,35 @@ export const action = async ({
             await new Promise(r => setTimeout(r, 700));
           }
         }
-        return redirect(`/${page.classroom.slug}/${pageId}?notice=preview-accepted`);
+        // Surface the semantic layer's auto-merged count in the success toast.
+        const autoMerged = ('auto_merged' in result && result.auto_merged) || 0;
+        const autoParam = autoMerged > 0 ? `&auto_merged=${autoMerged}` : '';
+        return redirect(`/${page.classroom.slug}/${pageId}?notice=preview-accepted${autoParam}`);
       }
       // Merge conflict — nothing merged, branch kept. Surface the per-unit
-      // report so the UI can list the conflicted blocks.
-      return Response.json({ conflict: true, units: result.units }, { status: 409 });
+      // report (plus the auto-merged count) so the chooser can render it.
+      return Response.json(
+        { conflict: true, units: result.units, autoMerged: result.auto_merged },
+        { status: 409 }
+      );
     } catch (error: unknown) {
+      // Bad/stale resolutions (missing ids, unknown ids, duplicates, no
+      // preview) — a clear 400 naming the offending ids; the client re-runs
+      // accept for a fresh report.
+      if (error instanceof ClassmojiService.pageContent.PreviewResolutionError) {
+        return Response.json(
+          { error: error.message, code: error.code, ids: error.ids },
+          { status: 400 }
+        );
+      }
+      // Mid-merge CAS loss: main moved while committing the resolved merge
+      // (the service already retried once). Nothing was written.
+      if ((error as { status?: number } | null)?.status === 409) {
+        return Response.json(
+          { error: 'The live page changed while merging — try accepting again.' },
+          { status: 409 }
+        );
+      }
       console.error('Failed to accept preview:', error);
       return Response.json(
         { error: error instanceof Error ? error.message : 'Unknown error' },

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -554,6 +554,7 @@ export const action = async ({
         {
           conflict: true,
           units: result.units,
+          unitPreviews: result.unit_previews ?? null,
           autoMerged: result.auto_merged,
           oursSha: result.ours_sha,
           theirsSha: result.theirs_sha,

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -322,7 +322,10 @@ export const action = async ({
   if (intent === 'preview-accept') {
     // Chooser resolutions (Phase 7): when present, this accept is a conflict
     // resolution pass — one {id, choose: 'ours'|'theirs'} per currently
-    // conflicted unit; the resolved merge is committed to main.
+    // conflicted unit; the resolved merge is committed to main. Element-shape
+    // validation (non-empty string id, choose ∈ ours|theirs) lives in the
+    // service's indexResolutions, so malformed choices throw
+    // PreviewResolutionError (→ 400 below) instead of defaulting to a side.
     let resolutions: { id: string; choose: 'ours' | 'theirs' }[] | null = null;
     if (data.resolutions != null) {
       try {
@@ -339,10 +342,21 @@ export const action = async ({
         );
       }
     }
+    // Sha pins (F3): the chooser posts back the ours_sha it rendered its
+    // conflict report from, so the resolve fails cleanly (CONTENT_CONFLICT)
+    // if the live page moved after the report was reviewed.
+    const expectedOursSha =
+      typeof data.ours_sha === 'string' && data.ours_sha ? data.ours_sha : undefined;
+    const expectedTheirsSha =
+      typeof data.theirs_sha === 'string' && data.theirs_sha ? data.theirs_sha : undefined;
 
     try {
       const result = resolutions
-        ? await ClassmojiService.pageContent.resolvePreviewConflicts(actionPage, { resolutions })
+        ? await ClassmojiService.pageContent.resolvePreviewConflicts(actionPage, {
+            resolutions,
+            ...(expectedOursSha ? { expectedOursSha } : {}),
+            ...(expectedTheirsSha ? { expectedTheirsSha } : {}),
+          })
         : await ClassmojiService.pageContent.acceptPreview(actionPage);
       if (result.merged) {
         // Settle guard: GitHub's Contents API lags a merge by ~1-2s, so an
@@ -364,16 +378,30 @@ export const action = async ({
         return redirect(`/${page.classroom.slug}/${pageId}?notice=preview-accepted${autoParam}`);
       }
       // Merge conflict — nothing merged, branch kept. Surface the per-unit
-      // report (plus the auto-merged count) so the chooser can render it.
+      // report (plus the auto-merged count and the shas the report was built
+      // from — the chooser posts them back with its resolutions) so the
+      // chooser can render it.
       return Response.json(
-        { conflict: true, units: result.units, autoMerged: result.auto_merged },
+        {
+          conflict: true,
+          units: result.units,
+          autoMerged: result.auto_merged,
+          oursSha: result.ours_sha,
+          theirsSha: result.theirs_sha,
+        },
         { status: 409 }
       );
     } catch (error: unknown) {
-      // Bad/stale resolutions (missing ids, unknown ids, duplicates, no
-      // preview) — a clear 400 naming the offending ids; the client re-runs
-      // accept for a fresh report.
       if (error instanceof ClassmojiService.pageContent.PreviewResolutionError) {
+        // Stale report pin: the content moved since the reviewed conflict
+        // report — same 409 semantics as a mid-merge CAS loss (re-run accept).
+        if (error.code === 'CONTENT_CONFLICT') {
+          return Response.json({ error: error.message, code: error.code }, { status: 409 });
+        }
+        // Bad/stale resolutions (missing ids, unknown ids, duplicates,
+        // malformed elements, no preview, main content deleted) — a clear 400
+        // naming the offending ids; the client re-runs accept for a fresh
+        // report.
         return Response.json(
           { error: error.message, code: error.code, ids: error.ids },
           { status: 400 }

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -10,9 +10,16 @@ import {
   PendingPreviewBanner,
   NoPreviewNotice,
   ConflictPanel,
-  type ConflictUnit,
 } from '~/components/preview/PreviewControls.tsx';
 import { diffBlockOps, type BlockOp } from '~/components/editor/blockOpsDiff.ts';
+import {
+  opsPathEligible,
+  deriveSaveMergeReport,
+  deriveSaveConflict,
+  fetcherMatchesPage,
+  type SaveBaseline,
+  type SaveFetcherData,
+} from './saveState.ts';
 
 const PageEditor = lazy(() => import('~/components/editor/PageEditor.tsx'));
 const BlockNoteViewer = lazy(() => import('~/components/viewer/BlockNoteViewer.tsx'));
@@ -55,7 +62,15 @@ const PageRoute = () => {
   // Save state (explicit saves only)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [saveStatus, setSaveStatus] = useState('saved');
-  const lastSavedContent = useRef<string | null>(null);
+  // The diff-at-save baseline, bound to the sha it represents (P1): the
+  // NORMALIZED editor document at that sha. Captured from the editor after
+  // mount (P2 — same BlockNote normalization on both sides, so untouched
+  // stored blocks never emit phantom updates) and re-captured after a
+  // merged-adoption remount. `null` until the editor's onReady fires.
+  const savedBaselineRef = useRef<SaveBaseline | null>(null);
+  // The sha the NEXT editor onReady should pair its snapshot with (the loaded
+  // sha, or a merged save's new sha set just before the epoch remount).
+  const pendingBaselineShaRef = useRef<string | null>(contentSha);
 
   // Conflict token (F2, 4b parity with slides): content.json's sha, seeded
   // ONCE from the loader (deliberately not re-synced on revalidation — the
@@ -63,23 +78,24 @@ const PageRoute = () => {
   // the token mid-edit would let a stale save pass the server's sha check).
   // Refreshed only from a successful save's response; echoed on every save.
   const [contentToken, setContentToken] = useState<string | null>(contentSha);
+  // The page id the CURRENT save fetcher exchange was stamped for (P4). The
+  // fetcher survives same-route param navigation, so its data is read only
+  // while this still matches page.id — otherwise a pending conflict chooser
+  // ghosts onto the next page and Apply fires a wrong-page save chain. Set at
+  // every save submission; deliberately NOT cleared on navigation (a stale
+  // stamp keeps the gate closed on the new page until it saves).
+  const saveReportPageIdRef = useRef(page.id);
+  const fetcherData = fetcher.data as SaveFetcherData | undefined;
+  const fetcherMatches = fetcherMatchesPage(saveReportPageIdRef.current, page.id);
   // Phase 7.5: a stale save's 3-way merge hit true collisions — the per-unit
-  // report the save-variant conflict chooser renders (derived straight from
-  // the fetcher; a successful re-submit replaces it).
+  // report the save-variant conflict chooser renders (gated to this page, P4).
   const saveMergeReport = useMemo(
-    () =>
-      fetcher.data?.conflict && fetcher.data?.units
-        ? {
-            units: fetcher.data.units as ConflictUnit[],
-            autoMerged: (fetcher.data.autoMerged as number) ?? 0,
-            oursSha: (fetcher.data.oursSha as string | null) ?? null,
-          }
-        : null,
-    [fetcher.data]
+    () => deriveSaveMergeReport(fetcherData, fetcherMatches),
+    [fetcherData, fetcherMatches]
   );
   // True once a save 409'd with NO mergeable report (legacy/fallback path):
-  // the page changed underneath this editor session — reload banner.
-  const saveConflict = Boolean(fetcher.data?.conflict) && !saveMergeReport;
+  // the page changed underneath this editor session — reload banner (P4-gated).
+  const saveConflict = deriveSaveConflict(fetcherData, fetcherMatches, saveMergeReport);
   // The exact content string the last save posted — a chooser re-submit (or
   // auto re-run) carries the SAME document.
   const lastPostedContentRef = useRef<string | null>(null);
@@ -101,16 +117,20 @@ const PageRoute = () => {
   const [editorEpoch, setEditorEpoch] = useState(0);
   // Navigating to a different page keeps this component mounted (same route,
   // new params) — re-seed the per-page editing state (React's sanctioned
-  // render-time reset for prop-derived state).
+  // render-time reset for prop-derived state), including the pending
+  // save/conflict UI (P4) so nothing ghosts across pages.
   const lastPageIdRef = useRef(page.id);
   if (lastPageIdRef.current !== page.id) {
     lastPageIdRef.current = page.id;
     setEditorDoc(content);
     setEditorEpoch(0);
     setContentToken(contentSha);
-    lastSavedContent.current = null;
+    savedBaselineRef.current = null;
+    pendingBaselineShaRef.current = contentSha;
     lastPostedContentRef.current = null;
     lastPostedOpsRef.current = null;
+    setHasUnsavedChanges(false);
+    setSaveStatus('saved');
   }
 
   // Client-only flag — prevents BlockNote from rendering during SSR
@@ -130,30 +150,36 @@ const PageRoute = () => {
     const currentContent = editorRef.current.getContent();
     const currentContentStr = JSON.stringify(currentContent);
 
-    if (lastSavedContent.current === currentContentStr) return;
+    const baseline = savedBaselineRef.current;
+    if (baseline && baseline.content === currentContentStr) return;
 
     // Preserved for the save-merge chooser and the whole-doc fallback: a
     // conflict re-submit must carry the SAME document that produced the report.
     lastPostedContentRef.current = currentContentStr;
+    // Stamp this exchange with the current page (P4).
+    saveReportPageIdRef.current = page.id;
 
-    // Diff-at-save: with a conflict token (content.json exists — the base the
-    // server replays against) and a baseline (the document this editor
-    // mounted from), post only the changed blocks as ops. Any anomaly (no
-    // baseline, duplicate ids, cross-scope move, complex reorder) → null →
-    // the whole-document save below (the 7.5 path, unchanged).
+    // Diff-at-save: post only the CHANGED blocks as ops — but ONLY when the
+    // baseline we diff against is the document the conflict token names (P1
+    // pairing guard). The server replays the ops onto base_sha, so a desynced
+    // baseline (e.g. a cover write advanced the token past this document)
+    // would replay onto the wrong base and silently clobber concurrent edits —
+    // fall back to the whole-document save (always correct) instead. Any
+    // anomaly in the diff itself (duplicate ids, cross-scope move, complex
+    // reorder) also yields null → the whole-document save (the 7.5 path).
     let ops: BlockOp[] | null = null;
-    if (contentToken && lastSavedContent.current) {
+    if (opsPathEligible(baseline, contentToken)) {
       try {
-        ops = diffBlockOps(JSON.parse(lastSavedContent.current), currentContent);
+        ops = diffBlockOps(JSON.parse(baseline.content), currentContent);
       } catch {
         ops = null;
       }
     }
 
     if (ops && ops.length === 0) {
-      // Canonically identical (only serialization order differs) — nothing
-      // to commit.
-      lastSavedContent.current = currentContentStr;
+      // Canonically identical (only serialization order differs) — nothing to
+      // commit; re-pin the baseline to the exact current string.
+      savedBaselineRef.current = { sha: contentToken, content: currentContentStr };
       setHasUnsavedChanges(false);
       setSaveStatus('saved');
       return;
@@ -179,7 +205,7 @@ const PageRoute = () => {
       { intent: 'save', content: currentContentStr, content_sha: contentToken },
       { method: 'POST', encType: 'application/json' }
     );
-  }, [canEdit, fetcher, contentToken]);
+  }, [canEdit, fetcher, contentToken, page.id]);
 
   // Apply the save-merge chooser's decisions (Phase 7.5): re-submit the SAME
   // posted content with one {id, choose} per conflict and the report's
@@ -188,6 +214,8 @@ const PageRoute = () => {
   const handleApplySaveResolutions = useCallback(
     (resolutions: Array<{ id: string; choose: 'ours' | 'theirs' }>) => {
       if (!saveMergeReport) return;
+      // Stamp the resolution exchange with the current page (P4).
+      saveReportPageIdRef.current = page.id;
 
       // Ops-save conflict: the re-submit carries the SAME ops (the server
       // re-materializes theirs = base + ops and re-validates the set).
@@ -223,7 +251,7 @@ const PageRoute = () => {
         { method: 'POST', encType: 'application/json' }
       );
     },
-    [fetcher, contentToken, saveMergeReport]
+    [fetcher, contentToken, saveMergeReport, page.id]
   );
 
   // A `code`-bearing refusal: a chooser re-submit hit a stale ours_sha pin or
@@ -233,17 +261,21 @@ const PageRoute = () => {
   // (possibly merged) or produces a FRESH report. Bounded: a plain whole-doc
   // save never answers with `code`, so this runs at most once per attempt.
   useEffect(() => {
+    // Only recover the fetcher exchange that belongs to THIS page (P4) — a
+    // stale code-bearing refusal from another page must not fire a save here.
+    if (saveReportPageIdRef.current !== page.id) return;
     if (fetcher.state !== 'idle') return;
     if (!fetcher.data?.code || fetcher.data?.conflict) return;
     const content = lastPostedContentRef.current;
     if (!content) return;
     lastPostedOpsRef.current = null;
+    saveReportPageIdRef.current = page.id;
     setSaveStatus('saving');
     fetcher.submit(
       { intent: 'save', content, content_sha: contentToken },
       { method: 'POST', encType: 'application/json' }
     );
-  }, [fetcher.state, fetcher.data, fetcher, contentToken]);
+  }, [fetcher.state, fetcher.data, fetcher, contentToken, page.id]);
 
   // Track editor changes (mark unsaved, but don't auto-save)
   const handleEditorChange = useCallback(
@@ -251,7 +283,9 @@ const PageRoute = () => {
       if (!canEdit) return;
 
       const currentContentStr = JSON.stringify(document);
-      if (lastSavedContent.current === currentContentStr) return;
+      // Compared against the normalized baseline (P2) — an unchanged document
+      // stringifies identically on both sides, so it never marks unsaved.
+      if (savedBaselineRef.current?.content === currentContentStr) return;
 
       setHasUnsavedChanges(true);
       setSaveStatus('unsaved');
@@ -290,62 +324,75 @@ const PageRoute = () => {
     window.history.replaceState({}, '', url);
   }, [notice, noticeAutoMerged]);
 
-  // Initialize lastSavedContent on mount
-  useEffect(() => {
-    if (canEdit && content && lastSavedContent.current === null) {
-      lastSavedContent.current = JSON.stringify(content);
-    }
-  }, [canEdit, content]);
+  // Baseline capture is the editor's onReady (P2), not the raw loader JSON —
+  // see handleEditorReady below.
 
   // Track save completion
   useEffect(() => {
+    // Only settle the fetcher exchange that belongs to THIS page (P4).
+    if (saveReportPageIdRef.current !== page.id) return;
     if (fetcher.state === 'idle' && fetcher.data?.success) {
+      const newSha =
+        typeof fetcher.data.sha === 'string' && fetcher.data.sha ? fetcher.data.sha : null;
       if (Array.isArray(fetcher.data.merged_content)) {
         // Semantic save-merge (7.5): the committed document is the MERGE of
         // this editor's content and concurrent server-side changes — adopt it
         // (remount) so the editor matches the fresh token, and tell the user.
+        // The NORMALIZED baseline for the adopted doc is captured by the
+        // editor's onReady after the epoch remount, paired with the new sha.
+        pendingBaselineShaRef.current = newSha;
         setEditorDoc(fetcher.data.merged_content);
         setEditorEpoch(epoch => epoch + 1);
-        lastSavedContent.current = JSON.stringify(fetcher.data.merged_content);
         const n = fetcher.data.merged_with_concurrent;
         if (typeof n === 'number' && n > 0) {
           toast.success(`Saved — merged with ${n} concurrent change${n === 1 ? '' : 's'}.`);
         }
-      } else if (lastPostedContentRef.current) {
-        // No adoption needed: the committed document IS the posted one. The
-        // baseline must be exactly what was committed (the next diff-at-save
-        // is computed against it), so use the posted string — not a re-read
-        // of the live editor, which may already contain post-save typing.
-        lastSavedContent.current = lastPostedContentRef.current;
-      } else if (editorRef.current) {
-        const currentContent = editorRef.current.getContent();
-        lastSavedContent.current = JSON.stringify(currentContent);
+      } else {
+        // No adoption/remount: pin the baseline directly to the committed sha.
+        // The content is the exact string posted (the normalized editor doc at
+        // save time) — not a re-read of the live editor, which may already
+        // contain post-save typing.
+        const committed =
+          lastPostedContentRef.current ??
+          (editorRef.current ? JSON.stringify(editorRef.current.getContent()) : null);
+        if (committed !== null) {
+          savedBaselineRef.current = { sha: newSha, content: committed };
+        }
       }
       // Refresh the conflict token — content.json's new sha after our save.
-      if (typeof fetcher.data.sha === 'string' && fetcher.data.sha) {
-        setContentToken(fetcher.data.sha);
+      if (newSha) {
+        setContentToken(newSha);
       }
       setHasUnsavedChanges(false);
       setSaveStatus('saved');
     } else if (fetcher.state === 'idle' && (fetcher.data?.error || fetcher.data?.conflict)) {
+      // P9: a code-bearing refusal that is NOT a conflict (OPS_BASE_MISMATCH /
+      // OPS_MALFORMED) is being auto-recovered by the whole-document fallback
+      // effect above — keep showing 'saving' for the recovery round-trip, not
+      // 'error' (the two effects fire in the same commit).
+      if (fetcher.data?.code && !fetcher.data?.conflict) return;
       // Conflict (409) keeps hasUnsavedChanges true — the chooser/banner
       // offers a way out; the editor content is preserved until the user
       // decides.
       setSaveStatus('error');
     }
-  }, [fetcher.state, fetcher.data]);
+  }, [fetcher.state, fetcher.data, page.id]);
 
-  // Surface cover-image failures (incl. the F5 409 "page changed — try
-  // again") — the cover flow has no inline status indicator of its own.
-  // On success, refresh the conflict token: a cover write advances
-  // content.json's sha, so a save still carrying the pre-cover token would
-  // self-conflict against our own change.
+  // Surface cover-image failures (incl. the F5 409 "page changed — try again") —
+  // the cover flow has no inline status indicator of its own.
+  //
+  // NOTE (P1): we deliberately do NOT advance the conflict token to the cover
+  // write's sha. savePageCoverImage folds the cover into main's CURRENT blocks,
+  // which may include a concurrent editor's edits this session never saw;
+  // adopting its sha as our base would let the next save replay against a
+  // document this editor isn't derived from and silently clobber those edits.
+  // Leaving the token at the loaded sha makes the next save a 3-way merge
+  // (base = what this editor loaded), which folds the cover in AND preserves
+  // the concurrent edits — the cover is already committed to main regardless.
   useEffect(() => {
     if (coverFetcher.state !== 'idle') return;
     if (coverFetcher.data?.error) {
       toast.error(coverFetcher.data.error);
-    } else if (coverFetcher.data?.sha) {
-      setContentToken(coverFetcher.data.sha);
     }
   }, [coverFetcher.state, coverFetcher.data]);
 
@@ -403,6 +450,18 @@ const PageRoute = () => {
     window.location.reload();
   }, []);
 
+  // Baseline capture (P2): once the editor has mounted (or remounted after a
+  // merged adoption), snapshot its NORMALIZED document as the diff-at-save
+  // baseline, paired with the sha it represents. Same BlockNote normalization
+  // on both diff sides, so untouched stored blocks never emit phantom updates.
+  // Stable identity (reads refs only) so a remounted editor captures it once.
+  const handleEditorReady = useCallback((document: unknown) => {
+    savedBaselineRef.current = {
+      sha: pendingBaselineShaRef.current,
+      content: JSON.stringify(document),
+    };
+  }, []);
+
   return (
     <>
       {!isEmbedded && (
@@ -416,10 +475,14 @@ const PageRoute = () => {
         />
       )}
 
-      {/* Preview-branch chrome (staff only — `preview` is null otherwise) */}
-      {preview?.active && <PreviewBar preview={preview} isEmbedded={isEmbedded} />}
+      {/* Preview-branch chrome (staff only — `preview` is null otherwise).
+          Keyed on page.id so the preview fetcher's conflict state resets on
+          same-route navigation (P4) instead of ghosting onto the next page. */}
+      {preview?.active && <PreviewBar key={page.id} preview={preview} isEmbedded={isEmbedded} />}
       {preview?.missing && <NoPreviewNotice />}
-      {preview && !preview.active && preview.exists && <PendingPreviewBanner preview={preview} />}
+      {preview && !preview.active && preview.exists && (
+        <PendingPreviewBanner key={page.id} preview={preview} />
+      )}
 
       {/* Save-merge chooser (Phase 7.5): a stale save hit true collisions —
           pick a side per block, then the same content re-submits with the
@@ -578,6 +641,11 @@ const PageRoute = () => {
                 pageId={page.id}
                 darkMode={darkMode}
                 onChange={handleEditorChange}
+                onReady={handleEditorReady}
+                // P5: block editing while the save-merge chooser is open so no
+                // edits are silently discarded when the resolved merge remounts
+                // the editor. The chooser is the way forward (Apply / Reload).
+                editable={!saveMergeReport}
               />
             </Suspense>
           ) : (

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -305,10 +305,35 @@ const PageRoute = () => {
     setIsEditingTitle(false);
   }, [page.id, page.title]);
 
-  // Post-accept/discard success notice (round-tripped via redirect param)
+  // Post-accept/discard success notice (round-tripped via redirect param).
+  // Keyed on notice+sha so each accept is handled exactly once — the stripped
+  // URL param leaves `notice` in the loader data until the next revalidation,
+  // and a second accept can arrive with the same notice string but a new sha.
+  const handledNoticeRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!notice) return;
+    if (!notice) {
+      handledNoticeRef.current = null;
+      return;
+    }
+    const noticeKey = `${notice}:${contentSha ?? ''}`;
+    if (handledNoticeRef.current === noticeKey) return;
+    handledNoticeRef.current = noticeKey;
     if (notice === 'preview-accepted') {
+      // The post-accept redirect revalidated the loader, so `content` and
+      // `contentSha` are the freshly merged main document — but the mounted
+      // editor still shows its pre-merge copy. Adopt through the epoch-remount
+      // protocol (baseline recaptured by onReady, same as a merged save).
+      // Skipped when this session has unsaved edits: remounting would discard
+      // them, and the next save's 3-way merge reconciles them against the new
+      // main instead.
+      if (!hasUnsavedChanges) {
+        pendingBaselineShaRef.current = contentSha;
+        savedBaselineRef.current = null;
+        setEditorDoc(content);
+        setEditorEpoch(epoch => epoch + 1);
+        setContentToken(contentSha);
+        setSaveStatus('saved');
+      }
       toast.success(
         noticeAutoMerged
           ? `Preview merged —${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
@@ -322,7 +347,7 @@ const PageRoute = () => {
     url.searchParams.delete('notice');
     url.searchParams.delete('auto_merged');
     window.history.replaceState({}, '', url);
-  }, [notice, noticeAutoMerged]);
+  }, [notice, noticeAutoMerged, content, contentSha, hasUnsavedChanges]);
 
   // Baseline capture is the editor's onReady (P2), not the raw loader JSON —
   // see handleEditorReady below.

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -1,5 +1,5 @@
 import { useLoaderData, useFetcher, useOutletContext } from 'react-router';
-import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, lazy, Suspense } from 'react';
 import { IconPhoto } from '@tabler/icons-react';
 import { toast } from 'react-toastify';
 
@@ -9,6 +9,8 @@ import {
   PreviewBar,
   PendingPreviewBanner,
   NoPreviewNotice,
+  ConflictPanel,
+  type ConflictUnit,
 } from '~/components/preview/PreviewControls.tsx';
 
 const PageEditor = lazy(() => import('~/components/editor/PageEditor.tsx'));
@@ -60,12 +62,50 @@ const PageRoute = () => {
   // the token mid-edit would let a stale save pass the server's sha check).
   // Refreshed only from a successful save's response; echoed on every save.
   const [contentToken, setContentToken] = useState<string | null>(contentSha);
-  // True once a save 409'd: the page changed underneath this editor session.
-  const saveConflict = Boolean(fetcher.data?.conflict);
+  // Phase 7.5: a stale save's 3-way merge hit true collisions — the per-unit
+  // report the save-variant conflict chooser renders (derived straight from
+  // the fetcher; a successful re-submit replaces it).
+  const saveMergeReport = useMemo(
+    () =>
+      fetcher.data?.conflict && fetcher.data?.units
+        ? {
+            units: fetcher.data.units as ConflictUnit[],
+            autoMerged: (fetcher.data.autoMerged as number) ?? 0,
+            oursSha: (fetcher.data.oursSha as string | null) ?? null,
+          }
+        : null,
+    [fetcher.data]
+  );
+  // True once a save 409'd with NO mergeable report (legacy/fallback path):
+  // the page changed underneath this editor session — reload banner.
+  const saveConflict = Boolean(fetcher.data?.conflict) && !saveMergeReport;
+  // The exact content string the last save posted — a chooser re-submit (or
+  // auto re-run) carries the SAME document.
+  const lastPostedContentRef = useRef<string | null>(null);
   // Set when the user chooses Reload from the conflict banner — the banner
   // already warned that unsaved changes are discarded, so skip the browser's
   // beforeunload double-prompt.
   const skipUnloadWarningRef = useRef(false);
+
+  // The document the editor mounts from. Normally the loader's content; after
+  // a merged save (7.5) it becomes the server's MERGED document and the epoch
+  // bump remounts the editor — its local copy lacked the folded-in concurrent
+  // changes, and a fresh token over a stale document would clobber them on
+  // the next save.
+  const [editorDoc, setEditorDoc] = useState(content);
+  const [editorEpoch, setEditorEpoch] = useState(0);
+  // Navigating to a different page keeps this component mounted (same route,
+  // new params) — re-seed the per-page editing state (React's sanctioned
+  // render-time reset for prop-derived state).
+  const lastPageIdRef = useRef(page.id);
+  if (lastPageIdRef.current !== page.id) {
+    lastPageIdRef.current = page.id;
+    setEditorDoc(content);
+    setEditorEpoch(0);
+    setContentToken(contentSha);
+    lastSavedContent.current = null;
+    lastPostedContentRef.current = null;
+  }
 
   // Client-only flag — prevents BlockNote from rendering during SSR
   const [isClient, setIsClient] = useState(false);
@@ -86,6 +126,9 @@ const PageRoute = () => {
 
     if (lastSavedContent.current === currentContentStr) return;
 
+    // Preserved for the save-merge chooser: a conflict re-submit must carry
+    // the SAME document that produced the report.
+    lastPostedContentRef.current = currentContentStr;
     setSaveStatus('saving');
     fetcher.submit(
       // content_sha: the conflict token the action CAS-checks the write
@@ -94,6 +137,47 @@ const PageRoute = () => {
       { method: 'POST', encType: 'application/json' }
     );
   }, [canEdit, fetcher, contentToken]);
+
+  // Apply the save-merge chooser's decisions (Phase 7.5): re-submit the SAME
+  // posted content with one {id, choose} per conflict and the report's
+  // ours_sha pin. The editor is still mounted, so prefer its live document
+  // (the server re-validates the conflict set either way).
+  const handleApplySaveResolutions = useCallback(
+    (resolutions: Array<{ id: string; choose: 'ours' | 'theirs' }>) => {
+      const current = editorRef.current?.getContent();
+      const content = current ? JSON.stringify(current) : lastPostedContentRef.current;
+      if (!content || !saveMergeReport) return;
+      lastPostedContentRef.current = content;
+      setSaveStatus('saving');
+      fetcher.submit(
+        {
+          intent: 'save',
+          content,
+          content_sha: contentToken,
+          resolutions: JSON.stringify(resolutions),
+          ...(saveMergeReport.oursSha ? { ours_sha: saveMergeReport.oursSha } : {}),
+        },
+        { method: 'POST', encType: 'application/json' }
+      );
+    },
+    [fetcher, contentToken, saveMergeReport]
+  );
+
+  // A chooser re-submit was refused (stale ours_sha pin, or the conflict set
+  // changed): re-run the plain save with the SAME posted content — it either
+  // lands (possibly merged) or produces a FRESH report. Bounded: a plain save
+  // never answers with `code`, so this runs at most once per Apply click.
+  useEffect(() => {
+    if (fetcher.state !== 'idle') return;
+    if (!fetcher.data?.code || fetcher.data?.conflict) return;
+    const content = lastPostedContentRef.current;
+    if (!content) return;
+    setSaveStatus('saving');
+    fetcher.submit(
+      { intent: 'save', content, content_sha: contentToken },
+      { method: 'POST', encType: 'application/json' }
+    );
+  }, [fetcher.state, fetcher.data, fetcher, contentToken]);
 
   // Track editor changes (mark unsaved, but don't auto-save)
   const handleEditorChange = useCallback(
@@ -150,7 +234,18 @@ const PageRoute = () => {
   // Track save completion
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data?.success) {
-      if (editorRef.current) {
+      if (Array.isArray(fetcher.data.merged_content)) {
+        // Semantic save-merge (7.5): the committed document is the MERGE of
+        // this editor's content and concurrent server-side changes — adopt it
+        // (remount) so the editor matches the fresh token, and tell the user.
+        setEditorDoc(fetcher.data.merged_content);
+        setEditorEpoch(epoch => epoch + 1);
+        lastSavedContent.current = JSON.stringify(fetcher.data.merged_content);
+        const n = fetcher.data.merged_with_concurrent;
+        if (typeof n === 'number' && n > 0) {
+          toast.success(`Saved — merged with ${n} concurrent change${n === 1 ? '' : 's'}.`);
+        }
+      } else if (editorRef.current) {
         const currentContent = editorRef.current.getContent();
         lastSavedContent.current = JSON.stringify(currentContent);
       }
@@ -161,8 +256,9 @@ const PageRoute = () => {
       setHasUnsavedChanges(false);
       setSaveStatus('saved');
     } else if (fetcher.state === 'idle' && (fetcher.data?.error || fetcher.data?.conflict)) {
-      // Conflict (409) keeps hasUnsavedChanges true — the banner offers
-      // Reload; the editor content is preserved until the user decides.
+      // Conflict (409) keeps hasUnsavedChanges true — the chooser/banner
+      // offers a way out; the editor content is preserved until the user
+      // decides.
       setSaveStatus('error');
     }
   }, [fetcher.state, fetcher.data]);
@@ -252,6 +348,24 @@ const PageRoute = () => {
       {preview?.active && <PreviewBar preview={preview} isEmbedded={isEmbedded} />}
       {preview?.missing && <NoPreviewNotice />}
       {preview && !preview.active && preview.exists && <PendingPreviewBanner preview={preview} />}
+
+      {/* Save-merge chooser (Phase 7.5): a stale save hit true collisions —
+          pick a side per block, then the same content re-submits with the
+          choices. The editor (and lastPostedContentRef) preserve the document
+          until the resolution completes. */}
+      {canEdit && saveMergeReport && (
+        <div className={`sticky ${isEmbedded ? 'top-0' : 'top-12'} z-30 shadow-lg`}>
+          <ConflictPanel
+            variant="save"
+            units={saveMergeReport.units}
+            autoMerged={saveMergeReport.autoMerged}
+            oursSha={saveMergeReport.oursSha}
+            busy={fetcher.state !== 'idle'}
+            onApply={handleApplySaveResolutions}
+            onDiscard={handleConflictReload}
+          />
+        </div>
+      )}
 
       {/* Save-conflict notice (F2): the last save 409'd — content.json changed
           under this editor session (another editor, an MCP apply). Amber, same
@@ -386,9 +500,9 @@ const PageRoute = () => {
               }
             >
               <PageEditor
-                key={page.id}
+                key={`${page.id}:${editorEpoch}`}
                 ref={editorRef}
-                initialContent={content}
+                initialContent={editorDoc}
                 pageId={page.id}
                 darkMode={darkMode}
                 onChange={handleEditorChange}

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -127,8 +127,8 @@ const PageRoute = () => {
     if (notice === 'preview-accepted') {
       toast.success(
         noticeAutoMerged
-          ? `Preview accepted — ${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
-          : 'Preview accepted — changes are now live.'
+          ? `Preview merged —${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
+          : 'Preview merged —changes are now live.'
       );
     } else if (notice === 'preview-discarded') {
       toast.success('Preview discarded.');

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -12,6 +12,7 @@ import {
   ConflictPanel,
   type ConflictUnit,
 } from '~/components/preview/PreviewControls.tsx';
+import { diffBlockOps, type BlockOp } from '~/components/editor/blockOpsDiff.ts';
 
 const PageEditor = lazy(() => import('~/components/editor/PageEditor.tsx'));
 const BlockNoteViewer = lazy(() => import('~/components/viewer/BlockNoteViewer.tsx'));
@@ -82,6 +83,10 @@ const PageRoute = () => {
   // The exact content string the last save posted — a chooser re-submit (or
   // auto re-run) carries the SAME document.
   const lastPostedContentRef = useRef<string | null>(null);
+  // The serialized ops of the last save when it went down the diff-at-save
+  // path (null = it was a whole-document save). A chooser re-submit carries
+  // the SAME ops; the whole-doc fallback clears it.
+  const lastPostedOpsRef = useRef<string | null>(null);
   // Set when the user chooses Reload from the conflict banner — the banner
   // already warned that unsaved changes are discarded, so skip the browser's
   // beforeunload double-prompt.
@@ -105,6 +110,7 @@ const PageRoute = () => {
     setContentToken(contentSha);
     lastSavedContent.current = null;
     lastPostedContentRef.current = null;
+    lastPostedOpsRef.current = null;
   }
 
   // Client-only flag — prevents BlockNote from rendering during SSR
@@ -126,10 +132,47 @@ const PageRoute = () => {
 
     if (lastSavedContent.current === currentContentStr) return;
 
-    // Preserved for the save-merge chooser: a conflict re-submit must carry
-    // the SAME document that produced the report.
+    // Preserved for the save-merge chooser and the whole-doc fallback: a
+    // conflict re-submit must carry the SAME document that produced the report.
     lastPostedContentRef.current = currentContentStr;
+
+    // Diff-at-save: with a conflict token (content.json exists — the base the
+    // server replays against) and a baseline (the document this editor
+    // mounted from), post only the changed blocks as ops. Any anomaly (no
+    // baseline, duplicate ids, cross-scope move, complex reorder) → null →
+    // the whole-document save below (the 7.5 path, unchanged).
+    let ops: BlockOp[] | null = null;
+    if (contentToken && lastSavedContent.current) {
+      try {
+        ops = diffBlockOps(JSON.parse(lastSavedContent.current), currentContent);
+      } catch {
+        ops = null;
+      }
+    }
+
+    if (ops && ops.length === 0) {
+      // Canonically identical (only serialization order differs) — nothing
+      // to commit.
+      lastSavedContent.current = currentContentStr;
+      setHasUnsavedChanges(false);
+      setSaveStatus('saved');
+      return;
+    }
+
     setSaveStatus('saving');
+    if (ops) {
+      const opsStr = JSON.stringify(ops);
+      lastPostedOpsRef.current = opsStr;
+      fetcher.submit(
+        // base_sha: the token names the exact document the ops were diffed
+        // against; content_sha rides along as the CAS token (same value).
+        { intent: 'save', ops: opsStr, base_sha: contentToken, content_sha: contentToken },
+        { method: 'POST', encType: 'application/json' }
+      );
+      return;
+    }
+
+    lastPostedOpsRef.current = null;
     fetcher.submit(
       // content_sha: the conflict token the action CAS-checks the write
       // against (null = content.json doesn't exist yet → creation).
@@ -144,9 +187,29 @@ const PageRoute = () => {
   // (the server re-validates the conflict set either way).
   const handleApplySaveResolutions = useCallback(
     (resolutions: Array<{ id: string; choose: 'ours' | 'theirs' }>) => {
+      if (!saveMergeReport) return;
+
+      // Ops-save conflict: the re-submit carries the SAME ops (the server
+      // re-materializes theirs = base + ops and re-validates the set).
+      if (lastPostedOpsRef.current) {
+        setSaveStatus('saving');
+        fetcher.submit(
+          {
+            intent: 'save',
+            ops: lastPostedOpsRef.current,
+            base_sha: contentToken,
+            content_sha: contentToken,
+            resolutions: JSON.stringify(resolutions),
+            ...(saveMergeReport.oursSha ? { ours_sha: saveMergeReport.oursSha } : {}),
+          },
+          { method: 'POST', encType: 'application/json' }
+        );
+        return;
+      }
+
       const current = editorRef.current?.getContent();
       const content = current ? JSON.stringify(current) : lastPostedContentRef.current;
-      if (!content || !saveMergeReport) return;
+      if (!content) return;
       lastPostedContentRef.current = content;
       setSaveStatus('saving');
       fetcher.submit(
@@ -163,15 +226,18 @@ const PageRoute = () => {
     [fetcher, contentToken, saveMergeReport]
   );
 
-  // A chooser re-submit was refused (stale ours_sha pin, or the conflict set
-  // changed): re-run the plain save with the SAME posted content — it either
-  // lands (possibly merged) or produces a FRESH report. Bounded: a plain save
-  // never answers with `code`, so this runs at most once per Apply click.
+  // A `code`-bearing refusal: a chooser re-submit hit a stale ours_sha pin or
+  // a changed conflict set, or an ops save's base didn't match
+  // (OPS_BASE_MISMATCH). Either way the recovery is the same: ONE plain
+  // whole-document re-run with the SAME posted content — it either lands
+  // (possibly merged) or produces a FRESH report. Bounded: a plain whole-doc
+  // save never answers with `code`, so this runs at most once per attempt.
   useEffect(() => {
     if (fetcher.state !== 'idle') return;
     if (!fetcher.data?.code || fetcher.data?.conflict) return;
     const content = lastPostedContentRef.current;
     if (!content) return;
+    lastPostedOpsRef.current = null;
     setSaveStatus('saving');
     fetcher.submit(
       { intent: 'save', content, content_sha: contentToken },
@@ -245,6 +311,12 @@ const PageRoute = () => {
         if (typeof n === 'number' && n > 0) {
           toast.success(`Saved — merged with ${n} concurrent change${n === 1 ? '' : 's'}.`);
         }
+      } else if (lastPostedContentRef.current) {
+        // No adoption needed: the committed document IS the posted one. The
+        // baseline must be exactly what was committed (the next diff-at-save
+        // is computed against it), so use the posted string — not a re-read
+        // of the live editor, which may already contain post-save typing.
+        lastSavedContent.current = lastPostedContentRef.current;
       } else if (editorRef.current) {
         const currentContent = editorRef.current.getContent();
         lastSavedContent.current = JSON.stringify(currentContent);

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -34,6 +34,7 @@ const PageRoute = () => {
     canEdit: canEditRole,
     preview,
     notice,
+    noticeAutoMerged,
     contentSha,
   } = useLoaderData<typeof import('./route.server.ts').loader>();
   const outletContext = useOutletContext<{ isEmbedded?: boolean }>();
@@ -124,15 +125,20 @@ const PageRoute = () => {
   useEffect(() => {
     if (!notice) return;
     if (notice === 'preview-accepted') {
-      toast.success('Preview accepted — changes are now live.');
+      toast.success(
+        noticeAutoMerged
+          ? `Preview accepted — ${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
+          : 'Preview accepted — changes are now live.'
+      );
     } else if (notice === 'preview-discarded') {
       toast.success('Preview discarded.');
     }
-    // Strip the param so a refresh doesn't re-toast
+    // Strip the params so a refresh doesn't re-toast
     const url = new URL(window.location.href);
     url.searchParams.delete('notice');
+    url.searchParams.delete('auto_merged');
     window.history.replaceState({}, '', url);
-  }, [notice]);
+  }, [notice, noticeAutoMerged]);
 
   // Initialize lastSavedContent on mount
   useEffect(() => {

--- a/apps/pages/app/routes/$classroomSlug.$pageId/saveState.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/saveState.ts
@@ -1,0 +1,110 @@
+/**
+ * saveState.ts — pure decision helpers for the page editor's save/conflict
+ * state machine.
+ *
+ * No React imports: the route component wires these in, and the Playwright
+ * runner unit-tests them directly (tests/unit/save-state.spec.ts) without a
+ * browser. Extracting the load-bearing decisions here keeps the review
+ * findings' fixes (P1 pairing guard, P4 per-page stamping, P9 status race)
+ * verifiable in isolation.
+ */
+
+import type { ConflictUnit } from '~/components/preview/conflictChooser.ts';
+
+/**
+ * The document the editor's next diff-at-save is computed against, bound to the
+ * conflict-token sha it represents. Keeping the two together is the P1 fix: a
+ * cover write (or any path) that advances the token WITHOUT re-basing this
+ * document would otherwise let the ops replay onto the wrong base and silently
+ * clobber concurrent edits.
+ */
+export interface SaveBaseline {
+  /** content.json's blob sha this baseline document corresponds to. */
+  sha: string | null;
+  /** The normalized editor document (JSON string) at that sha. */
+  content: string;
+}
+
+/**
+ * P1 pairing guard: the diff-at-save (ops) path is only trustworthy when the
+ * baseline we diff against is EXACTLY the document the conflict token names —
+ * the server replays the ops onto `base_sha`, so a mismatch replays onto the
+ * wrong base. Any desync forces the whole-document save (always correct).
+ */
+export function opsPathEligible(
+  baseline: SaveBaseline | null,
+  token: string | null
+): baseline is SaveBaseline & { sha: string } {
+  return Boolean(token) && baseline != null && baseline.sha === token;
+}
+
+/** The save fetcher's JSON payload shapes this module reasons about. */
+export interface SaveFetcherData {
+  success?: boolean;
+  conflict?: boolean;
+  units?: ConflictUnit[];
+  autoMerged?: number;
+  oursSha?: string | null;
+  error?: string;
+  code?: string;
+  sha?: string;
+  merged_content?: unknown;
+  merged_with_concurrent?: number;
+}
+
+export interface SaveMergeReport {
+  units: ConflictUnit[];
+  autoMerged: number;
+  oursSha: string | null;
+}
+
+/**
+ * P4: a save exchange belongs to the page whose editor produced it. `fetcher`
+ * state survives same-route param navigation, so its data must be read only
+ * when the page it was stamped for still matches — otherwise page A's conflict
+ * chooser ghosts onto page B and Apply fires a wrong-page save chain.
+ */
+export function fetcherMatchesPage(stampedPageId: string | null, currentPageId: string): boolean {
+  return stampedPageId === currentPageId;
+}
+
+/**
+ * The save-merge chooser report — derived from the fetcher ONLY when the data
+ * was stamped for the current page (P4). A stale cross-page report returns null.
+ */
+export function deriveSaveMergeReport(
+  data: SaveFetcherData | undefined,
+  matchesPage: boolean
+): SaveMergeReport | null {
+  if (!matchesPage) return null;
+  if (data?.conflict && data?.units) {
+    return {
+      units: data.units,
+      autoMerged: data.autoMerged ?? 0,
+      oursSha: data.oursSha ?? null,
+    };
+  }
+  return null;
+}
+
+/**
+ * The plain "page changed — reload" banner state: a 409 with NO mergeable
+ * report, and only for a fetcher exchange stamped for the current page (P4).
+ */
+export function deriveSaveConflict(
+  data: SaveFetcherData | undefined,
+  matchesPage: boolean,
+  mergeReport: SaveMergeReport | null
+): boolean {
+  return matchesPage && Boolean(data?.conflict) && !mergeReport;
+}
+
+/**
+ * P9: a `code`-bearing refusal that is NOT a conflict (e.g. OPS_BASE_MISMATCH,
+ * OPS_MALFORMED) is being auto-recovered by the whole-document fallback effect.
+ * The completion effect must keep showing 'saving' for it, not flash 'error'
+ * for the multi-second recovery round-trip.
+ */
+export function isCodeFallbackRefusal(data: SaveFetcherData | undefined): boolean {
+  return Boolean(data?.code) && !data?.conflict;
+}

--- a/apps/pages/tests/e2e/pages-preview.spec.ts
+++ b/apps/pages/tests/e2e/pages-preview.spec.ts
@@ -82,7 +82,7 @@ test.describe('Pages preview mode', () => {
 
     if (barCount === 1) {
       // Preview bar carries the three actions
-      await expect(page.getByRole('button', { name: 'Accept' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Merge' })).toBeVisible();
       await expect(page.getByRole('button', { name: 'Discard' })).toBeVisible();
       await expect(page.getByRole('link', { name: /Diff/ })).toBeVisible();
     }

--- a/apps/pages/tests/e2e/pages-preview.spec.ts
+++ b/apps/pages/tests/e2e/pages-preview.spec.ts
@@ -124,4 +124,39 @@ test.describe('Pages preview mode', () => {
     // 3. expect pending-preview-banner with "View preview", Accept, Discard
     // 4. Cleanup: delete the branch
   });
+
+  // ── Phase 7: side-by-side conflict chooser ────────────────────────────────
+  // Needs the same content-repo fixture PLUS a seeded conflict: edit block B
+  // differently on main and on the preview branch so accept 409s with a
+  // per-unit report instead of merging.
+
+  test.skip('staff: conflicting accept shows the chooser; Apply is gated on choosing every card', async () => {
+    // 1. Seed a conflict (same block edited differently on main and preview)
+    // 2. loginAs(page, 'owner'); goto the page; click Accept (banner flow)
+    // 3. expect preview-conflict-panel with conflict-card-<blockId> showing
+    //    "Live version (yours)" and "Preview version (agent's)" side by side
+    // 4. expect conflict-apply disabled while any card lacks a choice
+    // 5. click conflict-choose-theirs-<blockId>; expect conflict-apply enabled
+  });
+
+  test.skip('staff: Apply choices commits the resolved merge and redirects with the accepted toast', async () => {
+    // 1. Seed a conflict; open the chooser via Accept (in ?preview=1 bar flow)
+    // 2. choose a side for every card; click conflict-apply
+    // 3. expect redirect to the live view + "Preview accepted" toast
+    //    (mentioning the auto-merged count when > 0)
+    // 4. expect the chosen side's content live on main; branch deleted
+  });
+
+  test.skip('staff: delete-vs-edit conflicts render a tombstone for the deleted side', async () => {
+    // 1. Seed: delete block B on the preview, edit the same block on main
+    // 2. Accept → chooser; expect the theirs side of conflict-card-<blockId>
+    //    to show the "Deleted in the preview" tombstone card
+  });
+
+  test.skip('staff: stale resolutions surface the 400 error and a re-accept refreshes the report', async () => {
+    // 1. Open the chooser, then change main again behind its back (new apply)
+    // 2. click conflict-apply → expect the error line (UNKNOWN_RESOLUTIONS /
+    //    "re-run accept") instead of a silent failure
+    // 3. click Accept again → expect a fresh conflict report
+  });
 });

--- a/apps/pages/tests/unit/block-ops-diff.spec.ts
+++ b/apps/pages/tests/unit/block-ops-diff.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for the diff-at-save helper (blockOpsDiff.ts).
+ *
+ * These run in the Playwright runner WITHOUT a browser or the dev stack —
+ * the module under test is pure (no React, no BlockNote, no network).
+ *
+ * The contract under test: diffBlockOps(baseline, current) emits the minimal
+ * update/delete/move/insert script the server replays against the SAME base
+ * (ops order: updates → deletes → moves → inserts), and returns null for any
+ * document it can't diff trustworthily — the caller then falls back to the
+ * whole-document save.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  diffBlockOps,
+  MAX_MOVES,
+  type BlockOp,
+} from '../../app/components/editor/blockOpsDiff.ts';
+
+const block = (id: string, text: string, children: unknown[] = []) => ({
+  id,
+  type: 'paragraph',
+  props: { textColor: 'default' },
+  content: [{ type: 'text', text, styles: {} }],
+  children,
+});
+
+/**
+ * Reference replay of the server's applyBlockOps semantics (top-level only —
+ * the diff never emits nested-addressed ops): proves each emitted script
+ * reproduces `current` exactly when applied to `baseline`.
+ */
+function replay(baseline: { id: string }[], ops: BlockOp[]): unknown[] {
+  let doc: { id: string }[] = structuredClone(baseline);
+  const indexOf = (id: string) => {
+    const index = doc.findIndex(b => b.id === id);
+    if (index === -1) throw new Error(`unknown id ${id}`);
+    return index;
+  };
+  const insertAt = (blocks: unknown[], position: { after?: string; at?: string }) => {
+    if (position.after) doc.splice(indexOf(position.after) + 1, 0, ...(blocks as { id: string }[]));
+    else if (position.at === 'start') doc.unshift(...(blocks as { id: string }[]));
+    else doc.push(...(blocks as { id: string }[]));
+  };
+  for (const op of ops) {
+    if (op.op === 'update') doc[indexOf(op.id)] = op.block as { id: string };
+    else if (op.op === 'delete') doc.splice(indexOf(op.id), 1);
+    else if (op.op === 'move') {
+      const [moved] = doc.splice(indexOf(op.id), 1);
+      insertAt([moved], op.position as { after?: string; at?: string });
+    } else insertAt(op.blocks, op.position as { after?: string; at?: string });
+  }
+  return doc;
+}
+
+test.describe('diffBlockOps — update', () => {
+  test('a changed block becomes one update op; untouched blocks never transmit', () => {
+    const baseline = [block('a', 'one'), block('b', 'two'), block('c', 'three')];
+    const current = [block('a', 'one EDITED'), block('b', 'two'), block('c', 'three')];
+
+    const ops = diffBlockOps(baseline, current);
+
+    expect(ops).toEqual([{ op: 'update', id: 'a', block: current[0] }]);
+  });
+
+  test('a changed nested child = an update op on its TOP-LEVEL block (the merge unit)', () => {
+    const baseline = [block('a', 'one', [block('a1', 'child')]), block('b', 'two')];
+    const current = [block('a', 'one', [block('a1', 'child EDITED')]), block('b', 'two')];
+
+    const ops = diffBlockOps(baseline, current);
+
+    expect(ops).toEqual([{ op: 'update', id: 'a', block: current[0] }]);
+  });
+
+  test('canonically identical docs (only key order differs) → empty script, not an update', () => {
+    const baseline = [{ id: 'a', type: 'paragraph', content: [] }];
+    const current = [{ content: [], type: 'paragraph', id: 'a' }];
+
+    expect(diffBlockOps(baseline, current)).toEqual([]);
+  });
+});
+
+test.describe('diffBlockOps — insert', () => {
+  test('a new block mid-document inserts after its left neighbor', () => {
+    const baseline = [block('a', 'one'), block('b', 'two')];
+    const current = [block('a', 'one'), block('x', 'new'), block('b', 'two')];
+
+    expect(diffBlockOps(baseline, current)).toEqual([
+      { op: 'insert', blocks: [current[1]], position: { after: 'a' } },
+    ]);
+  });
+
+  test('a new block at the top inserts at start; consecutive new blocks group into one op', () => {
+    const baseline = [block('a', 'one')];
+    const current = [block('x', 'new1'), block('y', 'new2'), block('a', 'one')];
+
+    expect(diffBlockOps(baseline, current)).toEqual([
+      { op: 'insert', blocks: [current[0], current[1]], position: { at: 'start' } },
+    ]);
+  });
+
+  test('an empty baseline (fresh doc) becomes one insert run at start', () => {
+    const current = [block('a', 'one'), block('b', 'two')];
+    expect(diffBlockOps([], current)).toEqual([
+      { op: 'insert', blocks: current, position: { at: 'start' } },
+    ]);
+  });
+});
+
+test.describe('diffBlockOps — delete', () => {
+  test('removed blocks become delete ops', () => {
+    const baseline = [block('a', 'one'), block('b', 'two'), block('c', 'three')];
+    const current = [block('b', 'two')];
+
+    expect(diffBlockOps(baseline, current)).toEqual([
+      { op: 'delete', id: 'a' },
+      { op: 'delete', id: 'c' },
+    ]);
+  });
+});
+
+test.describe('diffBlockOps — move', () => {
+  test('a single block moved emits ONE move op that replays to the exact order', () => {
+    const baseline = [block('a', 'one'), block('b', 'two'), block('c', 'three')];
+    const current = [block('c', 'three'), block('a', 'one'), block('b', 'two')];
+
+    const ops = diffBlockOps(baseline, current)!;
+
+    expect(ops).toEqual([{ op: 'move', id: 'c', position: { at: 'start' } }]);
+    expect(replay(baseline, ops)).toEqual(current);
+  });
+
+  test('an adjacent swap emits one move', () => {
+    const baseline = [block('a', 'one'), block('b', 'two'), block('c', 'three')];
+    const current = [block('a', 'one'), block('c', 'three'), block('b', 'two')];
+
+    const ops = diffBlockOps(baseline, current)!;
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0].op).toBe('move');
+    expect(replay(baseline, ops)).toEqual(current);
+  });
+
+  test('mixed update+delete+move+insert replays to the exact target document', () => {
+    const baseline = [block('a', 'one'), block('b', 'two'), block('c', 'three'), block('d', 'four')];
+    const current = [
+      block('d', 'four'),
+      block('a', 'one EDITED'),
+      block('x', 'new'),
+      block('c', 'three'),
+    ];
+
+    const ops = diffBlockOps(baseline, current)!;
+
+    expect(ops).not.toBeNull();
+    // Op order: updates → deletes → moves → inserts.
+    expect(ops.map(o => o.op)).toEqual(['update', 'delete', 'move', 'insert']);
+    expect(replay(baseline, ops)).toEqual(current);
+  });
+});
+
+test.describe('diffBlockOps — null fallbacks (whole-document save)', () => {
+  test(`a complex permutation (more than ${MAX_MOVES} blocks out of place) → null`, () => {
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const baseline = ids.map(id => block(id, id));
+    const current = [...baseline].reverse();
+
+    expect(diffBlockOps(baseline, current)).toBeNull();
+  });
+
+  test('no baseline (null/undefined/non-array) → null', () => {
+    const doc = [block('a', 'one')];
+    expect(diffBlockOps(null, doc)).toBeNull();
+    expect(diffBlockOps(undefined, doc)).toBeNull();
+    expect(diffBlockOps('<html>legacy</html>', doc)).toBeNull();
+    expect(diffBlockOps(doc, null)).toBeNull();
+  });
+
+  test('a top-level block without a usable id → null', () => {
+    const baseline = [block('a', 'one')];
+    expect(diffBlockOps(baseline, [{ type: 'paragraph', content: [] }])).toBeNull();
+    expect(diffBlockOps(baseline, [{ id: '', type: 'paragraph' }])).toBeNull();
+    expect(diffBlockOps([{ type: 'paragraph' }], baseline)).toBeNull();
+  });
+
+  test('duplicate ids anywhere in either tree → null', () => {
+    const dupTop = [block('a', 'one'), block('a', 'clone')];
+    const ok = [block('a', 'one')];
+    expect(diffBlockOps(dupTop, ok)).toBeNull();
+    expect(diffBlockOps(ok, dupTop)).toBeNull();
+
+    // Nested duplicate of a top-level id — id-addressed ops would be ambiguous.
+    const dupNested = [block('a', 'one', [block('b', 'child')]), block('b', 'two')];
+    expect(diffBlockOps(dupNested, ok)).toBeNull();
+    expect(diffBlockOps(ok, dupNested)).toBeNull();
+  });
+
+  test('an id that changes scope (nested ⇄ top-level) → null', () => {
+    // b escapes its parent to top level: the op vocabulary cannot express a
+    // cross-scope move without id churn — whole-doc save handles it.
+    const baseline = [block('a', 'one', [block('b', 'child')])];
+    const current = [block('a', 'one'), block('b', 'child')];
+    expect(diffBlockOps(baseline, current)).toBeNull();
+
+    // ...and the reverse (b tucked INTO a parent).
+    expect(diffBlockOps(current, baseline)).toBeNull();
+  });
+
+  test('identical documents → empty script (caller skips the save)', () => {
+    const doc = [block('a', 'one'), block('b', 'two')];
+    expect(diffBlockOps(doc, structuredClone(doc))).toEqual([]);
+  });
+});

--- a/apps/pages/tests/unit/conflict-chooser.spec.ts
+++ b/apps/pages/tests/unit/conflict-chooser.spec.ts
@@ -14,6 +14,7 @@ import {
   chooserCopy,
   chooserSubtitle,
   conflictIds,
+  orderDiffIds,
   reasonLabel,
   type ConflictUnit,
 } from '../../app/components/preview/conflictChooser.ts';
@@ -77,6 +78,28 @@ test.describe('blockSummary', () => {
       text: '',
       childCount: 0,
     });
+  });
+});
+
+test.describe('orderDiffIds (moved-block highlight)', () => {
+  test('flags every block whose position differs between the two orderings', () => {
+    const moved = orderDiffIds(['b', 'a', 'c'], ['a', 'c', 'b']);
+    expect(moved).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  test('a block that keeps its position is NOT flagged', () => {
+    const moved = orderDiffIds(['a', 'b', 'c'], ['a', 'c', 'b']);
+    expect(moved.has('a')).toBe(false);
+    expect(moved.has('b')).toBe(true);
+    expect(moved.has('c')).toBe(true);
+  });
+
+  test('identical orderings flag nothing', () => {
+    expect(orderDiffIds(['a', 'b', 'c'], ['a', 'b', 'c'])).toEqual(new Set());
+  });
+
+  test('a block present in only one ordering counts as moved', () => {
+    expect(orderDiffIds(['a', 'b'], ['a', 'b', 'c'])).toEqual(new Set(['c']));
   });
 });
 

--- a/apps/pages/tests/unit/conflict-chooser.spec.ts
+++ b/apps/pages/tests/unit/conflict-chooser.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the conflict-chooser helpers (plan §3b Phase 7).
+ *
+ * These run in the Playwright runner WITHOUT a browser or the dev stack —
+ * the module under test is pure (no React, no network).
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  ORDER_CONFLICT_ID,
+  allResolved,
+  blockSummary,
+  buildResolutions,
+  conflictIds,
+  reasonLabel,
+  type ConflictUnit,
+} from '../../app/components/preview/conflictChooser.ts';
+
+test.describe('reasonLabel', () => {
+  test('maps every known reason to a human label', () => {
+    expect(reasonLabel('content')).toBe('Edited in both versions');
+    expect(reasonLabel('delete_vs_edit')).toBe('Deleted in one version, edited in the other');
+    expect(reasonLabel('both_added')).toBe('Added in both versions');
+    expect(reasonLabel('order')).toBe('Blocks reordered differently in both versions');
+  });
+
+  test('falls back for unknown/missing reasons', () => {
+    expect(reasonLabel(undefined)).toBe('Changed in both versions');
+    expect(reasonLabel('some_future_reason')).toBe('Changed in both versions');
+  });
+});
+
+test.describe('blockSummary', () => {
+  test('extracts type, flattened text, and child count from a BlockNote block', () => {
+    const block = {
+      id: 'abc12345',
+      type: 'paragraph',
+      props: {},
+      content: [
+        { type: 'text', text: 'Hello ', styles: {} },
+        { type: 'text', text: 'world', styles: { bold: true } },
+        { type: 'link', href: 'https://x.test', content: [{ type: 'text', text: ' link' }] },
+      ],
+      children: [{ type: 'paragraph' }, { type: 'paragraph' }],
+    };
+    expect(blockSummary(block)).toEqual({
+      type: 'paragraph',
+      text: 'Hello world link',
+      childCount: 2,
+    });
+  });
+
+  test('flattens table content rows and cells', () => {
+    const block = {
+      type: 'table',
+      content: {
+        type: 'tableContent',
+        rows: [
+          { cells: [[{ type: 'text', text: 'A1' }], [{ type: 'text', text: 'B1' }]] },
+          { cells: [[{ type: 'text', text: 'A2' }], [{ type: 'text', text: 'B2' }]] },
+        ],
+      },
+    };
+    const summary = blockSummary(block);
+    expect(summary.type).toBe('table');
+    expect(summary.text).toContain('A1 · B1');
+    expect(summary.text).toContain('A2 · B2');
+  });
+
+  test('tolerates null, garbage, and content-less blocks', () => {
+    expect(blockSummary(null)).toEqual({ type: 'block', text: '', childCount: 0 });
+    expect(blockSummary('not a block')).toEqual({ type: 'block', text: '', childCount: 0 });
+    expect(blockSummary({ type: 'image', props: { url: 'x.png' } })).toEqual({
+      type: 'image',
+      text: '',
+      childCount: 0,
+    });
+  });
+});
+
+test.describe('resolution bookkeeping', () => {
+  const units: ConflictUnit[] = [
+    { id: 'blk1', index: 0, reason: 'content', ours: {}, theirs: {} },
+    { id: 'blk2', index: 3, reason: 'delete_vs_edit', ours: {} },
+    { id: ORDER_CONFLICT_ID, index: -1, reason: 'order', ours: ['a'], theirs: ['b'] },
+  ];
+
+  test('conflictIds lists every unit id including sentinels', () => {
+    expect(conflictIds(units)).toEqual(['blk1', 'blk2', ORDER_CONFLICT_ID]);
+  });
+
+  test('allResolved requires a valid choice for EVERY id', () => {
+    const ids = conflictIds(units);
+    expect(allResolved(ids, {})).toBe(false);
+    expect(allResolved(ids, { blk1: 'ours' })).toBe(false);
+    expect(allResolved(ids, { blk1: 'ours', blk2: 'theirs' })).toBe(false);
+    expect(allResolved(ids, { blk1: 'ours', blk2: 'theirs', [ORDER_CONFLICT_ID]: 'ours' })).toBe(
+      true
+    );
+  });
+
+  test('allResolved is false for an empty conflict set', () => {
+    expect(allResolved([], {})).toBe(false);
+  });
+
+  test('buildResolutions emits one {id, choose} per id, in order', () => {
+    const ids = conflictIds(units);
+    const choices = { blk1: 'ours', blk2: 'theirs', [ORDER_CONFLICT_ID]: 'theirs' } as const;
+    expect(buildResolutions(ids, choices)).toEqual([
+      { id: 'blk1', choose: 'ours' },
+      { id: 'blk2', choose: 'theirs' },
+      { id: ORDER_CONFLICT_ID, choose: 'theirs' },
+    ]);
+  });
+});

--- a/apps/pages/tests/unit/conflict-chooser.spec.ts
+++ b/apps/pages/tests/unit/conflict-chooser.spec.ts
@@ -11,6 +11,8 @@ import {
   allResolved,
   blockSummary,
   buildResolutions,
+  chooserCopy,
+  chooserSubtitle,
   conflictIds,
   reasonLabel,
   type ConflictUnit,
@@ -111,5 +113,48 @@ test.describe('resolution bookkeeping', () => {
       { id: 'blk2', choose: 'theirs' },
       { id: ORDER_CONFLICT_ID, choose: 'theirs' },
     ]);
+  });
+});
+
+test.describe('chooser variants (save vs preview, Phase 7.5)', () => {
+  test('preview copy keeps the accept-flow framing', () => {
+    const copy = chooserCopy('preview');
+    expect(copy.heading).toBe('Changes conflict with edits made on the live page');
+    expect(copy.sideTitle).toEqual({
+      ours: 'Live version (yours)',
+      theirs: "Preview version (agent's)",
+    });
+    expect(copy.sideAction).toEqual({ ours: 'Keep live', theirs: 'Take preview' });
+    expect(copy.tombstone).toEqual({
+      ours: 'Deleted in the live version',
+      theirs: 'Deleted in the preview',
+    });
+    expect(copy.secondaryAction).toBe('Discard preview');
+    expect(copy.busyLabel).toContain('Publishing your choices');
+  });
+
+  test('save copy flips the framing: ours = the server, theirs = the unsaved editor', () => {
+    const copy = chooserCopy('save');
+    expect(copy.heading).toBe('Your save collided with changes saved by someone else');
+    expect(copy.sideTitle).toEqual({
+      ours: 'Saved on the server',
+      theirs: 'Your unsaved version',
+    });
+    expect(copy.sideAction).toEqual({ ours: "Keep server's", theirs: 'Keep yours' });
+    expect(copy.tombstone).toEqual({
+      ours: 'Deleted on the server',
+      theirs: 'Deleted in your version',
+    });
+    expect(copy.secondaryAction).toBe('Reload latest');
+    expect(copy.footerNote).toContain('discard your unsaved changes');
+    expect(copy.busyLabel).toContain('Saving the merged version');
+  });
+
+  test('chooserSubtitle mentions the auto-merged count per variant', () => {
+    expect(chooserSubtitle('preview', 0)).toBe('Choose which version to keep for each conflict:');
+    expect(chooserSubtitle('save', 0)).toBe('Choose which version to keep for each conflict:');
+    expect(chooserSubtitle('preview', 3)).toBe('3 changes merged automatically; these need you:');
+    expect(chooserSubtitle('save', 1)).toBe('1 change merged automatically; choose per block:');
+    expect(chooserSubtitle('save', 2)).toBe('2 changes merged automatically; choose per block:');
   });
 });

--- a/apps/pages/tests/unit/save-state.spec.ts
+++ b/apps/pages/tests/unit/save-state.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the page editor's save/conflict decision helpers (saveState.ts).
+ *
+ * These run in the Playwright runner WITHOUT a browser or the dev stack — the
+ * module under test is pure (no React, no network). It carries the load-bearing
+ * logic of the review findings' client fixes so they're verifiable in isolation:
+ *  - P1: the diff-at-save (ops) path is trustworthy ONLY when the baseline is
+ *        bound to the sha the conflict token names (a cover-write desync must
+ *        force the whole-document save).
+ *  - P4: a conflict report/chooser is derived ONLY when the fetcher data is
+ *        stamped for the current page (no ghosting across in-route navigation).
+ *  - P9: a code-bearing refusal being auto-recovered by the fallback must not
+ *        flash 'error'.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  opsPathEligible,
+  fetcherMatchesPage,
+  deriveSaveMergeReport,
+  deriveSaveConflict,
+  isCodeFallbackRefusal,
+  type SaveBaseline,
+  type SaveFetcherData,
+} from '../../app/routes/$classroomSlug.$pageId/saveState.ts';
+
+const baseline = (sha: string | null, content = '[]'): SaveBaseline => ({ sha, content });
+
+// ─── P1: ops-path pairing guard ──────────────────────────────────────────────
+
+test.describe('opsPathEligible (P1 pairing guard)', () => {
+  test('eligible when the baseline sha matches the conflict token', () => {
+    expect(opsPathEligible(baseline('sha-A'), 'sha-A')).toBe(true);
+  });
+
+  test('NOT eligible when the token advanced past the baseline (cover-write desync)', () => {
+    // Baseline is the loaded document (sha-A); a cover write advanced the token
+    // to sha-B without re-basing this document — the ops must NOT replay onto
+    // sha-B, so the whole-document save is taken instead.
+    expect(opsPathEligible(baseline('sha-A'), 'sha-B')).toBe(false);
+  });
+
+  test('NOT eligible without a token (fresh / legacy page → whole-doc create)', () => {
+    expect(opsPathEligible(baseline('sha-A'), null)).toBe(false);
+    expect(opsPathEligible(baseline(null), null)).toBe(false);
+  });
+
+  test('NOT eligible before the editor onReady captures a baseline', () => {
+    expect(opsPathEligible(null, 'sha-A')).toBe(false);
+  });
+});
+
+// ─── P4: per-page stamping ────────────────────────────────────────────────────
+
+test.describe('fetcher-to-page stamping (P4)', () => {
+  test('matches only the page the exchange was stamped for', () => {
+    expect(fetcherMatchesPage('page-A', 'page-A')).toBe(true);
+    expect(fetcherMatchesPage('page-A', 'page-B')).toBe(false);
+  });
+
+  const conflictData: SaveFetcherData = {
+    conflict: true,
+    units: [{ id: 'a1', index: 0 }],
+    autoMerged: 2,
+    oursSha: 'sha-A-1',
+  };
+
+  test('a conflict report renders on the page it was stamped for', () => {
+    const report = deriveSaveMergeReport(conflictData, /* matchesPage */ true);
+    expect(report).toEqual({ units: [{ id: 'a1', index: 0 }], autoMerged: 2, oursSha: 'sha-A-1' });
+  });
+
+  test('the SAME report does NOT render after navigating to another page (no ghost)', () => {
+    expect(deriveSaveMergeReport(conflictData, /* matchesPage */ false)).toBeNull();
+  });
+
+  test('the plain reload banner is also gated to the stamped page', () => {
+    const legacyConflict: SaveFetcherData = { conflict: true };
+    // On the stamped page: banner shows (no mergeable report).
+    expect(deriveSaveConflict(legacyConflict, true, null)).toBe(true);
+    // After navigation: neither chooser nor banner ghosts onto the next page.
+    expect(deriveSaveConflict(legacyConflict, false, null)).toBe(false);
+  });
+
+  test('a mergeable report suppresses the plain reload banner', () => {
+    const report = deriveSaveMergeReport(conflictData, true);
+    expect(deriveSaveConflict(conflictData, true, report)).toBe(false);
+  });
+});
+
+// ─── P9: code-bearing refusal during auto-fallback ────────────────────────────
+
+test.describe('isCodeFallbackRefusal (P9)', () => {
+  test('true for a code-bearing refusal that is NOT a conflict (fallback in flight)', () => {
+    expect(isCodeFallbackRefusal({ error: 'x', code: 'OPS_BASE_MISMATCH' })).toBe(true);
+    expect(isCodeFallbackRefusal({ error: 'x', code: 'OPS_MALFORMED' })).toBe(true);
+  });
+
+  test('false for a mergeable conflict (the chooser handles it, not the fallback)', () => {
+    expect(isCodeFallbackRefusal({ conflict: true, code: 'OPS_BASE_MISMATCH' })).toBe(false);
+  });
+
+  test('false for a plain error and for success', () => {
+    expect(isCodeFallbackRefusal({ error: 'boom' })).toBe(false);
+    expect(isCodeFallbackRefusal({ success: true, sha: 'sha-1' })).toBe(false);
+    expect(isCodeFallbackRefusal(undefined)).toBe(false);
+  });
+});

--- a/apps/slides/app/components/RevealSlides.tsx
+++ b/apps/slides/app/components/RevealSlides.tsx
@@ -338,6 +338,19 @@ const RevealSlides = forwardRef(function RevealSlides(
     if (!isClient || !htmlContent || !deckRef.current) return;
 
     let mounted = true;
+    let resizeObserver: ResizeObserver | null = null;
+    let layoutRaf = 0;
+
+    // rAF-debounced re-layout: collapse a burst of geometry changes to a
+    // single deck.layout() per frame. Guarded by revealRef.current, which the
+    // cleanup nulls on destroy, so a queued frame after teardown is a no-op.
+    const scheduleLayout = () => {
+      if (layoutRaf) return;
+      layoutRaf = requestAnimationFrame(() => {
+        layoutRaf = 0;
+        revealRef.current?.layout();
+      });
+    };
 
     const initReveal = async () => {
       // Dynamically import Reveal.js and highlight plugin (client-side only)
@@ -391,6 +404,21 @@ const RevealSlides = forwardRef(function RevealSlides(
       }
 
       revealRef.current = deck;
+
+      // Reactive centering (the structural cure for intermittent off-center
+      // slides after save): observe the .reveal container and re-layout on any
+      // size change. Reveal's center:true positions each slide against the
+      // container height measured at layout() time; when geometry shifts AFTER
+      // that measurement — the saving scrim/strip unmounting, the edit↔view
+      // chrome swap reclaiming the sidebar, a window/panel resize, or future
+      // chrome — the old centering is stale and content renders pushed down.
+      // Re-laying out on the actual resize makes centering track real geometry
+      // instead of hoping React effects settle first. Debounced to one call
+      // per frame; disconnected on unmount.
+      if (typeof ResizeObserver !== 'undefined' && deckRef.current) {
+        resizeObserver = new ResizeObserver(() => scheduleLayout());
+        resizeObserver.observe(deckRef.current);
+      }
 
       // If editing, make slides contenteditable and attach input handlers
       if (isEditing) {
@@ -447,12 +475,37 @@ const RevealSlides = forwardRef(function RevealSlides(
 
         deckRef.current.addEventListener('keydown', handleKeyDown);
       }
+
+      // Settled recalc after content adoption: deck.initialize() ran its first
+      // centering layout while the container may still be mid-transition (the
+      // post-save batch that swaps in the committed content ALSO exits edit
+      // mode, so the scrim/strip unmount and the edit→view chrome swap happen
+      // in the same frame). Re-center once the DOM has settled — a double rAF
+      // (one frame to commit, one to measure) — and again after fonts load,
+      // since font metrics change text height and therefore the center math.
+      // `revealRef.current === deck` guards against this deck being destroyed
+      // or replaced by a remount between scheduling and firing.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (revealRef.current === deck) deck.layout();
+        });
+      });
+      if (typeof document !== 'undefined' && document.fonts?.ready) {
+        document.fonts.ready.then(() => {
+          if (revealRef.current === deck) deck.layout();
+        });
+      }
     };
 
     initReveal();
 
     return () => {
       mounted = false;
+      if (layoutRaf) cancelAnimationFrame(layoutRaf);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
       if (revealRef.current) {
         revealRef.current.destroy();
         revealRef.current = null;

--- a/apps/slides/app/components/RevealSlides.tsx
+++ b/apps/slides/app/components/RevealSlides.tsx
@@ -541,6 +541,12 @@ const RevealSlides = forwardRef(function RevealSlides(
       el.classList.remove('present', 'past', 'future');
     });
 
+    // Reveal paints `visible` / `current-fragment` on fragments as the presenter
+    // steps through them — runtime paint that must never persist (keep `fragment`).
+    slidesClone.querySelectorAll('.fragment').forEach((el: Element) => {
+      el.classList.remove('visible', 'current-fragment');
+    });
+
     // Build data attributes for theme settings (single theme)
     const revealDiv = deckRef.current;
     const dataAttrs = [];

--- a/apps/slides/app/components/preview/PreviewControls.tsx
+++ b/apps/slides/app/components/preview/PreviewControls.tsx
@@ -61,6 +61,8 @@ interface PreviewActionData {
   units?: ConflictUnit[];
   orderConflict?: OrderConflict | null;
   autoMerged?: number;
+  oursSha?: string | null;
+  theirsSha?: string | null;
   error?: string;
   code?: string;
   ids?: string[];
@@ -77,10 +79,17 @@ function usePreviewActions() {
   };
 
   // Chooser submit: same intent, plus one {id, choose} per listed conflict.
+  // The report's shas ride along so the server can refuse (CONTENT_CONFLICT)
+  // if the deck moved after the reviewed report (F3 pinning).
   const applyResolutions = (resolutions: MergeResolution[]) => {
     setPending('accept');
     fetcher.submit(
-      { intent: 'preview-accept', resolutions: JSON.stringify(resolutions) },
+      {
+        intent: 'preview-accept',
+        resolutions: JSON.stringify(resolutions),
+        ...(fetcher.data?.oursSha ? { ours_sha: fetcher.data.oursSha } : {}),
+        ...(fetcher.data?.theirsSha ? { theirs_sha: fetcher.data.theirsSha } : {}),
+      },
       { method: 'POST' }
     );
   };
@@ -96,6 +105,7 @@ function usePreviewActions() {
   const conflictUnits = fetcher.data?.conflict ? (fetcher.data.units ?? []) : null;
   const orderConflict = fetcher.data?.conflict ? (fetcher.data.orderConflict ?? null) : null;
   const autoMerged = fetcher.data?.conflict ? (fetcher.data.autoMerged ?? 0) : 0;
+  const conflictOursSha = fetcher.data?.conflict ? (fetcher.data.oursSha ?? null) : null;
   const error = fetcher.data?.error ?? null;
 
   return {
@@ -107,6 +117,7 @@ function usePreviewActions() {
     conflictUnits,
     orderConflict,
     autoMerged,
+    conflictOursSha,
     error,
   };
 }
@@ -313,6 +324,7 @@ const ConflictPanel = ({
   units,
   orderConflict,
   autoMerged,
+  oursSha,
   busy,
   onApply,
   onDiscard,
@@ -320,6 +332,7 @@ const ConflictPanel = ({
   units: ConflictUnit[];
   orderConflict: OrderConflict | null;
   autoMerged: number;
+  oursSha: string | null;
   busy: boolean;
   onApply: (resolutions: MergeResolution[]) => void;
   onDiscard: () => void;
@@ -341,7 +354,10 @@ const ConflictPanel = ({
       ]
     : units;
   const ids = allUnits.map(unit => unit.id);
-  const signature = ids.join('|');
+  // Keyed on the report's ours_sha too: a re-accept after main moved can
+  // yield the SAME conflict ids over different content — stale choices must
+  // not survive into the new report (F3).
+  const signature = `${oursSha ?? ''}::${ids.join('|')}`;
   const [choices, setChoices] = useState<Record<string, MergeChoice>>({});
   // Drop stale choices when the conflict set changes (a re-accept can shrink it).
   useEffect(() => setChoices({}), [signature]);
@@ -420,6 +436,7 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
     conflictUnits,
     orderConflict,
     autoMerged,
+    conflictOursSha,
     error,
   } = usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
@@ -477,6 +494,7 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
           units={conflictUnits}
           orderConflict={orderConflict}
           autoMerged={autoMerged}
+          oursSha={conflictOursSha}
           busy={busy}
           onApply={applyResolutions}
           onDiscard={discard}
@@ -499,6 +517,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
     conflictUnits,
     orderConflict,
     autoMerged,
+    conflictOursSha,
     error,
   } = usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
@@ -549,6 +568,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
           units={conflictUnits}
           orderConflict={orderConflict}
           autoMerged={autoMerged}
+          oursSha={conflictOursSha}
           busy={busy}
           onApply={applyResolutions}
           onDiscard={discard}

--- a/apps/slides/app/components/preview/PreviewControls.tsx
+++ b/apps/slides/app/components/preview/PreviewControls.tsx
@@ -11,6 +11,7 @@ import {
   buildSlideSrcdoc,
   chooserCopy,
   chooserSubtitle,
+  filmstripEntries,
   isChildOrderId,
   metaFieldRows,
   orderDiffIds,
@@ -20,10 +21,10 @@ import {
   type ChooserCopy,
   type ChooserVariant,
   type ConflictUnit,
+  type FilmstripEntry,
   type MergeChoice,
   type MergeResolution,
   type SlideSide,
-  type UnitPreview,
   type UnitPreviews,
 } from './conflictChooser.ts';
 
@@ -266,79 +267,103 @@ const OrderList = ({ ids }: { ids: string[] }) => (
   </ol>
 );
 
+/** Filmstrip layout: a horizontal row (top-level slide order) or a vertical
+ * column (a stack's child order — mirroring how a vertical stack actually lays
+ * its children out top-to-bottom). */
+type FilmstripOrientation = 'horizontal' | 'vertical';
+
 /**
- * One slide thumbnail in an order filmstrip: a bounded sandboxed SlideFrame
+ * One slide thumbnail in an order filmstrip: a bounded sandboxed slide render
  * (same srcdoc renderer as a conflict card, echoing the 2D SlideOverview visual
- * language) with a position badge + title caption. `moved` slides (a different
- * position in the two orderings) get an amber ring so the reordering reads at a
- * glance. Missing preview (server capped >50KB) falls back to the title/id.
+ * language) with a position badge + title caption. `entry.moved` slides (a
+ * different position in the two orderings) get an amber ring so the reordering
+ * reads at a glance. Missing html (server capped >50KB, or no preview) falls
+ * back to the title/id. Vertical thumbnails span the column width so a stack's
+ * child sequence reads as an actual top-to-bottom stack.
  */
 const FilmstripSlide = ({
-  id,
-  preview,
-  position,
-  moved,
+  entry,
+  orientation,
 }: {
-  id: string;
-  preview: UnitPreview | undefined;
-  position: number;
-  moved: boolean;
-}) => (
-  <div
-    data-testid={`filmstrip-slide-${id}`}
-    data-moved={moved ? 'true' : undefined}
-    className={`w-28 shrink-0 overflow-hidden rounded border bg-white dark:bg-neutral-900 ${
-      moved
-        ? 'border-amber-400 dark:border-amber-500 ring-1 ring-amber-400 dark:ring-amber-500'
-        : 'border-stone-200 dark:border-neutral-700'
-    }`}
-  >
-    <div className="relative">
-      {preview?.html ? (
-        <iframe
-          sandbox=""
-          srcDoc={buildSlideSrcdoc(preview.html)}
-          title={`Slide ${position}`}
-          loading="lazy"
-          className="h-20 w-full pointer-events-none bg-white"
-        />
-      ) : (
-        <div className="flex h-20 w-full items-center justify-center bg-stone-50 dark:bg-neutral-800 px-1 text-center text-[11px] italic text-gray-400 dark:text-gray-500">
-          {preview?.title || id}
-        </div>
-      )}
-      <span className="absolute bottom-0.5 left-0.5 rounded-sm bg-black/60 px-1 py-px text-[10px] font-medium tabular-nums text-white">
-        {position}
-      </span>
+  entry: FilmstripEntry;
+  orientation: FilmstripOrientation;
+}) => {
+  const vertical = orientation === 'vertical';
+  return (
+    <div
+      data-testid={`filmstrip-slide-${entry.id}`}
+      data-moved={entry.moved ? 'true' : undefined}
+      className={`overflow-hidden rounded border bg-white dark:bg-neutral-900 ${
+        vertical ? 'w-full' : 'w-28 shrink-0'
+      } ${
+        entry.moved
+          ? 'border-amber-400 dark:border-amber-500 ring-1 ring-amber-400 dark:ring-amber-500'
+          : 'border-stone-200 dark:border-neutral-700'
+      }`}
+    >
+      <div className="relative">
+        {entry.html ? (
+          <iframe
+            sandbox=""
+            srcDoc={buildSlideSrcdoc(entry.html)}
+            title={`Slide ${entry.position}`}
+            loading="lazy"
+            className="h-20 w-full pointer-events-none bg-white"
+          />
+        ) : (
+          <div className="flex h-20 w-full items-center justify-center bg-stone-50 dark:bg-neutral-800 px-1 text-center text-[11px] italic text-gray-400 dark:text-gray-500">
+            {entry.title || entry.id}
+          </div>
+        )}
+        <span className="absolute bottom-0.5 left-0.5 rounded-sm bg-black/60 px-1 py-px text-[10px] font-medium tabular-nums text-white">
+          {entry.position}
+        </span>
+      </div>
+      <div className="truncate border-t border-stone-200 dark:border-neutral-700 px-1.5 py-1 text-[11px] leading-tight text-gray-600 dark:text-gray-300">
+        {entry.title || <span className="font-mono">{entry.id}</span>}
+      </div>
     </div>
-    <div className="truncate border-t border-stone-200 dark:border-neutral-700 px-1.5 py-1 text-[11px] leading-tight text-gray-600 dark:text-gray-300">
-      {preview?.title || <span className="font-mono">{id}</span>}
-    </div>
-  </div>
-);
+  );
+};
 
-/** A horizontally-scrollable ordering rendered as a row of slide thumbnails. */
+/**
+ * An ordering rendered as a strip of slide thumbnails. Horizontal (a scrollable
+ * row) for the top-level slide order; vertical (a scrollable, height-capped
+ * column) for a stack's child order, so a VERTICAL stack's child sequence is
+ * shown the way it actually lays out. Both directions resolve each thumbnail's
+ * html through the same `filmstripEntries` helper — the top-level and
+ * child-order cards can never diverge in how they read `unit_previews`.
+ */
 const Filmstrip = ({
   ids,
   previews,
   moved,
+  orientation,
 }: {
   ids: string[];
   previews: UnitPreviews;
   moved: Set<string>;
-}) => (
-  <div className="flex gap-2 overflow-x-auto pb-1">
-    {ids.map((id, position) => (
-      <FilmstripSlide
-        key={`${id}-${position}`}
-        id={id}
-        preview={previews[id]}
-        position={position + 1}
-        moved={moved.has(id)}
-      />
-    ))}
-  </div>
-);
+  orientation: FilmstripOrientation;
+}) => {
+  const entries = filmstripEntries(ids, previews, moved);
+  return (
+    <div
+      className={
+        orientation === 'vertical'
+          ? 'flex flex-col gap-1.5 max-h-72 overflow-y-auto pr-1'
+          : 'flex gap-2 overflow-x-auto pb-1'
+      }
+    >
+      {entries.map(entry => (
+        <FilmstripSlide
+          key={`${entry.id}-${entry.position}`}
+          entry={entry}
+          orientation={orientation}
+        />
+      ))}
+    </div>
+  );
+};
 
 const EMPTY_MOVED: Set<string> = new Set();
 
@@ -383,8 +408,12 @@ const ConflictCard = ({
   onChoose: (id: string, choice: MergeChoice) => void;
   unitPreviews?: UnitPreviews | null;
 }) => {
-  const isOrder = unit.id === ORDER_CONFLICT_ID || isChildOrderId(unit.id);
+  const isChildOrder = isChildOrderId(unit.id);
+  const isOrder = unit.id === ORDER_CONFLICT_ID || isChildOrder;
   const isMeta = unit.id === META_CONFLICT_ID;
+  // A stack's children lay out vertically, so its reorder reads as a column;
+  // the top-level slide order stays a horizontal row.
+  const orientation: FilmstripOrientation = isChildOrder ? 'vertical' : 'horizontal';
   const title =
     unit.id === ORDER_CONFLICT_ID
       ? 'Slide order'
@@ -419,7 +448,14 @@ const ConflictCard = ({
     if (isOrder) {
       const ids = Array.isArray(value) ? (value as string[]) : [];
       if (hasPreviews) {
-        return <Filmstrip ids={ids} previews={unitPreviews as UnitPreviews} moved={movedIds} />;
+        return (
+          <Filmstrip
+            ids={ids}
+            previews={unitPreviews as UnitPreviews}
+            moved={movedIds}
+            orientation={orientation}
+          />
+        );
       }
       return <OrderList ids={ids} />;
     }
@@ -440,7 +476,9 @@ const ConflictCard = ({
       </div>
       <div
         className={`mt-2 grid gap-2 ${
-          isOrder && hasPreviews ? 'grid-cols-1' : 'grid-cols-1 sm:grid-cols-2'
+          isOrder && hasPreviews && orientation === 'horizontal'
+            ? 'grid-cols-1'
+            : 'grid-cols-1 sm:grid-cols-2'
         }`}
       >
         {(['ours', 'theirs'] as const).map(side => (

--- a/apps/slides/app/components/preview/PreviewControls.tsx
+++ b/apps/slides/app/components/preview/PreviewControls.tsx
@@ -9,10 +9,15 @@ import {
   allResolved,
   buildResolutions,
   buildSlideSrcdoc,
+  chooserCopy,
+  chooserSubtitle,
   isChildOrderId,
   metaFieldRows,
   reasonLabel,
+  sideNotesDiffer,
   slideSideHtml,
+  type ChooserCopy,
+  type ChooserVariant,
   type ConflictUnit,
   type MergeChoice,
   type MergeResolution,
@@ -70,7 +75,7 @@ interface PreviewActionData {
 
 function usePreviewActions() {
   const fetcher = useFetcher<PreviewActionData>();
-  const [pending, setPending] = useState<'accept' | 'discard' | null>(null);
+  const [pending, setPending] = useState<'accept' | 'resolve' | 'discard' | null>(null);
   const busy = fetcher.state !== 'idle';
 
   const accept = () => {
@@ -82,7 +87,7 @@ function usePreviewActions() {
   // The report's shas ride along so the server can refuse (CONTENT_CONFLICT)
   // if the deck moved after the reviewed report (F3 pinning).
   const applyResolutions = (resolutions: MergeResolution[]) => {
-    setPending('accept');
+    setPending('resolve');
     fetcher.submit(
       {
         intent: 'preview-accept',
@@ -122,27 +127,20 @@ function usePreviewActions() {
   };
 }
 
-// ─── Conflict chooser (Phase 7) ──────────────────────────────────────────────
-
-const SIDE_TITLE: Record<MergeChoice, string> = {
-  ours: 'Live version (yours)',
-  theirs: "Preview version (agent's)",
-};
-const SIDE_ACTION: Record<MergeChoice, string> = {
-  ours: 'Keep live',
-  theirs: 'Take preview',
-};
+// ─── Conflict chooser (Phase 7; save variant 7.5) ────────────────────────────
 
 /** One selectable side of a conflict card (radio + bounded preview). */
 const ChoiceSide = ({
   unitId,
   side,
+  copy,
   selected,
   onChoose,
   children,
 }: {
   unitId: string;
   side: MergeChoice;
+  copy: ChooserCopy;
   selected: boolean;
   onChoose: (side: MergeChoice) => void;
   children: ReactNode;
@@ -163,13 +161,32 @@ const ChoiceSide = ({
         onChange={() => onChoose(side)}
         className="accent-amber-600"
       />
-      {SIDE_TITLE[side]}
+      {copy.sideTitle[side]}
       <span className="ml-auto text-[11px] font-normal text-gray-500 dark:text-gray-400">
-        {SIDE_ACTION[side]}
+        {copy.sideAction[side]}
       </span>
     </span>
     {children}
   </label>
+);
+
+/**
+ * Prominent in-flight indicator for merge submissions: the accept/resolve
+ * round-trips take several seconds of GitHub calls, and a button-label change
+ * alone is easy to miss.
+ */
+export const MergeProgress = ({ label }: { label: string }) => (
+  <div
+    data-testid="merge-progress"
+    className="flex items-center gap-2.5 border-b border-amber-300 dark:border-amber-700/70 bg-amber-100/95 dark:bg-amber-900/90 px-4 sm:px-6 lg:px-8 py-2.5 text-sm font-medium text-amber-900 dark:text-amber-100"
+    role="status"
+  >
+    <span
+      className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-amber-600 dark:border-amber-300 border-t-transparent"
+      aria-hidden
+    />
+    {label}
+  </div>
 );
 
 /** Placeholder for a side where the slide was deleted. */
@@ -183,8 +200,12 @@ const Tombstone = ({ label }: { label: string }) => (
  * Bounded render of one slide side. The deck's html is already trusted by the
  * real viewer; here it renders scaled-down inside a fully sandboxed iframe
  * (empty sandbox allowlist = no scripts, no same-origin access).
+ *
+ * The notes strip only renders when `showNotes` — identical notes on both
+ * sides carry no decision signal, so the card hides them (and emphasizes the
+ * strip when the sides genuinely differ).
  */
-const SlideFrame = ({ side }: { side: SlideSide }) => {
+const SlideFrame = ({ side, showNotes }: { side: SlideSide; showNotes: boolean }) => {
   const html = slideSideHtml(side);
   return (
     <div className="rounded border border-stone-200 dark:border-neutral-700 bg-white overflow-hidden">
@@ -195,9 +216,12 @@ const SlideFrame = ({ side }: { side: SlideSide }) => {
         loading="lazy"
         className="h-36 w-full pointer-events-none"
       />
-      {side.notes ? (
+      {showNotes ? (
         <div className="border-t border-stone-200 dark:border-neutral-700 bg-stone-50 dark:bg-neutral-800 px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400 truncate">
-          Notes: {side.notes}
+          <span className="mr-1 rounded bg-amber-100 dark:bg-amber-900/60 px-1 py-px text-[10px] font-medium text-amber-800 dark:text-amber-200">
+            Notes differ
+          </span>
+          {side.notes || <span className="italic">no notes on this side</span>}
         </div>
       ) : null}
     </div>
@@ -245,13 +269,15 @@ const cardShell =
 const cardBadge =
   'rounded-full bg-rose-100 dark:bg-rose-900/60 px-2 py-0.5 text-[11px] text-rose-800 dark:text-rose-200';
 
-/** One conflict card: side-by-side live vs preview with a choice per side. */
+/** One conflict card: side-by-side ours vs theirs with a choice per side. */
 const ConflictCard = ({
   unit,
+  copy,
   choice,
   onChoose,
 }: {
   unit: ConflictUnit;
+  copy: ChooserCopy;
   choice: MergeChoice | undefined;
   onChoose: (id: string, choice: MergeChoice) => void;
 }) => {
@@ -271,6 +297,12 @@ const ConflictCard = ({
         unit.theirs as Record<string, unknown> | undefined
       )
     : [];
+  // Identical notes on both sides are noise — only show the strip when the
+  // notes are part of what differs.
+  const notesDiffer =
+    !isOrder &&
+    !isMeta &&
+    sideNotesDiffer(unit.ours as SlideSide | null, unit.theirs as SlideSide | null);
 
   const renderSide = (side: MergeChoice) => {
     const value = side === 'ours' ? unit.ours : unit.theirs;
@@ -281,13 +313,9 @@ const ConflictCard = ({
       return <MetaFieldList rows={metaRows} side={side} />;
     }
     if (value === undefined || value === null) {
-      return (
-        <Tombstone
-          label={side === 'ours' ? 'Deleted in the live version' : 'Deleted in the preview'}
-        />
-      );
+      return <Tombstone label={copy.tombstone[side]} />;
     }
-    return <SlideFrame side={value as SlideSide} />;
+    return <SlideFrame side={value as SlideSide} showNotes={notesDiffer} />;
   };
 
   return (
@@ -302,6 +330,7 @@ const ConflictCard = ({
             key={side}
             unitId={unit.id}
             side={side}
+            copy={copy}
             selected={choice === side}
             onChoose={chosen => onChoose(unit.id, chosen)}
           >
@@ -316,11 +345,17 @@ const ConflictCard = ({
 /**
  * Conflict chooser panel (Phase 7): a side-by-side card per conflicted slide
  * (plus stack-order / slide-order / deck-settings cards), an Apply footer that
- * submits a resolution for EVERY listed conflict, and a Discard escape.
- * Auto-merged counts from the accept report are surfaced so staff know only
- * the true collisions are listed.
+ * submits a resolution for EVERY listed conflict, and an escape hatch.
+ * Auto-merged counts from the report are surfaced so staff know only the true
+ * collisions are listed.
+ *
+ * Two variants share the machinery (7.5): `preview` (accept flow — ours = the
+ * live deck, theirs = the agent's preview; escape = discard the preview) and
+ * `save` (a stale editor save — ours = what's saved on the server, theirs =
+ * the editor's unsaved version; escape = reload latest). `onDiscard` is the
+ * variant's escape action.
  */
-const ConflictPanel = ({
+export const ConflictPanel = ({
   units,
   orderConflict,
   autoMerged,
@@ -328,6 +363,7 @@ const ConflictPanel = ({
   busy,
   onApply,
   onDiscard,
+  variant = 'preview',
 }: {
   units: ConflictUnit[];
   orderConflict: OrderConflict | null;
@@ -336,6 +372,7 @@ const ConflictPanel = ({
   busy: boolean;
   onApply: (resolutions: MergeResolution[]) => void;
   onDiscard: () => void;
+  variant?: ChooserVariant;
 }) => {
   // The top-level order conflict arrives separately in the accept payload;
   // fold it into the card list under its sentinel id so one chooser covers
@@ -365,27 +402,35 @@ const ConflictPanel = ({
   const choose = (id: string, choice: MergeChoice) =>
     setChoices(prev => ({ ...prev, [id]: choice }));
   const ready = allResolved(ids, choices);
+  const copy = chooserCopy(variant);
 
   return (
     <div
       data-testid="preview-conflict-panel"
       className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/95 px-4 sm:px-6 lg:px-8 py-3 max-h-[calc(100vh-8rem)] overflow-y-auto"
     >
-      <div className="text-sm font-medium text-rose-900 dark:text-rose-100">
-        Changes conflict with edits made on the live deck
-      </div>
+      {busy && (
+        <div className="-mx-4 sm:-mx-6 lg:-mx-8 -mt-3 mb-3">
+          <MergeProgress label={copy.busyLabel} />
+        </div>
+      )}
+      <div className="text-sm font-medium text-rose-900 dark:text-rose-100">{copy.heading}</div>
       <div
         data-testid="conflict-auto-merged"
         className="mt-0.5 text-sm text-rose-800 dark:text-rose-200"
       >
-        {autoMerged > 0
-          ? `${autoMerged} change${autoMerged === 1 ? '' : 's'} merged automatically; these need you:`
-          : 'Choose which version to keep for each conflict:'}
+        {chooserSubtitle(variant, autoMerged)}
       </div>
 
       <div className="mt-3 space-y-3">
         {allUnits.map(unit => (
-          <ConflictCard key={unit.id} unit={unit} choice={choices[unit.id]} onChoose={choose} />
+          <ConflictCard
+            key={unit.id}
+            unit={unit}
+            copy={copy}
+            choice={choices[unit.id]}
+            onChoose={choose}
+          />
         ))}
       </div>
 
@@ -406,13 +451,13 @@ const ConflictPanel = ({
           onClick={onDiscard}
           className={`${actionButtonBase} text-rose-800 dark:text-rose-200 ring-1 ring-rose-300 dark:ring-rose-700 hover:bg-rose-100 dark:hover:bg-rose-900/40`}
         >
-          Discard preview
+          {copy.secondaryAction}
         </button>
         <span className="text-xs text-rose-700 dark:text-rose-300">
           {ready
             ? 'Applies your choice for every conflict and publishes the merge.'
             : 'Pick a version for every conflict to enable Apply.'}{' '}
-          Or re-apply from the current version (via your agent).
+          {copy.footerNote}
         </span>
       </div>
     </div>
@@ -489,6 +534,9 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
         </div>
         {error && <div className="mt-2 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
+      {busy && pending === 'accept' && (
+        <MergeProgress label="Merging preview into the live deck — this can take a few seconds…" />
+      )}
       {conflictUnits && (
         <ConflictPanel
           units={conflictUnits}
@@ -563,6 +611,9 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
         </div>
         {error && <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
+      {busy && pending === 'accept' && (
+        <MergeProgress label="Merging preview into the live deck — this can take a few seconds…" />
+      )}
       {conflictUnits && (
         <ConflictPanel
           units={conflictUnits}

--- a/apps/slides/app/components/preview/PreviewControls.tsx
+++ b/apps/slides/app/components/preview/PreviewControls.tsx
@@ -13,6 +13,7 @@ import {
   chooserSubtitle,
   isChildOrderId,
   metaFieldRows,
+  orderDiffIds,
   reasonLabel,
   sideNotesDiffer,
   slideSideHtml,
@@ -22,6 +23,8 @@ import {
   type MergeChoice,
   type MergeResolution,
   type SlideSide,
+  type UnitPreview,
+  type UnitPreviews,
 } from './conflictChooser.ts';
 
 dayjs.extend(relativeTime);
@@ -65,6 +68,7 @@ interface PreviewActionData {
   conflict?: boolean;
   units?: ConflictUnit[];
   orderConflict?: OrderConflict | null;
+  unitPreviews?: UnitPreviews | null;
   autoMerged?: number;
   oursSha?: string | null;
   theirsSha?: string | null;
@@ -109,6 +113,7 @@ function usePreviewActions() {
 
   const conflictUnits = fetcher.data?.conflict ? (fetcher.data.units ?? []) : null;
   const orderConflict = fetcher.data?.conflict ? (fetcher.data.orderConflict ?? null) : null;
+  const unitPreviews = fetcher.data?.conflict ? (fetcher.data.unitPreviews ?? null) : null;
   const autoMerged = fetcher.data?.conflict ? (fetcher.data.autoMerged ?? 0) : 0;
   const conflictOursSha = fetcher.data?.conflict ? (fetcher.data.oursSha ?? null) : null;
   const error = fetcher.data?.error ?? null;
@@ -121,6 +126,7 @@ function usePreviewActions() {
     discard,
     conflictUnits,
     orderConflict,
+    unitPreviews,
     autoMerged,
     conflictOursSha,
     error,
@@ -189,6 +195,23 @@ export const MergeProgress = ({ label }: { label: string }) => (
   </div>
 );
 
+/**
+ * The accept round-trip's in-flight strip, pinned to the app's TOP chrome layer
+ * (`fixed top-14 z-[1100]`, matching the editor 'Saving…' strip) — the preview
+ * bar/banner it is triggered from sit at z-40, and an accept has no conflict
+ * panel yet to host the indicator, so nesting the strip there left it easy to
+ * miss / paint under the reveal viewport. As its own fixed overlay it is always
+ * visible from click→response, above every other slide-view fixed element.
+ */
+const SlideMergeProgressOverlay = ({ label }: { label: string }) => (
+  <div
+    data-testid="merge-progress-overlay"
+    className="fixed top-14 left-0 right-0 z-[1100] shadow-lg"
+  >
+    <MergeProgress label={label} />
+  </div>
+);
+
 /** Placeholder for a side where the slide was deleted. */
 const Tombstone = ({ label }: { label: string }) => (
   <div className="flex h-full min-h-24 items-center justify-center rounded border border-dashed border-gray-300 dark:border-neutral-600 bg-gray-50 dark:bg-neutral-800/60 px-3 py-4 text-xs italic text-gray-500 dark:text-gray-400">
@@ -228,7 +251,8 @@ const SlideFrame = ({ side, showNotes }: { side: SlideSide; showNotes: boolean }
   );
 };
 
-/** Numbered id list for an ordering conflict side. */
+/** Numbered id list for an ordering conflict side (fallback when previews are
+ * missing — e.g. the save-merge chooser, which carries no `unit_previews`). */
 const OrderList = ({ ids }: { ids: string[] }) => (
   <ol className="space-y-0.5 text-xs text-gray-700 dark:text-gray-300 max-h-36 overflow-y-auto">
     {ids.map((id, position) => (
@@ -241,6 +265,82 @@ const OrderList = ({ ids }: { ids: string[] }) => (
     ))}
   </ol>
 );
+
+/**
+ * One slide thumbnail in an order filmstrip: a bounded sandboxed SlideFrame
+ * (same srcdoc renderer as a conflict card, echoing the 2D SlideOverview visual
+ * language) with a position badge + title caption. `moved` slides (a different
+ * position in the two orderings) get an amber ring so the reordering reads at a
+ * glance. Missing preview (server capped >50KB) falls back to the title/id.
+ */
+const FilmstripSlide = ({
+  id,
+  preview,
+  position,
+  moved,
+}: {
+  id: string;
+  preview: UnitPreview | undefined;
+  position: number;
+  moved: boolean;
+}) => (
+  <div
+    data-testid={`filmstrip-slide-${id}`}
+    data-moved={moved ? 'true' : undefined}
+    className={`w-28 shrink-0 overflow-hidden rounded border bg-white dark:bg-neutral-900 ${
+      moved
+        ? 'border-amber-400 dark:border-amber-500 ring-1 ring-amber-400 dark:ring-amber-500'
+        : 'border-stone-200 dark:border-neutral-700'
+    }`}
+  >
+    <div className="relative">
+      {preview?.html ? (
+        <iframe
+          sandbox=""
+          srcDoc={buildSlideSrcdoc(preview.html)}
+          title={`Slide ${position}`}
+          loading="lazy"
+          className="h-20 w-full pointer-events-none bg-white"
+        />
+      ) : (
+        <div className="flex h-20 w-full items-center justify-center bg-stone-50 dark:bg-neutral-800 px-1 text-center text-[11px] italic text-gray-400 dark:text-gray-500">
+          {preview?.title || id}
+        </div>
+      )}
+      <span className="absolute bottom-0.5 left-0.5 rounded-sm bg-black/60 px-1 py-px text-[10px] font-medium tabular-nums text-white">
+        {position}
+      </span>
+    </div>
+    <div className="truncate border-t border-stone-200 dark:border-neutral-700 px-1.5 py-1 text-[11px] leading-tight text-gray-600 dark:text-gray-300">
+      {preview?.title || <span className="font-mono">{id}</span>}
+    </div>
+  </div>
+);
+
+/** A horizontally-scrollable ordering rendered as a row of slide thumbnails. */
+const Filmstrip = ({
+  ids,
+  previews,
+  moved,
+}: {
+  ids: string[];
+  previews: UnitPreviews;
+  moved: Set<string>;
+}) => (
+  <div className="flex gap-2 overflow-x-auto pb-1">
+    {ids.map((id, position) => (
+      <FilmstripSlide
+        key={`${id}-${position}`}
+        id={id}
+        preview={previews[id]}
+        position={position + 1}
+        moved={moved.has(id)}
+      />
+    ))}
+  </div>
+);
+
+const EMPTY_MOVED: Set<string> = new Set();
 
 /** Field diff list for one side of the `__meta__` deck-settings conflict. */
 const MetaFieldList = ({
@@ -275,11 +375,13 @@ const ConflictCard = ({
   copy,
   choice,
   onChoose,
+  unitPreviews,
 }: {
   unit: ConflictUnit;
   copy: ChooserCopy;
   choice: MergeChoice | undefined;
   onChoose: (id: string, choice: MergeChoice) => void;
+  unitPreviews?: UnitPreviews | null;
 }) => {
   const isOrder = unit.id === ORDER_CONFLICT_ID || isChildOrderId(unit.id);
   const isMeta = unit.id === META_CONFLICT_ID;
@@ -304,10 +406,22 @@ const ConflictCard = ({
     !isMeta &&
     sideNotesDiffer(unit.ours as SlideSide | null, unit.theirs as SlideSide | null);
 
+  // Order cards diff the two id arrays to highlight the moved slides, and use
+  // the report's `unit_previews` to draw each ordering as a filmstrip. Absent
+  // previews (e.g. a save-merge report) fall back to the numbered id list.
+  const oursIds = isOrder && Array.isArray(unit.ours) ? (unit.ours as string[]) : [];
+  const theirsIds = isOrder && Array.isArray(unit.theirs) ? (unit.theirs as string[]) : [];
+  const movedIds = isOrder ? orderDiffIds(oursIds, theirsIds) : EMPTY_MOVED;
+  const hasPreviews = Boolean(unitPreviews && Object.keys(unitPreviews).length > 0);
+
   const renderSide = (side: MergeChoice) => {
     const value = side === 'ours' ? unit.ours : unit.theirs;
     if (isOrder) {
-      return <OrderList ids={Array.isArray(value) ? (value as string[]) : []} />;
+      const ids = Array.isArray(value) ? (value as string[]) : [];
+      if (hasPreviews) {
+        return <Filmstrip ids={ids} previews={unitPreviews as UnitPreviews} moved={movedIds} />;
+      }
+      return <OrderList ids={ids} />;
     }
     if (isMeta) {
       return <MetaFieldList rows={metaRows} side={side} />;
@@ -324,7 +438,11 @@ const ConflictCard = ({
         <span className="font-semibold text-gray-700 dark:text-gray-200">{title}</span>
         <span className={cardBadge}>{reasonLabel(unit.reason)}</span>
       </div>
-      <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <div
+        className={`mt-2 grid gap-2 ${
+          isOrder && hasPreviews ? 'grid-cols-1' : 'grid-cols-1 sm:grid-cols-2'
+        }`}
+      >
         {(['ours', 'theirs'] as const).map(side => (
           <ChoiceSide
             key={side}
@@ -358,6 +476,7 @@ const ConflictCard = ({
 export const ConflictPanel = ({
   units,
   orderConflict,
+  unitPreviews,
   autoMerged,
   oursSha,
   busy,
@@ -367,6 +486,7 @@ export const ConflictPanel = ({
 }: {
   units: ConflictUnit[];
   orderConflict: OrderConflict | null;
+  unitPreviews?: UnitPreviews | null;
   autoMerged: number;
   oursSha: string | null;
   busy: boolean;
@@ -410,7 +530,7 @@ export const ConflictPanel = ({
       className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/95 px-4 sm:px-6 lg:px-8 py-3 max-h-[calc(100vh-8rem)] overflow-y-auto"
     >
       {busy && (
-        <div className="-mx-4 sm:-mx-6 lg:-mx-8 -mt-3 mb-3">
+        <div className="sticky top-0 z-10 -mx-4 sm:-mx-6 lg:-mx-8 -mt-3 mb-3 shadow-sm">
           <MergeProgress label={copy.busyLabel} />
         </div>
       )}
@@ -430,6 +550,7 @@ export const ConflictPanel = ({
             copy={copy}
             choice={choices[unit.id]}
             onChoose={choose}
+            unitPreviews={unitPreviews}
           />
         ))}
       </div>
@@ -480,6 +601,7 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
     discard,
     conflictUnits,
     orderConflict,
+    unitPreviews,
     autoMerged,
     conflictOursSha,
     error,
@@ -487,68 +609,71 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
-    <div data-testid="preview-bar" className="fixed top-14 left-0 right-0 z-40">
-      <div className="border-y border-amber-300 dark:border-amber-700/70 bg-amber-50/95 dark:bg-amber-950/90 backdrop-blur px-4 sm:px-6 lg:px-8 py-2">
-        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-          <div className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-100">
-            <span className="relative flex h-2 w-2" aria-hidden>
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-500 opacity-60" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
-            </span>
-            <span className="font-semibold">Previewing pending changes</span>
-            <span className="text-amber-700 dark:text-amber-300">
-              · {preview.commitsAhead} commit{preview.commitsAhead === 1 ? '' : 's'}
-              {age ? ` · ${age}` : ''}
-            </span>
-          </div>
+    <>
+      <div data-testid="preview-bar" className="fixed top-14 left-0 right-0 z-40">
+        <div className="border-y border-amber-300 dark:border-amber-700/70 bg-amber-50/95 dark:bg-amber-950/90 backdrop-blur px-4 sm:px-6 lg:px-8 py-2">
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <div className="flex items-center gap-2 text-sm text-amber-900 dark:text-amber-100">
+              <span className="relative flex h-2 w-2" aria-hidden>
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-500 opacity-60" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-amber-500" />
+              </span>
+              <span className="font-semibold">Previewing pending changes</span>
+              <span className="text-amber-700 dark:text-amber-300">
+                · {preview.commitsAhead} commit{preview.commitsAhead === 1 ? '' : 's'}
+                {age ? ` · ${age}` : ''}
+              </span>
+            </div>
 
-          <div className="flex items-center gap-2">
-            {preview.diffUrl && (
-              <a
-                href={preview.diffUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`${actionButtonBase} inline-flex items-center gap-1 text-amber-900 dark:text-amber-200 ring-1 ring-amber-300 dark:ring-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40`}
+            <div className="flex items-center gap-2">
+              {preview.diffUrl && (
+                <a
+                  href={preview.diffUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`${actionButtonBase} inline-flex items-center gap-1 text-amber-900 dark:text-amber-200 ring-1 ring-amber-300 dark:ring-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40`}
+                >
+                  GitHub diff
+                  <IconExternalLink size={14} />
+                </a>
+              )}
+              <button
+                type="button"
+                onClick={discard}
+                disabled={busy}
+                className={`${actionButtonBase} text-amber-900 dark:text-amber-200 ring-1 ring-amber-300 dark:ring-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40`}
               >
-                GitHub diff
-                <IconExternalLink size={14} />
-              </a>
-            )}
-            <button
-              type="button"
-              onClick={discard}
-              disabled={busy}
-              className={`${actionButtonBase} text-amber-900 dark:text-amber-200 ring-1 ring-amber-300 dark:ring-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40`}
-            >
-              {busy && pending === 'discard' ? 'Discarding…' : 'Discard'}
-            </button>
-            <button
-              type="button"
-              onClick={accept}
-              disabled={busy}
-              className={`${actionButtonBase} bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400`}
-            >
-              {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
-            </button>
+                {busy && pending === 'discard' ? 'Discarding…' : 'Discard'}
+              </button>
+              <button
+                type="button"
+                onClick={accept}
+                disabled={busy}
+                className={`${actionButtonBase} bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400`}
+              >
+                {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
+              </button>
+            </div>
           </div>
+          {error && <div className="mt-2 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
         </div>
-        {error && <div className="mt-2 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
+        {conflictUnits && (
+          <ConflictPanel
+            units={conflictUnits}
+            orderConflict={orderConflict}
+            unitPreviews={unitPreviews}
+            autoMerged={autoMerged}
+            oursSha={conflictOursSha}
+            busy={busy}
+            onApply={applyResolutions}
+            onDiscard={discard}
+          />
+        )}
       </div>
       {busy && pending === 'accept' && (
-        <MergeProgress label="Merging preview into the live deck — this can take a few seconds…" />
+        <SlideMergeProgressOverlay label="Merging preview into the live deck — this can take a few seconds…" />
       )}
-      {conflictUnits && (
-        <ConflictPanel
-          units={conflictUnits}
-          orderConflict={orderConflict}
-          autoMerged={autoMerged}
-          oursSha={conflictOursSha}
-          busy={busy}
-          onApply={applyResolutions}
-          onDiscard={discard}
-        />
-      )}
-    </div>
+    </>
   );
 };
 
@@ -564,6 +689,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
     discard,
     conflictUnits,
     orderConflict,
+    unitPreviews,
     autoMerged,
     conflictOursSha,
     error,
@@ -571,61 +697,64 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
-    <div data-testid="pending-preview-banner" className="fixed top-14 left-0 right-0 z-40">
-      <div className="border-b border-amber-200 dark:border-amber-800/70 bg-amber-50/90 dark:bg-amber-950/80 backdrop-blur px-4 sm:px-6 lg:px-8 py-1.5">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-amber-900 dark:text-amber-100">
-          <span className="inline-flex items-center gap-1.5">
-            <IconGitBranch size={14} className="text-amber-600 dark:text-amber-400" aria-hidden />A
-            preview with pending changes exists
-            {age ? (
-              <span className="text-amber-700 dark:text-amber-300">
-                ({preview.commitsAhead} commit{preview.commitsAhead === 1 ? '' : 's'}, {age})
-              </span>
-            ) : null}
-          </span>
-          <span className="text-amber-400 dark:text-amber-600" aria-hidden>
-            ·
-          </span>
-          <Link
-            to="?preview=1"
-            className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300"
-          >
-            View preview
-          </Link>
-          <button
-            type="button"
-            onClick={accept}
-            disabled={busy}
-            className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
-          </button>
-          <button
-            type="button"
-            onClick={discard}
-            disabled={busy}
-            className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {busy && pending === 'discard' ? 'Discarding…' : 'Discard'}
-          </button>
+    <>
+      <div data-testid="pending-preview-banner" className="fixed top-14 left-0 right-0 z-40">
+        <div className="border-b border-amber-200 dark:border-amber-800/70 bg-amber-50/90 dark:bg-amber-950/80 backdrop-blur px-4 sm:px-6 lg:px-8 py-1.5">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-amber-900 dark:text-amber-100">
+            <span className="inline-flex items-center gap-1.5">
+              <IconGitBranch size={14} className="text-amber-600 dark:text-amber-400" aria-hidden />
+              A preview with pending changes exists
+              {age ? (
+                <span className="text-amber-700 dark:text-amber-300">
+                  ({preview.commitsAhead} commit{preview.commitsAhead === 1 ? '' : 's'}, {age})
+                </span>
+              ) : null}
+            </span>
+            <span className="text-amber-400 dark:text-amber-600" aria-hidden>
+              ·
+            </span>
+            <Link
+              to="?preview=1"
+              className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300"
+            >
+              View preview
+            </Link>
+            <button
+              type="button"
+              onClick={accept}
+              disabled={busy}
+              className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
+            </button>
+            <button
+              type="button"
+              onClick={discard}
+              disabled={busy}
+              className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy && pending === 'discard' ? 'Discarding…' : 'Discard'}
+            </button>
+          </div>
+          {error && <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
         </div>
-        {error && <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
+        {conflictUnits && (
+          <ConflictPanel
+            units={conflictUnits}
+            orderConflict={orderConflict}
+            unitPreviews={unitPreviews}
+            autoMerged={autoMerged}
+            oursSha={conflictOursSha}
+            busy={busy}
+            onApply={applyResolutions}
+            onDiscard={discard}
+          />
+        )}
       </div>
       {busy && pending === 'accept' && (
-        <MergeProgress label="Merging preview into the live deck — this can take a few seconds…" />
+        <SlideMergeProgressOverlay label="Merging preview into the live deck — this can take a few seconds…" />
       )}
-      {conflictUnits && (
-        <ConflictPanel
-          units={conflictUnits}
-          orderConflict={orderConflict}
-          autoMerged={autoMerged}
-          oursSha={conflictOursSha}
-          busy={busy}
-          onApply={applyResolutions}
-          onDiscard={discard}
-        />
-      )}
-    </div>
+    </>
   );
 };
 

--- a/apps/slides/app/components/preview/PreviewControls.tsx
+++ b/apps/slides/app/components/preview/PreviewControls.tsx
@@ -1,8 +1,23 @@
-import { useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Link, useFetcher } from 'react-router';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { IconExternalLink, IconGitBranch } from '@tabler/icons-react';
+import {
+  META_CONFLICT_ID,
+  ORDER_CONFLICT_ID,
+  allResolved,
+  buildResolutions,
+  buildSlideSrcdoc,
+  isChildOrderId,
+  metaFieldRows,
+  reasonLabel,
+  slideSideHtml,
+  type ConflictUnit,
+  type MergeChoice,
+  type MergeResolution,
+  type SlideSide,
+} from './conflictChooser.ts';
 
 dayjs.extend(relativeTime);
 
@@ -10,12 +25,14 @@ dayjs.extend(relativeTime);
  * Preview-branch UI for slide decks (plan §3b, mirroring apps/pages'
  * PreviewControls): the persistent bar shown while rendering the pending
  * `preview/<content_path>` branch, the slim staff-only banner shown on the
- * live deck when a preview exists, and the conflict panel rendered when an
- * accept hits a git merge conflict.
+ * live deck when a preview exists, and the side-by-side conflict chooser
+ * rendered when an accept hits a genuine merge conflict (Phase 7).
  *
  * All accept/discard submissions post the same form intents the route action
  * handles (`preview-accept` / `preview-discard`) — staff-gated server-side
- * (assertSlideAccess edit tier, same gate as every edit intent).
+ * (assertSlideAccess edit tier, same gate as every edit intent). The chooser
+ * re-posts `preview-accept` with a `resolutions` payload covering every
+ * listed conflict.
  *
  * The slides navbar is `fixed top-0` and the reveal container fills the
  * viewport below it (`fixed inset-0 pt-14`), so preview chrome overlays as
@@ -31,20 +48,22 @@ export interface PreviewInfo {
   diffUrl: string | null;
 }
 
-/** A conflicted deck unit (diffDeckUnits shape): index is '4' or '4.2'. */
-export interface ConflictUnit {
-  id: string;
-  index: string;
-  ours?: unknown;
-  theirs?: unknown;
-  base?: unknown;
+export type { ConflictUnit };
+
+export interface OrderConflict {
+  base: string[];
+  ours: string[];
+  theirs: string[];
 }
 
 interface PreviewActionData {
   conflict?: boolean;
   units?: ConflictUnit[];
-  orderConflict?: { base: string[]; ours: string[]; theirs: string[] } | null;
+  orderConflict?: OrderConflict | null;
+  autoMerged?: number;
   error?: string;
+  code?: string;
+  ids?: string[];
 }
 
 function usePreviewActions() {
@@ -57,6 +76,15 @@ function usePreviewActions() {
     fetcher.submit({ intent: 'preview-accept' }, { method: 'POST' });
   };
 
+  // Chooser submit: same intent, plus one {id, choose} per listed conflict.
+  const applyResolutions = (resolutions: MergeResolution[]) => {
+    setPending('accept');
+    fetcher.submit(
+      { intent: 'preview-accept', resolutions: JSON.stringify(resolutions) },
+      { method: 'POST' }
+    );
+  };
+
   const discard = () => {
     if (!window.confirm('Discard the pending preview? Its changes will be permanently deleted.')) {
       return;
@@ -67,43 +95,313 @@ function usePreviewActions() {
 
   const conflictUnits = fetcher.data?.conflict ? (fetcher.data.units ?? []) : null;
   const orderConflict = fetcher.data?.conflict ? (fetcher.data.orderConflict ?? null) : null;
+  const autoMerged = fetcher.data?.conflict ? (fetcher.data.autoMerged ?? 0) : 0;
   const error = fetcher.data?.error ?? null;
 
-  return { busy, pending, accept, discard, conflictUnits, orderConflict, error };
+  return {
+    busy,
+    pending,
+    accept,
+    applyResolutions,
+    discard,
+    conflictUnits,
+    orderConflict,
+    autoMerged,
+    error,
+  };
 }
 
-function unitLabel(unit: ConflictUnit): string {
-  return `slide ${unit.index || '?'} (${unit.id})`;
-}
+// ─── Conflict chooser (Phase 7) ──────────────────────────────────────────────
+
+const SIDE_TITLE: Record<MergeChoice, string> = {
+  ours: 'Live version (yours)',
+  theirs: "Preview version (agent's)",
+};
+const SIDE_ACTION: Record<MergeChoice, string> = {
+  ours: 'Keep live',
+  theirs: 'Take preview',
+};
+
+/** One selectable side of a conflict card (radio + bounded preview). */
+const ChoiceSide = ({
+  unitId,
+  side,
+  selected,
+  onChoose,
+  children,
+}: {
+  unitId: string;
+  side: MergeChoice;
+  selected: boolean;
+  onChoose: (side: MergeChoice) => void;
+  children: ReactNode;
+}) => (
+  <label
+    data-testid={`conflict-choose-${side}-${unitId}`}
+    className={`flex flex-col gap-1.5 rounded-lg border p-2 cursor-pointer transition-colors ${
+      selected
+        ? 'border-amber-500 dark:border-amber-400 ring-1 ring-amber-500 dark:ring-amber-400 bg-amber-50/60 dark:bg-amber-950/40'
+        : 'border-stone-200 dark:border-neutral-700 hover:border-amber-300 dark:hover:border-amber-700'
+    }`}
+  >
+    <span className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-200">
+      <input
+        type="radio"
+        name={`conflict-${unitId}`}
+        checked={selected}
+        onChange={() => onChoose(side)}
+        className="accent-amber-600"
+      />
+      {SIDE_TITLE[side]}
+      <span className="ml-auto text-[11px] font-normal text-gray-500 dark:text-gray-400">
+        {SIDE_ACTION[side]}
+      </span>
+    </span>
+    {children}
+  </label>
+);
+
+/** Placeholder for a side where the slide was deleted. */
+const Tombstone = ({ label }: { label: string }) => (
+  <div className="flex h-full min-h-24 items-center justify-center rounded border border-dashed border-gray-300 dark:border-neutral-600 bg-gray-50 dark:bg-neutral-800/60 px-3 py-4 text-xs italic text-gray-500 dark:text-gray-400">
+    {label}
+  </div>
+);
 
 /**
- * Conflict panel: lists the slides that genuinely need a decision. The
- * per-slide chooser is Phase 7 — for now we name the conflicted units readably.
+ * Bounded render of one slide side. The deck's html is already trusted by the
+ * real viewer; here it renders scaled-down inside a fully sandboxed iframe
+ * (empty sandbox allowlist = no scripts, no same-origin access).
+ */
+const SlideFrame = ({ side }: { side: SlideSide }) => {
+  const html = slideSideHtml(side);
+  return (
+    <div className="rounded border border-stone-200 dark:border-neutral-700 bg-white overflow-hidden">
+      <iframe
+        sandbox=""
+        srcDoc={buildSlideSrcdoc(html)}
+        title="Slide preview"
+        loading="lazy"
+        className="h-36 w-full pointer-events-none"
+      />
+      {side.notes ? (
+        <div className="border-t border-stone-200 dark:border-neutral-700 bg-stone-50 dark:bg-neutral-800 px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400 truncate">
+          Notes: {side.notes}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+/** Numbered id list for an ordering conflict side. */
+const OrderList = ({ ids }: { ids: string[] }) => (
+  <ol className="space-y-0.5 text-xs text-gray-700 dark:text-gray-300 max-h-36 overflow-y-auto">
+    {ids.map((id, position) => (
+      <li key={`${id}-${position}`} className="flex gap-1.5">
+        <span className="w-5 shrink-0 text-right tabular-nums text-gray-400 dark:text-gray-500">
+          {position + 1}.
+        </span>
+        <span className="truncate font-mono text-[11px]">{id}</span>
+      </li>
+    ))}
+  </ol>
+);
+
+/** Field diff list for one side of the `__meta__` deck-settings conflict. */
+const MetaFieldList = ({
+  rows,
+  side,
+}: {
+  rows: ReturnType<typeof metaFieldRows>;
+  side: MergeChoice;
+}) => (
+  <dl className="space-y-1 text-xs max-h-36 overflow-y-auto">
+    {rows.map(row => (
+      <div key={row.field} className="flex gap-2">
+        <dt className="w-24 shrink-0 font-mono text-[11px] text-gray-500 dark:text-gray-400">
+          {row.field}
+        </dt>
+        <dd className="break-all text-gray-800 dark:text-gray-200">
+          {side === 'ours' ? row.ours : row.theirs}
+        </dd>
+      </div>
+    ))}
+  </dl>
+);
+
+const cardShell =
+  'rounded-lg border border-rose-200 dark:border-rose-800/70 bg-white dark:bg-neutral-900 p-3';
+const cardBadge =
+  'rounded-full bg-rose-100 dark:bg-rose-900/60 px-2 py-0.5 text-[11px] text-rose-800 dark:text-rose-200';
+
+/** One conflict card: side-by-side live vs preview with a choice per side. */
+const ConflictCard = ({
+  unit,
+  choice,
+  onChoose,
+}: {
+  unit: ConflictUnit;
+  choice: MergeChoice | undefined;
+  onChoose: (id: string, choice: MergeChoice) => void;
+}) => {
+  const isOrder = unit.id === ORDER_CONFLICT_ID || isChildOrderId(unit.id);
+  const isMeta = unit.id === META_CONFLICT_ID;
+  const title =
+    unit.id === ORDER_CONFLICT_ID
+      ? 'Slide order'
+      : isChildOrderId(unit.id)
+        ? `Stack ${unit.index || '?'} order`
+        : isMeta
+          ? 'Deck settings'
+          : `Slide ${unit.index || '?'}`;
+  const metaRows = isMeta
+    ? metaFieldRows(
+        unit.ours as Record<string, unknown> | undefined,
+        unit.theirs as Record<string, unknown> | undefined
+      )
+    : [];
+
+  const renderSide = (side: MergeChoice) => {
+    const value = side === 'ours' ? unit.ours : unit.theirs;
+    if (isOrder) {
+      return <OrderList ids={Array.isArray(value) ? (value as string[]) : []} />;
+    }
+    if (isMeta) {
+      return <MetaFieldList rows={metaRows} side={side} />;
+    }
+    if (value === undefined || value === null) {
+      return (
+        <Tombstone
+          label={side === 'ours' ? 'Deleted in the live version' : 'Deleted in the preview'}
+        />
+      );
+    }
+    return <SlideFrame side={value as SlideSide} />;
+  };
+
+  return (
+    <div data-testid={`conflict-card-${unit.id}`} className={cardShell}>
+      <div className="flex items-center gap-2 text-xs">
+        <span className="font-semibold text-gray-700 dark:text-gray-200">{title}</span>
+        <span className={cardBadge}>{reasonLabel(unit.reason)}</span>
+      </div>
+      <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {(['ours', 'theirs'] as const).map(side => (
+          <ChoiceSide
+            key={side}
+            unitId={unit.id}
+            side={side}
+            selected={choice === side}
+            onChoose={chosen => onChoose(unit.id, chosen)}
+          >
+            {renderSide(side)}
+          </ChoiceSide>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Conflict chooser panel (Phase 7): a side-by-side card per conflicted slide
+ * (plus stack-order / slide-order / deck-settings cards), an Apply footer that
+ * submits a resolution for EVERY listed conflict, and a Discard escape.
+ * Auto-merged counts from the accept report are surfaced so staff know only
+ * the true collisions are listed.
  */
 const ConflictPanel = ({
   units,
   orderConflict,
+  autoMerged,
+  busy,
+  onApply,
+  onDiscard,
 }: {
   units: ConflictUnit[];
-  orderConflict: { base: string[]; ours: string[]; theirs: string[] } | null;
-}) => (
-  <div
-    data-testid="preview-conflict-panel"
-    className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/90 px-4 sm:px-6 lg:px-8 py-3"
-  >
-    <div className="text-sm font-medium text-rose-900 dark:text-rose-100">
-      Changes conflict with edits made on the live deck
+  orderConflict: OrderConflict | null;
+  autoMerged: number;
+  busy: boolean;
+  onApply: (resolutions: MergeResolution[]) => void;
+  onDiscard: () => void;
+}) => {
+  // The top-level order conflict arrives separately in the accept payload;
+  // fold it into the card list under its sentinel id so one chooser covers
+  // the full conflict set the resolve service validates against.
+  const allUnits: ConflictUnit[] = orderConflict
+    ? [
+        ...units,
+        {
+          id: ORDER_CONFLICT_ID,
+          index: '',
+          reason: 'order',
+          base: orderConflict.base,
+          ours: orderConflict.ours,
+          theirs: orderConflict.theirs,
+        },
+      ]
+    : units;
+  const ids = allUnits.map(unit => unit.id);
+  const signature = ids.join('|');
+  const [choices, setChoices] = useState<Record<string, MergeChoice>>({});
+  // Drop stale choices when the conflict set changes (a re-accept can shrink it).
+  useEffect(() => setChoices({}), [signature]);
+
+  const choose = (id: string, choice: MergeChoice) =>
+    setChoices(prev => ({ ...prev, [id]: choice }));
+  const ready = allResolved(ids, choices);
+
+  return (
+    <div
+      data-testid="preview-conflict-panel"
+      className="border-b border-rose-300 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/95 px-4 sm:px-6 lg:px-8 py-3 max-h-[calc(100vh-8rem)] overflow-y-auto"
+    >
+      <div className="text-sm font-medium text-rose-900 dark:text-rose-100">
+        Changes conflict with edits made on the live deck
+      </div>
+      <div
+        data-testid="conflict-auto-merged"
+        className="mt-0.5 text-sm text-rose-800 dark:text-rose-200"
+      >
+        {autoMerged > 0
+          ? `${autoMerged} change${autoMerged === 1 ? '' : 's'} merged automatically; these need you:`
+          : 'Choose which version to keep for each conflict:'}
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {allUnits.map(unit => (
+          <ConflictCard key={unit.id} unit={unit} choice={choices[unit.id]} onChoose={choose} />
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          data-testid="conflict-apply"
+          disabled={!ready || busy}
+          onClick={() => onApply(buildResolutions(ids, choices))}
+          className={`${actionButtonBase} bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400`}
+        >
+          {busy ? 'Applying…' : 'Apply choices'}
+        </button>
+        <button
+          type="button"
+          data-testid="conflict-discard"
+          disabled={busy}
+          onClick={onDiscard}
+          className={`${actionButtonBase} text-rose-800 dark:text-rose-200 ring-1 ring-rose-300 dark:ring-rose-700 hover:bg-rose-100 dark:hover:bg-rose-900/40`}
+        >
+          Discard preview
+        </button>
+        <span className="text-xs text-rose-700 dark:text-rose-300">
+          {ready
+            ? 'Applies your choice for every conflict and publishes the merge.'
+            : 'Pick a version for every conflict to enable Apply.'}{' '}
+          Or re-apply from the current version (via your agent).
+        </span>
+      </div>
     </div>
-    <div className="mt-1 text-sm text-rose-800 dark:text-rose-200">
-      Conflicting slides:{' '}
-      {units.length > 0 ? units.map(unit => unitLabel(unit)).join(', ') : 'none reported'}
-      {orderConflict ? `${units.length > 0 ? '; ' : ''}slide ordering also conflicts` : ''}
-    </div>
-    <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">
-      Re-apply from the current version (via your agent) or discard the preview.
-    </div>
-  </div>
-);
+  );
+};
 
 const actionButtonBase =
   'rounded px-3 py-1 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
@@ -113,8 +411,17 @@ const actionButtonBase =
  * Amber identity in both light and dark modes; fixed under the slides navbar.
  */
 export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
-  const { busy, pending, accept, discard, conflictUnits, orderConflict, error } =
-    usePreviewActions();
+  const {
+    busy,
+    pending,
+    accept,
+    applyResolutions,
+    discard,
+    conflictUnits,
+    orderConflict,
+    autoMerged,
+    error,
+  } = usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
@@ -165,7 +472,16 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
         </div>
         {error && <div className="mt-2 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
-      {conflictUnits && <ConflictPanel units={conflictUnits} orderConflict={orderConflict} />}
+      {conflictUnits && (
+        <ConflictPanel
+          units={conflictUnits}
+          orderConflict={orderConflict}
+          autoMerged={autoMerged}
+          busy={busy}
+          onApply={applyResolutions}
+          onDiscard={discard}
+        />
+      )}
     </div>
   );
 };
@@ -174,8 +490,17 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
  * Slim staff-only banner on the normal (live) view when a preview branch exists.
  */
 export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
-  const { busy, pending, accept, discard, conflictUnits, orderConflict, error } =
-    usePreviewActions();
+  const {
+    busy,
+    pending,
+    accept,
+    applyResolutions,
+    discard,
+    conflictUnits,
+    orderConflict,
+    autoMerged,
+    error,
+  } = usePreviewActions();
   const age = preview.oldestCommitAt ? dayjs(preview.oldestCommitAt).fromNow() : null;
 
   return (
@@ -219,7 +544,16 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
         </div>
         {error && <div className="mt-1 text-sm text-rose-700 dark:text-rose-300">{error}</div>}
       </div>
-      {conflictUnits && <ConflictPanel units={conflictUnits} orderConflict={orderConflict} />}
+      {conflictUnits && (
+        <ConflictPanel
+          units={conflictUnits}
+          orderConflict={orderConflict}
+          autoMerged={autoMerged}
+          busy={busy}
+          onApply={applyResolutions}
+          onDiscard={discard}
+        />
+      )}
     </div>
   );
 };

--- a/apps/slides/app/components/preview/PreviewControls.tsx
+++ b/apps/slides/app/components/preview/PreviewControls.tsx
@@ -465,7 +465,7 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
                 rel="noopener noreferrer"
                 className={`${actionButtonBase} inline-flex items-center gap-1 text-amber-900 dark:text-amber-200 ring-1 ring-amber-300 dark:ring-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40`}
               >
-                Diff
+                GitHub diff
                 <IconExternalLink size={14} />
               </a>
             )}
@@ -483,7 +483,7 @@ export const PreviewBar = ({ preview }: { preview: PreviewInfo }) => {
               disabled={busy}
               className={`${actionButtonBase} bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:text-amber-950 dark:hover:bg-amber-400`}
             >
-              {busy && pending === 'accept' ? 'Accepting…' : 'Accept'}
+              {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
             </button>
           </div>
         </div>
@@ -550,7 +550,7 @@ export const PendingPreviewBanner = ({ preview }: { preview: PreviewInfo }) => {
             disabled={busy}
             className="font-medium underline decoration-amber-400 underline-offset-2 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {busy && pending === 'accept' ? 'Accepting…' : 'Accept'}
+            {busy && pending === 'accept' ? 'Merging…' : 'Merge'}
           </button>
           <button
             type="button"

--- a/apps/slides/app/components/preview/conflictChooser.ts
+++ b/apps/slides/app/components/preview/conflictChooser.ts
@@ -58,6 +58,36 @@ export interface SlideSide {
   children?: SlideSide[];
 }
 
+/**
+ * A slide as the order-conflict filmstrip renders it — one entry per referenced
+ * id in the accept report's `unit_previews`. In a pure ordering conflict the
+ * content is identical on both sides, so each slide is rendered ONCE here and
+ * shown in both orderings. `html` is absent for slides the server capped at
+ * ~50KB (the card falls back to the index + title).
+ */
+export interface UnitPreview {
+  index: string;
+  title: string;
+  html?: string;
+}
+
+/** id → filmstrip preview. Absent/empty ⇒ the card falls back to id lists. */
+export type UnitPreviews = Record<string, UnitPreview>;
+
+/**
+ * The ids whose position differs between the two orderings — the moved slides
+ * the filmstrip highlights (amber ring). An id present in only one ordering
+ * counts as moved. Symmetric: both sides agree on the same moved set.
+ */
+export function orderDiffIds(ours: string[], theirs: string[]): Set<string> {
+  const oursPos = new Map(ours.map((id, i) => [id, i] as const));
+  const theirsPos = new Map(theirs.map((id, i) => [id, i] as const));
+  const moved = new Set<string>();
+  for (const [id, i] of oursPos) if (theirsPos.get(id) !== i) moved.add(id);
+  for (const [id, i] of theirsPos) if (oursPos.get(id) !== i) moved.add(id);
+  return moved;
+}
+
 const REASON_LABELS: Record<string, string> = {
   content: 'Edited in both versions',
   delete_vs_edit: 'Deleted in one version, edited in the other',

--- a/apps/slides/app/components/preview/conflictChooser.ts
+++ b/apps/slides/app/components/preview/conflictChooser.ts
@@ -111,6 +111,18 @@ export function buildSlideSrcdoc(html: string): string {
   ].join('');
 }
 
+/**
+ * true when the two sides' speaker notes differ (an absent side counts as no
+ * notes). The card hides identical notes strips entirely — they carry no
+ * decision signal when only the slide html differed.
+ */
+export function sideNotesDiffer(
+  ours: SlideSide | null | undefined,
+  theirs: SlideSide | null | undefined
+): boolean {
+  return (ours?.notes ?? '') !== (theirs?.notes ?? '');
+}
+
 /** One row of the `__meta__` field diff table. */
 export interface MetaFieldRow {
   field: string;
@@ -137,6 +149,62 @@ export function metaFieldRows(
     ours: formatMetaValue((ours ?? {})[field]),
     theirs: formatMetaValue((theirs ?? {})[field]),
   }));
+}
+
+// ─── Chooser copy variants (preview accepts vs editor saves, Phase 7.5) ──────
+
+/**
+ * Which flow mounted the chooser. `preview` = a preview-branch accept
+ * (ours = the live deck, theirs = the agent's preview). `save` = an editor
+ * save whose conflict token was stale (ours = what's saved on the server,
+ * theirs = the editor's unsaved version) — same machinery, flipped framing.
+ */
+export type ChooserVariant = 'preview' | 'save';
+
+export interface ChooserCopy {
+  heading: string;
+  sideTitle: Record<MergeChoice, string>;
+  sideAction: Record<MergeChoice, string>;
+  tombstone: Record<MergeChoice, string>;
+  /** Label of the escape-hatch button (discard the preview / reload latest). */
+  secondaryAction: string;
+  /** Trailing footer sentence after the apply hint. */
+  footerNote: string;
+  /** Progress-strip copy while the apply submit is in flight. */
+  busyLabel: string;
+}
+
+const CHOOSER_COPY: Record<ChooserVariant, ChooserCopy> = {
+  preview: {
+    heading: 'Changes conflict with edits made on the live deck',
+    sideTitle: { ours: 'Live version (yours)', theirs: "Preview version (agent's)" },
+    sideAction: { ours: 'Keep live', theirs: 'Take preview' },
+    tombstone: { ours: 'Deleted in the live version', theirs: 'Deleted in the preview' },
+    secondaryAction: 'Discard preview',
+    footerNote: 'Or re-apply from the current version (via your agent).',
+    busyLabel: 'Publishing your choices — this can take a few seconds…',
+  },
+  save: {
+    heading: 'Your save collided with changes saved by someone else',
+    sideTitle: { ours: 'Saved on the server', theirs: 'Your unsaved version' },
+    sideAction: { ours: "Keep server's", theirs: 'Keep yours' },
+    tombstone: { ours: 'Deleted on the server', theirs: 'Deleted in your version' },
+    secondaryAction: 'Reload latest',
+    footerNote: 'Or reload the latest version and discard your unsaved changes.',
+    busyLabel: 'Saving the merged version — this can take a few seconds…',
+  },
+};
+
+/** The chooser's variant-dependent labels. */
+export function chooserCopy(variant: ChooserVariant): ChooserCopy {
+  return CHOOSER_COPY[variant];
+}
+
+/** The subtitle under the heading (mentions the auto-merged count when > 0). */
+export function chooserSubtitle(variant: ChooserVariant, autoMerged: number): string {
+  if (autoMerged <= 0) return 'Choose which version to keep for each conflict:';
+  const merged = `${autoMerged} change${autoMerged === 1 ? '' : 's'} merged automatically`;
+  return variant === 'save' ? `${merged}; choose per slide:` : `${merged}; these need you:`;
 }
 
 /** true when every listed conflict id has an ours/theirs choice. */

--- a/apps/slides/app/components/preview/conflictChooser.ts
+++ b/apps/slides/app/components/preview/conflictChooser.ts
@@ -88,6 +88,55 @@ export function orderDiffIds(ours: string[], theirs: string[]): Set<string> {
   return moved;
 }
 
+/**
+ * One resolved thumbnail in an order/child-order filmstrip. The SINGLE point
+ * where a referenced slide id is turned into renderable filmstrip data —
+ * consumed identically by BOTH the top-level order card (ids from the
+ * `orderConflict` payload) and the per-stack child-order card (ids from a
+ * `units[]` `__order__:<stackId>` sentinel), so the two card types can never
+ * drift in how they read `unit_previews[id].html`.
+ */
+export interface FilmstripEntry {
+  id: string;
+  /** 1-based position within THIS ordering. */
+  position: number;
+  /** true when the slide sits at a different position in the other ordering. */
+  moved: boolean;
+  /** Preview title (first heading/text); '' when the id has no preview. */
+  title: string;
+  /**
+   * Renderable slide html, resolved from `unit_previews[id].html`. Absent when
+   * the preview carried no html (server capped it at ~50KB) or the id has no
+   * preview at all — the thumbnail falls back to the title/id.
+   */
+  html?: string;
+}
+
+/**
+ * Resolve an ordering (a list of slide ids) into filmstrip thumbnails against
+ * the accept report's `unit_previews` map. This is the one shared resolver the
+ * top-level order card and the child-order card both call — each id's html and
+ * title come straight from `previews[id]`, keyed by the SAME id the ordering
+ * lists. An id missing from `previews` yields a title/html-less entry (the
+ * thumbnail shows the id).
+ */
+export function filmstripEntries(
+  ids: string[],
+  previews: UnitPreviews | null | undefined,
+  moved: Set<string>
+): FilmstripEntry[] {
+  return ids.map((id, i) => {
+    const preview = previews?.[id];
+    return {
+      id,
+      position: i + 1,
+      moved: moved.has(id),
+      title: preview?.title ?? '',
+      ...(preview?.html ? { html: preview.html } : {}),
+    };
+  });
+}
+
 const REASON_LABELS: Record<string, string> = {
   content: 'Edited in both versions',
   delete_vs_edit: 'Deleted in one version, edited in the other',

--- a/apps/slides/app/components/preview/conflictChooser.ts
+++ b/apps/slides/app/components/preview/conflictChooser.ts
@@ -1,0 +1,153 @@
+/**
+ * conflictChooser.ts — pure helpers for the side-by-side deck preview-conflict
+ * chooser (plan §3b Phase 7), mirroring apps/pages' twin.
+ *
+ * No JSX/React imports here: PreviewControls renders these, and the Playwright
+ * runner unit-tests them directly (tests/unit/conflict-chooser.spec.ts)
+ * without a browser.
+ */
+
+/** A per-conflict choice: `ours` = the live (main) side, `theirs` = the preview side. */
+export type MergeChoice = 'ours' | 'theirs';
+
+/** One chooser decision, keyed by the conflict id from the accept report. */
+export interface MergeResolution {
+  id: string;
+  choose: MergeChoice;
+}
+
+/** Sentinel conflict id for the top-level slide order; stacks use `__order__:<id>`. */
+export const ORDER_CONFLICT_ID = '__order__';
+/** Sentinel conflict id for deck-level meta (theme/config/css) collisions. */
+export const META_CONFLICT_ID = '__meta__';
+
+/** A stack's child-order conflict id (`__order__:<stackId>`). */
+export function isChildOrderId(id: string): boolean {
+  return id.startsWith(`${ORDER_CONFLICT_ID}:`);
+}
+
+/**
+ * One conflicted unit from the accept 409 payload (the service's
+ * DeckMergeConflict shapes). Slide units carry DeckSlide sides (null =
+ * deleted on that side); order sentinels carry id arrays; `__meta__` carries
+ * partial deck-meta objects with only the double-changed fields.
+ */
+export interface ConflictUnit {
+  id: string;
+  /** Dotted position, '4' or '4.2' ('' for sentinels). */
+  index: string;
+  reason?:
+    | 'content'
+    | 'delete_vs_edit'
+    | 'both_added'
+    | 'placement'
+    | 'child_order'
+    | 'order'
+    | 'meta'
+    | string;
+  ours?: unknown;
+  theirs?: unknown;
+  base?: unknown;
+}
+
+/** The slide fields the chooser reads (DeckSlide subset; sides are untyped JSON). */
+export interface SlideSide {
+  id?: string;
+  html?: string;
+  notes?: string;
+  children?: SlideSide[];
+}
+
+const REASON_LABELS: Record<string, string> = {
+  content: 'Edited in both versions',
+  delete_vs_edit: 'Deleted in one version, edited in the other',
+  both_added: 'Added in both versions',
+  placement: 'Moved differently in both versions',
+  child_order: 'Stack order changed in both versions',
+  order: 'Slide order changed in both versions',
+  meta: 'Deck settings changed in both versions',
+};
+
+/** Human label for a conflict reason (fallback for future reasons). */
+export function reasonLabel(reason: string | undefined): string {
+  return (reason && REASON_LABELS[reason]) || 'Changed in both versions';
+}
+
+/**
+ * The renderable HTML for one side of a slide conflict: the slide's own html,
+ * or — for vertical-stack containers — the children's htmls joined with a
+ * dashed separator.
+ */
+export function slideSideHtml(side: SlideSide | null | undefined): string {
+  if (!side) return '';
+  if (typeof side.html === 'string' && side.html.trim()) return side.html;
+  if (Array.isArray(side.children) && side.children.length > 0) {
+    return side.children
+      .map(child => (typeof child?.html === 'string' ? child.html : ''))
+      .filter(Boolean)
+      .join('\n<hr style="border:none;border-top:1px dashed #bbb;margin:12px 0">\n');
+  }
+  return '';
+}
+
+/**
+ * Self-contained srcdoc for a sandboxed slide-side preview. The hosting
+ * `<iframe sandbox srcdoc>` keeps scripts OFF (empty sandbox allowlist) — this
+ * doc adds none of its own, only bounding styles that scale the slide content
+ * down into the card.
+ */
+export function buildSlideSrcdoc(html: string): string {
+  return [
+    '<!doctype html><html><head><meta charset="utf-8"><style>',
+    'html,body{margin:0;padding:0;background:#fff;color:#111;}',
+    'body{padding:16px;font-family:system-ui,-apple-system,sans-serif;font-size:26px;',
+    'line-height:1.35;transform:scale(0.45);transform-origin:top left;width:222%;}',
+    'img,video,iframe{max-width:100%;height:auto;}',
+    'pre{white-space:pre-wrap;font-size:0.7em;}',
+    'h1,h2,h3{margin:0.3em 0;}',
+    '</style></head><body>',
+    html,
+    '</body></html>',
+  ].join('');
+}
+
+/** One row of the `__meta__` field diff table. */
+export interface MetaFieldRow {
+  field: string;
+  ours: string;
+  theirs: string;
+}
+
+/** Compact display value for a deck-meta field. */
+export function formatMetaValue(value: unknown): string {
+  if (value === undefined) return '(not set)';
+  if (value === null) return '(none)';
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  return text.length > 80 ? `${text.slice(0, 77)}…` : text;
+}
+
+/** Field diff rows for the `__meta__` card (union of both sides' fields). */
+export function metaFieldRows(
+  ours: Record<string, unknown> | null | undefined,
+  theirs: Record<string, unknown> | null | undefined
+): MetaFieldRow[] {
+  const fields = [...new Set([...Object.keys(ours ?? {}), ...Object.keys(theirs ?? {})])];
+  return fields.map(field => ({
+    field,
+    ours: formatMetaValue((ours ?? {})[field]),
+    theirs: formatMetaValue((theirs ?? {})[field]),
+  }));
+}
+
+/** true when every listed conflict id has an ours/theirs choice. */
+export function allResolved(ids: string[], choices: Record<string, MergeChoice>): boolean {
+  return ids.length > 0 && ids.every(id => choices[id] === 'ours' || choices[id] === 'theirs');
+}
+
+/** Build the resolutions payload the accept intent posts (one entry per id). */
+export function buildResolutions(
+  ids: string[],
+  choices: Record<string, MergeChoice>
+): MergeResolution[] {
+  return ids.map(id => ({ id, choose: choices[id] }));
+}

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -8,6 +8,7 @@ import { ClassmojiService } from '@classmoji/services';
 import {
   DeckConflictError,
   DeckParseError,
+  PreviewResolutionError,
   acceptDeckPreview,
   discardDeckPreview,
   generateDeckHtml,
@@ -15,11 +16,13 @@ import {
   loadDeck,
   parseSlidesFragment,
   previewBranchName,
+  resolveDeckPreviewConflicts,
   saveDeck,
   slideService,
   type DeckJson,
   type DeckShaSource,
   type DeckThemeUrls,
+  type MergeResolution,
 } from '@classmoji/services/slides';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import { useUser } from '~/hooks';
@@ -151,6 +154,13 @@ export const loader = async ({
   const notice =
     canEdit && (rawNotice === 'preview-accepted' || rawNotice === 'preview-discarded')
       ? rawNotice
+      : null;
+  // Semantic-merge accepts also round-trip how many changes auto-merged
+  // (Phase 7) so the success toast can mention them.
+  const rawAutoMerged = url.searchParams.get('auto_merged');
+  const noticeAutoMerged =
+    notice === 'preview-accepted' && rawAutoMerged && /^\d+$/.test(rawAutoMerged)
+      ? Number(rawAutoMerged)
       : null;
 
   let previewStatus: {
@@ -394,6 +404,7 @@ export const loader = async ({
     userRole: membership?.role || null,
     // Post-accept/discard notice (staff only; null otherwise)
     notice,
+    noticeAutoMerged,
     // Preview state is staff-only; students/anonymous always get null.
     preview: canEdit
       ? {
@@ -1101,28 +1112,67 @@ export const action = async ({
   // deletes the branch without touching main.
 
   if (intent === 'preview-accept') {
+    // Chooser resolutions (Phase 7): when present, this accept is a conflict
+    // resolution pass — one {id, choose: 'ours'|'theirs'} per currently
+    // conflicted unit; the resolved merge is committed to main.
+    let resolutions: MergeResolution[] | null = null;
+    const rawResolutions = formData.get('resolutions');
+    if (typeof rawResolutions === 'string' && rawResolutions) {
+      try {
+        const parsed = JSON.parse(rawResolutions);
+        if (!Array.isArray(parsed) || parsed.length === 0) {
+          throw new Error('resolutions must be a non-empty array');
+        }
+        resolutions = parsed;
+      } catch {
+        return data(
+          { error: 'Malformed resolutions payload — expected [{id, choose}]' },
+          { status: 400 }
+        );
+      }
+    }
+
     try {
       const status = await getDeckPreviewStatus(slide);
       if (!status.exists) {
         return { error: 'No pending preview to accept' };
       }
-      const result = await acceptDeckPreview(slide, {
-        resolveThemeUrls: deck => resolveReadThemeUrls(deck, gitOrgLogin, repo),
-      });
+      const resolveThemeUrls = (deck: DeckJson) => resolveReadThemeUrls(deck, gitOrgLogin, repo);
+      const result = resolutions
+        ? await resolveDeckPreviewConflicts(slide, { resolutions, resolveThemeUrls })
+        : await acceptDeckPreview(slide, { resolveThemeUrls });
       if (result.merged) {
-        return redirect(`/${slideId}?notice=preview-accepted`);
+        // Surface the semantic layer's auto-merged count in the success toast.
+        const autoMerged = ('auto_merged' in result && result.auto_merged) || 0;
+        const autoParam = autoMerged > 0 ? `&auto_merged=${autoMerged}` : '';
+        return redirect(`/${slideId}?notice=preview-accepted${autoParam}`);
       }
       // Merge conflict — nothing merged, branch kept. Surface the per-unit
-      // report so the UI can list the conflicted slides.
+      // report (plus the auto-merged count) so the chooser can render it.
       return data(
         {
           conflict: true,
           units: result.units,
           orderConflict: result.order_conflict ?? null,
+          autoMerged: result.auto_merged,
         },
         { status: 409 }
       );
     } catch (error: unknown) {
+      // Bad/stale resolutions (missing ids, unknown ids, duplicates, no
+      // preview) — a clear 400 naming the offending ids; the client re-runs
+      // accept for a fresh report.
+      if (error instanceof PreviewResolutionError) {
+        return data({ error: error.message, code: error.code, ids: error.ids }, { status: 400 });
+      }
+      // Mid-merge CAS loss: main moved while committing the resolved merge
+      // (the service already retried once). Nothing was written.
+      if (error instanceof DeckConflictError) {
+        return data(
+          { error: 'The live deck changed while merging — try accepting again.' },
+          { status: 409 }
+        );
+      }
       console.error('Failed to accept preview:', error);
       return { error: error instanceof Error ? error.message : String(error) };
     }
@@ -1320,6 +1370,7 @@ export default function SlideViewer() {
     sha_source: loaderShaSource,
     preview,
     notice,
+    noticeAutoMerged,
   } = useLoaderData<typeof loader>();
   // Preview mode is strictly read-only — editing chrome is suppressed while
   // rendering the pending preview branch (plan §3b).
@@ -1463,15 +1514,20 @@ export default function SlideViewer() {
   useEffect(() => {
     if (!notice) return;
     if (notice === 'preview-accepted') {
-      message.success('Preview accepted — changes are now live.');
+      message.success(
+        noticeAutoMerged
+          ? `Preview accepted — ${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
+          : 'Preview accepted — changes are now live.'
+      );
     } else if (notice === 'preview-discarded') {
       message.success('Preview discarded.');
     }
-    // Strip the param so a refresh doesn't re-toast
+    // Strip the params so a refresh doesn't re-toast
     const url = new URL(window.location.href);
     url.searchParams.delete('notice');
+    url.searchParams.delete('auto_merged');
     window.history.replaceState({}, '', url);
-  }, [notice]);
+  }, [notice, noticeAutoMerged]);
 
   // Auto-enter edit mode if ?mode=edit was in URL (for new slides where CDN hasn't caught up)
   // Only triggers once on mount, and only if user has permission to edit

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -733,7 +733,12 @@ export const action = async ({
       };
     } catch (error: unknown) {
       console.error('Failed to fetch latest content:', error);
-      return { error: error instanceof Error ? error.message : String(error) };
+      // Tag the intent so the client can distinguish a fetch-latest failure
+      // from a save error and clear its loading state (S8).
+      return {
+        intent: 'fetch-latest' as const,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 
@@ -1302,7 +1307,9 @@ export const action = async ({
         baseSha,
         ...(saveResolutions ? { resolutions: saveResolutions } : {}),
         ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
-        message: `Update slides: ${slide.title}`,
+        // No message override: the service marks the commit '(merged)' only
+        // when this save actually folds a concurrent change or applies a
+        // chooser resolution — a plain ops save stays 'Update slides: <title>'.
         // Theme URLs must be resolved from the MERGED deck (a concurrent
         // theme change on main may win the per-field meta merge).
         resolveThemeUrls: mergedDeck => resolveReadThemeUrls(mergedDeck, gitOrgLogin, repo),
@@ -1321,16 +1328,18 @@ export const action = async ({
         console.error('Failed to detect orphaned images:', err);
       }
 
-      // merged_with_concurrent only when concurrent main-side changes were
-      // folded in: savedContent then differs from the editor DOM beyond its
-      // own edits, so a live editor must remount from it. A concurrent-free
-      // ops save behaves exactly like a plain save (no remount).
+      // adoption_required gates the live-editor remount on a FULL comparison
+      // (committed deck vs base+ops — main-side reorders / cross-stack moves /
+      // deck-meta changes fold in with concurrent 0, AND server-minted insert
+      // ids the id-less DOM never carried), NOT the unit-content counter.
+      // merged_with_concurrent stays purely the toast count.
       return {
         success: true,
         sha: result.sha,
         sha_source: 'deck' as const,
         savedContent: result.html,
         orphanedImages,
+        adoption_required: result.adoption_required,
         ...(result.concurrent > 0 ? { merged_with_concurrent: result.concurrent } : {}),
       };
     } catch (error: unknown) {
@@ -1453,7 +1462,9 @@ export const action = async ({
         baseSha: expectedSha as string,
         ...(saveResolutions ? { resolutions: saveResolutions } : {}),
         ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
-        message: `Update slides: ${slide.title}`,
+        // No message override on the merge path: the service marks the commit
+        // '(merged)' (with a resolution summary) so a semantic-merge / chooser
+        // commit is distinguishable from a plain save in the git record.
         // Theme URLs must be resolved from the MERGED deck (a concurrent
         // theme change on main may win the per-field meta merge).
         resolveThemeUrls: mergedDeck => resolveReadThemeUrls(mergedDeck, gitOrgLogin, repo),
@@ -1747,7 +1758,11 @@ export default function SlideViewer() {
   // Note: Modern browsers ignore custom messages and show their own generic dialog
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (isEditing && hasChanges) {
+      // Warn on live unsaved edits, OR when a save 409 parked the ONLY copy of
+      // the work in the chooser / conflict banner. handleSave optimistically
+      // clears isEditing/hasChanges before the response, so those two flags no
+      // longer cover the chooser-open state — the report/banner presence does.
+      if ((isEditing && hasChanges) || saveMergeReport || saveConflict) {
         e.preventDefault();
         // Modern browsers ignore this, but it's required for the dialog to show
         e.returnValue = '';
@@ -1756,7 +1771,7 @@ export default function SlideViewer() {
 
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [isEditing, hasChanges]);
+  }, [isEditing, hasChanges, saveMergeReport, saveConflict]);
 
   // canEdit, canPresent, canViewSpeakerNotes now come from loader data (computed by assertSlideAccess)
 
@@ -1814,9 +1829,17 @@ export default function SlideViewer() {
       captureBaseline(fetcher.data.content, fetcher.data.content_sha, fetcher.data.sha_source);
       setSaveConflict(null);
       setSaveMergeReport(null);
+      lastPostedOpsRef.current = null;
       setHasChanges(false);
       setIsEditing(true);
       setIsLoadingLatest(false);
+    } else if (fetcher.data?.intent === 'fetch-latest' && fetcher.data?.error) {
+      // Fetch-latest failed (e.g. a transient GitHub error). Clear the loading
+      // flag so the Edit / Reload buttons re-enable, surface a retryable
+      // message, and KEEP any open chooser / conflict banner (they hold the
+      // only recovery path — do not strand the user, S8).
+      setIsLoadingLatest(false);
+      message.error(`Couldn't load the latest version: ${fetcher.data.error}. Please try again.`);
     } else if (fetcher.data?.intent === 'delete-images') {
       // Images were deleted
       setIsDeletingImages(false);
@@ -1948,11 +1971,21 @@ export default function SlideViewer() {
       lastPostedOpsRef.current = null;
       setSaveConflict(null);
       setSaveMergeReport(null);
-      // Semantic save-merge (7.5): savedContent is the MERGED document —
-      // remount a live editor so the DOM (the next save's source) matches the
-      // fresh token, and tell the user about the folded-in changes.
-      if (typeof fetcher.data.merged_with_concurrent === 'number') {
+      // Remount the live editor whenever the committed savedContent must
+      // REPLACE what the DOM holds — otherwise the next save diffs a stale DOM
+      // against the fresh baseline and reverts the folded-in change (or churns
+      // a server-minted insert id). The ops path signals this with
+      // adoption_required (a FULL compare: concurrent reorders/cross-stack
+      // moves/deck-meta folds AND minted insert ids the id-less DOM never had);
+      // the whole-doc merge path still signals it with merged_with_concurrent.
+      // The toast is purely the concurrent count.
+      if (
+        fetcher.data.adoption_required === true ||
+        typeof fetcher.data.merged_with_concurrent === 'number'
+      ) {
         setEditorEpoch(epoch => epoch + 1);
+      }
+      if (typeof fetcher.data.merged_with_concurrent === 'number') {
         const n = fetcher.data.merged_with_concurrent;
         if (n > 0) {
           message.success(`Saved — merged with ${n} concurrent change${n === 1 ? '' : 's'}`);
@@ -2094,9 +2127,11 @@ export default function SlideViewer() {
   // Recover from a save conflict: re-fetch the latest content + token
   // (the existing fetch-latest flow), discarding this session's unsaved changes
   const handleReloadLatest = useCallback(() => {
-    setSaveConflict(null);
-    setSaveMergeReport(null);
-    lastPostedOpsRef.current = null;
+    // Keep the chooser / conflict banner (and the posted ops) mounted until the
+    // reload actually SUCCEEDS — a failed fetch-latest must not clear the only
+    // recovery UI and leave the user stranded (S8). The fetch-latest success
+    // branch clears saveConflict/saveMergeReport/lastPostedOpsRef; a failure
+    // just re-enables the buttons.
     setIsLoadingLatest(true);
     fetcher.submit({ intent: 'fetch-latest' }, { method: 'post' });
   }, [fetcher]);
@@ -2424,6 +2459,23 @@ export default function SlideViewer() {
         {preview?.missing && <NoPreviewNotice />}
         {preview && !preview.active && preview.exists && !isEditing && (
           <PendingPreviewBanner preview={preview} />
+        )}
+
+        {/* Read-only scrim while the save-merge chooser is open (S5). An
+            auto-save (handleSaveContent) keeps edit mode, so without this the
+            user could keep typing into the live editor while resolving — and
+            Apply re-submits the ORIGINAL posted ops, then adoption remounts the
+            editor from the committed document, silently discarding those edits.
+            Preserving post-conflict edits across the innerHTML rebuild is not
+            reliably feasible, so we take the honest fix: BLOCK editing while the
+            chooser is open. The scrim sits below the chooser (z-1100) and above
+            the editor; the already-posted work is safe in the ops/content refs. */}
+        {saveMergeReport && !saveConflict && (
+          <div
+            className="fixed inset-0 z-[1050] bg-black/5 dark:bg-black/20 cursor-not-allowed"
+            aria-hidden="true"
+            data-testid="save-merge-editing-block"
+          />
         )}
 
         {/* Save-merge chooser (Phase 7.5): a stale save hit true collisions —

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -1114,7 +1114,10 @@ export const action = async ({
   if (intent === 'preview-accept') {
     // Chooser resolutions (Phase 7): when present, this accept is a conflict
     // resolution pass — one {id, choose: 'ours'|'theirs'} per currently
-    // conflicted unit; the resolved merge is committed to main.
+    // conflicted unit; the resolved merge is committed to main. Element-shape
+    // validation (non-empty string id, choose ∈ ours|theirs) lives in the
+    // service's indexResolutions, so malformed choices throw
+    // PreviewResolutionError (→ 400 below) instead of defaulting to a side.
     let resolutions: MergeResolution[] | null = null;
     const rawResolutions = formData.get('resolutions');
     if (typeof rawResolutions === 'string' && rawResolutions) {
@@ -1131,6 +1134,14 @@ export const action = async ({
         );
       }
     }
+    // Sha pins (F3): the chooser posts back the shas it rendered its conflict
+    // report from, so the resolve fails cleanly (CONTENT_CONFLICT) if the
+    // deck moved after the report was reviewed.
+    const rawOursSha = formData.get('ours_sha');
+    const expectedOursSha = typeof rawOursSha === 'string' && rawOursSha ? rawOursSha : undefined;
+    const rawTheirsSha = formData.get('theirs_sha');
+    const expectedTheirsSha =
+      typeof rawTheirsSha === 'string' && rawTheirsSha ? rawTheirsSha : undefined;
 
     try {
       const status = await getDeckPreviewStatus(slide);
@@ -1139,7 +1150,12 @@ export const action = async ({
       }
       const resolveThemeUrls = (deck: DeckJson) => resolveReadThemeUrls(deck, gitOrgLogin, repo);
       const result = resolutions
-        ? await resolveDeckPreviewConflicts(slide, { resolutions, resolveThemeUrls })
+        ? await resolveDeckPreviewConflicts(slide, {
+            resolutions,
+            resolveThemeUrls,
+            ...(expectedOursSha ? { expectedOursSha } : {}),
+            ...(expectedTheirsSha ? { expectedTheirsSha } : {}),
+          })
         : await acceptDeckPreview(slide, { resolveThemeUrls });
       if (result.merged) {
         // Surface the semantic layer's auto-merged count in the success toast.
@@ -1148,21 +1164,31 @@ export const action = async ({
         return redirect(`/${slideId}?notice=preview-accepted${autoParam}`);
       }
       // Merge conflict — nothing merged, branch kept. Surface the per-unit
-      // report (plus the auto-merged count) so the chooser can render it.
+      // report (plus the auto-merged count and the shas the report was built
+      // from — the chooser posts them back with its resolutions) so the
+      // chooser can render it.
       return data(
         {
           conflict: true,
           units: result.units,
           orderConflict: result.order_conflict ?? null,
           autoMerged: result.auto_merged,
+          oursSha: result.ours_sha,
+          theirsSha: result.theirs_sha,
         },
         { status: 409 }
       );
     } catch (error: unknown) {
-      // Bad/stale resolutions (missing ids, unknown ids, duplicates, no
-      // preview) — a clear 400 naming the offending ids; the client re-runs
-      // accept for a fresh report.
       if (error instanceof PreviewResolutionError) {
+        // Stale report pin: the content moved since the reviewed conflict
+        // report — same 409 semantics as a mid-merge CAS loss (re-run accept).
+        if (error.code === 'CONTENT_CONFLICT') {
+          return data({ error: error.message, code: error.code }, { status: 409 });
+        }
+        // Bad/stale resolutions (missing ids, unknown ids, duplicates,
+        // malformed elements, no preview, main deck deleted) — a clear 400
+        // naming the offending ids; the client re-runs accept for a fresh
+        // report.
         return data({ error: error.message, code: error.code, ids: error.ids }, { status: 400 });
       }
       // Mid-merge CAS loss: main moved while committing the resolved merge

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -7,9 +7,11 @@ import { assertSlideAccess } from '@classmoji/auth/server';
 import { ClassmojiService } from '@classmoji/services';
 import {
   DeckConflictError,
+  DeckOpsBaseMismatchError,
   DeckParseError,
   PreviewResolutionError,
   acceptDeckPreview,
+  deckOpsPayloadSchema,
   discardDeckPreview,
   generateDeckHtml,
   getDeckPreviewStatus,
@@ -18,6 +20,7 @@ import {
   previewBranchName,
   resolveDeckPreviewConflicts,
   saveDeck,
+  saveDeckFromOps,
   saveDeckWithMerge,
   slideService,
   type DeckJson,
@@ -28,6 +31,7 @@ import {
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import { useUser } from '~/hooks';
 import { fetchContent } from '~/utils/contentProxy';
+import { diffDeckSnapshots, extractDeckSnapshot, type DeckSnapshot } from '~/utils/deckOpsDiff';
 import { getThemeUrls } from '~/utils/themeService.server';
 import RevealSlides, { type RevealSlidesHandle } from '~/components/RevealSlides';
 import SlideToolbar from '~/components/SlideToolbar';
@@ -1218,15 +1222,14 @@ export const action = async ({
     }
   }
 
-  // Save content to GitHub (Phase 4b: dual-write deck.json + regenerated
-  // index.html through saveDeck, with sha-based conflict detection)
-  const htmlContent = formData.get('content') as string;
+  // ── Save paths ─────────────────────────────────────────────────────────────
   // Conflict token echoed back by the client (loader / fetch-latest / prior save).
   const expectedSha = (formData.get('content_sha') as string | null) || undefined;
   const shaSource: DeckShaSource = formData.get('sha_source') === 'deck' ? 'deck' : 'legacy_html';
 
   // Phase 7.5: a save-conflict chooser re-submit carries the SAME posted
-  // content plus one {id, choose} per conflict and the report's ours_sha pin.
+  // payload (ops or content) plus one {id, choose} per conflict and the
+  // report's ours_sha pin.
   let saveResolutions: MergeResolution[] | null = null;
   const rawSaveResolutions = formData.get('resolutions');
   if (typeof rawSaveResolutions === 'string' && rawSaveResolutions) {
@@ -1246,6 +1249,120 @@ export const action = async ({
   const rawSaveOursSha = formData.get('ours_sha');
   const saveOursSha =
     typeof rawSaveOursSha === 'string' && rawSaveOursSha ? rawSaveOursSha : undefined;
+
+  // Conflict report → 409 the chooser renders (the client re-submits the
+  // same payload + resolutions + the report's ours_sha). Shared by both save
+  // shapes.
+  const mergeReport = (report: {
+    units: unknown;
+    order_conflict?: unknown;
+    auto_merged: number;
+    ours_sha: string;
+  }) =>
+    data(
+      {
+        conflict: true,
+        units: report.units,
+        orderConflict: report.order_conflict ?? null,
+        autoMerged: report.auto_merged,
+        oursSha: report.ours_sha,
+      },
+      { status: 409 }
+    );
+
+  // ── Ops-shaped save (diff-at-save editor) ──────────────────────────────────
+  // The client diffed its DOM against its base snapshot and posted granular
+  // ops + the base token instead of the whole document. The server replays
+  // them onto the base (theirs = applyDeckOps(base, ops)) and runs the SAME
+  // 3-way merge → commit / chooser / resolutions flow as the whole-doc path.
+  // Any OPS_BASE_MISMATCH answer makes the client fall back to a whole-doc
+  // save ONCE — that path is always available and always correct.
+  const rawOps = formData.get('ops');
+  if (typeof rawOps === 'string' && rawOps) {
+    const opsFallback = (message: string) =>
+      data({ error: message, code: 'OPS_BASE_MISMATCH' }, { status: 409 });
+
+    const rawBaseSha = formData.get('base_sha');
+    const baseSha = typeof rawBaseSha === 'string' && rawBaseSha ? rawBaseSha : undefined;
+    if (!baseSha || shaSource !== 'deck') {
+      return opsFallback('Ops saves need a deck-sourced base token — use a full-document save.');
+    }
+
+    let ops;
+    try {
+      ops = deckOpsPayloadSchema.parse(JSON.parse(rawOps));
+    } catch {
+      return opsFallback('Malformed ops payload — use a full-document save.');
+    }
+
+    try {
+      const result = await saveDeckFromOps({
+        slide,
+        ops,
+        baseSha,
+        ...(saveResolutions ? { resolutions: saveResolutions } : {}),
+        ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
+        message: `Update slides: ${slide.title}`,
+        // Theme URLs must be resolved from the MERGED deck (a concurrent
+        // theme change on main may win the per-field meta merge).
+        resolveThemeUrls: mergedDeck => resolveReadThemeUrls(mergedDeck, gitOrgLogin, repo),
+      });
+      if (!result.merged) return mergeReport(result);
+
+      let orphanedImages: Array<{ path: string; name: string; url: string }> = [];
+      try {
+        orphanedImages = await ContentService.findOrphanedImages({
+          orgLogin: gitOrgLogin,
+          repo,
+          imagesFolder: `${slide.content_path}/images`,
+          htmlContent: result.html,
+        });
+      } catch (err: unknown) {
+        console.error('Failed to detect orphaned images:', err);
+      }
+
+      // merged_with_concurrent only when concurrent main-side changes were
+      // folded in: savedContent then differs from the editor DOM beyond its
+      // own edits, so a live editor must remount from it. A concurrent-free
+      // ops save behaves exactly like a plain save (no remount).
+      return {
+        success: true,
+        sha: result.sha,
+        sha_source: 'deck' as const,
+        savedContent: result.html,
+        orphanedImages,
+        ...(result.concurrent > 0 ? { merged_with_concurrent: result.concurrent } : {}),
+      };
+    } catch (error: unknown) {
+      if (error instanceof DeckOpsBaseMismatchError) {
+        return opsFallback(error.message);
+      }
+      if (error instanceof PreviewResolutionError) {
+        if (error.code === 'CONTENT_CONFLICT') {
+          return data({ error: error.message, code: error.code }, { status: 409 });
+        }
+        return data({ error: error.message, code: error.code, ids: error.ids }, { status: 400 });
+      }
+      if (
+        error instanceof DeckConflictError ||
+        (error instanceof Error && error.name === 'DeckConflictError')
+      ) {
+        return data(
+          {
+            conflict: true,
+            message:
+              'This deck changed since you opened it — reload to get the latest version before saving.',
+          },
+          { status: 409 }
+        );
+      }
+      console.error('Failed to save slide (ops):', error);
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  // ── Whole-document save (Phase 4b dual-write; also the ops fallback) ──────
+  const htmlContent = formData.get('content') as string;
 
   try {
     // Parse the editor's posted `<div class="slides">` wrapper into
@@ -1341,25 +1458,6 @@ export const action = async ({
         // theme change on main may win the per-field meta merge).
         resolveThemeUrls: mergedDeck => resolveReadThemeUrls(mergedDeck, gitOrgLogin, repo),
       });
-    // Conflict report → 409 the chooser renders (the client re-submits the
-    // same content + resolutions + the report's ours_sha).
-    const mergeReport = (report: {
-      units: unknown;
-      order_conflict?: unknown;
-      auto_merged: number;
-      ours_sha: string;
-    }) =>
-      data(
-        {
-          conflict: true,
-          units: report.units,
-          orderConflict: report.order_conflict ?? null,
-          autoMerged: report.auto_merged,
-          oursSha: report.ours_sha,
-        },
-        { status: 409 }
-      );
-
     let saved: { sha: string; html: string };
     let mergedWithConcurrent = 0;
     // true when the merge path committed: savedContent is then the MERGED
@@ -1519,6 +1617,34 @@ export default function SlideViewer() {
   // re-submit (or auto re-run) can carry the SAME document even though the
   // editor DOM was torn down when edit mode exited.
   const lastPostedContentRef = useRef<string | null>(null);
+  // Diff-at-save baseline: the canonical section snapshot of the document the
+  // editor is editing, paired with the deck sha it was read at. Captured at
+  // edit entry (fetch-latest) and refreshed after every successful save
+  // (merged-save adoption included — the adopted merged doc becomes the new
+  // baseline). null → no ops path; saves post the whole document.
+  const baselineRef = useRef<{ snapshot: DeckSnapshot; baseSha: string } | null>(null);
+  // The ops JSON the last save posted (when it was an ops save) — a chooser
+  // re-submit must carry the SAME ops so the server re-derives the SAME
+  // conflict report the choices answer.
+  const lastPostedOpsRef = useRef<{ ops: string; baseSha: string } | null>(null);
+  /** Capture/refresh the diff baseline from a server-rendered document. */
+  const captureBaseline = useCallback((content: unknown, sha: unknown, source: unknown): void => {
+    if (
+      typeof content === 'string' &&
+      content &&
+      typeof sha === 'string' &&
+      sha &&
+      source === 'deck' &&
+      typeof DOMParser !== 'undefined'
+    ) {
+      const snapshot = extractDeckSnapshot(content, html =>
+        new DOMParser().parseFromString(html, 'text/html')
+      );
+      baselineRef.current = snapshot ? { snapshot, baseSha: sha } : null;
+    } else {
+      baselineRef.current = null;
+    }
+  }, []);
   // Bumped when a merged save lands while editing: the committed document is
   // the MERGE (not what the DOM holds), so a live editor must remount from
   // the merged savedContent — otherwise the next save, carrying the fresh
@@ -1683,6 +1809,9 @@ export default function SlideViewer() {
           sha_source: fetcher.data.sha_source === 'deck' ? 'deck' : 'legacy_html',
         });
       }
+      // Diff-at-save baseline: this document + sha is what save-time ops
+      // will be diffed against (deck-sourced tokens only).
+      captureBaseline(fetcher.data.content, fetcher.data.content_sha, fetcher.data.sha_source);
       setSaveConflict(null);
       setSaveMergeReport(null);
       setHasChanges(false);
@@ -1788,12 +1917,14 @@ export default function SlideViewer() {
       );
       setSaveMergeReport(null);
     } else if (fetcher.data?.code && lastPostedContentRef.current) {
-      // A chooser re-submit was refused (stale ours_sha pin, or the conflict
-      // set changed). Re-run the plain save with the SAME posted content —
-      // it either lands (possibly merged) or produces a FRESH report. Bounded:
-      // a plain save never answers with `code`, so this runs at most once per
-      // Apply click.
+      // A chooser re-submit was refused (stale ours_sha pin, conflict set
+      // changed) OR an ops save answered OPS_BASE_MISMATCH. Re-run the plain
+      // WHOLE-DOCUMENT save with the SAME posted content — it either lands
+      // (possibly merged) or produces a FRESH report. Bounded: a plain
+      // whole-doc save never answers with `code`, so this runs at most once
+      // per save/Apply click.
       setSaveMergeReport(null);
+      lastPostedOpsRef.current = null;
       const payload: Record<string, string> = { content: lastPostedContentRef.current };
       if (contentToken.content_sha) {
         payload.content_sha = contentToken.content_sha;
@@ -1811,6 +1942,10 @@ export default function SlideViewer() {
           sha_source: fetcher.data.sha_source === 'deck' ? 'deck' : 'legacy_html',
         });
       }
+      // The committed document becomes the next diff-at-save baseline
+      // (merged-save adoption included).
+      captureBaseline(fetcher.data.savedContent, fetcher.data.sha, fetcher.data.sha_source);
+      lastPostedOpsRef.current = null;
       setSaveConflict(null);
       setSaveMergeReport(null);
       // Semantic save-merge (7.5): savedContent is the MERGED document —
@@ -1889,67 +2024,120 @@ export default function SlideViewer() {
     fetcher.submit({ intent: 'fetch-latest' }, { method: 'post' });
   }, [fetcher]);
 
+  // Build the save request from the current editor content. Diff-at-save:
+  // when a baseline snapshot matches the conflict token, the DOM is diffed
+  // against it and the delta posts as granular OPS + the base token —
+  // untouched slides never ride in the request. Any anomaly (no baseline,
+  // theme change, structure the op vocabulary can't express, zero delta)
+  // falls back to the existing whole-document save unchanged. The posted
+  // content string is ALWAYS preserved for the chooser / the server's
+  // OPS_BASE_MISMATCH whole-doc fallback re-submit.
+  const buildSavePayload = useCallback(
+    (content: string): Record<string, string> => {
+      lastPostedContentRef.current = content;
+      lastPostedOpsRef.current = null;
+
+      const baseline = baselineRef.current;
+      if (
+        baseline &&
+        contentToken.sha_source === 'deck' &&
+        contentToken.content_sha === baseline.baseSha &&
+        typeof DOMParser !== 'undefined'
+      ) {
+        const currSnapshot = extractDeckSnapshot(content, html =>
+          new DOMParser().parseFromString(html, 'text/html')
+        );
+        const ops = currSnapshot ? diffDeckSnapshots(baseline.snapshot, currSnapshot) : null;
+        if (ops && ops.length > 0) {
+          const opsJson = JSON.stringify(ops);
+          lastPostedOpsRef.current = { ops: opsJson, baseSha: baseline.baseSha };
+          return {
+            ops: opsJson,
+            base_sha: baseline.baseSha,
+            content_sha: contentToken.content_sha,
+            sha_source: 'deck',
+          };
+        }
+      }
+
+      // Whole-document save (7.5 path — also covers ops-ineligible states).
+      const payload: Record<string, string> = { content };
+      if (contentToken.content_sha) {
+        payload.content_sha = contentToken.content_sha;
+        payload.sha_source = contentToken.sha_source;
+      }
+      return payload;
+    },
+    [contentToken]
+  );
+
   // Save the current slide content and exit edit mode
   const handleSave = useCallback(() => {
     const content = revealRef.current?.getCurrentContent();
     if (!content) return;
 
-    // Preserved for the save-merge chooser: a conflict re-submit must carry
-    // the SAME document even after the editor DOM is torn down below.
-    lastPostedContentRef.current = content;
-    // Echo the conflict token so the server can 409 instead of clobbering
-    const payload: Record<string, string> = { content };
-    if (contentToken.content_sha) {
-      payload.content_sha = contentToken.content_sha;
-      payload.sha_source = contentToken.sha_source;
-    }
-    fetcher.submit(payload, { method: 'post' });
+    fetcher.submit(buildSavePayload(content), { method: 'post' });
     setHasChanges(false);
     setIsEditing(false);
-  }, [fetcher, contentToken]);
+  }, [fetcher, buildSavePayload]);
 
   // Save content without exiting edit mode (used for auto-save after destructive operations)
   const handleSaveContent = useCallback(() => {
     const content = revealRef.current?.getCurrentContent();
     if (!content) return;
 
-    // Same conflict-token treatment as handleSave
-    lastPostedContentRef.current = content;
-    const payload: Record<string, string> = { content };
-    if (contentToken.content_sha) {
-      payload.content_sha = contentToken.content_sha;
-      payload.sha_source = contentToken.sha_source;
-    }
-    fetcher.submit(payload, { method: 'post' });
+    fetcher.submit(buildSavePayload(content), { method: 'post' });
     setHasChanges(false);
     // Don't exit edit mode - user is still editing
-  }, [fetcher, contentToken]);
+  }, [fetcher, buildSavePayload]);
 
   // Recover from a save conflict: re-fetch the latest content + token
   // (the existing fetch-latest flow), discarding this session's unsaved changes
   const handleReloadLatest = useCallback(() => {
     setSaveConflict(null);
     setSaveMergeReport(null);
+    lastPostedOpsRef.current = null;
     setIsLoadingLatest(true);
     fetcher.submit({ intent: 'fetch-latest' }, { method: 'post' });
   }, [fetcher]);
 
   // Apply the save-merge chooser's decisions (Phase 7.5): re-submit the SAME
-  // posted content with one {id, choose} per conflict and the report's
-  // ours_sha pin. If the user is still in edit mode (auto-save conflicts),
-  // the live DOM is fresher than the preserved post — use it; the server
-  // re-validates the conflict set either way.
+  // posted payload with one {id, choose} per conflict and the report's
+  // ours_sha pin. An ops save re-submits the SAME ops (the report was derived
+  // from them — recomputing could change the conflict set under the reviewed
+  // choices). Whole-doc saves keep the pre-ops behavior: if the user is still
+  // in edit mode (auto-save conflicts), the live DOM is fresher than the
+  // preserved post — use it; the server re-validates the conflict set either
+  // way.
   const handleApplySaveResolutions = useCallback(
     (resolutions: Array<{ id: string; choose: 'ours' | 'theirs' }>) => {
-      const content =
-        (isEditing ? revealRef.current?.getCurrentContent() : null) || lastPostedContentRef.current;
-      if (!content || !saveMergeReport) return;
-      lastPostedContentRef.current = content;
-      const payload: Record<string, string> = {
-        content,
+      if (!saveMergeReport) return;
+
+      const shared: Record<string, string> = {
         resolutions: JSON.stringify(resolutions),
         ...(saveMergeReport.oursSha ? { ours_sha: saveMergeReport.oursSha } : {}),
       };
+
+      const postedOps = lastPostedOpsRef.current;
+      if (postedOps) {
+        fetcher.submit(
+          {
+            ops: postedOps.ops,
+            base_sha: postedOps.baseSha,
+            content_sha: postedOps.baseSha,
+            sha_source: 'deck',
+            ...shared,
+          },
+          { method: 'post' }
+        );
+        return;
+      }
+
+      const content =
+        (isEditing ? revealRef.current?.getCurrentContent() : null) || lastPostedContentRef.current;
+      if (!content) return;
+      lastPostedContentRef.current = content;
+      const payload: Record<string, string> = { content, ...shared };
       if (contentToken.content_sha) {
         payload.content_sha = contentToken.content_sha;
         payload.sha_source = contentToken.sha_source;

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -47,6 +47,7 @@ import {
   PendingPreviewBanner,
   NoPreviewNotice,
   ConflictPanel,
+  MergeProgress,
   type ConflictUnit,
   type OrderConflict,
 } from '~/components/preview/PreviewControls';
@@ -1607,6 +1608,19 @@ export default function SlideViewer() {
   const [isEditing, setIsEditing] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
   const [isLoadingLatest, setIsLoadingLatest] = useState(false);
+  // Save-in-flight hold (fixes the stale-view flash): a Save / auto-save keeps
+  // edit mode locked behind a read-only scrim + a 'Saving…' strip until the
+  // response confirms, instead of exiting to view optimistically — which
+  // flashed the PRE-save content for the 1-3s round-trip, then swapped in the
+  // committed content. `savingInFlight` drives that UI; `saveInFlightRef` gates
+  // the fetcher effect (a ref, so it stays out of the effect's dep array);
+  // `exitAfterSaveRef` records whether success drops to view mode (handleSave →
+  // true) or stays in edit (handleSaveContent → false). The exit intent
+  // persists through a conflict chooser so resolving a Save-initiated conflict
+  // still ends in view, an auto-save-initiated one still ends in edit.
+  const [savingInFlight, setSavingInFlight] = useState(false);
+  const saveInFlightRef = useRef(false);
+  const exitAfterSaveRef = useRef(false);
   // Conflict token (Phase 4b): sha of the deck's source of truth + which file
   // it came from. Seeded by the loader, refreshed by fetch-latest and every
   // successful save; echoed back with each save submit.
@@ -1759,9 +1773,11 @@ export default function SlideViewer() {
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       // Warn on live unsaved edits, OR when a save 409 parked the ONLY copy of
-      // the work in the chooser / conflict banner. handleSave optimistically
-      // clears isEditing/hasChanges before the response, so those two flags no
-      // longer cover the chooser-open state — the report/banner presence does.
+      // the work in the chooser / conflict banner. handleSave now HOLDS edit
+      // mode until the response confirms (hasChanges stays true through an
+      // in-flight save — S6), so `isEditing && hasChanges` already covers the
+      // saving and chooser-open states; the report/banner guards remain as
+      // belt-and-suspenders in case hasChanges was cleared elsewhere.
       if ((isEditing && hasChanges) || saveMergeReport || saveConflict) {
         e.preventDefault();
         // Modern browsers ignore this, but it's required for the dialog to show
@@ -1931,6 +1947,12 @@ export default function SlideViewer() {
         oursSha: fetcher.data.oursSha ?? null,
       });
       setSaveConflict(null);
+      // Stay in the edit context (no view switch). The chooser owns the
+      // read-only scrim now, so drop the saving-hold scrim/strip. Keep
+      // exitAfterSaveRef intact — resolving the conflict honors the original
+      // Save-vs-auto-save exit intent.
+      saveInFlightRef.current = false;
+      setSavingInFlight(false);
     } else if (fetcher.data?.conflict) {
       // Save 409'd with no mergeable report (legacy token, unreadable base,
       // or a double CAS loss). Show the reload prompt.
@@ -1939,6 +1961,12 @@ export default function SlideViewer() {
           'This deck changed since you opened it — reload to get the latest version before saving.'
       );
       setSaveMergeReport(null);
+      // Stay in edit mode with the reload banner (no view switch); drop the
+      // saving-hold scrim/strip. The exit intent is moot — reloading discards
+      // this session's edits — so reset it.
+      saveInFlightRef.current = false;
+      exitAfterSaveRef.current = false;
+      setSavingInFlight(false);
     } else if (fetcher.data?.code && lastPostedContentRef.current) {
       // A chooser re-submit was refused (stale ours_sha pin, conflict set
       // changed) OR an ops save answered OPS_BASE_MISMATCH. Re-run the plain
@@ -1948,6 +1976,11 @@ export default function SlideViewer() {
       // per save/Apply click.
       setSaveMergeReport(null);
       lastPostedOpsRef.current = null;
+      // Keep the saving-hold armed across the auto-retry (an ops→whole-doc
+      // fallback stays armed; a refused-chooser re-submit re-arms it) so the
+      // scrim/strip stays continuous until this fresh save resolves.
+      saveInFlightRef.current = true;
+      setSavingInFlight(true);
       const payload: Record<string, string> = { content: lastPostedContentRef.current };
       if (contentToken.content_sha) {
         payload.content_sha = contentToken.content_sha;
@@ -1996,6 +2029,32 @@ export default function SlideViewer() {
         setOrphanedImages(fetcher.data.orphanedImages);
         setShowOrphanedModal(true);
       }
+      // The committed content is now applied (editableContent + adoption
+      // remount above). ONLY now clear the unsaved flags and, for a Save-&-exit
+      // (handleSave), drop to view mode — its first render shows the committed
+      // document (merged concurrent changes included), so there's no stale-view
+      // flash. Auto-saves (handleSaveContent) set exitAfterSave=false and stay
+      // in edit. Clearing the saving-hold last removes the scrim/strip in the
+      // same transition.
+      setHasChanges(false);
+      if (exitAfterSaveRef.current) {
+        setIsEditing(false);
+      }
+      exitAfterSaveRef.current = false;
+      saveInFlightRef.current = false;
+      setSavingInFlight(false);
+    } else if (saveInFlightRef.current && fetcher.data?.error) {
+      // Plain save failure (non-conflict): drop the saving-hold scrim/strip but
+      // STAY in edit mode so the user can retry from the intact editor. Keep
+      // hasChanges true (honest — S6: still unsaved) and surface a retryable
+      // toast. Gated on the ref so an unrelated error (e.g. a failed image
+      // upload, which never arms the hold) can't trip this branch.
+      saveInFlightRef.current = false;
+      exitAfterSaveRef.current = false;
+      setSavingInFlight(false);
+      message.error(
+        `Couldn't save: ${fetcher.data.error}. Your changes are still here — please try again.`
+      );
     }
   }, [fetcher.data]);
 
@@ -2104,24 +2163,33 @@ export default function SlideViewer() {
     [contentToken]
   );
 
-  // Save the current slide content and exit edit mode
+  // Save the current slide content and, once the committed content is ready,
+  // exit edit mode. We do NOT exit optimistically: doing so flashed the
+  // pre-save content in view mode for the save round-trip. Instead arm the
+  // saving-hold (read-only scrim + 'Saving…' strip), keep hasChanges honest
+  // (S6: beforeunload stays armed until the response), and let the fetcher
+  // effect apply the committed document THEN drop to view in one transition.
   const handleSave = useCallback(() => {
     const content = revealRef.current?.getCurrentContent();
     if (!content) return;
 
+    exitAfterSaveRef.current = true;
+    saveInFlightRef.current = true;
+    setSavingInFlight(true);
     fetcher.submit(buildSavePayload(content), { method: 'post' });
-    setHasChanges(false);
-    setIsEditing(false);
   }, [fetcher, buildSavePayload]);
 
-  // Save content without exiting edit mode (used for auto-save after destructive operations)
+  // Save content without exiting edit mode (used for auto-save after destructive
+  // operations — uploads / orphan cleanup). Same saving-hold, but success stays
+  // in edit (exitAfterSave=false).
   const handleSaveContent = useCallback(() => {
     const content = revealRef.current?.getCurrentContent();
     if (!content) return;
 
+    exitAfterSaveRef.current = false;
+    saveInFlightRef.current = true;
+    setSavingInFlight(true);
     fetcher.submit(buildSavePayload(content), { method: 'post' });
-    setHasChanges(false);
-    // Don't exit edit mode - user is still editing
   }, [fetcher, buildSavePayload]);
 
   // Recover from a save conflict: re-fetch the latest content + token
@@ -2342,7 +2410,7 @@ export default function SlideViewer() {
             {/* Status badges */}
             {isEditing && (
               <span className="px-2 py-0.5 text-xs bg-yellow-100 text-yellow-800 rounded-full">
-                {hasChanges ? 'Unsaved' : 'Editing'}
+                {savingInFlight ? 'Saving…' : hasChanges ? 'Unsaved' : 'Editing'}
               </span>
             )}
             {saveSuccess && !hasChanges && !isEditing && (
@@ -2459,6 +2527,28 @@ export default function SlideViewer() {
         {preview?.missing && <NoPreviewNotice />}
         {preview && !preview.active && preview.exists && !isEditing && (
           <PendingPreviewBanner preview={preview} />
+        )}
+
+        {/* Saving-hold (fixes the stale-view flash): while a Save / auto-save
+            commits, freeze the editor behind the SAME read-only scrim the
+            chooser uses (prevents mid-save edits racing the posted snapshot)
+            and show a 'Saving…' strip. Holding edit mode here — instead of
+            exiting to view optimistically — is what keeps the pre-save content
+            from flashing: the fetcher effect applies the committed document,
+            then drops to view in one transition. Hidden once the chooser /
+            reload banner takes over (they own the scrim then). Scrim below the
+            strip (z-1050 < z-1100), both above the navbar (z-50). */}
+        {savingInFlight && !saveMergeReport && !saveConflict && (
+          <>
+            <div
+              className="fixed inset-0 z-[1050] bg-black/5 dark:bg-black/20 cursor-progress"
+              aria-hidden="true"
+              data-testid="saving-editing-block"
+            />
+            <div className="fixed top-14 left-0 right-0 z-[1100] shadow-lg">
+              <MergeProgress label="Saving your changes…" />
+            </div>
+          </>
         )}
 
         {/* Read-only scrim while the save-merge chooser is open (S5). An

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -319,7 +319,30 @@ export const loader = async ({
     }
   }
 
-  // CDN-first for view mode, or as fallback if API failed
+  // Staff view mode: API-first. The CDN (GitHub Pages) lags saves by minutes —
+  // and rapid consecutive saves can ERROR its builds, extending the lag — so a
+  // hard reload right after saving showed stale content to the very person who
+  // saved. Staff read the committed truth from the API; students keep the
+  // cheap CDN path (eventual consistency is fine for them). Thumbnails
+  // (?preview=true) stay CDN — a staff landing page renders ~20 at once and
+  // must not fan out API reads (the D4 amplification).
+  if (!contentResult && canEdit && !isThumbnail) {
+    try {
+      const result = await ContentService.getContent({
+        orgLogin: gitOrgLogin,
+        repo,
+        path: filePath,
+      });
+      if (result) {
+        contentResult = { content: result.content, source: 'api' };
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.warn('[Loader] Staff view API read failed, falling back to CDN:', message);
+    }
+  }
+
+  // CDN-first for student/anonymous view mode, or as fallback if API failed
   if (!contentResult) {
     contentResult = await fetchContent({
       org: gitOrgLogin,

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -1542,8 +1542,8 @@ export default function SlideViewer() {
     if (notice === 'preview-accepted') {
       message.success(
         noticeAutoMerged
-          ? `Preview accepted — ${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
-          : 'Preview accepted — changes are now live.'
+          ? `Preview merged —${noticeAutoMerged} change${noticeAutoMerged === 1 ? '' : 's'} merged automatically; changes are now live.`
+          : 'Preview merged —changes are now live.'
       );
     } else if (notice === 'preview-discarded') {
       message.success('Preview discarded.');

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -1209,6 +1209,7 @@ export const action = async ({
           conflict: true,
           units: result.units,
           orderConflict: result.order_conflict ?? null,
+          unitPreviews: result.unit_previews ?? null,
           autoMerged: result.auto_merged,
           oursSha: result.ours_sha,
           theirsSha: result.theirs_sha,

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -18,6 +18,7 @@ import {
   previewBranchName,
   resolveDeckPreviewConflicts,
   saveDeck,
+  saveDeckWithMerge,
   slideService,
   type DeckJson,
   type DeckShaSource,
@@ -41,6 +42,9 @@ import {
   PreviewBar,
   PendingPreviewBanner,
   NoPreviewNotice,
+  ConflictPanel,
+  type ConflictUnit,
+  type OrderConflict,
 } from '~/components/preview/PreviewControls';
 
 /**
@@ -1221,6 +1225,28 @@ export const action = async ({
   const expectedSha = (formData.get('content_sha') as string | null) || undefined;
   const shaSource: DeckShaSource = formData.get('sha_source') === 'deck' ? 'deck' : 'legacy_html';
 
+  // Phase 7.5: a save-conflict chooser re-submit carries the SAME posted
+  // content plus one {id, choose} per conflict and the report's ours_sha pin.
+  let saveResolutions: MergeResolution[] | null = null;
+  const rawSaveResolutions = formData.get('resolutions');
+  if (typeof rawSaveResolutions === 'string' && rawSaveResolutions) {
+    try {
+      const parsed = JSON.parse(rawSaveResolutions);
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        throw new Error('resolutions must be a non-empty array');
+      }
+      saveResolutions = parsed;
+    } catch {
+      return data(
+        { error: 'Malformed resolutions payload — expected [{id, choose}]' },
+        { status: 400 }
+      );
+    }
+  }
+  const rawSaveOursSha = formData.get('ours_sha');
+  const saveOursSha =
+    typeof rawSaveOursSha === 'string' && rawSaveOursSha ? rawSaveOursSha : undefined;
+
   try {
     // Parse the editor's posted `<div class="slides">` wrapper into
     // theme/codeTheme + structured slides (mints/keeps data-cm-ids).
@@ -1293,42 +1319,82 @@ export const action = async ({
       }
     }
 
-    // Merge rules (plan §5.1, review-hardened): an explicit theme change
-    // clears the paired dark theme (same for codeTheme), and drops
-    // starter-recognized customCss (exact match) so switching a starter deck
-    // to a dark theme doesn't keep #333 headings. All other customCss, the
-    // Reveal config, and extraCss carry over verbatim.
-    const themeChanged = currentDeck != null && theme !== currentDeck.theme;
-    const codeThemeChanged = currentDeck != null && codeTheme !== currentDeck.codeTheme;
-    let customCss = currentDeck?.customCss;
-    if (themeChanged && customCss === slideService.STARTER_CUSTOM_CSS) {
-      customCss = undefined;
+    // Merge rules (plan §5.1, review-hardened) live in buildEditorDeck: an
+    // explicit theme change clears the paired dark theme (same for codeTheme)
+    // and drops starter-recognized customCss; everything else carries over.
+    const deck: DeckJson = slideService.buildEditorDeck({ theme, codeTheme, slides, currentDeck });
+
+    // Semantic save-merge eligibility (Phase 7.5): a stale token whose sha
+    // came from deck.json is a trustworthy 3-way base. Legacy-html tokens are
+    // NOT (deterministic legacy ids can't be trusted across states) — those
+    // fall back to the plain 409 reload flow, as do base-fetch failures.
+    const canMergeSave = Boolean(expectedSha) && shaSource === 'deck';
+    const runMergeSave = () =>
+      saveDeckWithMerge({
+        slide,
+        theirs: deck,
+        baseSha: expectedSha as string,
+        ...(saveResolutions ? { resolutions: saveResolutions } : {}),
+        ...(saveOursSha ? { expectedOursSha: saveOursSha } : {}),
+        message: `Update slides: ${slide.title}`,
+        // Theme URLs must be resolved from the MERGED deck (a concurrent
+        // theme change on main may win the per-field meta merge).
+        resolveThemeUrls: mergedDeck => resolveReadThemeUrls(mergedDeck, gitOrgLogin, repo),
+      });
+    // Conflict report → 409 the chooser renders (the client re-submits the
+    // same content + resolutions + the report's ours_sha).
+    const mergeReport = (report: {
+      units: unknown;
+      order_conflict?: unknown;
+      auto_merged: number;
+      ours_sha: string;
+    }) =>
+      data(
+        {
+          conflict: true,
+          units: report.units,
+          orderConflict: report.order_conflict ?? null,
+          autoMerged: report.auto_merged,
+          oursSha: report.ours_sha,
+        },
+        { status: 409 }
+      );
+
+    let saved: { sha: string; html: string };
+    let mergedWithConcurrent = 0;
+    // true when the merge path committed: savedContent is then the MERGED
+    // document (not the posted one) and the client must adopt it.
+    let mergedSave = false;
+
+    if (saveResolutions && canMergeSave) {
+      // Resolution pass: the token is known-stale — go straight to the 3-way.
+      const mergeResult = await runMergeSave();
+      if (!mergeResult.merged) return mergeReport(mergeResult);
+      saved = mergeResult;
+      mergedWithConcurrent = mergeResult.concurrent;
+      mergedSave = true;
+    } else {
+      try {
+        // Single choke point: conflict check (§3 2×2 table) → generateDeckHtml
+        // → one atomic commit (deck.json + index.html) → updated_at bump.
+        saved = await saveDeck({
+          slide,
+          deck,
+          expectedSha,
+          shaSource,
+          message: `Update slides: ${slide.title}`,
+          themeUrls,
+        });
+      } catch (error: unknown) {
+        if (!(error instanceof DeckConflictError) || !canMergeSave) throw error;
+        // Stale token → the semantic 3-way merge instead of a blank refusal.
+        const mergeResult = await runMergeSave();
+        if (!mergeResult.merged) return mergeReport(mergeResult);
+        saved = mergeResult;
+        mergedWithConcurrent = mergeResult.concurrent;
+        mergedSave = true;
+      }
     }
-
-    const deck: DeckJson = {
-      version: 1,
-      theme,
-      codeTheme,
-      ...(!themeChanged && currentDeck?.themeDark ? { themeDark: currentDeck.themeDark } : {}),
-      ...(!codeThemeChanged && currentDeck?.codeThemeDark
-        ? { codeThemeDark: currentDeck.codeThemeDark }
-        : {}),
-      ...(currentDeck?.config ? { config: currentDeck.config } : {}),
-      ...(customCss != null ? { customCss } : {}),
-      ...(currentDeck?.extraCss ? { extraCss: currentDeck.extraCss } : {}),
-      slides,
-    };
-
-    // Single choke point: conflict check (§3 2×2 table) → generateDeckHtml →
-    // one atomic commit (deck.json + index.html) → updated_at bump.
-    const result = await saveDeck({
-      slide,
-      deck,
-      expectedSha,
-      shaSource,
-      message: `Update slides: ${slide.title}`,
-      themeUrls,
-    });
 
     // Check for orphaned images after save
     let orphanedImages: Array<{ path: string; name: string; url: string }> = [];
@@ -1337,7 +1403,7 @@ export const action = async ({
         orgLogin: gitOrgLogin,
         repo,
         imagesFolder: `${slide.content_path}/images`,
-        htmlContent: result.html,
+        htmlContent: saved.html,
       });
     } catch (err: unknown) {
       // Don't fail the save if orphan detection fails
@@ -1347,20 +1413,35 @@ export const action = async ({
     // Return the full HTML so UI can update without waiting for CDN.
     // sha is the DECK sha (+ sha_source 'deck') — deck.json now exists, so the
     // client's conflict token must point at it for the next save.
+    // merged_with_concurrent (present iff the merge path committed) → the
+    // savedContent is the MERGED document: the client adopts it and toasts
+    // the concurrent count.
     return {
       success: true,
-      sha: result.sha,
+      sha: saved.sha,
       sha_source: 'deck' as const,
-      savedContent: result.html,
+      savedContent: saved.html,
       orphanedImages,
+      ...(mergedSave ? { merged_with_concurrent: mergedWithConcurrent } : {}),
     };
   } catch (error: unknown) {
+    if (error instanceof PreviewResolutionError) {
+      // Stale resolution pin (main moved after the reviewed report) → 409;
+      // bad/stale resolutions → 400 naming the ids. Either way the client
+      // re-runs the plain save for a fresh report.
+      if (error.code === 'CONTENT_CONFLICT') {
+        return data({ error: error.message, code: error.code }, { status: 409 });
+      }
+      return data({ error: error.message, code: error.code, ids: error.ids }, { status: 400 });
+    }
     if (
       error instanceof DeckConflictError ||
       (error instanceof Error && error.name === 'DeckConflictError')
     ) {
       // Surfaced by the fetcher as data with a 409 status — the client shows
       // the "deck changed, reload" prompt instead of a generic save error.
+      // Reached only when the semantic merge is unavailable (legacy token,
+      // unreadable base, main deck gone) or lost its CAS retry.
       return data(
         {
           conflict: true,
@@ -1426,6 +1507,23 @@ export default function SlideViewer() {
   }>({ content_sha: loaderContentSha, sha_source: loaderShaSource });
   // Non-null when the last save 409'd (deck changed under this session).
   const [saveConflict, setSaveConflict] = useState<string | null>(null);
+  // Phase 7.5: non-null when a stale save's 3-way merge hit true collisions —
+  // the per-unit report the save-variant conflict chooser renders.
+  const [saveMergeReport, setSaveMergeReport] = useState<{
+    units: ConflictUnit[];
+    orderConflict: OrderConflict | null;
+    autoMerged: number;
+    oursSha: string | null;
+  } | null>(null);
+  // The exact content string the last save posted — preserved so a chooser
+  // re-submit (or auto re-run) can carry the SAME document even though the
+  // editor DOM was torn down when edit mode exited.
+  const lastPostedContentRef = useRef<string | null>(null);
+  // Bumped when a merged save lands while editing: the committed document is
+  // the MERGE (not what the DOM holds), so a live editor must remount from
+  // the merged savedContent — otherwise the next save, carrying the fresh
+  // token over the stale DOM, would clobber the folded-in concurrent changes.
+  const [editorEpoch, setEditorEpoch] = useState(0);
   const [autoEditTriggered, setAutoEditTriggered] = useState(false);
   // Track editable content separately from CDN content
   const [editableContent, setEditableContent] = useState<string | null>(null);
@@ -1586,6 +1684,7 @@ export default function SlideViewer() {
         });
       }
       setSaveConflict(null);
+      setSaveMergeReport(null);
       setHasChanges(false);
       setIsEditing(true);
       setIsLoadingLatest(false);
@@ -1669,13 +1768,38 @@ export default function SlideViewer() {
       } else if (fetcher.data.error) {
         message.error(`Failed to delete theme: ${fetcher.data.error}`);
       }
+    } else if (fetcher.data?.conflict && fetcher.data?.units) {
+      // Save-merge collision report (Phase 7.5): true same-unit conflicts the
+      // semantic merge could not decide — mount the save-variant chooser.
+      // Everything else already auto-merged server-side (nothing committed).
+      setSaveMergeReport({
+        units: fetcher.data.units,
+        orderConflict: fetcher.data.orderConflict ?? null,
+        autoMerged: fetcher.data.autoMerged ?? 0,
+        oursSha: fetcher.data.oursSha ?? null,
+      });
+      setSaveConflict(null);
     } else if (fetcher.data?.conflict) {
-      // Save 409'd: the deck changed since this session read it. Show the
-      // reload prompt instead of a generic save error.
+      // Save 409'd with no mergeable report (legacy token, unreadable base,
+      // or a double CAS loss). Show the reload prompt.
       setSaveConflict(
         fetcher.data.message ||
           'This deck changed since you opened it — reload to get the latest version before saving.'
       );
+      setSaveMergeReport(null);
+    } else if (fetcher.data?.code && lastPostedContentRef.current) {
+      // A chooser re-submit was refused (stale ours_sha pin, or the conflict
+      // set changed). Re-run the plain save with the SAME posted content —
+      // it either lands (possibly merged) or produces a FRESH report. Bounded:
+      // a plain save never answers with `code`, so this runs at most once per
+      // Apply click.
+      setSaveMergeReport(null);
+      const payload: Record<string, string> = { content: lastPostedContentRef.current };
+      if (contentToken.content_sha) {
+        payload.content_sha = contentToken.content_sha;
+        payload.sha_source = contentToken.sha_source;
+      }
+      fetcher.submit(payload, { method: 'post' });
     } else if (fetcher.data?.savedContent) {
       // After save, update our local content to match what was saved
       // This prevents stale content when CDN hasn't updated yet
@@ -1688,6 +1812,17 @@ export default function SlideViewer() {
         });
       }
       setSaveConflict(null);
+      setSaveMergeReport(null);
+      // Semantic save-merge (7.5): savedContent is the MERGED document —
+      // remount a live editor so the DOM (the next save's source) matches the
+      // fresh token, and tell the user about the folded-in changes.
+      if (typeof fetcher.data.merged_with_concurrent === 'number') {
+        setEditorEpoch(epoch => epoch + 1);
+        const n = fetcher.data.merged_with_concurrent;
+        if (n > 0) {
+          message.success(`Saved — merged with ${n} concurrent change${n === 1 ? '' : 's'}`);
+        }
+      }
       // Check if there are orphaned images to clean up
       if (fetcher.data.orphanedImages?.length > 0) {
         setOrphanedImages(fetcher.data.orphanedImages);
@@ -1759,6 +1894,9 @@ export default function SlideViewer() {
     const content = revealRef.current?.getCurrentContent();
     if (!content) return;
 
+    // Preserved for the save-merge chooser: a conflict re-submit must carry
+    // the SAME document even after the editor DOM is torn down below.
+    lastPostedContentRef.current = content;
     // Echo the conflict token so the server can 409 instead of clobbering
     const payload: Record<string, string> = { content };
     if (contentToken.content_sha) {
@@ -1776,6 +1914,7 @@ export default function SlideViewer() {
     if (!content) return;
 
     // Same conflict-token treatment as handleSave
+    lastPostedContentRef.current = content;
     const payload: Record<string, string> = { content };
     if (contentToken.content_sha) {
       payload.content_sha = contentToken.content_sha;
@@ -1790,9 +1929,35 @@ export default function SlideViewer() {
   // (the existing fetch-latest flow), discarding this session's unsaved changes
   const handleReloadLatest = useCallback(() => {
     setSaveConflict(null);
+    setSaveMergeReport(null);
     setIsLoadingLatest(true);
     fetcher.submit({ intent: 'fetch-latest' }, { method: 'post' });
   }, [fetcher]);
+
+  // Apply the save-merge chooser's decisions (Phase 7.5): re-submit the SAME
+  // posted content with one {id, choose} per conflict and the report's
+  // ours_sha pin. If the user is still in edit mode (auto-save conflicts),
+  // the live DOM is fresher than the preserved post — use it; the server
+  // re-validates the conflict set either way.
+  const handleApplySaveResolutions = useCallback(
+    (resolutions: Array<{ id: string; choose: 'ours' | 'theirs' }>) => {
+      const content =
+        (isEditing ? revealRef.current?.getCurrentContent() : null) || lastPostedContentRef.current;
+      if (!content || !saveMergeReport) return;
+      lastPostedContentRef.current = content;
+      const payload: Record<string, string> = {
+        content,
+        resolutions: JSON.stringify(resolutions),
+        ...(saveMergeReport.oursSha ? { ours_sha: saveMergeReport.oursSha } : {}),
+      };
+      if (contentToken.content_sha) {
+        payload.content_sha = contentToken.content_sha;
+        payload.sha_source = contentToken.sha_source;
+      }
+      fetcher.submit(payload, { method: 'post' });
+    },
+    [fetcher, contentToken, isEditing, saveMergeReport]
+  );
 
   // Exit editing mode (discards unsaved changes)
   const handleDoneEditing = useCallback(() => {
@@ -2073,6 +2238,25 @@ export default function SlideViewer() {
           <PendingPreviewBanner preview={preview} />
         )}
 
+        {/* Save-merge chooser (Phase 7.5): a stale save hit true collisions —
+            pick a side per slide, then re-submit the same content with the
+            choices. The posted document is preserved in lastPostedContentRef
+            until the resolution completes. */}
+        {saveMergeReport && !saveConflict && (
+          <div className="fixed top-14 left-0 right-0 z-[1100] shadow-lg">
+            <ConflictPanel
+              variant="save"
+              units={saveMergeReport.units}
+              orderConflict={saveMergeReport.orderConflict}
+              autoMerged={saveMergeReport.autoMerged}
+              oursSha={saveMergeReport.oursSha}
+              busy={fetcher.state !== 'idle'}
+              onApply={handleApplySaveResolutions}
+              onDiscard={handleReloadLatest}
+            />
+          </div>
+        )}
+
         {/* Save-conflict banner (Phase 4b): the deck changed under this session */}
         {saveConflict && (
           <div className="fixed top-16 left-1/2 -translate-x-1/2 z-[1100] w-[calc(100%-2rem)] max-w-xl">
@@ -2124,7 +2308,7 @@ export default function SlideViewer() {
                   This ensures Reveal.js reinitializes with the correct content source */}
               <RevealSlides
                 ref={revealRef}
-                key={isEditing ? 'editing' : 'viewing'}
+                key={isEditing ? `editing-${editorEpoch}` : 'viewing'}
                 contentUrl={contentUrl}
                 initialContent={displayContent}
                 initialError={contentError}

--- a/apps/slides/app/utils/deckOpsDiff.ts
+++ b/apps/slides/app/utils/deckOpsDiff.ts
@@ -1,0 +1,657 @@
+/**
+ * deckOpsDiff.ts — client-side diff-at-save for the slides editor.
+ *
+ * The editor no longer posts whole documents on the happy path: at save time
+ * it diffs its current DOM state against a BASELINE snapshot (captured at
+ * edit entry and refreshed after every successful save) and posts granular
+ * ops + the base token. Untouched slides are never transmitted, which kills
+ * browser-serialization phantom conflicts structurally: the server replays
+ * the ops onto the base (`theirs = applyDeckOps(base, ops)`), so anything the
+ * diff didn't touch is byte-identical to base by construction.
+ *
+ * Two layers:
+ *  - `extractDeckSnapshot` (DOM): parses a document/wrapper string into a
+ *    canonical section list. BOTH sides (the server-generated baseline and
+ *    the getCurrentContent post) run through the same parser + cleanup in the
+ *    same browser, so per-id string comparison is safe — both sides are
+ *    same-DOM serializations.
+ *  - `diffDeckSnapshots` (pure, unit-tested): plans ops (update / insert /
+ *    move / delete / reorder), then SIMULATES them against the base and
+ *    verifies the result matches the current snapshot. Anything the op
+ *    vocabulary cannot express — or any planner miss the simulation catches —
+ *    returns null, and the caller falls back to the existing whole-document
+ *    save (the 7.5 merge path, unchanged).
+ *
+ * The attribute cleanup here mirrors the server parser's runtime-cruft strip
+ * (packages/services/src/slides/deckHtml.ts stripRuntimeCruft): update-op
+ * attrs land verbatim in deck.json, so the client must clean exactly what
+ * parseSlidesFragment would have cleaned.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface DiffSection {
+  /** data-cm-id, or null for sections created this session. */
+  id: string | null;
+  /** Inner html minus notes asides; null for stack containers. */
+  html: string | null;
+  /** Concatenated notes-aside inner html; null when the slide has no notes. */
+  notes: string | null;
+  hidden: boolean;
+  /** Cleaned attributes (data-cm-id / data-hidden / runtime cruft excluded). */
+  attrs: Record<string, string>;
+  /** Child slides for stack containers; null for leaves. */
+  children: DiffSection[] | null;
+}
+
+export interface DeckSnapshot {
+  theme: string;
+  codeTheme: string;
+  sections: DiffSection[];
+}
+
+export type DeckDiffPosition = { after: string } | { at: 'start' | 'end' };
+
+export interface NewSlideSpec {
+  html?: string;
+  notes?: string;
+  hidden?: boolean;
+  attrs?: Record<string, string>;
+  children?: NewSlideSpec[];
+}
+
+/** Structural mirror of the server op vocabulary (deckOps deckOpSchema). */
+export type DeckDiffOp =
+  | {
+      op: 'update';
+      id: string;
+      html?: string;
+      /** Empty string removes the notes (server contract). */
+      notes?: string;
+      hidden?: boolean;
+      /** null clears all extra attributes. */
+      attrs?: Record<string, string> | null;
+    }
+  | { op: 'insert'; slides: NewSlideSpec[]; position: DeckDiffPosition }
+  | { op: 'move'; id: string; position: DeckDiffPosition }
+  | { op: 'delete'; id: string }
+  | { op: 'reorder'; order: string[] };
+
+export type DocumentParser = (html: string) => Document;
+
+// Server-schema limits — anything over them bails to the whole-doc save.
+const MAX_HTML = 200_000;
+const MAX_NOTES = 50_000;
+const MAX_INSERT_GROUP = 20;
+const MAX_OPS = 400;
+
+// ─── Extraction (DOM layer) ──────────────────────────────────────────────────
+
+/** Runtime paint the Reveal viewer/editor leaves on sections (server list). */
+const CRUFT_CLASSES = new Set([
+  'editing-mode',
+  'slide-hidden',
+  'stack',
+  'present',
+  'past',
+  'future',
+]);
+
+/** Mirror of getCurrentContent's cleanup, applied to BOTH diff sides. */
+function cleanupContainer(container: Element): void {
+  // Runtime contenteditable never persists.
+  container.querySelectorAll('[contenteditable]').forEach(el => {
+    el.removeAttribute('contenteditable');
+  });
+
+  // Code blocks: flatten to escaped plain text, drop hljs (idempotent — the
+  // same normalization the editor applies on load and save, and the server
+  // applies in normalizeSlideHtml).
+  container.querySelectorAll('pre code').forEach(codeEl => {
+    const plainText = codeEl.textContent || '';
+    const escaped = plainText.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    codeEl.innerHTML = escaped;
+    codeEl.classList.remove('hljs');
+    if ((codeEl.getAttribute('class') ?? '') === '') codeEl.removeAttribute('class');
+  });
+
+  // Sandpack blocks: rebuild sl-block-content to the canonical embed shape
+  // (same rebuild getCurrentContent performs — running it on the baseline too
+  // keeps the two sides byte-comparable).
+  container.querySelectorAll('.sl-block[data-block-type="sandpack"]').forEach(block => {
+    const embed = block.querySelector('.sandpack-embed') as HTMLElement | null;
+    const scriptTag = embed?.querySelector('script[data-sandpack-files]');
+    if (!embed || !scriptTag) {
+      block.remove();
+      return;
+    }
+    const filesJson = scriptTag.textContent ?? '';
+    const template = embed.dataset.template || 'vanilla';
+    const theme = embed.dataset.theme || 'auto';
+    const layout = embed.dataset.layout || 'preview-right';
+    const { showTabs, showLineNumbers, showConsole, readOnly, editorWidth } = embed.dataset;
+
+    const contentDiv = block.querySelector('.sl-block-content');
+    if (contentDiv) {
+      let dataAttrs = `data-template="${template}" data-theme="${theme}" data-layout="${layout}"`;
+      if (showTabs === 'false') dataAttrs += ' data-show-tabs="false"';
+      if (showLineNumbers === 'false') dataAttrs += ' data-show-line-numbers="false"';
+      if (showConsole === 'true') dataAttrs += ' data-show-console="true"';
+      if (readOnly === 'true') dataAttrs += ' data-read-only="true"';
+      if (editorWidth && editorWidth !== '50') dataAttrs += ` data-editor-width="${editorWidth}"`;
+      const safeJson = filesJson.replace(/<\/script>/gi, '<\\/script>');
+      contentDiv.innerHTML = `<div class="sandpack-embed" ${dataAttrs}><script type="application/json" data-sandpack-files>${safeJson}</script></div>`;
+    }
+  });
+
+  // Reveal runtime position classes.
+  container.querySelectorAll('.present, .past, .future').forEach(el => {
+    el.classList.remove('present', 'past', 'future');
+    if ((el.getAttribute('class') ?? '') === '') el.removeAttribute('class');
+  });
+}
+
+/**
+ * Cleaned attribute record for a section — mirrors the server parser's
+ * stripRuntimeCruft + attr snapshot (data-cm-id/data-hidden excluded, event
+ * handlers dropped, cruft classes filtered, display style stripped).
+ */
+function cleanSectionAttrs(el: Element): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const attr of Array.from(el.attributes)) {
+    const name = attr.name;
+    const value = attr.value;
+    if (name === 'data-cm-id' || name === 'data-hidden') continue;
+    if (/^on/i.test(name)) continue; // event handlers never persist
+    if (name === 'aria-hidden' || name === 'hidden') continue; // runtime paint
+    if (name === 'class') {
+      const kept = value.split(/\s+/).filter(c => c !== '' && !CRUFT_CLASSES.has(c));
+      if (kept.length > 0) attrs['class'] = kept.join(' ');
+      continue;
+    }
+    if (name === 'style') {
+      // Remove just the `display` property, keep other inline styles —
+      // EXACT server join format: 'p1; p2;'.
+      const props = value
+        .split(';')
+        .map(p => p.trim())
+        .filter(p => p !== '' && !/^display\s*:/i.test(p));
+      if (props.length > 0) attrs['style'] = props.join('; ') + ';';
+      continue;
+    }
+    attrs[name] = value;
+  }
+  return attrs;
+}
+
+/** One section element → DiffSection; null on inexpressible nesting. */
+function sectionToDiff(el: Element, allowChildren: boolean): DiffSection | null {
+  const childSections = Array.from(el.children).filter(
+    child => child.tagName.toLowerCase() === 'section'
+  );
+  const isContainer = childSections.length > 0;
+  if (isContainer && !allowChildren) return null; // >2 nesting levels
+
+  // Children first: their recursion removes THEIR notes asides, so any aside
+  // left whose closest section is this element belongs to this section.
+  let children: DiffSection[] | null = null;
+  if (isContainer) {
+    children = [];
+    for (const child of childSections) {
+      const childSection = sectionToDiff(child, false);
+      if (!childSection) return null;
+      children.push(childSection);
+    }
+  }
+
+  const asides = Array.from(el.querySelectorAll('aside')).filter(
+    aside => aside.classList.contains('notes') && aside.closest('section') === el
+  );
+  const notes = asides.length > 0 ? asides.map(aside => aside.innerHTML).join('\n') : null;
+  asides.forEach(aside => aside.remove());
+
+  const rawId = el.getAttribute('data-cm-id');
+  return {
+    id: rawId && rawId !== '' ? rawId : null,
+    html: isContainer ? null : el.innerHTML,
+    notes,
+    hidden: el.getAttribute('data-hidden') === 'true',
+    attrs: cleanSectionAttrs(el),
+    children,
+  };
+}
+
+/**
+ * Parse a full document (loader/fetch-latest/savedContent) or the editor's
+ * posted `<div class="slides">` wrapper into a canonical snapshot. Returns
+ * null when the content cannot be snapshotted (no sections, deep nesting) —
+ * the caller then has no ops path and uses the whole-doc save.
+ */
+export function extractDeckSnapshot(
+  html: string,
+  parseDocument: DocumentParser
+): DeckSnapshot | null {
+  let doc: Document;
+  try {
+    doc = parseDocument(html);
+  } catch {
+    return null;
+  }
+  const container = doc.querySelector('.slides') ?? doc.body;
+  if (!container) return null;
+
+  const reveal = doc.querySelector('.reveal');
+  const theme =
+    reveal?.getAttribute('data-theme') ?? container.getAttribute('data-theme') ?? 'white';
+  const codeTheme =
+    reveal?.getAttribute('data-code-theme') ??
+    container.getAttribute('data-code-theme') ??
+    'github';
+
+  cleanupContainer(container);
+
+  const rootSections = Array.from(container.querySelectorAll('section')).filter(
+    section => !section.parentElement?.closest('section')
+  );
+  if (rootSections.length === 0) return null;
+
+  const sections: DiffSection[] = [];
+  for (const el of rootSections) {
+    const section = sectionToDiff(el, true);
+    if (!section) return null;
+    sections.push(section);
+  }
+  return { theme, codeTheme, sections };
+}
+
+// ─── Pure diff planner + simulator ───────────────────────────────────────────
+
+const ROOT = '__root__';
+
+/** Thrown internally when the plan hits anything inexpressible — mapped to null. */
+class DiffBail extends Error {}
+
+interface FlatEntry {
+  section: DiffSection;
+  parent: string; // ROOT or container id
+}
+
+function flatten(sections: DiffSection[], requireIds: boolean): Map<string, FlatEntry> | null {
+  const map = new Map<string, FlatEntry>();
+  const add = (section: DiffSection, parent: string): boolean => {
+    if (section.id == null) {
+      if (requireIds) return false; // baseline must be fully id-tagged
+      return true; // new sections are not flat entries
+    }
+    if (map.has(section.id)) return false; // duplicate id — never diffable
+    map.set(section.id, { section, parent });
+    return true;
+  };
+  for (const section of sections) {
+    if (!add(section, ROOT)) return null;
+    for (const child of section.children ?? []) {
+      if (child.children != null) return null; // impossible nesting
+      if (!add(child, section.id ?? ROOT)) return null;
+      if (section.id == null && child.id != null) {
+        // A NEW container wrapping EXISTING slides cannot be expressed as an
+        // insert (inserts mint fresh child ids) — bail.
+        return null;
+      }
+    }
+  }
+  return map;
+}
+
+const eqRecord = (a: Record<string, string>, b: Record<string, string>): boolean => {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(key => b[key] === a[key]);
+};
+
+// ── Simulation (mirrors applyDeckOps semantics, minus html normalization) ──
+
+interface SimNode {
+  id: string | null; // null = inserted this save (spec carried for compare)
+  html: string | null;
+  notes: string | null;
+  hidden: boolean;
+  attrs: Record<string, string>;
+  children: SimNode[] | null;
+}
+
+function simFromSection(section: DiffSection): SimNode {
+  return {
+    id: section.id,
+    html: section.html,
+    notes: section.notes,
+    hidden: section.hidden,
+    attrs: { ...section.attrs },
+    children: section.children ? section.children.map(simFromSection) : null,
+  };
+}
+
+function simFromSpec(spec: NewSlideSpec): SimNode {
+  return {
+    id: null,
+    html: spec.children ? null : (spec.html ?? ''),
+    notes: spec.notes != null && spec.notes !== '' ? spec.notes : null,
+    hidden: spec.hidden === true,
+    attrs: { ...(spec.attrs ?? {}) },
+    children: spec.children ? spec.children.map(simFromSpec) : null,
+  };
+}
+
+function findSim(
+  root: SimNode[],
+  id: string
+): { parent: SimNode[]; index: number; node: SimNode } | null {
+  for (let i = 0; i < root.length; i++) {
+    if (root[i].id === id) return { parent: root, index: i, node: root[i] };
+    const children = root[i].children;
+    if (children) {
+      for (let j = 0; j < children.length; j++) {
+        if (children[j].id === id) return { parent: children, index: j, node: children[j] };
+      }
+    }
+  }
+  return null;
+}
+
+function simInsertAt(root: SimNode[], nodes: SimNode[], position: DeckDiffPosition): void {
+  if ('after' in position) {
+    const target = findSim(root, position.after);
+    if (!target) throw new DiffBail(`unknown anchor ${position.after}`);
+    if (nodes.some(n => n.children != null) && target.parent !== root) {
+      throw new DiffBail('stack cannot land inside a stack');
+    }
+    target.parent.splice(target.index + 1, 0, ...nodes);
+  } else if (position.at === 'start') {
+    root.unshift(...nodes);
+  } else {
+    root.push(...nodes);
+  }
+}
+
+/** Apply one op to the sim tree; throws DiffBail on anything the engine would refuse. */
+function simApply(root: SimNode[], op: DeckDiffOp): void {
+  switch (op.op) {
+    case 'update': {
+      const found = findSim(root, op.id);
+      if (!found) throw new DiffBail(`unknown id ${op.id}`);
+      if (op.html !== undefined) {
+        if (found.node.children?.length) throw new DiffBail('html update on a container');
+        found.node.html = op.html;
+      }
+      if (op.notes !== undefined) found.node.notes = op.notes === '' ? null : op.notes;
+      if (op.hidden !== undefined) found.node.hidden = op.hidden;
+      if (op.attrs !== undefined) found.node.attrs = { ...(op.attrs ?? {}) };
+      break;
+    }
+    case 'insert':
+      simInsertAt(root, op.slides.map(simFromSpec), op.position);
+      break;
+    case 'move': {
+      if ('after' in op.position && op.position.after === op.id) {
+        throw new DiffBail('move relative to itself');
+      }
+      const source = findSim(root, op.id);
+      if (!source) throw new DiffBail(`unknown id ${op.id}`);
+      const [moved] = source.parent.splice(source.index, 1);
+      simInsertAt(root, [moved], op.position);
+      break;
+    }
+    case 'delete': {
+      const found = findSim(root, op.id);
+      if (!found) throw new DiffBail(`unknown id ${op.id}`);
+      if (found.parent === root && root.length === 1) {
+        throw new DiffBail('cannot delete the last slide');
+      }
+      found.parent.splice(found.index, 1);
+      break;
+    }
+    case 'reorder': {
+      const ids = root.map(n => n.id);
+      if (ids.some(id => id == null)) throw new DiffBail('reorder over unminted inserts');
+      const idSet = new Set(ids as string[]);
+      const isPermutation =
+        op.order.length === ids.length &&
+        new Set(op.order).size === op.order.length &&
+        op.order.every(id => idSet.has(id));
+      if (!isPermutation) throw new DiffBail('reorder is not a permutation');
+      const byId = new Map(root.map(n => [n.id as string, n]));
+      root.splice(0, root.length, ...op.order.map(id => byId.get(id) as SimNode));
+      break;
+    }
+  }
+}
+
+/** Deep equality: simulated final tree vs the current snapshot. */
+function simMatches(nodes: SimNode[], sections: DiffSection[]): boolean {
+  if (nodes.length !== sections.length) return false;
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const section = sections[i];
+    if (node.id !== section.id) return false;
+    if ((node.children != null) !== (section.children != null)) return false;
+    if (node.children && section.children) {
+      if (!simMatches(node.children, section.children)) return false;
+    } else if (node.html !== section.html) {
+      return false;
+    }
+    if ((node.notes ?? null) !== (section.notes ?? null)) return false;
+    if (node.hidden !== section.hidden) return false;
+    if (!eqRecord(node.attrs, section.attrs)) return false;
+  }
+  return true;
+}
+
+// ── Planner ──
+
+function planUpdate(base: DiffSection, curr: DiffSection): DeckDiffOp | null {
+  const op: DeckDiffOp = { op: 'update', id: curr.id as string };
+  let changed = false;
+  if (curr.children == null && base.html !== curr.html) {
+    const html = curr.html ?? '';
+    if (html.length > MAX_HTML) throw new DiffBail('html too large');
+    op.html = html;
+    changed = true;
+  }
+  if ((base.notes ?? null) !== (curr.notes ?? null)) {
+    const notes = curr.notes ?? '';
+    if (notes.length > MAX_NOTES) throw new DiffBail('notes too large');
+    op.notes = notes;
+    changed = true;
+  }
+  if (base.hidden !== curr.hidden) {
+    op.hidden = curr.hidden;
+    changed = true;
+  }
+  if (!eqRecord(base.attrs, curr.attrs)) {
+    op.attrs = Object.keys(curr.attrs).length > 0 ? { ...curr.attrs } : null;
+    changed = true;
+  }
+  return changed ? op : null;
+}
+
+function specFromSection(section: DiffSection): NewSlideSpec {
+  const spec: NewSlideSpec = {};
+  if (section.children) {
+    if (section.children.length > MAX_INSERT_GROUP) throw new DiffBail('stack too large');
+    spec.children = section.children.map(child => {
+      if (child.id != null || child.children != null) {
+        throw new DiffBail('new stack may only hold new leaves');
+      }
+      return specFromSection(child);
+    });
+  } else {
+    const html = section.html ?? '';
+    if (html.length > MAX_HTML) throw new DiffBail('html too large');
+    spec.html = html;
+  }
+  if (section.notes != null && section.notes !== '') {
+    if (section.notes.length > MAX_NOTES) throw new DiffBail('notes too large');
+    spec.notes = section.notes;
+  }
+  if (section.hidden) spec.hidden = true;
+  if (Object.keys(section.attrs).length > 0) spec.attrs = { ...section.attrs };
+  return spec;
+}
+
+/**
+ * Diff two snapshots into an op list the server replays onto the base.
+ *
+ * Returns:
+ *  - `DeckDiffOp[]` (possibly empty — no changes) when the delta is
+ *    expressible AND the simulation verifies the replay reproduces `curr`;
+ *  - `null` for anything else (theme change, duplicate/unknown ids,
+ *    containerness changes, inexpressible positions, planner misses) — the
+ *    caller falls back to the whole-document save.
+ */
+export function diffDeckSnapshots(base: DeckSnapshot, curr: DeckSnapshot): DeckDiffOp[] | null {
+  try {
+    // Theme/code-theme changes take the whole-doc path: their merge rules
+    // (dark-pair clearing, starter-CSS drop) live in buildEditorDeck.
+    if (base.theme !== curr.theme || base.codeTheme !== curr.codeTheme) return null;
+
+    const baseFlat = flatten(base.sections, true);
+    const currFlat = flatten(curr.sections, false);
+    if (!baseFlat || !currFlat) return null;
+
+    // Every current id must exist in base (ids are never minted client-side;
+    // an unknown id means a duplicate re-mint or foreign paste — not diffable),
+    // and containerness must be stable per id.
+    for (const [id, entry] of currFlat) {
+      const baseEntry = baseFlat.get(id);
+      if (!baseEntry) return null;
+      if ((baseEntry.section.children != null) !== (entry.section.children != null)) return null;
+    }
+
+    const ops: DeckDiffOp[] = [];
+    const sim = base.sections.map(simFromSection);
+    const push = (op: DeckDiffOp): void => {
+      simApply(sim, op);
+      ops.push(op);
+    };
+
+    // 1. Content updates (leaves and containers, by id).
+    for (const [id, entry] of currFlat) {
+      const baseEntry = baseFlat.get(id);
+      if (!baseEntry) return null; // unreachable — validated above
+      const op = planUpdate(baseEntry.section, entry.section);
+      if (op) push(op);
+    }
+
+    // Current scope orders (existing ids only) + preceding-existing-id anchors.
+    const currScopes = new Map<string, DiffSection[]>();
+    currScopes.set(ROOT, curr.sections);
+    for (const section of curr.sections) {
+      if (section.id != null && section.children != null) {
+        currScopes.set(section.id, section.children);
+      }
+    }
+
+    // 2. Cross-scope moves, in current document order: membership first —
+    //    exact ordering is restored by the reorder op (root) / chains (stacks).
+    for (const [scopeId, sections] of currScopes) {
+      for (const section of sections) {
+        if (section.id == null) continue;
+        if (baseFlat.get(section.id)?.parent === scopeId) continue;
+        // Anchor: nearest preceding sibling with an id (already settled —
+        // earlier moves in document order have run).
+        let anchor: string | null = null;
+        for (const sibling of sections) {
+          if (sibling === section) break;
+          if (sibling.id != null) anchor = sibling.id;
+        }
+        if (anchor != null) {
+          push({ op: 'move', id: section.id, position: { after: anchor } });
+        } else if (scopeId === ROOT) {
+          push({ op: 'move', id: section.id, position: { at: 'start' } });
+        } else {
+          // First position of a stack has no expressible anchor.
+          return null;
+        }
+      }
+    }
+
+    // 3. Deletes — top-most deleted nodes only (a deleted container takes its
+    //    still-deleted children with it; children that survived moved out in 2).
+    for (const section of base.sections) {
+      const id = section.id as string;
+      if (!currFlat.has(id)) {
+        push({ op: 'delete', id });
+        continue;
+      }
+      for (const child of section.children ?? []) {
+        const childId = child.id as string;
+        if (!currFlat.has(childId)) push({ op: 'delete', id: childId });
+      }
+    }
+
+    // 4. Top-level reorder (existing ids — inserts are not minted yet).
+    const currRootIds = curr.sections
+      .filter(section => section.id != null)
+      .map(section => section.id as string);
+    const simRootIds = sim.map(node => node.id);
+    if (JSON.stringify(simRootIds) !== JSON.stringify(currRootIds)) {
+      if (currRootIds.length === 0) return null; // total wipe — whole-doc handles
+      push({ op: 'reorder', order: currRootIds });
+    }
+
+    // 5. Stack child order: a chain of after-anchored moves forces the exact
+    //    final sequence (membership settled in 2/3).
+    for (const [scopeId, sections] of currScopes) {
+      if (scopeId === ROOT) continue;
+      const currIds = sections.filter(s => s.id != null).map(s => s.id as string);
+      const container = findSim(sim, scopeId);
+      if (!container) return null;
+      const simIds = (container.node.children ?? []).map(n => n.id);
+      if (JSON.stringify(simIds) === JSON.stringify(currIds)) continue;
+      for (let i = 1; i < currIds.length; i++) {
+        push({ op: 'move', id: currIds[i], position: { after: currIds[i - 1] } });
+      }
+    }
+
+    // 6. Inserts: consecutive id-less runs, anchored on their preceding
+    //    existing sibling (now in its final slot).
+    for (const [scopeId, sections] of currScopes) {
+      let group: DiffSection[] = [];
+      let anchor: string | null = null;
+      const flush = (): void => {
+        if (group.length === 0) return;
+        if (group.length > MAX_INSERT_GROUP) throw new DiffBail('insert group too large');
+        const slides = group.map(specFromSection);
+        if (anchor != null) {
+          push({ op: 'insert', slides, position: { after: anchor } });
+        } else if (scopeId === ROOT) {
+          push({ op: 'insert', slides, position: { at: 'start' } });
+        } else {
+          throw new DiffBail('stack-front insert has no anchor');
+        }
+        group = [];
+      };
+      for (const section of sections) {
+        if (section.id == null) {
+          if (scopeId !== ROOT && section.children != null) return null; // nested stack
+          group.push(section);
+        } else {
+          flush();
+          anchor = section.id;
+        }
+      }
+      flush();
+    }
+
+    if (ops.length > MAX_OPS) return null;
+
+    // 7. The proof: replaying the plan must reproduce the current snapshot
+    //    exactly. Any miss → whole-doc fallback.
+    if (!simMatches(sim, curr.sections)) return null;
+
+    return ops;
+  } catch (error) {
+    if (error instanceof DiffBail) return null;
+    throw error;
+  }
+}

--- a/apps/slides/app/utils/deckOpsDiff.ts
+++ b/apps/slides/app/utils/deckOpsDiff.ts
@@ -149,6 +149,13 @@ function cleanupContainer(container: Element): void {
     el.classList.remove('present', 'past', 'future');
     if ((el.getAttribute('class') ?? '') === '') el.removeAttribute('class');
   });
+
+  // Reveal fragment runtime paint (`visible` / `current-fragment`) is added as
+  // the presenter steps through fragments — never authored, must never persist,
+  // or a merely-VIEWED slide reads as edited. `fragment` itself stays.
+  container.querySelectorAll('.fragment').forEach(el => {
+    el.classList.remove('visible', 'current-fragment');
+  });
 }
 
 /**

--- a/apps/slides/tests/unit/conflict-chooser.spec.ts
+++ b/apps/slides/tests/unit/conflict-chooser.spec.ts
@@ -12,10 +12,13 @@ import {
   allResolved,
   buildResolutions,
   buildSlideSrcdoc,
+  chooserCopy,
+  chooserSubtitle,
   formatMetaValue,
   isChildOrderId,
   metaFieldRows,
   reasonLabel,
+  sideNotesDiffer,
   slideSideHtml,
 } from '../../app/components/preview/conflictChooser.ts';
 
@@ -139,5 +142,66 @@ test.describe('resolution bookkeeping', () => {
       { id: META_CONFLICT_ID, choose: 'theirs' },
       { id: ORDER_CONFLICT_ID, choose: 'ours' },
     ]);
+  });
+});
+
+test.describe('chooser variants (save vs preview, Phase 7.5)', () => {
+  test('preview copy keeps the accept-flow framing', () => {
+    const copy = chooserCopy('preview');
+    expect(copy.heading).toBe('Changes conflict with edits made on the live deck');
+    expect(copy.sideTitle).toEqual({
+      ours: 'Live version (yours)',
+      theirs: "Preview version (agent's)",
+    });
+    expect(copy.sideAction).toEqual({ ours: 'Keep live', theirs: 'Take preview' });
+    expect(copy.tombstone).toEqual({
+      ours: 'Deleted in the live version',
+      theirs: 'Deleted in the preview',
+    });
+    expect(copy.secondaryAction).toBe('Discard preview');
+    expect(copy.busyLabel).toContain('Publishing your choices');
+  });
+
+  test('save copy flips the framing: ours = the server, theirs = the unsaved editor', () => {
+    const copy = chooserCopy('save');
+    expect(copy.heading).toBe('Your save collided with changes saved by someone else');
+    expect(copy.sideTitle).toEqual({
+      ours: 'Saved on the server',
+      theirs: 'Your unsaved version',
+    });
+    expect(copy.sideAction).toEqual({ ours: "Keep server's", theirs: 'Keep yours' });
+    expect(copy.tombstone).toEqual({
+      ours: 'Deleted on the server',
+      theirs: 'Deleted in your version',
+    });
+    expect(copy.secondaryAction).toBe('Reload latest');
+    expect(copy.footerNote).toContain('discard your unsaved changes');
+    expect(copy.busyLabel).toContain('Saving the merged version');
+  });
+
+  test('chooserSubtitle mentions the auto-merged count per variant', () => {
+    expect(chooserSubtitle('preview', 0)).toBe('Choose which version to keep for each conflict:');
+    expect(chooserSubtitle('save', 0)).toBe('Choose which version to keep for each conflict:');
+    expect(chooserSubtitle('preview', 3)).toBe('3 changes merged automatically; these need you:');
+    expect(chooserSubtitle('save', 1)).toBe('1 change merged automatically; choose per slide:');
+    expect(chooserSubtitle('save', 2)).toBe('2 changes merged automatically; choose per slide:');
+  });
+});
+
+test.describe('sideNotesDiffer', () => {
+  test('identical notes on both sides carry no signal', () => {
+    expect(sideNotesDiffer({ notes: 'same' }, { notes: 'same' })).toBe(false);
+    expect(sideNotesDiffer({}, {})).toBe(false);
+    expect(sideNotesDiffer({ html: '<p>a</p>' }, { html: '<p>b</p>' })).toBe(false);
+  });
+
+  test('differing notes (including one side missing them) do', () => {
+    expect(sideNotesDiffer({ notes: 'mine' }, { notes: 'theirs' })).toBe(true);
+    expect(sideNotesDiffer({ notes: 'mine' }, {})).toBe(true);
+    expect(sideNotesDiffer(null, { notes: 'theirs' })).toBe(true);
+  });
+
+  test('a deleted side vs a note-less survivor stays quiet', () => {
+    expect(sideNotesDiffer(null, { html: '<p>x</p>' })).toBe(false);
   });
 });

--- a/apps/slides/tests/unit/conflict-chooser.spec.ts
+++ b/apps/slides/tests/unit/conflict-chooser.spec.ts
@@ -17,6 +17,7 @@ import {
   formatMetaValue,
   isChildOrderId,
   metaFieldRows,
+  orderDiffIds,
   reasonLabel,
   sideNotesDiffer,
   slideSideHtml,
@@ -185,6 +186,32 @@ test.describe('chooser variants (save vs preview, Phase 7.5)', () => {
     expect(chooserSubtitle('preview', 3)).toBe('3 changes merged automatically; these need you:');
     expect(chooserSubtitle('save', 1)).toBe('1 change merged automatically; choose per slide:');
     expect(chooserSubtitle('save', 2)).toBe('2 changes merged automatically; choose per slide:');
+  });
+});
+
+test.describe('orderDiffIds (filmstrip moved-slide highlight)', () => {
+  test('flags every slide whose position differs between the two orderings', () => {
+    // base order [a,b,c]; both sides reorder differently.
+    const moved = orderDiffIds(['b', 'a', 'c'], ['a', 'c', 'b']);
+    // a: pos 1 vs 0 → moved; b: pos 0 vs 2 → moved; c: pos 2 vs 1 → moved.
+    expect(moved).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  test('a slide that keeps its position is NOT flagged', () => {
+    // Only b and c swap; a stays at index 0.
+    const moved = orderDiffIds(['a', 'b', 'c'], ['a', 'c', 'b']);
+    expect(moved.has('a')).toBe(false);
+    expect(moved.has('b')).toBe(true);
+    expect(moved.has('c')).toBe(true);
+  });
+
+  test('identical orderings flag nothing', () => {
+    expect(orderDiffIds(['a', 'b', 'c'], ['a', 'b', 'c'])).toEqual(new Set());
+  });
+
+  test('a slide present in only one ordering counts as moved (add/remove)', () => {
+    const moved = orderDiffIds(['a', 'b'], ['a', 'b', 'c']);
+    expect(moved).toEqual(new Set(['c']));
   });
 });
 

--- a/apps/slides/tests/unit/conflict-chooser.spec.ts
+++ b/apps/slides/tests/unit/conflict-chooser.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the deck conflict-chooser helpers (plan §3b Phase 7).
+ *
+ * These run in the Playwright runner WITHOUT a browser or the dev stack —
+ * the module under test is pure (no React, no network).
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  META_CONFLICT_ID,
+  ORDER_CONFLICT_ID,
+  allResolved,
+  buildResolutions,
+  buildSlideSrcdoc,
+  formatMetaValue,
+  isChildOrderId,
+  metaFieldRows,
+  reasonLabel,
+  slideSideHtml,
+} from '../../app/components/preview/conflictChooser.ts';
+
+test.describe('reasonLabel', () => {
+  test('maps every known deck reason to a human label', () => {
+    expect(reasonLabel('content')).toBe('Edited in both versions');
+    expect(reasonLabel('delete_vs_edit')).toBe('Deleted in one version, edited in the other');
+    expect(reasonLabel('both_added')).toBe('Added in both versions');
+    expect(reasonLabel('placement')).toBe('Moved differently in both versions');
+    expect(reasonLabel('child_order')).toBe('Stack order changed in both versions');
+    expect(reasonLabel('order')).toBe('Slide order changed in both versions');
+    expect(reasonLabel('meta')).toBe('Deck settings changed in both versions');
+  });
+
+  test('falls back for unknown/missing reasons', () => {
+    expect(reasonLabel(undefined)).toBe('Changed in both versions');
+    expect(reasonLabel('mystery')).toBe('Changed in both versions');
+  });
+});
+
+test.describe('sentinel ids', () => {
+  test('isChildOrderId matches only the __order__:<stackId> form', () => {
+    expect(isChildOrderId(`${ORDER_CONFLICT_ID}:abc123`)).toBe(true);
+    expect(isChildOrderId(ORDER_CONFLICT_ID)).toBe(false);
+    expect(isChildOrderId(META_CONFLICT_ID)).toBe(false);
+    expect(isChildOrderId('slide-id')).toBe(false);
+  });
+});
+
+test.describe('slideSideHtml', () => {
+  test('returns the slide html directly', () => {
+    expect(slideSideHtml({ id: 's1', html: '<h2>Title</h2>' })).toBe('<h2>Title</h2>');
+  });
+
+  test('joins a stack container children with a separator', () => {
+    const html = slideSideHtml({
+      id: 'stack',
+      children: [
+        { id: 'c1', html: '<p>one</p>' },
+        { id: 'c2', html: '<p>two</p>' },
+      ],
+    });
+    expect(html).toContain('<p>one</p>');
+    expect(html).toContain('<p>two</p>');
+    expect(html).toContain('<hr');
+  });
+
+  test('empty for null/absent sides', () => {
+    expect(slideSideHtml(null)).toBe('');
+    expect(slideSideHtml(undefined)).toBe('');
+    expect(slideSideHtml({ id: 'x' })).toBe('');
+  });
+});
+
+test.describe('buildSlideSrcdoc', () => {
+  test('embeds the slide html in a self-contained scaled document', () => {
+    const doc = buildSlideSrcdoc('<h2>Hello</h2>');
+    expect(doc).toContain('<!doctype html>');
+    expect(doc).toContain('<h2>Hello</h2>');
+    expect(doc).toContain('transform:scale');
+  });
+
+  test('adds no script of its own (sandbox keeps embedded ones inert)', () => {
+    expect(buildSlideSrcdoc('<p>x</p>')).not.toContain('<script');
+  });
+});
+
+test.describe('metaFieldRows / formatMetaValue', () => {
+  test('unions both sides and formats values compactly', () => {
+    const rows = metaFieldRows(
+      { theme: 'white', config: { center: false } },
+      { theme: 'black', customCss: '.x{color:red}' }
+    );
+    expect(rows).toEqual([
+      { field: 'theme', ours: 'white', theirs: 'black' },
+      { field: 'config', ours: '{"center":false}', theirs: '(not set)' },
+      { field: 'customCss', ours: '(not set)', theirs: '.x{color:red}' },
+    ]);
+  });
+
+  test('formatMetaValue truncates long values and handles null', () => {
+    expect(formatMetaValue(null)).toBe('(none)');
+    expect(formatMetaValue(undefined)).toBe('(not set)');
+    const long = 'x'.repeat(200);
+    const shown = formatMetaValue(long);
+    expect(shown.length).toBeLessThanOrEqual(80);
+    expect(shown.endsWith('…')).toBe(true);
+  });
+});
+
+test.describe('resolution bookkeeping', () => {
+  const ids = ['slide1', `${ORDER_CONFLICT_ID}:stack1`, META_CONFLICT_ID, ORDER_CONFLICT_ID];
+
+  test('allResolved requires a valid choice for EVERY id', () => {
+    expect(allResolved(ids, {})).toBe(false);
+    expect(allResolved(ids, { slide1: 'ours' })).toBe(false);
+    expect(
+      allResolved(ids, {
+        slide1: 'ours',
+        [`${ORDER_CONFLICT_ID}:stack1`]: 'theirs',
+        [META_CONFLICT_ID]: 'ours',
+        [ORDER_CONFLICT_ID]: 'theirs',
+      })
+    ).toBe(true);
+  });
+
+  test('allResolved is false for an empty conflict set', () => {
+    expect(allResolved([], {})).toBe(false);
+  });
+
+  test('buildResolutions emits one {id, choose} per id, in order', () => {
+    const choices = {
+      slide1: 'theirs',
+      [`${ORDER_CONFLICT_ID}:stack1`]: 'ours',
+      [META_CONFLICT_ID]: 'theirs',
+      [ORDER_CONFLICT_ID]: 'ours',
+    } as const;
+    expect(buildResolutions(ids, choices)).toEqual([
+      { id: 'slide1', choose: 'theirs' },
+      { id: `${ORDER_CONFLICT_ID}:stack1`, choose: 'ours' },
+      { id: META_CONFLICT_ID, choose: 'theirs' },
+      { id: ORDER_CONFLICT_ID, choose: 'ours' },
+    ]);
+  });
+});

--- a/apps/slides/tests/unit/deck-ops-diff.spec.ts
+++ b/apps/slides/tests/unit/deck-ops-diff.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for the diff-at-save planner (deckOpsDiff diffDeckSnapshots).
+ *
+ * These run in the Playwright runner WITHOUT a browser or the dev stack —
+ * the module under test is pure (no React, no DOM, no network): snapshots
+ * are hand-built section lists, exactly what extractDeckSnapshot produces.
+ *
+ * Contract pinned here: expressible deltas become ops (update / insert /
+ * move / delete / reorder) that REPLAY onto the base to exactly the current
+ * document (the planner self-verifies by simulation); anything the op
+ * vocabulary can't express returns null, so the caller falls back to the
+ * whole-document save.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  diffDeckSnapshots,
+  type DeckSnapshot,
+  type DiffSection,
+} from '../../app/utils/deckOpsDiff.ts';
+
+/** Leaf section shorthand. */
+function s(id: string | null, html: string, extra: Partial<DiffSection> = {}): DiffSection {
+  return {
+    id,
+    html,
+    notes: null,
+    hidden: false,
+    attrs: {},
+    children: null,
+    ...extra,
+  };
+}
+
+/** Stack container shorthand. */
+function stack(id: string | null, children: DiffSection[], extra: Partial<DiffSection> = {}): DiffSection {
+  return {
+    id,
+    html: null,
+    notes: null,
+    hidden: false,
+    attrs: {},
+    children,
+    ...extra,
+  };
+}
+
+function snap(sections: DiffSection[], theme = 'white', codeTheme = 'github'): DeckSnapshot {
+  return { theme, codeTheme, sections };
+}
+
+const base3 = () => snap([s('aaa', '<p>one</p>'), s('bbb', '<p>two</p>'), s('ccc', '<p>three</p>')]);
+
+test.describe('no-op and updates', () => {
+  test('identical snapshots → empty op list (caller falls back to whole-doc no-op semantics)', () => {
+    expect(diffDeckSnapshots(base3(), base3())).toEqual([]);
+  });
+
+  test('html change → one update op with only html', () => {
+    const curr = base3();
+    curr.sections[1] = s('bbb', '<h2>edited</h2>');
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      { op: 'update', id: 'bbb', html: '<h2>edited</h2>' },
+    ]);
+  });
+
+  test('notes added / edited / removed', () => {
+    const base = snap([s('aaa', '<p>x</p>', { notes: '<p>old</p>' }), s('bbb', '<p>y</p>')]);
+    const curr = snap([s('aaa', '<p>x</p>'), s('bbb', '<p>y</p>', { notes: '<p>new</p>' })]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      // Empty string = remove notes (server contract).
+      { op: 'update', id: 'aaa', notes: '' },
+      { op: 'update', id: 'bbb', notes: '<p>new</p>' },
+    ]);
+  });
+
+  test('hidden toggle and attrs change ride one update; cleared attrs post null', () => {
+    const base = snap([
+      s('aaa', '<p>x</p>', { attrs: { 'data-background-color': '#fff' } }),
+      s('bbb', '<p>y</p>'),
+    ]);
+    const curr = snap([
+      s('aaa', '<p>x</p>', { hidden: true }),
+      s('bbb', '<p>y</p>', { attrs: { class: 'fancy' } }),
+    ]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      { op: 'update', id: 'aaa', hidden: true, attrs: null },
+      { op: 'update', id: 'bbb', attrs: { class: 'fancy' } },
+    ]);
+  });
+
+  test('untouched slides are never transmitted', () => {
+    const curr = base3();
+    curr.sections[0] = s('aaa', '<h1>only this</h1>');
+    const ops = diffDeckSnapshots(base3(), curr)!;
+    expect(ops).toHaveLength(1);
+    expect(JSON.stringify(ops)).not.toContain('two');
+    expect(JSON.stringify(ops)).not.toContain('three');
+  });
+});
+
+test.describe('inserts', () => {
+  test('new section mid-deck → insert after its predecessor', () => {
+    const curr = base3();
+    curr.sections.splice(1, 0, s(null, '<p>new</p>'));
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      { op: 'insert', slides: [{ html: '<p>new</p>' }], position: { after: 'aaa' } },
+    ]);
+  });
+
+  test('new first section → insert at start', () => {
+    const curr = base3();
+    curr.sections.unshift(s(null, '<p>new</p>', { notes: '<p>n</p>', hidden: true }));
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      {
+        op: 'insert',
+        slides: [{ html: '<p>new</p>', notes: '<p>n</p>', hidden: true }],
+        position: { at: 'start' },
+      },
+    ]);
+  });
+
+  test('consecutive new sections group into ONE insert', () => {
+    const curr = base3();
+    curr.sections.splice(2, 0, s(null, '<p>n1</p>'), s(null, '<p>n2</p>'));
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      {
+        op: 'insert',
+        slides: [{ html: '<p>n1</p>' }, { html: '<p>n2</p>' }],
+        position: { after: 'bbb' },
+      },
+    ]);
+  });
+
+  test('new vertical stack (id-less container with new children) → insert with children', () => {
+    const curr = base3();
+    curr.sections.push(stack(null, [s(null, '<p>c1</p>'), s(null, '<p>c2</p>')]));
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      {
+        op: 'insert',
+        slides: [{ children: [{ html: '<p>c1</p>' }, { html: '<p>c2</p>' }] }],
+        position: { after: 'ccc' },
+      },
+    ]);
+  });
+
+  test('new child appended inside an existing stack → insert after the last child', () => {
+    const base = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>')])]);
+    const curr = snap([
+      s('aaa', '<p>x</p>'),
+      stack('st', [s('c1', '<p>c1</p>'), s(null, '<p>c2</p>')]),
+    ]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      { op: 'insert', slides: [{ html: '<p>c2</p>' }], position: { after: 'c1' } },
+    ]);
+  });
+
+  test('new FIRST child of a stack has no expressible anchor → null', () => {
+    const base = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>')])]);
+    const curr = snap([
+      s('aaa', '<p>x</p>'),
+      stack('st', [s(null, '<p>new</p>'), s('c1', '<p>c1</p>')]),
+    ]);
+    expect(diffDeckSnapshots(base, curr)).toBeNull();
+  });
+});
+
+test.describe('deletes, reorder, moves', () => {
+  test('removed section → delete op', () => {
+    const curr = snap([s('aaa', '<p>one</p>'), s('ccc', '<p>three</p>')]);
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([{ op: 'delete', id: 'bbb' }]);
+  });
+
+  test('deleted stack (children gone with it) → one container delete', () => {
+    const base = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>'), s('c2', '<p>c2</p>')])]);
+    const curr = snap([s('aaa', '<p>x</p>')]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([{ op: 'delete', id: 'st' }]);
+  });
+
+  test('top-level reorder → one reorder op with the full permutation', () => {
+    const curr = snap([s('ccc', '<p>three</p>'), s('aaa', '<p>one</p>'), s('bbb', '<p>two</p>')]);
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      { op: 'reorder', order: ['ccc', 'aaa', 'bbb'] },
+    ]);
+  });
+
+  test('edit + delete + reorder + insert compose in replay order', () => {
+    const curr = snap([
+      s('ccc', '<h3>edited three</h3>'),
+      s(null, '<p>new</p>'),
+      s('aaa', '<p>one</p>'),
+    ]);
+    expect(diffDeckSnapshots(base3(), curr)).toEqual([
+      { op: 'update', id: 'ccc', html: '<h3>edited three</h3>' },
+      { op: 'delete', id: 'bbb' },
+      { op: 'reorder', order: ['ccc', 'aaa'] },
+      { op: 'insert', slides: [{ html: '<p>new</p>' }], position: { after: 'ccc' } },
+    ]);
+  });
+
+  test('stack child reorder → after-anchored move chain', () => {
+    const base = snap([
+      s('aaa', '<p>x</p>'),
+      stack('st', [s('c1', '<p>c1</p>'), s('c2', '<p>c2</p>'), s('c3', '<p>c3</p>')]),
+    ]);
+    const curr = snap([
+      s('aaa', '<p>x</p>'),
+      stack('st', [s('c3', '<p>c3</p>'), s('c1', '<p>c1</p>'), s('c2', '<p>c2</p>')]),
+    ]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      { op: 'move', id: 'c1', position: { after: 'c3' } },
+      { op: 'move', id: 'c2', position: { after: 'c1' } },
+    ]);
+  });
+
+  test('child escapes its stack to the top level → move op', () => {
+    const base = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>'), s('c2', '<p>c2</p>')])]);
+    const curr = snap([
+      s('aaa', '<p>x</p>'),
+      stack('st', [s('c2', '<p>c2</p>')]),
+      s('c1', '<p>c1</p>'),
+    ]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      { op: 'move', id: 'c1', position: { after: 'st' } },
+    ]);
+  });
+
+  test('top-level slide joins a stack (after an existing child) → move op', () => {
+    const base = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>')]), s('bbb', '<p>y</p>')]);
+    const curr = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>'), s('bbb', '<p>y</p>')])]);
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      { op: 'move', id: 'bbb', position: { after: 'c1' } },
+    ]);
+  });
+
+  test('move to the FRONT of a stack from outside → null (no expressible anchor)', () => {
+    const base = snap([s('aaa', '<p>x</p>'), stack('st', [s('c1', '<p>c1</p>')]), s('bbb', '<p>y</p>')]);
+    const curr = snap([s('aaa', '<p>x</p>'), stack('st', [s('bbb', '<p>y</p>'), s('c1', '<p>c1</p>')])]);
+    expect(diffDeckSnapshots(base, curr)).toBeNull();
+  });
+});
+
+test.describe('anomalies → null (whole-doc fallback)', () => {
+  test('theme or code-theme change', () => {
+    expect(diffDeckSnapshots(base3(), snap(base3().sections, 'black'))).toBeNull();
+    expect(diffDeckSnapshots(base3(), snap(base3().sections, 'white', 'monokai'))).toBeNull();
+  });
+
+  test('duplicate ids in the current document (editor slide duplication)', () => {
+    const curr = base3();
+    curr.sections.push(s('aaa', '<p>dup</p>'));
+    expect(diffDeckSnapshots(base3(), curr)).toBeNull();
+  });
+
+  test('unknown id in the current document (foreign paste)', () => {
+    const curr = base3();
+    curr.sections.push(s('zzz', '<p>pasted</p>'));
+    expect(diffDeckSnapshots(base3(), curr)).toBeNull();
+  });
+
+  test('baseline missing an id (never diffable against an untagged base)', () => {
+    const base = snap([s('aaa', '<p>x</p>'), s(null, '<p>untagged</p>')]);
+    expect(diffDeckSnapshots(base, base)).toBeNull();
+  });
+
+  test('leaf became a stack container (containerness change)', () => {
+    const curr = base3();
+    curr.sections[0] = stack('aaa', [s(null, '<p>c</p>')]);
+    expect(diffDeckSnapshots(base3(), curr)).toBeNull();
+  });
+
+  test('NEW stack wrapping EXISTING slides (overview grouping) is inexpressible', () => {
+    const curr = snap([stack(null, [s('aaa', '<p>one</p>'), s('bbb', '<p>two</p>')]), s('ccc', '<p>three</p>')]);
+    expect(diffDeckSnapshots(base3(), curr)).toBeNull();
+  });
+
+  test('replacing every slide (delete-last engine refusal) → null', () => {
+    const curr = snap([s(null, '<p>all new</p>')]);
+    expect(diffDeckSnapshots(base3(), curr)).toBeNull();
+  });
+
+  test('NOT an anomaly: dissolved stack with a surviving child — move-out precedes the delete', () => {
+    const base = snap([stack('st', [s('c1', '<p>c1</p>')]), s('aaa', '<p>x</p>')]);
+    const curr = snap([s('c1', '<p>c1</p>'), s('aaa', '<p>x</p>')]);
+    // c1 moves OUT to the root front (expressible at root) BEFORE st deletes,
+    // so the surviving child is never destroyed with its old container.
+    expect(diffDeckSnapshots(base, curr)).toEqual([
+      { op: 'move', id: 'c1', position: { at: 'start' } },
+      { op: 'delete', id: 'st' },
+    ]);
+  });
+});

--- a/apps/slides/tests/unit/filmstrip-resolution.spec.ts
+++ b/apps/slides/tests/unit/filmstrip-resolution.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for `filmstripEntries` — the single resolver both the top-level
+ * order card and the per-stack child-order card use to turn an ordering (a list
+ * of slide ids) into filmstrip thumbnails against the accept report's
+ * `unit_previews` map.
+ *
+ * Regression guard for the child-order blank-thumbnail bug: a genuine
+ * `__order__:<stackId>` conflict rides in the 409 `units[]` array (NOT the
+ * separate `orderConflict` payload the top-level order uses), and its thumbnails
+ * came back blank. These specs pin that BOTH id sources resolve html for every
+ * referenced id through the SAME helper, so the two card types can never drift.
+ *
+ * The payloads below are copied verbatim from the SERVER's real accept report
+ * for a stack whose three children are reordered on both sides — the exact shape
+ * `deckPreview.service`'s `buildDeckUnitPreviews` + `splitDeckConflicts` emit
+ * (units carry the `__order__:<stackId>` sentinel with child-id arrays;
+ * `unit_previews` is keyed by those same child ids, each with `{index,title,
+ * html}`). Runs in the Playwright runner WITHOUT a browser — the module is pure.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  filmstripEntries,
+  isChildOrderId,
+  orderDiffIds,
+  ORDER_CONFLICT_ID,
+  type ConflictUnit,
+  type UnitPreviews,
+} from '../../app/components/preview/conflictChooser.ts';
+
+// ── The real server accept-report body for a child-order conflict ────────────
+// (stack `s14` at deck position 2; children c1,c2,c3 reordered on both sides.)
+// Shape verified against deckPreview.service's report construction.
+const CHILD_ORDER_UNIT: ConflictUnit = {
+  id: `${ORDER_CONFLICT_ID}:s14`,
+  index: '2',
+  reason: 'child_order',
+  base: ['c1', 'c2', 'c3'],
+  ours: ['c2', 'c1', 'c3'],
+  theirs: ['c1', 'c3', 'c2'],
+};
+
+const UNIT_PREVIEWS: UnitPreviews = {
+  c2: { index: '2.1', title: 'Child Two', html: '<h3>Child Two</h3><p>beta</p>' },
+  c1: { index: '2.2', title: 'Child One', html: '<h3>Child One</h3><p>alpha</p>' },
+  c3: { index: '2.3', title: 'Child Three', html: '<h3>Child Three</h3><p>gamma</p>' },
+};
+
+test.describe('filmstripEntries — child-order card resolves child thumbnails', () => {
+  test('the conflict unit IS a child-order sentinel carrying child-id arrays', () => {
+    // Guards the assumptions the card reads: child order rides in units[] under
+    // the __order__:<stackId> sentinel, with ours/theirs as child-id arrays.
+    expect(isChildOrderId(CHILD_ORDER_UNIT.id)).toBe(true);
+    expect(Array.isArray(CHILD_ORDER_UNIT.ours)).toBe(true);
+    expect(Array.isArray(CHILD_ORDER_UNIT.theirs)).toBe(true);
+  });
+
+  test('EVERY child id in BOTH orderings resolves to its preview html', () => {
+    const oursIds = CHILD_ORDER_UNIT.ours as string[];
+    const theirsIds = CHILD_ORDER_UNIT.theirs as string[];
+    const moved = orderDiffIds(oursIds, theirsIds);
+
+    for (const [ids, label] of [
+      [oursIds, 'ours'],
+      [theirsIds, 'theirs'],
+    ] as const) {
+      const entries = filmstripEntries(ids, UNIT_PREVIEWS, moved);
+      expect(entries, label).toHaveLength(ids.length);
+      for (const entry of entries) {
+        // The core assertion: the filmstrip receives HTML for every child id —
+        // not just a title. A blank thumbnail = html dropped here.
+        expect(entry.html, `${label} ${entry.id} html`).toBe(UNIT_PREVIEWS[entry.id].html);
+        expect(entry.html, `${label} ${entry.id} html non-empty`).toBeTruthy();
+        expect(entry.title, `${label} ${entry.id} title`).toBe(UNIT_PREVIEWS[entry.id].title);
+      }
+    }
+  });
+
+  test('positions are 1-based in each ordering and moved children are flagged', () => {
+    const oursIds = CHILD_ORDER_UNIT.ours as string[];
+    const theirsIds = CHILD_ORDER_UNIT.theirs as string[];
+    const moved = orderDiffIds(oursIds, theirsIds);
+    const entries = filmstripEntries(oursIds, UNIT_PREVIEWS, moved);
+
+    expect(entries.map(e => [e.id, e.position])).toEqual([
+      ['c2', 1],
+      ['c1', 2],
+      ['c3', 3],
+    ]);
+    // ours [c2,c1,c3] vs theirs [c1,c3,c2]: every child lands at a different
+    // position across the two orderings, so all three get the moved (amber) ring.
+    expect(entries.every(e => e.moved)).toBe(true);
+  });
+
+  test('the SAME helper resolves the top-level order card identically', () => {
+    // Top-level order ids arrive via the orderConflict payload, not units[].
+    // Resolving them through the same helper must yield html the same way —
+    // proving the two card types share one resolution path.
+    const ours = ['c1', 'c2', 'c3'];
+    const theirs = ['c3', 'c2', 'c1'];
+    const entries = filmstripEntries(ours, UNIT_PREVIEWS, orderDiffIds(ours, theirs));
+    for (const entry of entries) {
+      expect(entry.html).toBe(UNIT_PREVIEWS[entry.id].html);
+    }
+  });
+
+  test('an id with no preview yields a title/html-less entry (thumbnail falls back to id)', () => {
+    const entries = filmstripEntries(['c1', 'missing'], UNIT_PREVIEWS, new Set());
+    expect(entries[0].html).toBe(UNIT_PREVIEWS.c1.html);
+    expect(entries[1].html).toBeUndefined();
+    expect(entries[1].title).toBe('');
+    expect(entries[1].id).toBe('missing');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37924,7 +37924,8 @@
         "marked": "^15.0.4",
         "octokit": "^3.1.2",
         "prettier": "^3.6.2",
-        "simple-git": "^3.36.0"
+        "simple-git": "^3.36.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "vitest": "^4.1.4"

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -12,20 +12,22 @@
   "exports": {
     ".": "./src/index.ts",
     "./flags": "./src/classmoji/repoAnalytics.flags.ts",
-    "./slides": "./src/slides/index.ts"
+    "./slides": "./src/slides/index.ts",
+    "./slides/ops": "./src/slides/deckOps.ts"
   },
   "dependencies": {
     "@classmoji/database": "*",
     "@classmoji/utils": "*",
     "@octokit/auth-app": "^7.1.3",
-    "cheerio": "^1.1.2",
     "@trigger.dev/sdk": "4.4.0",
     "async": "^3.2.5",
+    "cheerio": "^1.1.2",
     "ics": "^3.8.1",
     "marked": "^15.0.4",
     "octokit": "^3.1.2",
     "prettier": "^3.6.2",
-    "simple-git": "^3.36.0"
+    "simple-git": "^3.36.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "vitest": "^4.1.4"

--- a/packages/services/src/classmoji/__tests__/pageContent.merge.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.merge.test.ts
@@ -1,0 +1,228 @@
+/**
+ * merge3Blocks fixture matrix (content-tools plan §3b Phase 7).
+ *
+ * Pure engine tests — ContentService is stubbed only so importing the service
+ * module never touches the git-provider chain. The contract under test:
+ * one-side edits merge, identical edits merge, true collisions conflict,
+ * adds keep their side position, delete-vs-unchanged lets the delete win,
+ * delete-vs-edit conflicts, the top-level order 3-way merges with the
+ * __order__ sentinel on double reorders, children subtrees ride with their
+ * top-level block, and resolutions apply chooser decisions ('ours' = main,
+ * 'theirs' = preview). The accept/resolve flows are covered in
+ * pageContent.semantic.test.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub ContentService BEFORE the service module loads, so the import never
+// drags in the git-provider/octokit/prisma chain (merge3Blocks is pure).
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {},
+}));
+
+const { merge3Blocks, ORDER_CONFLICT_ID } = await import('../pageContent.service.ts');
+
+const block = (id: string, text: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  type: 'paragraph',
+  content: [{ type: 'text', text }],
+  ...extra,
+});
+const ids = (blocks: unknown[]) => (blocks as Array<{ id: string }>).map(b => b.id);
+
+// ─── merge3Blocks — fixture matrix ───────────────────────────────────────────
+
+describe('merge3Blocks', () => {
+  it('one-side edits are taken (both directions), edits to different blocks both land', () => {
+    const base = [block('a', 'one'), block('b', 'two')];
+    const ours = [block('a', 'one MAIN'), block('b', 'two')];
+    const theirs = [block('a', 'one'), block('b', 'two PREVIEW')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged).toEqual([block('a', 'one MAIN'), block('b', 'two PREVIEW')]);
+    expect(result.autoMerged).toBe(2);
+  });
+
+  it('identical edits on both sides merge without conflict', () => {
+    const base = [block('a', 'original')];
+    const same = [block('a', 'both agree')];
+
+    const result = merge3Blocks(base, same, structuredClone(same));
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged).toEqual(same);
+    expect(result.autoMerged).toBe(1);
+  });
+
+  it('both-changed-differently is a content conflict (theirs provisional)', () => {
+    const base = [block('a', 'original'), block('b', 'stable')];
+    const ours = [block('a', 'main'), block('b', 'stable')];
+    const theirs = [block('a', 'preview'), block('b', 'stable')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: 'a',
+        index: 0,
+        reason: 'content',
+        ours: block('a', 'main'),
+        theirs: block('a', 'preview'),
+        base: block('a', 'original'),
+      },
+    ]);
+    expect(result.merged[0]).toEqual(block('a', 'preview'));
+    expect(result.autoMerged).toBe(0);
+  });
+
+  it('adds keep their side positions', () => {
+    const base = [block('a', 'a'), block('b', 'b')];
+    const ours = [block('a', 'a'), block('x', 'added on main'), block('b', 'b')];
+    const theirs = [block('a', 'a'), block('b', 'b'), block('y', 'added on preview')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(ids(result.merged)).toEqual(['a', 'x', 'b', 'y']);
+  });
+
+  it('the same id added differently on both sides is a both_added conflict', () => {
+    const base = [block('a', 'a')];
+    const ours = [block('a', 'a'), block('x', 'main add')];
+    const theirs = [block('a', 'a'), block('x', 'preview add')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({ id: 'x', reason: 'both_added' });
+    expect('base' in result.conflicts[0]).toBe(false);
+  });
+
+  it('delete vs unchanged: the delete wins (both directions)', () => {
+    const base = [block('a', 'a'), block('b', 'b')];
+    const deleted = [block('b', 'b')];
+    const untouched = structuredClone(base);
+
+    expect(ids(merge3Blocks(base, deleted, untouched).merged)).toEqual(['b']);
+    expect(ids(merge3Blocks(base, untouched, deleted).merged)).toEqual(['b']);
+    expect(merge3Blocks(base, deleted, untouched).conflicts).toEqual([]);
+  });
+
+  it('delete vs edit is a delete_vs_edit conflict (deleted side absent)', () => {
+    const base = [block('a', 'original'), block('b', 'b')];
+    const ours = [block('b', 'b')];
+    const theirs = [block('a', 'edited on preview'), block('b', 'b')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: 'a',
+        index: 0,
+        reason: 'delete_vs_edit',
+        theirs: block('a', 'edited on preview'),
+        base: block('a', 'original'),
+      },
+    ]);
+    expect(ids(result.merged)).toEqual(['a', 'b']); // edited side provisional
+  });
+
+  it('a one-side reorder is taken; both-differently raises the __order__ sentinel', () => {
+    const base = [block('a', 'a'), block('b', 'b'), block('c', 'c')];
+    const oursReordered = [block('c', 'c'), block('a', 'a'), block('b', 'b')];
+
+    const oneSide = merge3Blocks(base, oursReordered, structuredClone(base));
+    expect(oneSide.conflicts).toEqual([]);
+    expect(ids(oneSide.merged)).toEqual(['c', 'a', 'b']);
+
+    const theirsReordered = [block('a', 'a'), block('c', 'c'), block('b', 'b')];
+    const bothSides = merge3Blocks(base, oursReordered, theirsReordered);
+    expect(bothSides.conflicts).toEqual([
+      {
+        id: ORDER_CONFLICT_ID,
+        index: -1,
+        reason: 'order',
+        base: ['a', 'b', 'c'],
+        ours: ['c', 'a', 'b'],
+        theirs: ['a', 'c', 'b'],
+      },
+    ]);
+    expect(ids(bothSides.merged)).toEqual(['a', 'c', 'b']); // theirs provisional
+  });
+
+  it('children subtrees ride with their top-level block (one-sided child edits merge)', () => {
+    const withChild = (text: string) => block('p', 'parent', { children: [block('n', text)] });
+    const base = [withChild('child'), block('q', 'q')];
+    const ours = [withChild('child'), block('q', 'q EDITED')];
+    const theirs = [withChild('child PREVIEW'), block('q', 'q')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged).toEqual([withChild('child PREVIEW'), block('q', 'q EDITED')]);
+  });
+
+  it("both sides editing the same block's children differently is ONE conflict on the block", () => {
+    const withChild = (text: string) => block('p', 'parent', { children: [block('n', text)] });
+    const base = [withChild('child')];
+    const ours = [withChild('child MAIN')];
+    const theirs = [withChild('child PREVIEW')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({ id: 'p', reason: 'content' });
+  });
+
+  it('blocks missing ids align via the deterministic derived ids', () => {
+    const noId = { type: 'paragraph', content: [{ type: 'text', text: 'stable' }] };
+    const base = [structuredClone(noId), block('b', 'b')];
+    const ours = [structuredClone(noId), block('b', 'b MAIN')];
+    const theirs = [structuredClone(noId), block('b', 'b')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    // The unedited id-less block aligned across versions (kept once) and the
+    // b edit merged.
+    expect(result.merged).toHaveLength(2);
+    expect((result.merged[1] as { content: Array<{ text: string }> }).content[0].text).toBe(
+      'b MAIN'
+    );
+  });
+
+  it('resolutions apply chooser decisions (content, delete, order)', () => {
+    const base = [block('a', 'original'), block('b', 'b'), block('c', 'c')];
+    const ours = [block('b', 'b'), block('a', 'main'), block('c', 'c')];
+    const theirs = [block('a', 'preview'), block('c', 'c'), block('b', 'b')];
+
+    const result = merge3Blocks(base, ours, theirs, {
+      resolutions: { a: 'ours', [ORDER_CONFLICT_ID]: 'theirs' },
+    });
+
+    expect(result.conflicts).toEqual([]);
+    expect(ids(result.merged)).toEqual(['a', 'c', 'b']);
+    expect((result.merged[0] as { content: Array<{ text: string }> }).content[0].text).toBe('main');
+
+    // Delete resolution: choosing the deleting side drops the block.
+    const delBase = [block('x', 'original'), block('y', 'y')];
+    const delOurs = [block('y', 'y')];
+    const delTheirs = [block('x', 'edited'), block('y', 'y')];
+    const dropped = merge3Blocks(delBase, delOurs, delTheirs, { resolutions: { x: 'ours' } });
+    expect(dropped.conflicts).toEqual([]);
+    expect(ids(dropped.merged)).toEqual(['y']);
+  });
+
+  it('never mutates its inputs', () => {
+    const base = [block('a', 'a')];
+    const ours = [block('a', 'a MAIN')];
+    const theirs = [block('a', 'a'), block('z', 'z')];
+    const snapshots = [structuredClone(base), structuredClone(ours), structuredClone(theirs)];
+
+    merge3Blocks(base, ours, theirs);
+
+    expect([base, ours, theirs]).toEqual(snapshots);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.merge.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.merge.test.ts
@@ -226,3 +226,130 @@ describe('merge3Blocks', () => {
     expect([base, ours, theirs]).toEqual(snapshots);
   });
 });
+
+// ─── Cross-scope moves + id uniqueness (Phase 7 fix batch F1) ───────────────
+//
+// Review-probe scenarios: a preview that moves a nested block OUT of its
+// parent to the top level while main edits that block in place used to leave
+// the edited copy nested inside the parent's conflict subtree AND a stale
+// top-level copy — resolving 'ours' committed a DUPLICATE block id to main.
+// The engine now merges the moved block as its own unit and strips the
+// nested copies; a final sweep asserts id uniqueness on every merged doc.
+
+describe('merge3Blocks — cross-scope moves', () => {
+  const deepIds = (blocks: unknown[]): string[] => {
+    const out: string[] = [];
+    const walk = (list: Array<{ id?: string; children?: unknown[] }>): void => {
+      for (const node of list) {
+        if (node?.id) out.push(node.id);
+        if (Array.isArray(node?.children)) {
+          walk(node.children as Array<{ id?: string; children?: unknown[] }>);
+        }
+      }
+    };
+    walk(blocks as Array<{ id?: string; children?: unknown[] }>);
+    return out;
+  };
+  const assertUniqueIds = (blocks: unknown[]) => {
+    const all = deepIds(blocks);
+    expect(new Set(all).size).toBe(all.length);
+  };
+  const textOf = (node: unknown): string =>
+    (node as { content: Array<{ text: string }> }).content[0].text;
+
+  it('preview moves a nested block to the top level + main edits it in place → clean auto-merge (probe dir 1)', () => {
+    const base = [block('p', 'parent', { children: [block('c', 'child')] }), block('q', 'q')];
+    const ours = [
+      block('p', 'parent', { children: [block('c', 'child EDITED')] }),
+      block('q', 'q'),
+    ];
+    const theirs = [block('p', 'parent', { children: [] }), block('q', 'q'), block('c', 'child')];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(ids(result.merged)).toEqual(['p', 'q', 'c']);
+    // The edit followed the moved block; the parent kept no nested copy.
+    expect(textOf(result.merged[2])).toBe('child EDITED');
+    expect((result.merged[0] as { children: unknown[] }).children).toEqual([]);
+    assertUniqueIds(result.merged);
+  });
+
+  it('main moves a nested block out + preview edits it in place → clean auto-merge (probe dir 2)', () => {
+    const base = [block('p', 'parent', { children: [block('c', 'child')] }), block('q', 'q')];
+    const ours = [block('p', 'parent', { children: [] }), block('c', 'child'), block('q', 'q')];
+    const theirs = [
+      block('p', 'parent', { children: [block('c', 'child EDITED')] }),
+      block('q', 'q'),
+    ];
+
+    const result = merge3Blocks(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(ids(result.merged)).toEqual(['p', 'c', 'q']);
+    expect(textOf(result.merged[1])).toBe('child EDITED');
+    expect((result.merged[0] as { children: unknown[] }).children).toEqual([]);
+    assertUniqueIds(result.merged);
+  });
+
+  it('move-out + parent-content collision → parent conflict whose cards exclude the moved block; resolutions differ and match the cards', () => {
+    const base = [block('p', 'parent', { children: [block('c', 'child')] })];
+    const ours = [block('p', 'parent MAIN', { children: [block('c', 'child EDITED')] })];
+    const theirs = [block('p', 'parent PREVIEW', { children: [] }), block('c', 'child')];
+
+    const report = merge3Blocks(base, ours, theirs);
+    expect(report.conflicts).toHaveLength(1);
+    const conflict = report.conflicts[0];
+    expect(conflict).toMatchObject({ id: 'p', reason: 'content' });
+    // Neither card carries the moved block — its fate is not this choice's.
+    expect(deepIds([conflict.ours])).toEqual(['p']);
+    expect(deepIds([conflict.theirs])).toEqual(['p']);
+
+    const keepOurs = merge3Blocks(base, ours, theirs, { resolutions: { p: 'ours' } });
+    const keepTheirs = merge3Blocks(base, ours, theirs, { resolutions: { p: 'theirs' } });
+    expect(keepOurs.conflicts).toEqual([]);
+    expect(keepTheirs.conflicts).toEqual([]);
+
+    // The choice is honored: different documents, each matching its card.
+    expect(keepOurs.merged).not.toEqual(keepTheirs.merged);
+    expect(textOf(keepOurs.merged[0])).toBe('parent MAIN');
+    expect(keepOurs.merged[0]).toEqual(conflict.ours);
+    expect(textOf(keepTheirs.merged[0])).toBe('parent PREVIEW');
+    expect(keepTheirs.merged[0]).toEqual(conflict.theirs);
+
+    // NO duplicate id in either outcome (the original probe committed one),
+    // and the moved block lives once at the top with main's edit.
+    for (const resolved of [keepOurs.merged, keepTheirs.merged]) {
+      assertUniqueIds(resolved);
+      expect(ids(resolved)).toEqual(['p', 'c']);
+      expect(textOf(resolved[1])).toBe('child EDITED');
+    }
+  });
+
+  it('id-uniqueness sweep: a deep cross-parent nested move cannot commit a duplicate id', () => {
+    // c nested under p everywhere except theirs, where it moved under q
+    // (nested → nested, never top-level: below the promotion machinery).
+    const base = [
+      block('p', 'p', { children: [block('c', 'child')] }),
+      block('q', 'q', { children: [] }),
+    ];
+    const ours = [
+      block('p', 'p', { children: [block('c', 'child EDITED')] }),
+      block('q', 'q', { children: [] }),
+    ];
+    const theirs = [
+      block('p', 'p', { children: [] }),
+      block('q', 'q', { children: [block('c', 'child')] }),
+    ];
+
+    // p and q both changed on both sides → conflicts on each.
+    const keepBoth = merge3Blocks(base, ours, theirs, {
+      resolutions: { p: 'ours', q: 'theirs' },
+    });
+    expect(keepBoth.conflicts).toEqual([]);
+    // Without the sweep this document would carry c twice (p's edited copy +
+    // q's stale copy). The sweep keeps ONE copy.
+    assertUniqueIds(keepBoth.merged);
+    expect(deepIds(keepBoth.merged).filter(id => id === 'c')).toHaveLength(1);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.saveMerge.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.saveMerge.test.ts
@@ -358,3 +358,38 @@ describe('savePageContentWithMerge — CAS retry', () => {
     expect(putMock).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('savePageContentWithMerge — commit message (plan "commit-message")', () => {
+  it('a resolution pass records a resolution summary in the commit', async () => {
+    // A discarded B commits an edit to block b; A resolves the collision to
+    // "theirs" (A's version) — the commit that records B's discarded edit must
+    // be distinguishable from a plain save.
+    primeSave({
+      base: [block('a', 'one'), block('b', 'original')],
+      ours: [block('a', 'one'), block('b', 'REWRITTEN BY B')],
+    });
+    const theirs = [block('a', 'one'), block('b', 'version from A')];
+
+    const result = await savePageContentWithMerge(page, theirs, {
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'b', choose: 'theirs' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(result).toMatchObject({ merged: true });
+    expect(callArg(putMock)).toMatchObject({
+      message: 'Update page (merged; resolved 1 conflict): Syllabus',
+    });
+    // B's committed content is really gone…
+    expect(JSON.stringify(writtenWrapper().blocks)).toContain('version from A');
+    expect(JSON.stringify(writtenWrapper().blocks)).not.toContain('REWRITTEN BY B');
+  });
+
+  it('a clean stale-token merge with no concurrency keeps the PLAIN message', async () => {
+    primeSave({ base: [block('a', 'one')], ours: [block('a', 'one')] });
+
+    await savePageContentWithMerge(page, [block('a', 'one MINE')], { baseSha: BASE_SHA });
+
+    expect(callArg(putMock)).toMatchObject({ message: 'Update page: Syllabus' });
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.saveMerge.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.saveMerge.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Semantic 3-way merge for EDITOR page saves (content-tools plan §3b Phase 7.5).
+ *
+ * ContentService is mocked (same idiom as pageContent.semantic.test.ts) to pin
+ * the exact GitHub interactions: a stale-token save whose 3-way merges cleanly
+ * commits the merged document CAS'd on FRESH main's sha (main's current cover
+ * preserved) and reports the concurrent-change count; true collisions return
+ * only the colliding units + auto_merged + the ours_sha pin with nothing
+ * written; resolutions must exactly cover the current conflict set; an
+ * unreadable base falls back to a status-409 PageSaveConflictError (today's
+ * reload-banner flow).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getContentMock = vi.fn();
+const getBlobContentMock = vi.fn();
+const putMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getBlobContent: (...args: unknown[]) => getBlobContentMock(...args),
+    put: (...args: unknown[]) => putMock(...args),
+  },
+}));
+
+const { savePageContentWithMerge, PageSaveConflictError, PreviewResolutionError } =
+  await import('../pageContent.service.ts');
+
+const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
+const page = {
+  title: 'Syllabus',
+  content_path: 'pages/syllabus',
+  classroom: { content_namespace: 'cs101', git_organization: gitOrganization },
+};
+
+const PATH = 'pages/syllabus/content.json';
+const BASE_SHA = 'base-sha';
+
+const block = (id: string, text: string) => ({
+  id,
+  type: 'paragraph',
+  content: [{ type: 'text', text }],
+});
+
+const wrapper = (blocks: unknown[], coverImage?: unknown) =>
+  JSON.stringify({ blocks, ...(coverImage !== undefined ? { coverImage } : {}) });
+
+type CallArg = Record<string, unknown>;
+const callArg = (mock: ReturnType<typeof vi.fn>, n = 0) => mock.mock.calls[n][0] as CallArg;
+const writtenWrapper = (n = 0) =>
+  JSON.parse((putMock.mock.calls[n][0] as { content: string }).content);
+
+/** Prime the two save-merge reads: base = blob at the token, ours = fresh main. */
+function primeSave({
+  base,
+  ours,
+  baseCover,
+  oursCover,
+}: {
+  base: unknown[];
+  ours: unknown[];
+  baseCover?: unknown;
+  oursCover?: unknown;
+}) {
+  getBlobContentMock.mockImplementation(async (arg: unknown) => {
+    const { sha } = arg as { sha: string };
+    if (sha === BASE_SHA) return { content: wrapper(base, baseCover), sha: BASE_SHA };
+    return null;
+  });
+  getContentMock.mockResolvedValue({ content: wrapper(ours, oursCover), sha: 'ours-sha' });
+}
+
+beforeEach(() => {
+  for (const mock of [getContentMock, getBlobContentMock, putMock]) {
+    mock.mockReset();
+  }
+  putMock.mockResolvedValue({ sha: 'merged-sha', commit: 'merge-commit' });
+});
+
+describe('savePageContentWithMerge — clean 3-way', () => {
+  it('folds a concurrent main edit into the save: one CAS write on fresh main', async () => {
+    primeSave({
+      base: [block('a', 'one'), block('b', 'two')],
+      ours: [block('a', 'one'), block('b', 'two CONCURRENT')],
+    });
+    const theirs = [block('a', 'one MINE'), block('b', 'two')];
+
+    const result = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA });
+
+    expect(result).toEqual({
+      merged: true,
+      sha: 'merged-sha',
+      commit: 'merge-commit',
+      // The committed document rides back — the editor must adopt it (its
+      // local copy lacks b's concurrent edit).
+      document: [block('a', 'one MINE'), block('b', 'two CONCURRENT')],
+      auto_merged: 2,
+      concurrent: 1, // b — the one change main made that this editor never saw
+    });
+
+    expect(putMock).toHaveBeenCalledTimes(1);
+    expect(callArg(putMock)).toMatchObject({
+      path: PATH,
+      expectedSha: 'ours-sha', // CAS'd on FRESH main — not the stale token
+      message: 'Update page (merged): Syllabus',
+    });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'one MINE'), block('b', 'two CONCURRENT')]);
+
+    // Base fetched content-addressed; ours read bypassed the cache.
+    expect(getBlobContentMock).toHaveBeenCalledWith(expect.objectContaining({ sha: BASE_SHA }));
+    expect(getContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: PATH, skipCache: true })
+    );
+  });
+
+  it("preserves main's CURRENT cover image in the merged wrapper", async () => {
+    const cover = { url: 'https://img.example/cover.png', position: 40 };
+    primeSave({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      oursCover: cover,
+    });
+
+    await savePageContentWithMerge(page, [block('a', 'one MINE')], { baseSha: BASE_SHA });
+
+    expect(writtenWrapper().coverImage).toEqual(cover);
+  });
+
+  it('a cover-less page merges WITHOUT a coverImage key (no cosmetic null)', async () => {
+    primeSave({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one CONCURRENT')],
+    });
+
+    await savePageContentWithMerge(page, [block('a', 'one'), block('b', 'added MINE')], {
+      baseSha: BASE_SHA,
+    });
+
+    expect('coverImage' in writtenWrapper()).toBe(false);
+  });
+});
+
+describe('savePageContentWithMerge — collision report', () => {
+  it('a same-block double edit → report with ONLY that unit + auto_merged + ours_sha, nothing written', async () => {
+    primeSave({
+      base: [block('a', 'original'), block('b', 'two')],
+      ours: [block('a', 'main'), block('b', 'two')],
+    });
+    const theirs = [block('a', 'mine'), block('b', 'two edited')];
+
+    const result = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({
+      merged: false,
+      conflict: true,
+      auto_merged: 1, // b's one-sided edit
+      ours_sha: 'ours-sha',
+    });
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([
+      {
+        id: 'a',
+        index: 0,
+        reason: 'content',
+        base: block('a', 'original'),
+        ours: block('a', 'main'),
+        theirs: block('a', 'mine'),
+      },
+    ]);
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('savePageContentWithMerge — resolutions', () => {
+  const conflicted = () => {
+    primeSave({
+      base: [block('a', 'original'), block('b', 'two')],
+      ours: [block('a', 'main'), block('b', 'two')],
+    });
+    return [block('a', 'mine'), block('b', 'two edited')];
+  };
+
+  it("applies the choices and commits: 'theirs' keeps the editor's version, clean edits still land", async () => {
+    const theirs = conflicted();
+
+    const result = await savePageContentWithMerge(page, theirs, {
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'a', choose: 'theirs' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(result).toMatchObject({ merged: true, sha: 'merged-sha', auto_merged: 1 });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'mine'), block('b', 'two edited')]);
+  });
+
+  it("'ours' keeps the server's version", async () => {
+    const theirs = conflicted();
+
+    await savePageContentWithMerge(page, theirs, {
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'a', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(writtenWrapper().blocks[0]).toEqual(block('a', 'main'));
+  });
+
+  it('errors naming UNRESOLVED conflict ids — nothing written', async () => {
+    primeSave({
+      base: [block('a', 'a0'), block('b', 'b0')],
+      ours: [block('a', 'a-main'), block('b', 'b-main')],
+    });
+    const theirs = [block('a', 'a-mine'), block('b', 'b-mine')];
+
+    const failure = await savePageContentWithMerge(page, theirs, {
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'UNRESOLVED_CONFLICTS', ids: ['b'] });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('errors on UNKNOWN resolution ids', async () => {
+    const theirs = conflicted();
+
+    const failure = await savePageContentWithMerge(page, theirs, {
+      baseSha: BASE_SHA,
+      resolutions: [
+        { id: 'a', choose: 'ours' },
+        { id: 'ghost', choose: 'theirs' },
+      ],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'UNKNOWN_RESOLUTIONS',
+      ids: ['ghost'],
+    });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('the ours_sha pin refuses when main moved after the reviewed report (CONTENT_CONFLICT)', async () => {
+    const theirs = conflicted();
+    getContentMock.mockResolvedValue({
+      content: wrapper([block('a', 'even newer')]),
+      sha: 'ours-sha-2',
+    });
+
+    const failure = await savePageContentWithMerge(page, theirs, {
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'a', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'CONTENT_CONFLICT' });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('savePageContentWithMerge — fallbacks', () => {
+  const theirs = [block('a', 'mine')];
+
+  it('base blob missing → PageSaveConflictError (status 409), nothing read from main, nothing written', async () => {
+    getBlobContentMock.mockResolvedValue(null);
+
+    const failure = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(PageSaveConflictError);
+    expect(failure).toMatchObject({ status: 409, code: 'CONTENT_CONFLICT' });
+    expect(getContentMock).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('base blob read throwing → same fallback', async () => {
+    getBlobContentMock.mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+
+    const failure = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(PageSaveConflictError);
+  });
+
+  it('base blob unparseable as blocks → same fallback', async () => {
+    getBlobContentMock.mockResolvedValue({ content: '<html>legacy</html>', sha: BASE_SHA });
+
+    const failure = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(PageSaveConflictError);
+  });
+
+  it("main's content.json deleted → PageSaveConflictError, never an unguarded write", async () => {
+    getBlobContentMock.mockResolvedValue({ content: wrapper([block('a', 'one')]), sha: BASE_SHA });
+    getContentMock.mockResolvedValue(null);
+
+    const failure = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(PageSaveConflictError);
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('savePageContentWithMerge — CAS retry', () => {
+  it('a CAS loss on the commit retries ONCE against fresh main (re-running the 3-way)', async () => {
+    getBlobContentMock.mockResolvedValue({
+      content: wrapper([block('a', 'one'), block('b', 'two')]),
+      sha: BASE_SHA,
+    });
+    let mainReads = 0;
+    getContentMock.mockImplementation(async () => {
+      mainReads += 1;
+      return mainReads === 1
+        ? { content: wrapper([block('a', 'one'), block('b', 'two')]), sha: 'ours-sha' }
+        : {
+            content: wrapper([block('a', 'one'), block('b', 'two RACER')]),
+            sha: 'ours-sha-2',
+          };
+    });
+    // First commit loses the CAS (a racer landed b's edit); second lands.
+    putMock
+      .mockRejectedValueOnce(Object.assign(new Error('409 sha mismatch'), { status: 409 }))
+      .mockResolvedValueOnce({ sha: 'merged-sha-2', commit: 'merge-commit-2' });
+
+    const theirs = [block('a', 'one MINE'), block('b', 'two')];
+    const result = await savePageContentWithMerge(page, theirs, { baseSha: BASE_SHA });
+
+    expect(getContentMock).toHaveBeenCalledTimes(2);
+    expect(putMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ merged: true, sha: 'merged-sha-2', concurrent: 1 });
+    // The retry re-ran the 3-way against fresh main: the racer's edit landed too.
+    expect(callArg(putMock, 1)).toMatchObject({ expectedSha: 'ours-sha-2' });
+    expect(writtenWrapper(1).blocks).toEqual([block('a', 'one MINE'), block('b', 'two RACER')]);
+  });
+
+  it('a second CAS loss rethrows (the plain 409 fallback)', async () => {
+    getBlobContentMock.mockResolvedValue({
+      content: wrapper([block('a', 'one')]),
+      sha: BASE_SHA,
+    });
+    getContentMock.mockResolvedValue({ content: wrapper([block('a', 'one')]), sha: 'ours-sha' });
+    putMock.mockRejectedValue(Object.assign(new Error('409 sha mismatch'), { status: 409 }));
+
+    const failure = await savePageContentWithMerge(page, [block('a', 'mine')], {
+      baseSha: BASE_SHA,
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ status: 409 });
+    expect(putMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.saveOps.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.saveOps.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Ops saves for the pages editor (diff-at-save): savePageContentFromOps
+ * materializes theirs = applyBlockOps(base, ops) against the document at the
+ * conflict token and reuses the Phase 7.5 save-merge core.
+ *
+ * ContentService is mocked (same idiom as pageContent.saveMerge.test.ts) to
+ * pin the GitHub interactions: disjoint-block edits auto-merge with ONE CAS
+ * write on fresh main; a clean (non-stale) ops save commits base+ops and
+ * signals `document: null` (no editor adoption); same-block collisions return
+ * only the conflicted units + ours_sha with nothing written; resolutions
+ * re-submits carry the SAME ops; ops that don't apply to the base throw the
+ * typed OPS_BASE_MISMATCH; coverImage is preserved from main (ops never
+ * carry it); an unreadable base falls back to the status-409
+ * PageSaveConflictError.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getContentMock = vi.fn();
+const getBlobContentMock = vi.fn();
+const putMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getBlobContent: (...args: unknown[]) => getBlobContentMock(...args),
+    put: (...args: unknown[]) => putMock(...args),
+  },
+}));
+
+const {
+  savePageContentFromOps,
+  PageOpsBaseMismatchError,
+  PageSaveConflictError,
+  PreviewResolutionError,
+} = await import('../pageContent.service.ts');
+
+const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
+const page = {
+  title: 'Syllabus',
+  content_path: 'pages/syllabus',
+  classroom: { content_namespace: 'cs101', git_organization: gitOrganization },
+};
+
+const PATH = 'pages/syllabus/content.json';
+const BASE_SHA = 'base-sha';
+
+const block = (id: string, text: string) => ({
+  id,
+  type: 'paragraph',
+  content: [{ type: 'text', text }],
+});
+
+const wrapper = (blocks: unknown[], coverImage?: unknown) =>
+  JSON.stringify({ blocks, ...(coverImage !== undefined ? { coverImage } : {}) });
+
+type CallArg = Record<string, unknown>;
+const callArg = (mock: ReturnType<typeof vi.fn>, n = 0) => mock.mock.calls[n][0] as CallArg;
+const writtenWrapper = (n = 0) =>
+  JSON.parse((putMock.mock.calls[n][0] as { content: string }).content);
+
+/** Prime the two save-merge reads: base = blob at the token, ours = fresh main. */
+function primeSave({
+  base,
+  ours,
+  baseCover,
+  oursCover,
+}: {
+  base: unknown[];
+  ours: unknown[];
+  baseCover?: unknown;
+  oursCover?: unknown;
+}) {
+  getBlobContentMock.mockImplementation(async (arg: unknown) => {
+    const { sha } = arg as { sha: string };
+    if (sha === BASE_SHA) return { content: wrapper(base, baseCover), sha: BASE_SHA };
+    return null;
+  });
+  getContentMock.mockResolvedValue({ content: wrapper(ours, oursCover), sha: 'ours-sha' });
+}
+
+beforeEach(() => {
+  for (const mock of [getContentMock, getBlobContentMock, putMock]) {
+    mock.mockReset();
+  }
+  putMock.mockResolvedValue({ sha: 'merged-sha', commit: 'merge-commit' });
+});
+
+describe('savePageContentFromOps — disjoint-block auto-merge', () => {
+  it('folds a concurrent main edit into an update-op save: one CAS write on fresh main', async () => {
+    primeSave({
+      base: [block('a', 'one'), block('b', 'two')],
+      ours: [block('a', 'one'), block('b', 'two CONCURRENT')],
+    });
+
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'one MINE') }],
+    });
+
+    expect(result).toEqual({
+      merged: true,
+      sha: 'merged-sha',
+      commit: 'merge-commit',
+      // Concurrent changes folded in → the editor must adopt this document.
+      document: [block('a', 'one MINE'), block('b', 'two CONCURRENT')],
+      auto_merged: 2,
+      concurrent: 1, // b — main's change this editor never saw
+    });
+
+    expect(putMock).toHaveBeenCalledTimes(1);
+    expect(callArg(putMock)).toMatchObject({
+      path: PATH,
+      expectedSha: 'ours-sha', // CAS'd on FRESH main — not the stale token
+    });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'one MINE'), block('b', 'two CONCURRENT')]);
+    expect(getBlobContentMock).toHaveBeenCalledWith(expect.objectContaining({ sha: BASE_SHA }));
+    expect(getContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: PATH, skipCache: true })
+    );
+  });
+});
+
+describe('savePageContentFromOps — clean (non-stale) saves', () => {
+  it('main unchanged since the token → commits base+ops with document: null (no adoption)', async () => {
+    const base = [block('a', 'one'), block('b', 'two')];
+    primeSave({ base, ours: base });
+
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'one MINE') }],
+    });
+
+    expect(result).toMatchObject({
+      merged: true,
+      sha: 'merged-sha',
+      document: null,
+      concurrent: 0,
+    });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'one MINE'), block('b', 'two')]);
+  });
+
+  it('materializes insert/delete/move ops in sequence against the base', async () => {
+    const base = [block('a', 'one'), block('b', 'two'), block('c', 'three')];
+    primeSave({ base, ours: base });
+
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [
+        { op: 'delete', id: 'b' },
+        { op: 'insert', blocks: [block('d', 'four')], position: { after: 'c' } },
+        { op: 'move', id: 'c', position: { at: 'start' } },
+      ],
+    });
+
+    expect(result).toMatchObject({ merged: true, document: null });
+    // [a,b,c] → delete b → [a,c] → insert d after c → [a,c,d] → move c to start
+    expect(writtenWrapper().blocks).toEqual([
+      block('c', 'three'),
+      block('a', 'one'),
+      block('d', 'four'),
+    ]);
+  });
+});
+
+describe('savePageContentFromOps — collision report', () => {
+  const prime = () =>
+    primeSave({
+      base: [block('a', 'original'), block('b', 'two')],
+      ours: [block('a', 'main'), block('b', 'two')],
+    });
+  const conflictingOps = [
+    { op: 'update', id: 'a', block: block('a', 'mine') },
+    { op: 'update', id: 'b', block: block('b', 'two edited') },
+  ] as const;
+
+  it('a same-block double edit → report with ONLY that unit + ours_sha, nothing written', async () => {
+    prime();
+
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [...conflictingOps],
+    });
+
+    expect(result).toMatchObject({
+      merged: false,
+      conflict: true,
+      auto_merged: 1, // b's one-sided edit
+      ours_sha: 'ours-sha',
+    });
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([
+      {
+        id: 'a',
+        index: 0,
+        reason: 'content',
+        base: block('a', 'original'),
+        ours: block('a', 'main'),
+        theirs: block('a', 'mine'),
+      },
+    ]);
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("resolutions re-submit with the SAME ops: 'theirs' keeps the editor's block (document: null)", async () => {
+    prime();
+
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [...conflictingOps],
+      resolutions: [{ id: 'a', choose: 'theirs' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    // All-theirs resolution with no other main-side change: committed doc IS
+    // base+ops — no adoption needed.
+    expect(result).toMatchObject({ merged: true, sha: 'merged-sha', document: null });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'mine'), block('b', 'two edited')]);
+  });
+
+  it("'ours' keeps the server's block — the committed document differs from base+ops, so it rides back", async () => {
+    prime();
+
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [...conflictingOps],
+      resolutions: [{ id: 'a', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(result).toMatchObject({
+      merged: true,
+      document: [block('a', 'main'), block('b', 'two edited')],
+    });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'main'), block('b', 'two edited')]);
+  });
+
+  it('resolution validation runs on the ops path too (UNRESOLVED_CONFLICTS names the ids)', async () => {
+    primeSave({
+      base: [block('a', 'a0'), block('b', 'b0')],
+      ours: [block('a', 'a-main'), block('b', 'b-main')],
+    });
+
+    const failure = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [
+        { op: 'update', id: 'a', block: block('a', 'a-mine') },
+        { op: 'update', id: 'b', block: block('b', 'b-mine') },
+      ],
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'UNRESOLVED_CONFLICTS', ids: ['b'] });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('savePageContentFromOps — OPS_BASE_MISMATCH', () => {
+  it('an op naming a block the base lacks → typed 409, nothing read from main, nothing written', async () => {
+    primeSave({ base: [block('a', 'one')], ours: [block('a', 'one')] });
+
+    const failure = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'ghost', block: block('ghost', 'nope') }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PageOpsBaseMismatchError);
+    expect(failure).toMatchObject({ status: 409, code: 'OPS_BASE_MISMATCH' });
+    expect(getContentMock).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('a malformed op → same typed mismatch (the client falls back to a whole-doc save)', async () => {
+    primeSave({ base: [block('a', 'one')], ours: [block('a', 'one')] });
+
+    type Ops = Parameters<typeof savePageContentFromOps>[1]['ops'];
+    const failure = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'explode' }] as unknown as Ops, // deliberately malformed
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PageOpsBaseMismatchError);
+  });
+});
+
+describe('savePageContentFromOps — coverImage', () => {
+  it("preserves main's CURRENT cover in the merged wrapper (ops never carry it)", async () => {
+    const cover = { url: 'https://img.example/cover.png', position: 40 };
+    primeSave({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      oursCover: cover,
+    });
+
+    await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'one MINE') }],
+    });
+
+    expect(writtenWrapper().coverImage).toEqual(cover);
+  });
+
+  it('a cover-less page commits WITHOUT a coverImage key', async () => {
+    primeSave({ base: [block('a', 'one')], ours: [block('a', 'one')] });
+
+    await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'one MINE') }],
+    });
+
+    expect('coverImage' in writtenWrapper()).toBe(false);
+  });
+});
+
+describe('savePageContentFromOps — base fallbacks', () => {
+  it('base blob missing → PageSaveConflictError (status 409), nothing written', async () => {
+    getBlobContentMock.mockResolvedValue(null);
+
+    const failure = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'mine') }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PageSaveConflictError);
+    expect(failure).toMatchObject({ status: 409, code: 'CONTENT_CONFLICT' });
+    expect(getContentMock).not.toHaveBeenCalled();
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.saveOps.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.saveOps.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../content/ContentService.ts', () => ({
 
 const {
   savePageContentFromOps,
+  pageBlockOpsPayloadSchema,
   PageOpsBaseMismatchError,
   PageSaveConflictError,
   PreviewResolutionError,
@@ -326,5 +327,78 @@ describe('savePageContentFromOps — base fallbacks', () => {
     expect(failure).toMatchObject({ status: 409, code: 'CONTENT_CONFLICT' });
     expect(getContentMock).not.toHaveBeenCalled();
     expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('savePageContentFromOps — the base the ops replay against is honored (plan §P1)', () => {
+  it('a concurrent edit to the SAME block the ops touched → conflict report, nothing committed', async () => {
+    // base = the document the client diffed its ops against; main (ours) has a
+    // DIFFERENT edit to the same block. Replaying ops onto the base and
+    // 3-way-merging against fresh main must REPORT the collision, not silently
+    // auto-merge (the desync the P1 client pairing guard prevents by binding
+    // base_sha to the baseline it diffed).
+    primeSave({
+      base: [block('a', 'intro'), block('b', 'ORIGINAL')],
+      ours: [block('a', 'intro'), block('b', 'INSTRUCTOR B EDIT')],
+    });
+    const result = await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'b', block: block('b', 'INSTRUCTOR A EDIT') }],
+    });
+
+    expect(result).toMatchObject({ merged: false, conflict: true, ours_sha: 'ours-sha' });
+    expect((result as { units: Array<{ id: string }> }).units.some(u => u.id === 'b')).toBe(true);
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('savePageContentFromOps — commit message (plan "commit-message")', () => {
+  it('a clean ops save (no concurrency, no resolutions) keeps the PLAIN message', async () => {
+    primeSave({ base: [block('a', 'one')], ours: [block('a', 'one')] });
+
+    await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'one MINE') }],
+    });
+
+    expect(callArg(putMock)).toMatchObject({ message: 'Update page: Syllabus' });
+  });
+
+  it('a concurrent fold-in records the (merged) marker', async () => {
+    primeSave({
+      base: [block('a', 'one'), block('b', 'two')],
+      ours: [block('a', 'one'), block('b', 'two CONCURRENT')],
+    });
+
+    await savePageContentFromOps(page, {
+      baseSha: BASE_SHA,
+      ops: [{ op: 'update', id: 'a', block: block('a', 'one MINE') }],
+    });
+
+    expect(callArg(putMock)).toMatchObject({ message: 'Update page (merged): Syllabus' });
+  });
+});
+
+describe('pageBlockOpsPayloadSchema — single-source op validation (plan §7 P8)', () => {
+  it.each([
+    ['position:null', [{ op: 'move', id: 'b1', position: null }]],
+    ['block string', [{ op: 'update', id: 'b1', block: 'x' }]],
+    ['insert blocks string', [{ op: 'insert', blocks: 'oops', position: { at: 'end' } }]],
+    ['null op entry', [null]],
+    ['unknown op', [{ op: 'frobnicate', id: 'b1' }]],
+    ['empty array', []],
+  ])('rejects %s', (_label, ops) => {
+    expect(pageBlockOpsPayloadSchema.safeParse(ops).success).toBe(false);
+  });
+
+  it('accepts a well-formed op array', () => {
+    const parsed = pageBlockOpsPayloadSchema.safeParse([
+      { op: 'update', id: 'b1', block: { id: 'b1', type: 'paragraph', content: [] } },
+      { op: 'delete', id: 'b2' },
+      { op: 'insert', blocks: [{ type: 'paragraph' }], position: { after: 'b1' } },
+      { op: 'move', id: 'b1', position: { at: 'start' } },
+      { op: 'replace_all', blocks: [{ type: 'paragraph' }] },
+    ]);
+    expect(parsed.success).toBe(true);
   });
 });

--- a/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Semantic auto-merge on page accept + per-unit conflict resolution
+ * (content-tools plan §3b Phase 7).
+ *
+ * ContentService is mocked (same idiom as pageContent.service.test.ts) to pin
+ * the exact GitHub interactions: a git-conflicted accept that 3-way-merges
+ * cleanly commits the merged doc to main CAS'd on main's pre-write sha and
+ * deletes the branch; true collisions return only the colliding units plus
+ * the auto_merged count with the branch kept; resolutions must exactly cover
+ * the current conflict set. The engine itself is fixture-tested in
+ * pageContent.merge.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getContentMock = vi.fn();
+const getMetaMock = vi.fn();
+const putMock = vi.fn();
+const compareBranchesMock = vi.fn();
+const deleteBranchMock = vi.fn();
+const mergeBranchMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getMeta: (...args: unknown[]) => getMetaMock(...args),
+    put: (...args: unknown[]) => putMock(...args),
+    compareBranches: (...args: unknown[]) => compareBranchesMock(...args),
+    deleteBranch: (...args: unknown[]) => deleteBranchMock(...args),
+    mergeBranch: (...args: unknown[]) => mergeBranchMock(...args),
+  },
+}));
+
+const { acceptPreview, resolvePreviewConflicts, PreviewResolutionError, ORDER_CONFLICT_ID } =
+  await import('../pageContent.service.ts');
+
+const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
+const page = {
+  title: 'Syllabus',
+  content_path: 'pages/syllabus',
+  classroom: { content_namespace: 'cs101', git_organization: gitOrganization },
+};
+const PREVIEW_BRANCH = 'preview/pages/syllabus';
+
+const block = (id: string, text: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  type: 'paragraph',
+  content: [{ type: 'text', text }],
+  ...extra,
+});
+
+// ─── acceptPreview — semantic fallback on git conflict ───────────────────────
+
+type CallArg = Record<string, unknown>;
+const callArg = (mock: ReturnType<typeof vi.fn>, n = 0) => mock.mock.calls[n][0] as CallArg;
+const writtenWrapper = (n = 0) =>
+  JSON.parse((putMock.mock.calls[n][0] as { content: string }).content);
+
+const wrapper = (blocks: unknown[], coverImage?: unknown) =>
+  JSON.stringify({ blocks, ...(coverImage !== undefined ? { coverImage } : {}) });
+
+/** Standard 3-way content reads: ours = fresh main, theirs = branch, base = fork-point. */
+function primeThreeWay({
+  base,
+  ours,
+  theirs,
+  baseCover,
+  oursCover,
+  theirsCover,
+}: {
+  base: unknown[];
+  ours: unknown[];
+  theirs: unknown[];
+  baseCover?: unknown;
+  oursCover?: unknown;
+  theirsCover?: unknown;
+}) {
+  mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
+  compareBranchesMock.mockResolvedValue({
+    ahead_by: 1,
+    behind_by: 1,
+    base_sha: 'main-head',
+    head_sha: 'preview-head',
+    merge_base_sha: 'fork-point',
+    commits: [],
+  });
+  getContentMock.mockImplementation(async (arg: unknown) => {
+    const { ref } = arg as { ref?: string };
+    if (ref === PREVIEW_BRANCH) return { content: wrapper(theirs, theirsCover), sha: 'theirs-sha' };
+    if (ref === 'fork-point') return { content: wrapper(base, baseCover), sha: 'base-sha' };
+    return { content: wrapper(ours, oursCover), sha: 'ours-sha' };
+  });
+}
+
+beforeEach(() => {
+  for (const mock of [
+    getContentMock,
+    getMetaMock,
+    putMock,
+    compareBranchesMock,
+    deleteBranchMock,
+    mergeBranchMock,
+  ]) {
+    mock.mockReset();
+  }
+  putMock.mockResolvedValue({ sha: 'merged-sha', commit: 'merge-commit' });
+  deleteBranchMock.mockResolvedValue({ deleted: true });
+  // Branch guard: the branch's content.json still matches the merged theirs.
+  getMetaMock.mockResolvedValue({ sha: 'theirs-sha', size: 1 });
+});
+
+describe('acceptPreview — semantic auto-merge on git conflict', () => {
+  it('zero true collisions → commits the merged doc to main (CAS on ours sha) and deletes the branch', async () => {
+    primeThreeWay({
+      base: [block('a', 'one'), block('b', 'two')],
+      ours: [block('a', 'one MAIN'), block('b', 'two')],
+      theirs: [block('a', 'one'), block('b', 'two PREVIEW')],
+    });
+
+    const result = await acceptPreview(page);
+
+    expect(result).toEqual({ merged: true, semantic: true, auto_merged: 2, sha: 'merged-sha' });
+
+    // One CAS'd write on main: merged blocks, expectedSha = main's pre-write sha.
+    expect(putMock).toHaveBeenCalledTimes(1);
+    const putArgs = callArg(putMock);
+    expect(putArgs).toMatchObject({
+      path: 'pages/syllabus/content.json',
+      expectedSha: 'ours-sha',
+      message: 'Accept preview (auto-merged): Syllabus',
+    });
+    expect('branch' in putArgs).toBe(false); // main, not the preview branch
+    expect(writtenWrapper().blocks).toEqual([block('a', 'one MAIN'), block('b', 'two PREVIEW')]);
+
+    // Branch guard read the BRANCH's blob sha, then deleted the branch.
+    expect(getMetaMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: PREVIEW_BRANCH, path: 'pages/syllabus/content.json' })
+    );
+    expect(deleteBranchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ branch: PREVIEW_BRANCH })
+    );
+  });
+
+  it('a preview-side cover change rides into the merged wrapper', async () => {
+    const cover = { url: 'https://img.example/new.png', position: 30 };
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      theirs: [block('a', 'one PREVIEW')],
+      theirsCover: cover,
+    });
+
+    await acceptPreview(page);
+
+    expect(writtenWrapper().coverImage).toEqual(cover);
+  });
+
+  it('true collisions → report with ONLY the colliding units + auto_merged, branch kept, nothing written', async () => {
+    primeThreeWay({
+      base: [block('a', 'original'), block('b', 'two')],
+      ours: [block('a', 'main'), block('b', 'two')],
+      theirs: [block('a', 'preview'), block('b', 'two PREVIEW')],
+    });
+
+    const result = await acceptPreview(page);
+
+    expect(result).toEqual({
+      merged: false,
+      conflict: true,
+      units: [
+        {
+          id: 'a',
+          index: 0,
+          reason: 'content',
+          ours: block('a', 'main'),
+          theirs: block('a', 'preview'),
+          base: block('a', 'original'),
+        },
+      ],
+      auto_merged: 1, // b's one-sided edit
+      ours_sha: 'ours-sha',
+      theirs_sha: 'theirs-sha',
+    });
+    expect(putMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('a CAS loss on the semantic commit retries ONCE against fresh main', async () => {
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      theirs: [block('a', 'one PREVIEW')],
+    });
+    // First write loses the race; the fresh main re-read yields a new sha
+    // (the racer changed something merge-compatible, e.g. the cover).
+    putMock
+      .mockRejectedValueOnce(Object.assign(new Error('modified'), { status: 409 }))
+      .mockResolvedValueOnce({ sha: 'merged-sha-2', commit: 'merge-commit-2' });
+    const cover = { url: 'https://img.example/raced.png', position: 10 };
+    let freshServed = false;
+    const baseImpl = getContentMock.getMockImplementation()!;
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === undefined && putMock.mock.calls.length > 0 && !freshServed) {
+        freshServed = true;
+        return { content: wrapper([block('a', 'one')], cover), sha: 'ours-sha-2' };
+      }
+      return baseImpl(arg);
+    });
+
+    const result = await acceptPreview(page);
+
+    expect(putMock).toHaveBeenCalledTimes(2);
+    expect(callArg(putMock, 1).expectedSha).toBe('ours-sha-2');
+    // The retry re-merged against fresh main: theirs' edit + the racer's cover.
+    expect(writtenWrapper(1).blocks).toEqual([block('a', 'one PREVIEW')]);
+    expect(writtenWrapper(1).coverImage).toEqual(cover);
+    expect(result).toMatchObject({ merged: true, semantic: true, sha: 'merged-sha-2' });
+  });
+
+  it('keeps the branch when it gained edits during the semantic accept', async () => {
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      theirs: [block('a', 'one PREVIEW')],
+    });
+    getMetaMock.mockResolvedValue({ sha: 'newer-theirs-sha', size: 1 });
+
+    const result = await acceptPreview(page);
+
+    expect(result).toMatchObject({
+      merged: true,
+      semantic: true,
+      preview_kept: true,
+      reason: expect.stringContaining('retained'),
+    });
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('a clean git merge keeps the fast path untouched (no semantic flag, no 3-way reads)', async () => {
+    mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });
+    getContentMock.mockResolvedValue({ content: wrapper([]), sha: 'merged-blob-sha' });
+    compareBranchesMock.mockResolvedValue({
+      ahead_by: 0,
+      behind_by: 0,
+      base_sha: 'x',
+      head_sha: 'x',
+      merge_base_sha: 'x',
+      commits: [],
+    });
+
+    const result = await acceptPreview(page);
+
+    expect(result).toEqual({ merged: true, sha: 'merged-blob-sha' });
+    expect('semantic' in result).toBe(false);
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── resolvePreviewConflicts ─────────────────────────────────────────────────
+
+describe('resolvePreviewConflicts', () => {
+  const conflicted = () =>
+    primeThreeWay({
+      base: [block('a', 'original'), block('b', 'two')],
+      ours: [block('a', 'main'), block('b', 'two')],
+      theirs: [block('a', 'preview'), block('b', 'two PREVIEW')],
+    });
+
+  it('applies the choices, commits the resolved merge, deletes the branch', async () => {
+    conflicted();
+
+    const result = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    });
+
+    expect(result).toEqual({
+      merged: true,
+      semantic: true,
+      sha: 'merged-sha',
+      auto_merged: 1,
+      resolved: [{ id: 'a', choose: 'ours' }],
+    });
+    expect(writtenWrapper().blocks).toEqual([block('a', 'main'), block('b', 'two PREVIEW')]);
+    expect(callArg(putMock)).toMatchObject({ expectedSha: 'ours-sha' });
+    expect(deleteBranchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("'theirs' keeps the preview's version", async () => {
+    conflicted();
+
+    await resolvePreviewConflicts(page, { resolutions: [{ id: 'a', choose: 'theirs' }] });
+
+    expect(writtenWrapper().blocks[0]).toEqual(block('a', 'preview'));
+  });
+
+  it('errors naming UNRESOLVED conflict ids — nothing written', async () => {
+    // Two conflicts: block a and the order sentinel.
+    primeThreeWay({
+      base: [block('a', 'original'), block('b', 'b'), block('c', 'c')],
+      ours: [block('b', 'b'), block('a', 'main'), block('c', 'c')],
+      theirs: [block('a', 'preview'), block('c', 'c'), block('b', 'b')],
+    });
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect((failure as InstanceType<typeof PreviewResolutionError>).code).toBe(
+      'UNRESOLVED_CONFLICTS'
+    );
+    expect((failure as InstanceType<typeof PreviewResolutionError>).ids).toEqual([
+      ORDER_CONFLICT_ID,
+    ]);
+    expect(putMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('errors on UNKNOWN resolution ids', async () => {
+    conflicted();
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [
+        { id: 'a', choose: 'ours' },
+        { id: 'ghost', choose: 'theirs' },
+      ],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'UNKNOWN_RESOLUTIONS' });
+    expect((failure as InstanceType<typeof PreviewResolutionError>).ids).toEqual(['ghost']);
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('errors on duplicate resolution ids', async () => {
+    conflicted();
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [
+        { id: 'a', choose: 'ours' },
+        { id: 'a', choose: 'theirs' },
+      ],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'DUPLICATE_RESOLUTIONS',
+    });
+  });
+
+  it('errors with NOTHING_TO_RESOLVE when the merge is now clean', async () => {
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      theirs: [block('a', 'one PREVIEW')],
+    });
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'NOTHING_TO_RESOLVE' });
+  });
+
+  it('errors with NO_PREVIEW when the branch is gone', async () => {
+    mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
+    compareBranchesMock.mockResolvedValue(null);
+    getContentMock.mockResolvedValue(null);
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'NO_PREVIEW' });
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
@@ -155,6 +155,47 @@ describe('acceptPreview — semantic auto-merge on git conflict', () => {
     expect(writtenWrapper().coverImage).toEqual(cover);
   });
 
+  it('a cover-less page merges WITHOUT a coverImage key (no cosmetic null)', async () => {
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one MAIN')],
+      theirs: [block('a', 'one'), block('b', 'added PREVIEW')],
+    });
+
+    await acceptPreview(page);
+
+    // Pre-Phase-7 saves never wrote the key for cover-less pages; the
+    // semantic accept must not introduce `"coverImage": null`.
+    expect('coverImage' in writtenWrapper()).toBe(false);
+  });
+
+  it("main's content.json deleted → typed MAIN_CONTENT_MISSING, never an unguarded write", async () => {
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'one')],
+      theirs: [block('a', 'one PREVIEW')],
+    });
+    // Main's file is gone: the fresh main read (no ref) returns null.
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === PREVIEW_BRANCH) {
+        return { content: wrapper([block('a', 'one PREVIEW')]), sha: 'theirs-sha' };
+      }
+      if (ref === 'fork-point') return { content: wrapper([block('a', 'one')]), sha: 'base-sha' };
+      return null;
+    });
+
+    const failure = await acceptPreview(page).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'MAIN_CONTENT_MISSING',
+      message: expect.stringContaining('deleted'),
+    });
+    expect(putMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
   it('true collisions → report with ONLY the colliding units + auto_merged, branch kept, nothing written', async () => {
     primeThreeWay({
       base: [block('a', 'original'), block('b', 'two')],
@@ -372,5 +413,88 @@ describe('resolvePreviewConflicts', () => {
     }).catch((e: unknown) => e);
 
     expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'NO_PREVIEW' });
+  });
+
+  it('malformed resolution elements → INVALID_RESOLUTIONS, nothing written (never defaults to theirs)', async () => {
+    conflicted();
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'banana' } as unknown as { id: string; choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'INVALID_RESOLUTIONS',
+    });
+    expect(putMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  // ── Sha pinning (F3): resolutions apply only to the reviewed report ──
+
+  it('expected_ours_sha mismatch → CONTENT_CONFLICT, nothing written', async () => {
+    conflicted(); // fresh main reads as ours-sha
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+      expectedOursSha: 'sha-from-an-older-report',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'CONTENT_CONFLICT',
+      message: expect.stringContaining('re-run accept'),
+    });
+    expect(putMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('expected_theirs_sha mismatch (preview stacked since the report) → CONTENT_CONFLICT', async () => {
+    conflicted(); // preview branch reads as theirs-sha
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+      expectedTheirsSha: 'sha-from-an-older-report',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'CONTENT_CONFLICT' });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('matching sha pins resolve normally', async () => {
+    conflicted();
+
+    const result = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+      expectedTheirsSha: 'theirs-sha',
+    });
+
+    expect(result).toMatchObject({ merged: true, semantic: true });
+    expect(writtenWrapper().blocks[0]).toEqual(block('a', 'main'));
+  });
+
+  it("main's content.json deleted → MAIN_CONTENT_MISSING from the resolve flow too", async () => {
+    conflicted();
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === PREVIEW_BRANCH) {
+        return { content: wrapper([block('a', 'preview')]), sha: 'theirs-sha' };
+      }
+      if (ref === 'fork-point') {
+        return { content: wrapper([block('a', 'original')]), sha: 'base-sha' };
+      }
+      return null; // main's file is gone
+    });
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'MAIN_CONTENT_MISSING',
+    });
+    expect(putMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
@@ -498,3 +498,69 @@ describe('resolvePreviewConflicts', () => {
     expect(putMock).not.toHaveBeenCalled();
   });
 });
+
+describe('accept/resolve refuse a missing or unparseable merge base (plan §7 P3)', () => {
+  /** git conflict + a valid comparison, but the merge-base read yields `base`. */
+  function primeMissingBase(base: string | null) {
+    mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
+    compareBranchesMock.mockResolvedValue({
+      ahead_by: 1,
+      behind_by: 1,
+      base_sha: 'main-head',
+      head_sha: 'preview-head',
+      merge_base_sha: 'fork-point',
+      commits: [],
+    });
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === PREVIEW_BRANCH) return { content: wrapper([block('a', 'preview')]), sha: 'theirs-sha' };
+      if (ref === 'fork-point') return base == null ? null : { content: base, sha: 'base-sha' };
+      return { content: wrapper([block('a', 'main')]), sha: 'ours-sha' };
+    });
+  }
+
+  it('acceptPreview: merge-base content.json 404 (add/add) → MERGE_BASE_MISSING, nothing committed, branch kept', async () => {
+    primeMissingBase(null);
+
+    const failure = await acceptPreview(page).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'MERGE_BASE_MISSING' });
+    expect(putMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('acceptPreview: unparseable merge-base → MERGE_BASE_MISSING', async () => {
+    primeMissingBase('{ not valid json !!!');
+
+    const failure = await acceptPreview(page).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ code: 'MERGE_BASE_MISSING' });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it('resolvePreviewConflicts: missing merge-base → MERGE_BASE_MISSING (reviewed choices never applied over an empty base)', async () => {
+    primeMissingBase(null);
+
+    const failure = await resolvePreviewConflicts(page, {
+      resolutions: [{ id: 'a', choose: 'theirs' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ code: 'MERGE_BASE_MISSING' });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('acceptPreview refuses a vanished preview mid-accept (plan §7 P7)', () => {
+  it('a concurrent discard (compareBranches null) → NO_PREVIEW, nothing auto-merged', async () => {
+    mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
+    compareBranchesMock.mockResolvedValue(null); // preview branch gone
+    getContentMock.mockResolvedValue(null);
+
+    const failure = await acceptPreview(page).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'NO_PREVIEW' });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
@@ -226,6 +226,66 @@ describe('acceptPreview — semantic auto-merge on git conflict', () => {
     expect(deleteBranchMock).not.toHaveBeenCalled();
   });
 
+  it('a both-sides block reorder reports __order__ with numbered unit_previews', async () => {
+    primeThreeWay({
+      base: [block('a', 'one'), block('b', 'two'), block('c', 'three')],
+      ours: [block('b', 'two'), block('a', 'one'), block('c', 'three')],
+      theirs: [block('a', 'one'), block('c', 'three'), block('b', 'two')],
+    });
+
+    const result = await acceptPreview(page);
+
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([
+      {
+        id: ORDER_CONFLICT_ID,
+        index: -1,
+        reason: 'order',
+        base: ['a', 'b', 'c'],
+        ours: ['b', 'a', 'c'],
+        theirs: ['a', 'c', 'b'],
+      },
+    ]);
+    // Each referenced block summarized ONCE from the ours doc: position + text.
+    expect(result.unit_previews).toEqual({
+      a: { index: 1, summary: 'paragraph: one' },
+      b: { index: 0, summary: 'paragraph: two' },
+      c: { index: 2, summary: 'paragraph: three' },
+    });
+  });
+
+  it('a block-order preview summary truncates long text to ≤80 chars', async () => {
+    const long = 'w'.repeat(200);
+    primeThreeWay({
+      base: [block('a', long), block('b', 'two'), block('c', 'three')],
+      ours: [block('b', 'two'), block('a', long), block('c', 'three')],
+      theirs: [block('a', long), block('c', 'three'), block('b', 'two')],
+    });
+
+    const result = await acceptPreview(page);
+
+    if (result.merged) throw new Error('unreachable');
+    const summary = result.unit_previews?.a.summary ?? '';
+    // `type: ` prefix + ≤80 chars of text ending in an ellipsis.
+    expect(summary.startsWith('paragraph: ')).toBe(true);
+    expect(summary.endsWith('…')).toBe(true);
+    expect(summary.length).toBeLessThanOrEqual('paragraph: '.length + 80);
+  });
+
+  it('a pure content collision has no unit_previews (no order conflict)', async () => {
+    primeThreeWay({
+      base: [block('a', 'one')],
+      ours: [block('a', 'main')],
+      theirs: [block('a', 'preview')],
+    });
+
+    const result = await acceptPreview(page);
+
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toHaveLength(1);
+    expect(result.unit_previews).toBeUndefined();
+  });
+
   it('a CAS loss on the semantic commit retries ONCE against fresh main', async () => {
     primeThreeWay({
       base: [block('a', 'one')],
@@ -513,7 +573,8 @@ describe('accept/resolve refuse a missing or unparseable merge base (plan §7 P3
     });
     getContentMock.mockImplementation(async (arg: unknown) => {
       const { ref } = arg as { ref?: string };
-      if (ref === PREVIEW_BRANCH) return { content: wrapper([block('a', 'preview')]), sha: 'theirs-sha' };
+      if (ref === PREVIEW_BRANCH)
+        return { content: wrapper([block('a', 'preview')]), sha: 'theirs-sha' };
       if (ref === 'fork-point') return base == null ? null : { content: base, sha: 'base-sha' };
       return { content: wrapper([block('a', 'main')]), sha: 'ours-sha' };
     });

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -199,11 +199,14 @@ describe('pageContent.savePageContent', () => {
     expect(writtenWrapper()).toEqual({ blocks, coverImage: newCover });
   });
 
-  it('removes the coverImage on explicit null', async () => {
+  it('removes the coverImage on explicit null (key omitted, matching cover-less saves)', async () => {
     await savePageContent(page, blocks, { coverImage: null });
 
     expect(getContentMock).not.toHaveBeenCalled();
-    expect(writtenWrapper()).toEqual({ blocks, coverImage: null });
+    // Removal serializes as NO key — semantic accepts must not sprinkle
+    // `"coverImage": null` into documents that never had one.
+    expect(writtenWrapper()).toEqual({ blocks });
+    expect('coverImage' in writtenWrapper()).toBe(false);
   });
 
   it('forwards expectedSha to put and propagates its 409', async () => {
@@ -240,7 +243,7 @@ describe('pageContent.savePageContent', () => {
     const arg = callArg(putMock);
     expect(arg.message).toBe('Agent edit: fix typo');
     expect(arg.content).toBe(
-      JSON.stringify({ blocks, coverImage: null }, null, 2) // 2-space pretty wrapper
+      JSON.stringify({ blocks }, null, 2) // 2-space pretty wrapper, null cover omitted
     );
   });
 });

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -848,7 +848,17 @@ describe('pageContent.acceptPreview', () => {
     expect(result).toEqual({
       merged: false,
       conflict: true,
-      units: [{ id: 'x', index: 0, ours: oursBlock, theirs: theirsBlock, base: baseBlock }],
+      units: [
+        {
+          id: 'x',
+          index: 0,
+          reason: 'content',
+          ours: oursBlock,
+          theirs: theirsBlock,
+          base: baseBlock,
+        },
+      ],
+      auto_merged: 0,
       ours_sha: 'ours-sha',
       theirs_sha: 'theirs-sha',
     });

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -41,8 +41,6 @@ const {
   ensurePreviewBranch,
   acceptPreview,
   discardPreview,
-  diffBlockUnits,
-  ORDER_CONFLICT_ID,
 } = await import('../pageContent.service.ts');
 
 const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
@@ -905,100 +903,8 @@ describe('pageContent.discardPreview', () => {
   });
 });
 
-// ─── diffBlockUnits (3-way conflict report) ──────────────────────────────────
-
-describe('pageContent.diffBlockUnits', () => {
-  const block = (id: string, text: string, extra: Record<string, unknown> = {}) => ({
-    id,
-    type: 'paragraph',
-    content: [{ type: 'text', text }],
-    ...extra,
-  });
-
-  it('one-sided changes are NOT conflicts (git auto-merges them)', () => {
-    const base = [block('a', 'one'), block('b', 'two')];
-    const ours = [block('a', 'one EDITED ON MAIN'), block('b', 'two')];
-    const theirs = [block('a', 'one'), block('b', 'two EDITED ON PREVIEW')];
-
-    // Each block changed on exactly one side → nothing to report.
-    expect(diffBlockUnits(base, ours, theirs)).toEqual([]);
-  });
-
-  it('both-sides-changed-differently is a conflict carrying ours/theirs/base', () => {
-    const base = [block('a', 'original'), block('b', 'stable')];
-    const ours = [block('a', 'main version'), block('b', 'stable')];
-    const theirs = [block('a', 'preview version'), block('b', 'stable')];
-
-    expect(diffBlockUnits(base, ours, theirs)).toEqual([
-      {
-        id: 'a',
-        index: 0,
-        ours: block('a', 'main version'),
-        theirs: block('a', 'preview version'),
-        base: block('a', 'original'),
-      },
-    ]);
-  });
-
-  it('identical changes on both sides are not conflicts', () => {
-    const base = [block('a', 'original')];
-    const same = [block('a', 'both sides agree')];
-
-    expect(diffBlockUnits(base, same, structuredClone(same))).toEqual([]);
-  });
-
-  it('edit-vs-delete is a conflict (deleted side absent from the unit)', () => {
-    const base = [block('a', 'original'), block('b', 'keep')];
-    const ours = [block('b', 'keep')]; // deleted on main
-    const theirs = [block('a', 'edited on preview'), block('b', 'keep')];
-
-    expect(diffBlockUnits(base, ours, theirs)).toEqual([
-      {
-        id: 'a',
-        index: 0,
-        theirs: block('a', 'edited on preview'),
-        base: block('a', 'original'),
-      },
-    ]);
-  });
-
-  it('deep-equal covers nested children (a child edit conflicts the parent unit)', () => {
-    const withChild = (text: string) => block('p', 'parent', { children: [block('c', text)] });
-    const base = [withChild('child')];
-    const ours = [withChild('child main')];
-    const theirs = [withChild('child preview')];
-
-    const units = diffBlockUnits(base, ours, theirs);
-    expect(units).toHaveLength(1);
-    expect(units[0].id).toBe('p');
-  });
-
-  it('order conflict: both sides reordered differently → sentinel __order__ unit', () => {
-    const a = block('a', 'a');
-    const b = block('b', 'b');
-    const c = block('c', 'c');
-    const base = [a, b, c];
-    const ours = [b, a, c]; // main swapped a/b
-    const theirs = [a, c, b]; // preview swapped b/c
-
-    const units = diffBlockUnits(base, ours, theirs);
-    expect(units).toEqual([
-      {
-        id: ORDER_CONFLICT_ID,
-        index: -1,
-        ours: ['b', 'a', 'c'],
-        theirs: ['a', 'c', 'b'],
-        base: ['a', 'b', 'c'],
-      },
-    ]);
-  });
-
-  it('same reorder on both sides is not an order conflict', () => {
-    const a = block('a', 'a');
-    const b = block('b', 'b');
-    const base = [a, b];
-    const swapped = [b, a];
-
-    expect(diffBlockUnits(base, swapped, structuredClone(swapped))).toEqual([]);
-  });
-});
+// NOTE (plan §7 P10): the `diffBlockUnits` unit tests were removed with the
+// dead function itself — it had zero production callers post-Phase-7 and its
+// raw-string comparison diverged from the shipping engine. The authoritative
+// 3-way conflict reporting is exercised through merge3Blocks (see
+// pageContent.merge.test.ts) and the accept/save merge suites.

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1234,6 +1234,32 @@ export type SavePageMergeResult =
     };
 
 /**
+ * Read + parse the save-merge base: the document at the editor's conflict
+ * token, fetched content-addressed via ContentService.getBlobContent. A
+ * failed or unparseable read means no trustworthy 3-way exists — throw the
+ * fallback conflict rather than merging against a guessed base.
+ *
+ * @throws {PageSaveConflictError}
+ */
+async function readSaveMergeBase(page: PageWithContentRepo, baseSha: string): Promise<BlockNode[]> {
+  const { gitOrganization, repo } = contentRepoFor(page);
+  let baseFile: { content: string } | null = null;
+  try {
+    baseFile = await ContentService.getBlobContent({ gitOrganization, repo, sha: baseSha });
+  } catch (error: unknown) {
+    console.warn(
+      `[pageContent.saveMerge] Base blob read failed for ${repo}@${baseSha}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+  const baseBlocks = baseFile ? parseBlocksStrict(baseFile.content) : null;
+  if (!baseBlocks) {
+    throw new PageSaveConflictError('This page changed since it was read — reload before saving');
+  }
+  return baseBlocks;
+}
+
+/**
  * Save an editor's posted blocks over a stale conflict token by 3-way
  * semantic merge (plan §3b Phase 7.5). The token IS the merge base: it is
  * content.json's blob sha at editor-load time, fetched content-addressed via
@@ -1254,25 +1280,29 @@ export async function savePageContentWithMerge(
   theirs: unknown[],
   { baseSha, resolutions, expectedOursSha, message }: SavePageMergeArgs
 ): Promise<SavePageMergeResult> {
+  const baseBlocks = await readSaveMergeBase(page, baseSha);
+  return runSaveMerge(page, theirs, baseBlocks, { resolutions, expectedOursSha, message });
+}
+
+/**
+ * The save-merge core shared by the whole-document entry
+ * (savePageContentWithMerge) and the ops entry (savePageContentFromOps):
+ * 3-way merge of base (the token's document) / ours (fresh main) / theirs
+ * (the posted or materialized document), the resolutions validation, the
+ * concurrent-change count, and the CAS'd commit with one retry.
+ */
+async function runSaveMerge(
+  page: PageWithContentRepo,
+  theirs: unknown[],
+  baseBlocks: BlockNode[],
+  {
+    resolutions,
+    expectedOursSha,
+    message,
+  }: Pick<SavePageMergeArgs, 'resolutions' | 'expectedOursSha' | 'message'>
+): Promise<SavePageMergeResult> {
   const { gitOrganization, repo } = contentRepoFor(page);
   const path = `${page.content_path}/content.json`;
-
-  // Base = the document at the editor's token. A failed or unparseable base
-  // read means no trustworthy 3-way exists — fall back rather than merging
-  // against a guessed base.
-  let baseFile: { content: string } | null = null;
-  try {
-    baseFile = await ContentService.getBlobContent({ gitOrganization, repo, sha: baseSha });
-  } catch (error: unknown) {
-    console.warn(
-      `[pageContent.saveMerge] Base blob read failed for ${repo}@${baseSha}:`,
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-  const baseBlocks = baseFile ? parseBlocksStrict(baseFile.content) : null;
-  if (!baseBlocks) {
-    throw new PageSaveConflictError('This page changed since it was read — reload before saving');
-  }
 
   const chosen = resolutions ? indexResolutions(resolutions) : null;
 
@@ -1375,6 +1405,105 @@ export async function savePageContentWithMerge(
   }
   /* c8 ignore next */
   throw new Error('unreachable');
+}
+
+// ─── Ops saves (diff-at-save) ────────────────────────────────────────────────
+
+/**
+ * Typed refusal for an ops save whose operations don't apply to the document
+ * at base_sha (unknown block id or anchor, bad position, malformed op). The
+ * client's recovery is ONE whole-document save of its current editor content —
+ * that path needs no base to replay against. Carries `status: 409` so an
+ * unhandled propagation degrades to the reload-banner flow, never a 500.
+ */
+export class PageOpsBaseMismatchError extends Error {
+  status = 409 as const;
+  code = 'OPS_BASE_MISMATCH' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'PageOpsBaseMismatchError';
+  }
+}
+
+export interface SavePageOpsArgs extends SavePageMergeArgs {
+  /**
+   * Block operations the client diffed against the document at baseSha.
+   * Ids and positions resolve against that BASE document.
+   */
+  ops: BlockOp[];
+}
+
+export type SavePageOpsResult =
+  | (Omit<Extract<SavePageMergeResult, { merged: true }>, 'document'> & {
+      /**
+       * The merged blocks as committed, when they differ from the
+       * ops-materialized document (concurrent main-side changes folded in, or
+       * server-side id re-mints) — the editor must adopt them. `null` = the
+       * committed document is exactly base+ops, i.e. the document the client
+       * already shows; no adoption/remount needed.
+       */
+      document: unknown[] | null;
+    })
+  | Extract<SavePageMergeResult, { merged: false }>;
+
+/**
+ * Save an editor's diff-at-save block operations: materialize
+ * `theirs = applyBlockOps(base, ops)` where base is the document at the
+ * editor's conflict token (same blob-addressed base as
+ * savePageContentWithMerge), then run the SAME 3-way merge/commit/report/
+ * resolutions machinery. Untouched blocks never transmit, and concurrent
+ * saves to different blocks auto-merge by construction. coverImage: ops
+ * never carry it — main's current cover is preserved exactly like the
+ * whole-document merge path.
+ *
+ * A conflict report's chooser re-submit carries the SAME ops plus
+ * resolutions and the report's `ours_sha` pin.
+ *
+ * @throws {PageOpsBaseMismatchError} the ops don't apply to the document at
+ *   baseSha — the client falls back to one whole-document save.
+ * @throws {PageSaveConflictError} unreadable base → the plain 409 reload flow.
+ * @throws {PreviewResolutionError} same resolution-validation errors as
+ *   savePageContentWithMerge.
+ */
+export async function savePageContentFromOps(
+  page: PageWithContentRepo,
+  { ops, baseSha, resolutions, expectedOursSha, message }: SavePageOpsArgs
+): Promise<SavePageOpsResult> {
+  const baseBlocks = await readSaveMergeBase(page, baseSha);
+
+  // Materialize theirs = base + ops. Any BlockOpError (unknown id/anchor —
+  // the client diffed against a different document than the token names — or
+  // a malformed op) is the typed mismatch, NOT a merge conflict.
+  let theirs: unknown[];
+  let reminted = 0;
+  try {
+    theirs = applyBlockOps(baseBlocks, ops, { onIdRemint: () => reminted++ });
+  } catch (error: unknown) {
+    if (error instanceof BlockOpError) {
+      throw new PageOpsBaseMismatchError(
+        `Ops do not apply to the document at base_sha — ${error.message}`
+      );
+    }
+    throw error;
+  }
+
+  const result = await runSaveMerge(page, theirs, baseBlocks, {
+    resolutions,
+    expectedOursSha,
+    message,
+  });
+  if (!result.merged) return result;
+
+  // Adoption signal: when the committed document is exactly the materialized
+  // base+ops, the client's editor already shows it — `document: null` skips
+  // the adopt/remount (a clean ops save must not cost cursor position).
+  // Compared against ensureBlockIds(theirs) because the merge engine fills
+  // missing ids on every side; any server-side id re-mint forces adoption
+  // (the client's copy carries the pre-remint ids).
+  const unchanged =
+    reminted === 0 && canonicalJson(result.document) === canonicalJson(ensureBlockIds(theirs));
+  return unchanged ? { ...result, document: null } : result;
 }
 
 /**

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1,7 +1,16 @@
 import { createHash } from 'node:crypto';
 import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
-import { mergeIdSequence3, type MergeChoice } from '../content/merge3.ts';
+import {
+  indexResolutions,
+  mergeIdSequence3,
+  PreviewResolutionError,
+  type MergeChoice,
+  type MergeResolution,
+} from '../content/merge3.ts';
+
+export { PreviewResolutionError } from '../content/merge3.ts';
+export type { MergeChoice, MergeResolution } from '../content/merge3.ts';
 
 /**
  * Page Content Service
@@ -672,6 +681,10 @@ export type AcceptPreviewResult =
       merged: true;
       /** content.json's blob sha on main post-merge (read at the merge commit) — the fresh expected_sha for future applies. */
       sha: string | null;
+      /** Present when the git merge conflicted but the semantic 3-way auto-merge committed the result. */
+      semantic?: true;
+      /** Changes auto-merged by the semantic layer (present iff semantic). */
+      auto_merged?: number;
       /** true when a concurrent stacking apply landed after the merge snapshot — the branch was kept, not deleted. */
       preview_kept?: boolean;
       /** Why the preview branch was retained (present iff preview_kept). */
@@ -680,10 +693,25 @@ export type AcceptPreviewResult =
   | {
       merged: false;
       conflict: true;
-      units: PreviewConflictUnit[];
+      /** ONLY the true collisions — everything else auto-merges on accept. */
+      units: BlockMergeConflict[];
+      /** Changes the semantic layer can merge without a decision. */
+      auto_merged: number;
       ours_sha: string | null;
       theirs_sha: string | null;
     };
+
+/** Result of resolvePreviewConflicts: the resolved merge committed to main. */
+export interface ResolvePreviewResult {
+  merged: true;
+  semantic: true;
+  sha: string | null;
+  auto_merged: number;
+  /** The applied choices, echoed for auditing. */
+  resolved: MergeResolution[];
+  preview_kept?: boolean;
+  reason?: string;
+}
 
 /** Parse a content.json body (wrapper or legacy bare array) into its blocks. */
 function extractBlocks(content: string | null | undefined): BlockNode[] {
@@ -783,15 +811,36 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
     };
   }
 
-  // Conflict: build the per-unit report. The branch is left alone so the
-  // caller can inspect, re-apply on fresh main, or discard explicitly.
+  // Git-level conflict: run the semantic 3-way merge (Phase 7). Zero true
+  // collisions → the auto-merged result is committed to main (CAS'd on main's
+  // pre-write sha) and the branch is deleted; genuine collisions → structured
+  // report with only the units that need a decision, branch kept.
+  return acceptSemanticFallback(page);
+}
+
+// ─── Semantic merge on accept (Phase 7) ──────────────────────────────────────
+
+type ContentRead = Awaited<ReturnType<typeof ContentService.getContent>>;
+
+interface PreviewThreeWay {
+  comparison: Awaited<ReturnType<typeof ContentService.compareBranches>>;
+  ours: ContentRead;
+  theirs: ContentRead;
+  base: ContentRead;
+}
+
+/** Read the 3-way (ours = fresh main, theirs = the preview branch, base = merge-base). */
+async function readPreviewThreeWay(page: PageWithContentRepo): Promise<PreviewThreeWay> {
+  const { gitOrganization, repo } = contentRepoFor(page);
+  const branch = previewBranchName(page.content_path);
+  const path = `${page.content_path}/content.json`;
+
   const comparison = await ContentService.compareBranches({
     gitOrganization,
     repo,
     base: 'main',
     head: branch,
   });
-  const path = `${page.content_path}/content.json`;
   const [ours, theirs, base] = await Promise.all([
     ContentService.getContent({ gitOrganization, repo, path, skipCache: true }),
     ContentService.getContent({ gitOrganization, repo, path, ref: branch }),
@@ -799,20 +848,250 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
       ? ContentService.getContent({ gitOrganization, repo, path, ref: comparison.merge_base_sha })
       : Promise.resolve(null),
   ]);
+  return { comparison, ours, theirs, base };
+}
 
-  const units = diffBlockUnits(
-    extractBlocks(base?.content),
-    extractBlocks(ours?.content),
-    extractBlocks(theirs?.content)
-  );
+/** Read a fresh copy of main's content.json (retry path after a CAS loss). */
+async function readFreshOurs(page: PageWithContentRepo) {
+  const { gitOrganization, repo } = contentRepoFor(page);
+  return ContentService.getContent({
+    gitOrganization,
+    repo,
+    path: `${page.content_path}/content.json`,
+    skipCache: true,
+  });
+}
 
-  return {
-    merged: false,
-    conflict: true,
-    units,
-    ours_sha: ours?.sha ?? null,
-    theirs_sha: theirs?.sha ?? null,
-  };
+/** Pull the coverImage out of a raw content.json body (wrapper format only). */
+function extractCover(content: string | null | undefined): PageCoverImage | null {
+  if (!content) return null;
+  try {
+    const parsed = JSON.parse(content);
+    if (parsed && !Array.isArray(parsed) && parsed.coverImage) {
+      return parsed.coverImage as PageCoverImage;
+    }
+  } catch {
+    // Malformed JSON — no cover.
+  }
+  return null;
+}
+
+/**
+ * 3-way cover merge: a preview-side change wins (the accept publishes the
+ * preview's intent), anything else keeps main's. MCP previews never touch the
+ * cover, so a genuine double-change is out of scope — main's survives.
+ */
+function mergeCover(
+  base: PageCoverImage | null,
+  ours: PageCoverImage | null,
+  theirs: PageCoverImage | null
+): PageCoverImage | null {
+  const oursChanged = canonicalJson(ours) !== canonicalJson(base);
+  const theirsChanged = canonicalJson(theirs) !== canonicalJson(base);
+  if (theirsChanged && !oursChanged) return theirs;
+  return ours;
+}
+
+/**
+ * Commit a semantically merged document to main (CAS'd on main's pre-write
+ * sha via savePageContent's expectedSha), then delete the preview branch —
+ * unless the branch's content moved past the `theirs` we merged (a concurrent
+ * stacking apply), in which case it is kept. Note: `compareBranches.ahead_by`
+ * cannot make that call here — the semantic commit is a NEW commit on main,
+ * so the branch's commits are never git-ancestors; the branch's content blob
+ * sha vs the merged theirs sha is the reliable signal.
+ */
+async function commitSemanticMergeToMain(
+  page: PageWithContentRepo,
+  mergedBlocks: unknown[],
+  {
+    oursSha,
+    theirsSha,
+    coverImage,
+  }: { oursSha?: string; theirsSha: string | null; coverImage: PageCoverImage | null }
+): Promise<{ sha: string; preview_kept?: boolean; reason?: string }> {
+  const { gitOrganization, repo } = contentRepoFor(page);
+  const branch = previewBranchName(page.content_path);
+  const path = `${page.content_path}/content.json`;
+
+  const saved = await savePageContent(page, mergedBlocks, {
+    coverImage,
+    ...(oursSha ? { expectedSha: oursSha } : {}),
+    message: `Accept preview (auto-merged): ${page.title}`,
+  });
+
+  let previewKept = false;
+  let reason: string | undefined;
+  try {
+    const branchMeta = await ContentService.getMeta({
+      gitOrganization,
+      repo,
+      path,
+      ref: branch,
+      skipCache: true,
+    });
+    if (branchMeta && theirsSha && branchMeta.sha !== theirsSha) {
+      previewKept = true;
+      reason = 'Preview branch gained new edits during accept — retained with the newer changes';
+    } else {
+      try {
+        await ContentService.deleteBranch({ gitOrganization, repo, branch });
+      } catch (error: unknown) {
+        const status = (error as { status?: number }).status;
+        if (status !== 404 && status !== 422) throw error; // already gone is fine
+      }
+    }
+  } catch (error: unknown) {
+    previewKept = true;
+    reason = 'Could not verify the preview branch was unchanged — retained for safety';
+    console.warn(
+      `[pageContent.acceptPreview] Post-merge branch check failed for ${repo}/${branch}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  return { sha: saved.sha, ...(previewKept ? { preview_kept: true, reason } : {}) };
+}
+
+/** The accept path taken when the git merge reports a conflict. */
+async function acceptSemanticFallback(page: PageWithContentRepo): Promise<AcceptPreviewResult> {
+  const threeWay = await readPreviewThreeWay(page);
+  const { theirs, base } = threeWay;
+  let ours = threeWay.ours;
+  const baseBlocks = extractBlocks(base?.content);
+  const theirsBlocks = extractBlocks(theirs?.content);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const merge = merge3Blocks(baseBlocks, extractBlocks(ours?.content), theirsBlocks);
+    if (merge.conflicts.length > 0) {
+      // Only the true collisions are reported; the branch is left alone so
+      // the caller can resolve (resolvePreviewConflicts), re-apply, or discard.
+      return {
+        merged: false,
+        conflict: true,
+        units: merge.conflicts,
+        auto_merged: merge.autoMerged,
+        ours_sha: ours?.sha ?? null,
+        theirs_sha: theirs?.sha ?? null,
+      };
+    }
+
+    const coverImage = mergeCover(
+      extractCover(base?.content),
+      extractCover(ours?.content),
+      extractCover(theirs?.content)
+    );
+    try {
+      const committed = await commitSemanticMergeToMain(page, merge.merged, {
+        oursSha: ours?.sha,
+        theirsSha: theirs?.sha ?? null,
+        coverImage,
+      });
+      return { merged: true, semantic: true, auto_merged: merge.autoMerged, ...committed };
+    } catch (error: unknown) {
+      if ((error as { status?: number }).status !== 409 || attempt === 1) throw error;
+      // Main moved while we were auto-merging — one retry against fresh main.
+      ours = await readFreshOurs(page);
+    }
+  }
+  /* c8 ignore next */
+  throw new Error('unreachable');
+}
+
+/**
+ * Apply chooser decisions to a conflicted preview accept: re-runs the 3-way
+ * merge, requires the resolutions to exactly cover the current conflict set
+ * (`ours` = keep main's version, `theirs` = keep the preview's; the sentinel
+ * `__order__` addresses a top-level order conflict), commits the resolved
+ * merge to main exactly like a semantic accept, and deletes the branch.
+ *
+ * @throws {PreviewResolutionError} NO_PREVIEW / NOTHING_TO_RESOLVE /
+ *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS.
+ */
+export async function resolvePreviewConflicts(
+  page: PageWithContentRepo,
+  { resolutions }: { resolutions: MergeResolution[] }
+): Promise<ResolvePreviewResult> {
+  if (!resolutions?.length) {
+    throw new PreviewResolutionError(
+      'No resolutions supplied — pass one {id, choose} per conflict',
+      'UNRESOLVED_CONFLICTS'
+    );
+  }
+  const chosen = indexResolutions(resolutions);
+
+  const threeWay = await readPreviewThreeWay(page);
+  if (!threeWay.comparison) {
+    throw new PreviewResolutionError(
+      'No pending preview for this page — nothing to resolve',
+      'NO_PREVIEW'
+    );
+  }
+  const { theirs, base } = threeWay;
+  let ours = threeWay.ours;
+  const baseBlocks = extractBlocks(base?.content);
+  const theirsBlocks = extractBlocks(theirs?.content);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const oursBlocks = extractBlocks(ours?.content);
+    const current = merge3Blocks(baseBlocks, oursBlocks, theirsBlocks);
+    const conflictIds = new Set(current.conflicts.map(unit => unit.id));
+    if (conflictIds.size === 0) {
+      throw new PreviewResolutionError(
+        'Nothing to resolve — the preview now merges cleanly; accept it without resolutions',
+        'NOTHING_TO_RESOLVE'
+      );
+    }
+    const missing = [...conflictIds].filter(id => !(id in chosen));
+    if (missing.length > 0) {
+      throw new PreviewResolutionError(
+        `Every conflict needs a choice — missing: ${missing.join(', ')}`,
+        'UNRESOLVED_CONFLICTS',
+        missing
+      );
+    }
+    const unknown = Object.keys(chosen).filter(id => !conflictIds.has(id));
+    if (unknown.length > 0) {
+      throw new PreviewResolutionError(
+        `Not current conflict ids: ${unknown.join(', ')} — re-run accept for the current report`,
+        'UNKNOWN_RESOLUTIONS',
+        unknown
+      );
+    }
+
+    const resolved = merge3Blocks(baseBlocks, oursBlocks, theirsBlocks, { resolutions: chosen });
+    if (resolved.conflicts.length > 0) {
+      throw new Error(
+        `Resolution pass left conflicts standing (${resolved.conflicts.map(u => u.id).join(', ')}) — this is a bug`
+      );
+    }
+
+    const coverImage = mergeCover(
+      extractCover(base?.content),
+      extractCover(ours?.content),
+      extractCover(theirs?.content)
+    );
+    try {
+      const committed = await commitSemanticMergeToMain(page, resolved.merged, {
+        oursSha: ours?.sha,
+        theirsSha: theirs?.sha ?? null,
+        coverImage,
+      });
+      return {
+        merged: true,
+        semantic: true,
+        auto_merged: resolved.autoMerged,
+        resolved: resolutions,
+        ...committed,
+      };
+    } catch (error: unknown) {
+      if ((error as { status?: number }).status !== 409 || attempt === 1) throw error;
+      // Main moved under us — re-read, re-validate the conflict set, retry once.
+      ours = await readFreshOurs(page);
+    }
+  }
+  /* c8 ignore next */
+  throw new Error('unreachable');
 }
 
 /**

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -748,11 +748,30 @@ export type AcceptPreviewResult =
       conflict: true;
       /** ONLY the true collisions — everything else auto-merges on accept. */
       units: BlockMergeConflict[];
+      /**
+       * Text preview of every block referenced by the `__order__` sentinel,
+       * keyed by block id — lets the chooser list the two orderings as numbered
+       * title/summary rows instead of raw ids. In a pure ordering conflict a
+       * block's CONTENT is identical on both sides, so it is summarized ONCE
+       * here. Absent when there is no order conflict. See PageUnitPreview.
+       */
+      unit_previews?: Record<string, PageUnitPreview>;
       /** Changes the semantic layer can merge without a decision. */
       auto_merged: number;
       ours_sha: string | null;
       theirs_sha: string | null;
     };
+
+/** A block as the order-conflict chooser lists it (text-only; no editor mounted). */
+export interface PageUnitPreview {
+  /** Position in the source document. */
+  index: number;
+  /** Block type + a short slice of its text (≤80 chars). */
+  summary: string;
+}
+
+/** Slice of a block's text kept in an order-conflict summary. */
+const UNIT_PREVIEW_SUMMARY_CAP = 80;
 
 /** Result of resolvePreviewConflicts: the resolved merge committed to main. */
 export interface ResolvePreviewResult {
@@ -1046,6 +1065,77 @@ function mergeBaseMissing(): PreviewResolutionError {
   );
 }
 
+/** Flatten a block's inline content (styled text, links, table rows) to plain text. */
+function blockInlineText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map(node => {
+        const inline = node as { text?: unknown; content?: unknown };
+        if (typeof inline.text === 'string') return inline.text;
+        if (inline.content !== undefined) return blockInlineText(inline.content);
+        return '';
+      })
+      .join('');
+  }
+  const rows = (content as { rows?: { cells?: unknown[] }[] } | null | undefined)?.rows;
+  if (Array.isArray(rows)) {
+    return rows
+      .map(row => (Array.isArray(row?.cells) ? row.cells.map(blockInlineText).join(' · ') : ''))
+      .join('\n');
+  }
+  return '';
+}
+
+/** A one-line `type: text…` summary of a block for the order-conflict list. */
+function blockPreviewSummary(block: BlockNode): string {
+  const type = typeof block.type === 'string' ? block.type : 'block';
+  const text = blockInlineText(block.content).replace(/\s+/g, ' ').trim();
+  if (!text) return type;
+  const shown =
+    text.length > UNIT_PREVIEW_SUMMARY_CAP
+      ? `${text.slice(0, UNIT_PREVIEW_SUMMARY_CAP - 1)}…`
+      : text;
+  return `${type}: ${shown}`;
+}
+
+/**
+ * Build the `unit_previews` map for a block-order conflict: every block id the
+ * `__order__` sentinel references, summarized ONCE from the ours document
+ * (falling back to theirs for ids only present there). Undefined when there is
+ * no order conflict. Blocks are id-normalized to align with the merge engine's
+ * conflict ids (merge3Blocks fills derived ids internally).
+ */
+function buildPageUnitPreviews(
+  conflicts: BlockMergeConflict[],
+  oursBlocks: BlockNode[],
+  theirsBlocks: BlockNode[]
+): Record<string, PageUnitPreview> | undefined {
+  const ids = new Set<string>();
+  for (const conflict of conflicts) {
+    if (conflict.reason === 'order') {
+      for (const list of [conflict.ours, conflict.theirs, conflict.base]) {
+        if (Array.isArray(list)) for (const id of list) if (typeof id === 'string') ids.add(id);
+      }
+    }
+  }
+  if (ids.size === 0) return undefined;
+
+  const index = new Map<string, { block: BlockNode; index: number }>();
+  for (const blocks of [ensureBlockIds(oursBlocks), ensureBlockIds(theirsBlocks)]) {
+    (blocks as BlockNode[]).forEach((block, i) => {
+      if (block?.id && !index.has(block.id)) index.set(block.id, { block, index: i });
+    });
+  }
+  const previews: Record<string, PageUnitPreview> = {};
+  for (const id of ids) {
+    const entry = index.get(id);
+    if (!entry) continue;
+    previews[id] = { index: entry.index, summary: blockPreviewSummary(entry.block) };
+  }
+  return Object.keys(previews).length > 0 ? previews : undefined;
+}
+
 /** The accept path taken when the git merge reports a conflict. */
 async function acceptSemanticFallback(page: PageWithContentRepo): Promise<AcceptPreviewResult> {
   const threeWay = await readPreviewThreeWay(page);
@@ -1073,14 +1163,17 @@ async function acceptSemanticFallback(page: PageWithContentRepo): Promise<Accept
     // never commit without a CAS precondition — refuse with a typed error.
     if (!ours?.sha) throw mainContentMissing();
 
-    const merge = merge3Blocks(baseBlocks, extractBlocks(ours.content), theirsBlocks);
+    const oursBlocks = extractBlocks(ours.content);
+    const merge = merge3Blocks(baseBlocks, oursBlocks, theirsBlocks);
     if (merge.conflicts.length > 0) {
       // Only the true collisions are reported; the branch is left alone so
       // the caller can resolve (resolvePreviewConflicts), re-apply, or discard.
+      const unitPreviews = buildPageUnitPreviews(merge.conflicts, oursBlocks, theirsBlocks);
       return {
         merged: false,
         conflict: true,
         units: merge.conflicts,
+        ...(unitPreviews ? { unit_previews: unitPreviews } : {}),
         auto_merged: merge.autoMerged,
         ours_sha: ours.sha,
         theirs_sha: theirs?.sha ?? null,

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { z } from 'zod';
 import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import {
@@ -365,12 +366,59 @@ export class BlockOpError extends Error {
 
 export type BlockPosition = { after: string } | { at: 'start' | 'end' };
 
-export type BlockOp =
-  | { op: 'update'; id: string; block: unknown }
-  | { op: 'insert'; blocks: unknown[]; position: BlockPosition }
-  | { op: 'move'; id: string; position: BlockPosition }
-  | { op: 'delete'; id: string }
-  | { op: 'replace_all'; blocks: unknown[] };
+/**
+ * Single source of truth for the page block-op vocabulary (content-tools plan
+ * §7 P8) — the pages twin of slides' deckOpSchema. Consumed by:
+ *  - the pages editor save action (route.server.ts) via
+ *    `pageBlockOpsPayloadSchema` (op cap 400 — an editor session may touch many
+ *    blocks between saves), which 400s a malformed payload instead of letting a
+ *    raw TypeError escape as a 500, and
+ *  - the page_content_apply MCP tool (which keeps its own tighter `.max(25)`
+ *    total-op cap as an override).
+ * It also types `applyBlockOps`' input. The client diff (blockOpsDiff.ts)
+ * mirrors a SUBSET of this vocabulary (it never emits replace_all); it cannot
+ * import server code into the browser bundle, so its BlockOp type is a
+ * hand-kept structural twin that stays assignable to this one.
+ */
+const pageBlockBodySchema = z.record(z.unknown());
+const pageBlockPositionSchema = z.union([
+  z.object({ after: z.string().min(1) }).strict(),
+  z.object({ at: z.enum(['start', 'end']) }).strict(),
+]);
+
+export const pageBlockOpSchema = z.discriminatedUnion('op', [
+  z.object({
+    op: z.literal('update'),
+    id: z.string().min(1),
+    block: pageBlockBodySchema.describe('Full replacement block (its id is preserved)'),
+  }),
+  z.object({
+    op: z.literal('insert'),
+    blocks: z.array(pageBlockBodySchema).min(1).max(400),
+    position: pageBlockPositionSchema,
+  }),
+  z.object({
+    op: z.literal('move'),
+    id: z.string().min(1),
+    position: pageBlockPositionSchema,
+  }),
+  z.object({
+    op: z.literal('delete'),
+    id: z.string().min(1),
+  }),
+  z.object({
+    op: z.literal('replace_all'),
+    blocks: z.array(pageBlockBodySchema),
+  }),
+]);
+
+export type BlockOp = z.infer<typeof pageBlockOpSchema>;
+
+/**
+ * Payload schema for the editor's ops-shaped save (a JSON array of ops). The
+ * MCP tool applies a tighter `.max(25)` in its own inputSchema.
+ */
+export const pageBlockOpsPayloadSchema = z.array(pageBlockOpSchema).min(1).max(400);
 
 /** Collect every id in the tree (incl. nested children). */
 function collectBlockIds(blocks: BlockNode[], out = new Set<string>()): Set<string> {
@@ -981,12 +1029,43 @@ function mainContentMissing(): PreviewResolutionError {
   );
 }
 
+/**
+ * Typed refusal for a missing/unparseable merge base (plan §7 P3): without the
+ * content.json the preview forked from there is no trustworthy 3-way base, and
+ * merging against an EMPTY base silently resurrects deletions and duplicates
+ * blocks (the add/add case, where content.json was created independently on
+ * both sides). Refuse rather than commit a corrupt document — mirroring the
+ * save path's readSaveMergeBase refusal.
+ */
+function mergeBaseMissing(): PreviewResolutionError {
+  return new PreviewResolutionError(
+    'This preview has no common merge base with the live page (its content.json was created ' +
+      'or replaced independently on both sides) — discard the preview or re-apply it as a fresh ' +
+      'document',
+    'MERGE_BASE_MISSING'
+  );
+}
+
 /** The accept path taken when the git merge reports a conflict. */
 async function acceptSemanticFallback(page: PageWithContentRepo): Promise<AcceptPreviewResult> {
   const threeWay = await readPreviewThreeWay(page);
   const { theirs, base } = threeWay;
   let ours = threeWay.ours;
-  const baseBlocks = extractBlocks(base?.content);
+  // P7: a concurrent discard can delete the preview branch between the git
+  // merge conflict and this 3-way read — with no preview there is nothing to
+  // accept, and merging against the vanished theirs would auto-merge junk.
+  // Mirror the resolvePreviewConflicts NO_PREVIEW guard.
+  if (!threeWay.comparison) {
+    throw new PreviewResolutionError(
+      'No pending preview for this page — nothing to accept',
+      'NO_PREVIEW'
+    );
+  }
+  // P3: the 3-way needs a real merge base. A missing/unparseable base (the
+  // add/add degenerate) would degrade to [] and silently resurrect deletions
+  // or duplicate blocks — refuse instead.
+  const baseBlocks = base?.content ? parseBlocksStrict(base.content) : null;
+  if (!baseBlocks) throw mergeBaseMissing();
   const theirsBlocks = extractBlocks(theirs?.content);
 
   for (let attempt = 0; attempt < 2; attempt++) {
@@ -1077,7 +1156,10 @@ export async function resolvePreviewConflicts(
   }
   const { theirs, base } = threeWay;
   let ours = threeWay.ours;
-  const baseBlocks = extractBlocks(base?.content);
+  // P3: refuse a missing/unparseable merge base (add/add degenerate) rather
+  // than apply reviewed choices over an empty base that resurrects/duplicates.
+  const baseBlocks = base?.content ? parseBlocksStrict(base.content) : null;
+  if (!baseBlocks) throw mergeBaseMissing();
   const theirsBlocks = extractBlocks(theirs?.content);
 
   if (expectedTheirsSha && (theirs?.sha ?? null) !== expectedTheirsSha) {
@@ -1382,13 +1464,27 @@ async function runSaveMerge(
     // merge (theirs = base) counts exactly the blocks ours changed vs base.
     const concurrent = merge3Blocks(baseBlocks, oursBlocks, baseBlocks).autoMerged;
 
+    // Commit message: a resolution pass or a genuine concurrent fold-in is
+    // recorded distinctly so the git history isn't indistinguishable from a
+    // plain save (the routes no longer override with a plain message — plan
+    // "commit-message" finding). A clean save with no concurrency and no
+    // resolutions keeps the plain message (nothing was actually merged).
+    const resolvedCount = chosen ? Object.keys(chosen).length : 0;
+    const committedMessage =
+      message ??
+      (resolvedCount > 0
+        ? `Update page (merged; resolved ${resolvedCount} conflict${resolvedCount === 1 ? '' : 's'}): ${page.title}`
+        : concurrent > 0
+          ? `Update page (merged): ${page.title}`
+          : `Update page: ${page.title}`);
+
     try {
       const saved = await savePageContent(page, merge.merged, {
         // Preserve main's CURRENT cover explicitly (the editor save carries no
         // cover; passing it avoids savePageContent's extra preserve re-read).
         coverImage: extractCover(ours.content),
         expectedSha: ours.sha,
-        message: message ?? `Update page (merged): ${page.title}`,
+        message: committedMessage,
       });
       return {
         merged: true,
@@ -1537,87 +1633,12 @@ export const ORDER_CONFLICT_ID = '__order__';
 const idsOf = (blocks: BlockNode[]): string[] =>
   blocks.map(block => block?.id).filter((id): id is string => typeof id === 'string');
 
-const deepEqual = (a: unknown, b: unknown): boolean =>
-  a === b || canonicalJson(a) === canonicalJson(b);
-
-/**
- * 3-way diff of a block document by top-level unit (block) id, for conflict
- * reporting after a failed preview merge. Pure.
- *
- * A unit conflicts when BOTH sides changed it relative to base (edit/edit,
- * edit/delete, or both-added-differently) and the two sides disagree. A
- * one-sided change is not a conflict (git would have auto-merged it — the
- * report only names what genuinely needs a human/agent decision).
- *
- * The top-level ordering is compared as id sequences the same way: reordered
- * differently on both sides → one sentinel `__order__` unit whose ours/theirs/
- * base carry the id arrays. Nested children ride inside their parent unit
- * (deep-equal covers the whole subtree).
- */
-export function diffBlockUnits(
-  base: BlockNode[],
-  ours: BlockNode[],
-  theirs: BlockNode[]
-): PreviewConflictUnit[] {
-  const byId = (blocks: BlockNode[]): Map<string, { block: BlockNode; index: number }> => {
-    const map = new Map<string, { block: BlockNode; index: number }>();
-    blocks.forEach((block, index) => {
-      if (block && typeof block.id === 'string' && !map.has(block.id)) {
-        map.set(block.id, { block, index });
-      }
-    });
-    return map;
-  };
-
-  const baseMap = byId(base);
-  const oursMap = byId(ours);
-  const theirsMap = byId(theirs);
-
-  const seen = new Set<string>();
-  const orderedIds = [...theirsMap.keys(), ...oursMap.keys(), ...baseMap.keys()].filter(id => {
-    if (seen.has(id)) return false;
-    seen.add(id);
-    return true;
-  });
-
-  const units: PreviewConflictUnit[] = [];
-  for (const id of orderedIds) {
-    const inBase = baseMap.get(id);
-    const inOurs = oursMap.get(id);
-    const inTheirs = theirsMap.get(id);
-
-    const oursChanged = !deepEqual(inBase?.block, inOurs?.block);
-    const theirsChanged = !deepEqual(inBase?.block, inTheirs?.block);
-    if (!oursChanged || !theirsChanged) continue; // one-sided → auto-mergeable
-    if (deepEqual(inOurs?.block, inTheirs?.block)) continue; // both sides agree
-
-    units.push({
-      id,
-      index: inTheirs?.index ?? inOurs?.index ?? inBase?.index ?? -1,
-      ...(inOurs ? { ours: inOurs.block } : {}),
-      ...(inTheirs ? { theirs: inTheirs.block } : {}),
-      ...(inBase ? { base: inBase.block } : {}),
-    });
-  }
-
-  // Ordering conflict: both sides changed the top-level sequence, differently.
-  const baseIds = idsOf(base);
-  const oursIds = idsOf(ours);
-  const theirsIds = idsOf(theirs);
-  const oursOrderChanged = !deepEqual(baseIds, oursIds);
-  const theirsOrderChanged = !deepEqual(baseIds, theirsIds);
-  if (oursOrderChanged && theirsOrderChanged && !deepEqual(oursIds, theirsIds)) {
-    units.push({
-      id: ORDER_CONFLICT_ID,
-      index: -1,
-      ours: oursIds,
-      theirs: theirsIds,
-      base: baseIds,
-    });
-  }
-
-  return units;
-}
+// NOTE (plan §7 P10): the Level-1 `diffBlockUnits` walker was removed here — it
+// had zero production callers after Phase 7 (accept/save conflict reports come
+// straight from merge3Blocks' `conflicts`), and its raw-string unit comparison
+// diverged from the shipping engine's canonical, serialization-tolerant merge
+// (re-adopting it would regress the Phase 7.5 phantom-conflict fix). The
+// authoritative 3-way is `merge3Blocks` below.
 
 // ─── merge3Blocks — semantic 3-way merge (Phase 7) ───────────────────────────
 

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import {
+  dedupeMergedTreeIds,
   indexResolutions,
   mergeIdSequence3,
   PreviewResolutionError,
@@ -220,8 +221,12 @@ export async function savePageContent(
     }
   }
 
-  const wrapper: { blocks: unknown; coverImage?: PageCoverImage | null } = { blocks };
-  if (coverImage !== undefined) {
+  // The key is only written when a cover actually exists: `null` (remove) and
+  // absence both serialize as no key, matching what pre-merge saves produced —
+  // a semantic accept must not sprinkle `"coverImage": null` into documents
+  // that never had one. Reads treat a missing key and null identically.
+  const wrapper: { blocks: unknown; coverImage?: PageCoverImage } = { blocks };
+  if (coverImage != null) {
     wrapper.coverImage = coverImage;
   }
 
@@ -908,18 +913,28 @@ async function commitSemanticMergeToMain(
     oursSha,
     theirsSha,
     coverImage,
-  }: { oursSha?: string; theirsSha: string | null; coverImage: PageCoverImage | null }
+  }: { oursSha: string; theirsSha: string | null; coverImage: PageCoverImage | null }
 ): Promise<{ sha: string; preview_kept?: boolean; reason?: string }> {
   const { gitOrganization, repo } = contentRepoFor(page);
   const branch = previewBranchName(page.content_path);
   const path = `${page.content_path}/content.json`;
 
+  // oursSha is REQUIRED: the merge commit is always CAS'd on main's pre-write
+  // content.json sha. Callers guard the main-file-deleted degenerate
+  // (MAIN_CONTENT_MISSING) before reaching here — never an unguarded write.
   const saved = await savePageContent(page, mergedBlocks, {
     coverImage,
-    ...(oursSha ? { expectedSha: oursSha } : {}),
+    expectedSha: oursSha,
     message: `Accept preview (auto-merged): ${page.title}`,
   });
 
+  // TOCTOU note: this guard is a compare-THEN-delete — a stacking apply can
+  // still land on the branch between the getMeta read and the deleteBranch
+  // call below, and would be discarded with the branch. Accepted: GitHub's
+  // refs DELETE has no precondition (no CAS delete), so the window cannot be
+  // closed API-side; the guard shrinks it from the whole merge duration to
+  // one request round-trip, and an apply racing an in-flight accept has no
+  // ordering guarantee either way.
   let previewKept = false;
   let reason: string | undefined;
   try {
@@ -953,6 +968,19 @@ async function commitSemanticMergeToMain(
   return { sha: saved.sha, ...(previewKept ? { preview_kept: true, reason } : {}) };
 }
 
+/**
+ * Typed refusal for the main-file-deleted degenerate: without main's
+ * content.json there is no sha to CAS the merge commit on, so committing
+ * would be an unguarded write over whatever deleted it.
+ */
+function mainContentMissing(): PreviewResolutionError {
+  return new PreviewResolutionError(
+    "Main's content.json was deleted while this preview was pending — discard the preview " +
+      'or re-apply it as a fresh document',
+    'MAIN_CONTENT_MISSING'
+  );
+}
+
 /** The accept path taken when the git merge reports a conflict. */
 async function acceptSemanticFallback(page: PageWithContentRepo): Promise<AcceptPreviewResult> {
   const threeWay = await readPreviewThreeWay(page);
@@ -962,7 +990,11 @@ async function acceptSemanticFallback(page: PageWithContentRepo): Promise<Accept
   const theirsBlocks = extractBlocks(theirs?.content);
 
   for (let attempt = 0; attempt < 2; attempt++) {
-    const merge = merge3Blocks(baseBlocks, extractBlocks(ours?.content), theirsBlocks);
+    // Main's content.json vanished (deleted while the preview was pending):
+    // never commit without a CAS precondition — refuse with a typed error.
+    if (!ours?.sha) throw mainContentMissing();
+
+    const merge = merge3Blocks(baseBlocks, extractBlocks(ours.content), theirsBlocks);
     if (merge.conflicts.length > 0) {
       // Only the true collisions are reported; the branch is left alone so
       // the caller can resolve (resolvePreviewConflicts), re-apply, or discard.
@@ -971,19 +1003,19 @@ async function acceptSemanticFallback(page: PageWithContentRepo): Promise<Accept
         conflict: true,
         units: merge.conflicts,
         auto_merged: merge.autoMerged,
-        ours_sha: ours?.sha ?? null,
+        ours_sha: ours.sha,
         theirs_sha: theirs?.sha ?? null,
       };
     }
 
     const coverImage = mergeCover(
       extractCover(base?.content),
-      extractCover(ours?.content),
+      extractCover(ours.content),
       extractCover(theirs?.content)
     );
     try {
       const committed = await commitSemanticMergeToMain(page, merge.merged, {
-        oursSha: ours?.sha,
+        oursSha: ours.sha,
         theirsSha: theirs?.sha ?? null,
         coverImage,
       });
@@ -1005,12 +1037,28 @@ async function acceptSemanticFallback(page: PageWithContentRepo): Promise<Accept
  * `__order__` addresses a top-level order conflict), commits the resolved
  * merge to main exactly like a semantic accept, and deletes the branch.
  *
+ * @param options.expectedOursSha - pin the resolution to the conflict report
+ *   the choices were made against (the report's `ours_sha`). When provided
+ *   and main's content.json no longer matches, the resolve fails with
+ *   CONTENT_CONFLICT instead of applying reviewed choices to unseen content.
+ * @param options.expectedTheirsSha - same pin for the preview side
+ *   (the report's `theirs_sha`).
+ *
  * @throws {PreviewResolutionError} NO_PREVIEW / NOTHING_TO_RESOLVE /
- *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS.
+ *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS /
+ *   INVALID_RESOLUTIONS / CONTENT_CONFLICT / MAIN_CONTENT_MISSING.
  */
 export async function resolvePreviewConflicts(
   page: PageWithContentRepo,
-  { resolutions }: { resolutions: MergeResolution[] }
+  {
+    resolutions,
+    expectedOursSha,
+    expectedTheirsSha,
+  }: {
+    resolutions: MergeResolution[];
+    expectedOursSha?: string;
+    expectedTheirsSha?: string;
+  }
 ): Promise<ResolvePreviewResult> {
   if (!resolutions?.length) {
     throw new PreviewResolutionError(
@@ -1032,8 +1080,27 @@ export async function resolvePreviewConflicts(
   const baseBlocks = extractBlocks(base?.content);
   const theirsBlocks = extractBlocks(theirs?.content);
 
+  if (expectedTheirsSha && (theirs?.sha ?? null) !== expectedTheirsSha) {
+    throw new PreviewResolutionError(
+      'The preview changed since the conflict report these choices were made against — ' +
+        're-run accept for a fresh report',
+      'CONTENT_CONFLICT'
+    );
+  }
+
   for (let attempt = 0; attempt < 2; attempt++) {
-    const oursBlocks = extractBlocks(ours?.content);
+    // Re-checked every attempt: a CAS-loss retry re-reads main, and choices
+    // pinned to the reviewed report must not silently apply to newer content.
+    if (expectedOursSha && (ours?.sha ?? null) !== expectedOursSha) {
+      throw new PreviewResolutionError(
+        'The live page changed since the conflict report these choices were made against — ' +
+          're-run accept for a fresh report',
+        'CONTENT_CONFLICT'
+      );
+    }
+    if (!ours?.sha) throw mainContentMissing();
+
+    const oursBlocks = extractBlocks(ours.content);
     const current = merge3Blocks(baseBlocks, oursBlocks, theirsBlocks);
     const conflictIds = new Set(current.conflicts.map(unit => unit.id));
     if (conflictIds.size === 0) {
@@ -1068,12 +1135,12 @@ export async function resolvePreviewConflicts(
 
     const coverImage = mergeCover(
       extractCover(base?.content),
-      extractCover(ours?.content),
+      extractCover(ours.content),
       extractCover(theirs?.content)
     );
     try {
       const committed = await commitSemanticMergeToMain(page, resolved.merged, {
-        oursSha: ours?.sha,
+        oursSha: ours.sha,
         theirsSha: theirs?.sha ?? null,
         coverImage,
       });
@@ -1242,6 +1309,13 @@ export interface BlockMergeResult {
  * - deleted on one side + edited other → conflict (side absent = deleted)
  * - top-level order 3-way merged; both reordered differently → the
  *   `__order__` sentinel conflict
+ * - a CROSS-SCOPE MOVE (an id that is top-level on one side but nested inside
+ *   a block's subtree on another) merges as its own top-level unit: each
+ *   side's copy is harvested from wherever it lives and the nested copies are
+ *   stripped from their old parents, so a parent conflict card never carries
+ *   a block with an independent fate — and a resolution can never commit a
+ *   duplicated id. A move-out on one side + an edit-in-place on the other
+ *   auto-merges (the edit follows the moved block).
  *
  * Ids are the merge identity: blocks missing one get the deterministic
  * derived id first (identical unedited blocks derive identical ids across
@@ -1271,9 +1345,72 @@ export function merge3Blocks(
     });
     return map;
   };
+
+  // ── Cross-scope moves ──
+  // Ids that are top-level on one side and nested on another are promoted to
+  // top-level units everywhere they exist; the nested copies are stripped.
+  const nestedById = (blocks: BlockNode[]): Map<string, BlockNode> => {
+    const map = new Map<string, BlockNode>();
+    const walk = (list: BlockNode[]): void => {
+      for (const node of list) {
+        if (!node || typeof node !== 'object') continue;
+        if (typeof node.id === 'string' && node.id && !map.has(node.id)) {
+          map.set(node.id, node);
+        }
+        if (Array.isArray(node.children)) walk(node.children);
+      }
+    };
+    for (const top of blocks) {
+      if (top && Array.isArray(top.children)) walk(top.children);
+    }
+    return map;
+  };
+  const topLevelIds = new Set([...idsOf(b), ...idsOf(o), ...idsOf(t)]);
+  const nestedSides = [nestedById(b), nestedById(o), nestedById(t)];
+  const escapedIds = new Set(
+    [...topLevelIds].filter(id => nestedSides.some(nested => nested.has(id)))
+  );
+  if (escapedIds.size > 0) {
+    const stripNested = (blocks: BlockNode[]): void => {
+      const prune = (list: BlockNode[]): void => {
+        for (let i = list.length - 1; i >= 0; i--) {
+          const node = list[i];
+          if (!node || typeof node !== 'object') continue;
+          if (typeof node.id === 'string' && escapedIds.has(node.id)) {
+            list.splice(i, 1);
+            continue;
+          }
+          if (Array.isArray(node.children)) prune(node.children);
+        }
+      };
+      for (const top of blocks) {
+        if (top && Array.isArray(top.children)) prune(top.children);
+      }
+    };
+    stripNested(b);
+    stripNested(o);
+    stripNested(t);
+  }
+
   const bMap = byId(b);
   const oMap = byId(o);
   const tMap = byId(t);
+
+  if (escapedIds.size > 0) {
+    // Promote each escaped id to a synthetic top-level entry on the sides
+    // where it only existed nested (its harvested copy is that side's
+    // version). Display index comes from wherever it is genuinely top-level.
+    const maps = [bMap, oMap, tMap] as const;
+    for (const id of escapedIds) {
+      const displayIndex = tMap.get(id)?.index ?? oMap.get(id)?.index ?? bMap.get(id)?.index ?? -1;
+      maps.forEach((map, side) => {
+        const harvested = nestedSides[side].get(id);
+        if (!map.has(id) && harvested) {
+          map.set(id, { block: harvested, index: displayIndex });
+        }
+      });
+    }
+  }
 
   const seen = new Set<string>();
   const allIds = [...tMap.keys(), ...oMap.keys(), ...bMap.keys()].filter(id => {
@@ -1289,6 +1426,8 @@ export function merge3Blocks(
   let autoMerged = 0;
   /** Survivors: id → the block the merged doc carries (chosen or provisional). */
   const kept = new Map<string, BlockNode>();
+  /** Ids that were (initially) conflicts — resolved or not (dedupe preference). */
+  const conflictedIds = new Set<string>();
 
   for (const id of allIds) {
     const inB = bMap.get(id);
@@ -1358,6 +1497,7 @@ export function merge3Blocks(
       fate = { kind: 'conflict', entry: makeEntry('both_added'), provisional: inT!.block };
     }
 
+    if (fate.kind === 'conflict') conflictedIds.add(id);
     const choice = resolutions[id];
     if (fate.kind === 'conflict' && choice) {
       const chosenBlock = (choice === 'ours' ? fate.entry.ours : fate.entry.theirs) as
@@ -1403,5 +1543,20 @@ export function merge3Blocks(
   }
 
   const merged = order.map(id => structuredClone(kept.get(id)!));
+
+  // Final safety assertion: no id may appear twice anywhere in the assembled
+  // document (a duplicate committed to main corrupts the page for every
+  // future merge and confuses id-addressed applies). Unreachable through the
+  // cross-scope-move promotion above, but deeply-nested cross-parent moves
+  // could still smuggle two copies in. Preference goes to the copy inside a
+  // conflict unit's subtree — that copy is what the chooser card showed.
+  const duplicateIds = dedupeMergedTreeIds(merged, conflictedIds);
+  if (duplicateIds.length > 0) {
+    console.warn(
+      `[pageContent.merge3Blocks] merged document carried duplicate block id(s) ` +
+        `${duplicateIds.join(', ')} — kept the conflict-resolution copy and dropped the stale one(s)`
+    );
+  }
+
   return { merged, conflicts, autoMerged };
 }

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1161,6 +1161,222 @@ export async function resolvePreviewConflicts(
   throw new Error('unreachable');
 }
 
+// ─── Semantic merge for EDITOR saves (plan §3b Phase 7.5) ────────────────────
+
+/**
+ * Fallback conflict for the save-merge path: carries `status: 409` so the
+ * existing route handling (the "page changed — reload" banner) applies
+ * unchanged. Thrown when no trustworthy 3-way exists (base blob unreadable,
+ * main's content.json gone) or when the CAS retry lost twice.
+ */
+export class PageSaveConflictError extends Error {
+  status = 409 as const;
+  code = 'CONTENT_CONFLICT' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'PageSaveConflictError';
+  }
+}
+
+/** Strict content.json parse — wrapper or legacy bare array; anything else null. */
+function parseBlocksStrict(content: string): BlockNode[] | null {
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && Array.isArray(parsed.blocks)) return parsed.blocks;
+  } catch {
+    // Malformed — the caller falls back to the plain conflict flow.
+  }
+  return null;
+}
+
+export interface SavePageMergeArgs {
+  /** The editor's conflict token — content.json's blob sha when the editor read it (the 3-way base). */
+  baseSha: string;
+  /** Chooser decisions from a prior conflict report (save re-submit). */
+  resolutions?: MergeResolution[];
+  /**
+   * Pin to the conflict report the resolutions were reviewed against (its
+   * `ours_sha`). When main's content.json no longer matches, the save fails
+   * with CONTENT_CONFLICT instead of applying reviewed choices to unseen
+   * content.
+   */
+  expectedOursSha?: string;
+  message?: string;
+}
+
+export type SavePageMergeResult =
+  | {
+      merged: true;
+      /** content.json's new blob sha — the editor's fresh conflict token. */
+      sha: string;
+      commit: string;
+      /**
+       * The merged blocks as committed — the editor must adopt this document
+       * (its own local copy lacks the folded-in concurrent changes, and a
+       * fresh token over a stale document would clobber them on the NEXT save).
+       */
+      document: unknown[];
+      /** Block-level changes (both sides) that merged without a conflict. */
+      auto_merged: number;
+      /** Concurrent (main-side) block changes folded into this save — the toast count. */
+      concurrent: number;
+    }
+  | {
+      merged: false;
+      conflict: true;
+      /** ONLY the true collisions (incl. the `__order__` sentinel). */
+      units: BlockMergeConflict[];
+      auto_merged: number;
+      /** Main's content.json sha the report was built from — the resolution pin. */
+      ours_sha: string;
+    };
+
+/**
+ * Save an editor's posted blocks over a stale conflict token by 3-way
+ * semantic merge (plan §3b Phase 7.5). The token IS the merge base: it is
+ * content.json's blob sha at editor-load time, fetched content-addressed via
+ * ContentService.getBlobContent. ours = fresh main, theirs = the posted
+ * blocks. Zero collisions → the merged document is committed (CAS'd on
+ * main's pre-write sha, main's current coverImage preserved) and the save
+ * succeeds with the concurrent-change count; true collisions → a structured
+ * per-unit report for the editor's conflict chooser. The client re-submits
+ * the SAME posted blocks plus resolutions and the report's `ours_sha` pin.
+ *
+ * @throws {PageSaveConflictError} fallback to the plain 409 reload flow.
+ * @throws {PreviewResolutionError} CONTENT_CONFLICT (ours pin stale) /
+ *   NOTHING_TO_RESOLVE / UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS /
+ *   DUPLICATE_RESOLUTIONS / INVALID_RESOLUTIONS.
+ */
+export async function savePageContentWithMerge(
+  page: PageWithContentRepo,
+  theirs: unknown[],
+  { baseSha, resolutions, expectedOursSha, message }: SavePageMergeArgs
+): Promise<SavePageMergeResult> {
+  const { gitOrganization, repo } = contentRepoFor(page);
+  const path = `${page.content_path}/content.json`;
+
+  // Base = the document at the editor's token. A failed or unparseable base
+  // read means no trustworthy 3-way exists — fall back rather than merging
+  // against a guessed base.
+  let baseFile: { content: string } | null = null;
+  try {
+    baseFile = await ContentService.getBlobContent({ gitOrganization, repo, sha: baseSha });
+  } catch (error: unknown) {
+    console.warn(
+      `[pageContent.saveMerge] Base blob read failed for ${repo}@${baseSha}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+  const baseBlocks = baseFile ? parseBlocksStrict(baseFile.content) : null;
+  if (!baseBlocks) {
+    throw new PageSaveConflictError('This page changed since it was read — reload before saving');
+  }
+
+  const chosen = resolutions ? indexResolutions(resolutions) : null;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    // Ours = fresh main. skipCache REQUIRED — this read pins the CAS sha.
+    const ours = await ContentService.getContent({ gitOrganization, repo, path, skipCache: true });
+
+    // Re-checked every attempt: a CAS-loss retry re-reads main, and choices
+    // reviewed against one report must not silently apply to newer content.
+    if (expectedOursSha && (ours?.sha ?? null) !== expectedOursSha) {
+      throw new PreviewResolutionError(
+        'The page changed since the conflict report these choices were made against — ' +
+          'save again for a fresh report',
+        'CONTENT_CONFLICT'
+      );
+    }
+
+    const oursBlocks = ours ? parseBlocksStrict(ours.content) : null;
+    if (!ours || !oursBlocks) {
+      // content.json deleted or unreadable on main: no CAS anchor, no 3-way.
+      throw new PageSaveConflictError(
+        'content.json no longer exists — reload the page before saving'
+      );
+    }
+
+    if (chosen) {
+      // The resolutions must exactly cover the CURRENT conflict set (same
+      // validation as resolvePreviewConflicts).
+      const current = merge3Blocks(baseBlocks, oursBlocks, theirs);
+      const conflictIds = new Set(current.conflicts.map(unit => unit.id));
+      if (conflictIds.size === 0) {
+        throw new PreviewResolutionError(
+          'Nothing to resolve — the save now merges cleanly; save again without resolutions',
+          'NOTHING_TO_RESOLVE'
+        );
+      }
+      const missing = [...conflictIds].filter(id => !(id in chosen));
+      if (missing.length > 0) {
+        throw new PreviewResolutionError(
+          `Every conflict needs a choice — missing: ${missing.join(', ')}`,
+          'UNRESOLVED_CONFLICTS',
+          missing
+        );
+      }
+      const unknown = Object.keys(chosen).filter(id => !conflictIds.has(id));
+      if (unknown.length > 0) {
+        throw new PreviewResolutionError(
+          `Not current conflict ids: ${unknown.join(', ')} — save again for the current report`,
+          'UNKNOWN_RESOLUTIONS',
+          unknown
+        );
+      }
+    }
+
+    const merge = merge3Blocks(
+      baseBlocks,
+      oursBlocks,
+      theirs,
+      chosen ? { resolutions: chosen } : {}
+    );
+    if (merge.conflicts.length > 0) {
+      if (chosen) {
+        throw new Error(
+          `Resolution pass left conflicts standing (${merge.conflicts.map(u => u.id).join(', ')}) — this is a bug`
+        );
+      }
+      return {
+        merged: false,
+        conflict: true,
+        units: merge.conflicts,
+        auto_merged: merge.autoMerged,
+        ours_sha: ours.sha,
+      };
+    }
+
+    // Concurrent (main-side) changes folded into this save: a theirs-less
+    // merge (theirs = base) counts exactly the blocks ours changed vs base.
+    const concurrent = merge3Blocks(baseBlocks, oursBlocks, baseBlocks).autoMerged;
+
+    try {
+      const saved = await savePageContent(page, merge.merged, {
+        // Preserve main's CURRENT cover explicitly (the editor save carries no
+        // cover; passing it avoids savePageContent's extra preserve re-read).
+        coverImage: extractCover(ours.content),
+        expectedSha: ours.sha,
+        message: message ?? `Update page (merged): ${page.title}`,
+      });
+      return {
+        merged: true,
+        sha: saved.sha,
+        commit: saved.commit,
+        document: merge.merged,
+        auto_merged: merge.autoMerged,
+        concurrent,
+      };
+    } catch (error: unknown) {
+      if ((error as { status?: number }).status !== 409 || attempt === 1) throw error;
+      // Main moved mid-commit — one retry re-runs the 3-way against fresh ours.
+    }
+  }
+  /* c8 ignore next */
+  throw new Error('unreachable');
+}
+
 /**
  * Discard the page's preview branch (delete it; main is untouched).
  * 404-tolerant: an already-gone branch reports `existed: false` instead of

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
+import { mergeIdSequence3, type MergeChoice } from '../content/merge3.ts';
 
 /**
  * Page Content Service
@@ -925,4 +926,203 @@ export function diffBlockUnits(
   }
 
   return units;
+}
+
+// ─── merge3Blocks — semantic 3-way merge (Phase 7) ───────────────────────────
+
+/** A true collision the semantic merge cannot decide. Same shape as
+ * PreviewConflictUnit (absent ours/theirs = deleted on that side; the
+ * `__order__` sentinel carries id arrays) plus the machine-readable reason. */
+export interface BlockMergeConflict extends PreviewConflictUnit {
+  reason: 'content' | 'delete_vs_edit' | 'both_added' | 'order';
+}
+
+export interface BlockMergeResult {
+  /**
+   * The merged document. Fully authoritative when `conflicts` is empty; while
+   * conflicts are pending, conflicted units carry the theirs side (or ours
+   * when theirs deleted) provisionally.
+   */
+  merged: unknown[];
+  conflicts: BlockMergeConflict[];
+  /** Block-level changes (edits/adds/deletes) that merged without a conflict. */
+  autoMerged: number;
+}
+
+/**
+ * Semantic 3-way merge of a BlockNote document by TOP-LEVEL block id
+ * (base = merge-base, ours = main, theirs = preview). Pure. The unit is the
+ * top-level block — its `children` subtree rides with it and compares
+ * deep-equal (a slide-style per-child merge does not apply to pages).
+ *
+ * Rules (mirroring the deck engine):
+ * - changed on one side only → take that side; identical changes → take either
+ * - changed differently on both sides → conflict
+ * - added on a side → keep (position woven from that side's order)
+ * - deleted on one side + unchanged other → the delete wins
+ * - deleted on one side + edited other → conflict (side absent = deleted)
+ * - top-level order 3-way merged; both reordered differently → the
+ *   `__order__` sentinel conflict
+ *
+ * Ids are the merge identity: blocks missing one get the deterministic
+ * derived id first (identical unedited blocks derive identical ids across
+ * versions, so they still align).
+ *
+ * @param opts.resolutions - chooser decisions keyed by conflict id
+ *   (`ours` = main's version, `theirs` = the preview's); a resolved conflict
+ *   is applied and not reported.
+ */
+export function merge3Blocks(
+  base: unknown[],
+  ours: unknown[],
+  theirs: unknown[],
+  opts: { resolutions?: Record<string, MergeChoice> } = {}
+): BlockMergeResult {
+  const resolutions = opts.resolutions ?? {};
+  const b = ensureBlockIds((base ?? []) as BlockNode[]) as BlockNode[];
+  const o = ensureBlockIds((ours ?? []) as BlockNode[]) as BlockNode[];
+  const t = ensureBlockIds((theirs ?? []) as BlockNode[]) as BlockNode[];
+
+  const byId = (blocks: BlockNode[]): Map<string, { block: BlockNode; index: number }> => {
+    const map = new Map<string, { block: BlockNode; index: number }>();
+    blocks.forEach((block, index) => {
+      if (block && typeof block.id === 'string' && !map.has(block.id)) {
+        map.set(block.id, { block, index });
+      }
+    });
+    return map;
+  };
+  const bMap = byId(b);
+  const oMap = byId(o);
+  const tMap = byId(t);
+
+  const seen = new Set<string>();
+  const allIds = [...tMap.keys(), ...oMap.keys(), ...bMap.keys()].filter(id => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  const sig = (entry: { block: BlockNode } | undefined): string =>
+    entry ? canonicalJson(entry.block) : 'absent';
+
+  const conflicts: BlockMergeConflict[] = [];
+  let autoMerged = 0;
+  /** Survivors: id → the block the merged doc carries (chosen or provisional). */
+  const kept = new Map<string, BlockNode>();
+
+  for (const id of allIds) {
+    const inB = bMap.get(id);
+    const inO = oMap.get(id);
+    const inT = tMap.get(id);
+
+    const makeEntry = (reason: BlockMergeConflict['reason']): BlockMergeConflict => ({
+      id,
+      index: inT?.index ?? inO?.index ?? inB?.index ?? -1,
+      reason,
+      ...(inO ? { ours: structuredClone(inO.block) } : {}),
+      ...(inT ? { theirs: structuredClone(inT.block) } : {}),
+      ...(inB ? { base: structuredClone(inB.block) } : {}),
+    });
+
+    type Fate =
+      | { kind: 'drop' }
+      | { kind: 'keep'; block: BlockNode }
+      | { kind: 'conflict'; entry: BlockMergeConflict; provisional: BlockNode };
+    let fate: Fate;
+
+    if (inB && inO && inT) {
+      const oursChanged = sig(inO) !== sig(inB);
+      const theirsChanged = sig(inT) !== sig(inB);
+      if (!oursChanged && !theirsChanged) fate = { kind: 'keep', block: inB.block };
+      else if (oursChanged && !theirsChanged) {
+        fate = { kind: 'keep', block: inO.block };
+        autoMerged++;
+      } else if (!oursChanged && theirsChanged) {
+        fate = { kind: 'keep', block: inT.block };
+        autoMerged++;
+      } else if (sig(inO) === sig(inT)) {
+        fate = { kind: 'keep', block: inO.block }; // identical edits
+        autoMerged++;
+      } else {
+        fate = { kind: 'conflict', entry: makeEntry('content'), provisional: inT.block };
+      }
+    } else if (inB && !inO && !inT) {
+      fate = { kind: 'drop' }; // deleted on both sides
+      autoMerged++;
+    } else if (inB && !inO && inT) {
+      // Deleted on ours (main).
+      if (sig(inT) === sig(inB)) {
+        fate = { kind: 'drop' }; // the delete wins over an unchanged block
+        autoMerged++;
+      } else {
+        fate = { kind: 'conflict', entry: makeEntry('delete_vs_edit'), provisional: inT.block };
+      }
+    } else if (inB && inO && !inT) {
+      // Deleted on theirs (the preview).
+      if (sig(inO) === sig(inB)) {
+        fate = { kind: 'drop' };
+        autoMerged++;
+      } else {
+        fate = { kind: 'conflict', entry: makeEntry('delete_vs_edit'), provisional: inO.block };
+      }
+    } else if (!inB && inO && !inT) {
+      fate = { kind: 'keep', block: inO.block }; // added on main
+      autoMerged++;
+    } else if (!inB && !inO && inT) {
+      fate = { kind: 'keep', block: inT.block }; // added on the preview
+      autoMerged++;
+    } else if (sig(inO) === sig(inT)) {
+      fate = { kind: 'keep', block: inO!.block }; // added identically on both
+      autoMerged++;
+    } else {
+      fate = { kind: 'conflict', entry: makeEntry('both_added'), provisional: inT!.block };
+    }
+
+    const choice = resolutions[id];
+    if (fate.kind === 'conflict' && choice) {
+      const chosenBlock = (choice === 'ours' ? fate.entry.ours : fate.entry.theirs) as
+        | BlockNode
+        | undefined;
+      fate = chosenBlock == null ? { kind: 'drop' } : { kind: 'keep', block: chosenBlock };
+    }
+
+    if (fate.kind === 'keep') {
+      kept.set(id, fate.block);
+    } else if (fate.kind === 'conflict') {
+      kept.set(id, fate.provisional);
+      conflicts.push(fate.entry);
+    }
+  }
+
+  // Top-level order: 3-way sequence merge with the survivors as members.
+  const members = new Set(kept.keys());
+  const seq = mergeIdSequence3(
+    idsOf(b),
+    idsOf(o),
+    idsOf(t),
+    members,
+    resolutions[ORDER_CONFLICT_ID]
+  );
+  let order: string[];
+  if (seq.conflict) {
+    conflicts.push({
+      id: ORDER_CONFLICT_ID,
+      index: -1,
+      reason: 'order',
+      base: seq.base,
+      ours: seq.ours,
+      theirs: seq.theirs,
+    });
+    order = seq.provisional;
+  } else {
+    order = seq.order;
+  }
+  // Safety net: every survivor must land somewhere.
+  for (const id of members) {
+    if (!order.includes(id)) order.push(id);
+  }
+
+  const merged = order.map(id => structuredClone(kept.get(id)!));
+  return { merged, conflicts, autoMerged };
 }

--- a/packages/services/src/content/ContentService.ts
+++ b/packages/services/src/content/ContentService.ts
@@ -441,7 +441,11 @@ export class ContentService {
    * @param {string} options.repo - Repository name
    * @param {string} options.path - File path
    * @param {string} options.content - File content
-   * @param {string} [options.expectedSha] - Expected SHA for optimistic locking
+   * @param {string} [options.expectedSha] - Expected SHA for optimistic
+   *   locking. Sent as the PUT's `sha` so GitHub enforces it ATOMICALLY
+   *   (compare-and-swap, not check-then-act); the uncached pre-check only
+   *   exists for a clear early 409 and the deleted-file case. Without it, the
+   *   write adopts whatever sha a fresh read returns (last-writer-wins).
    * @param {string} [options.branch] - Branch to commit to (default: repository default branch)
    * @param {string} [options.message] - Commit message
    * @param {boolean} [options.createOnly] - Create-only write: no sha is ever
@@ -481,10 +485,20 @@ export class ContentService {
       throw new Error('createOnly and expectedSha are mutually exclusive');
     }
 
-    // Check current SHA if optimistic locking is requested
-    // (branch writes check the sha on that branch; ref bypasses the cache)
+    // Pre-check when optimistic locking is requested (branch writes check the
+    // sha on that branch). skipCache is REQUIRED here: a cached read could
+    // vouch for a sha that main has already moved past, and the check exists
+    // to produce a clear, early 409 — GitHub enforces the real precondition
+    // below. The deleted-file case (404) can only be caught here: a sha-bearing
+    // PUT against a missing file is not a conflict to GitHub.
     if (expectedSha) {
-      const current = await this.getMeta({ gitOrganization: resolvedOrg, repo, path, ref: branch });
+      const current = await this.getMeta({
+        gitOrganization: resolvedOrg,
+        repo,
+        path,
+        ref: branch,
+        skipCache: true,
+      });
       if (!current) {
         // A sha was expected but the file is gone: deleted = changed. Silently
         // recreating would resurrect content the deleter meant to remove.
@@ -499,12 +513,16 @@ export class ContentService {
       }
     }
 
-    // Get current SHA for update (required by GitHub API). createOnly writes
-    // deliberately skip this and send no sha, so GitHub itself enforces
-    // non-existence (422 when the file materialized concurrently).
-    const existing = createOnly
-      ? null
-      : await this.getMeta({ gitOrganization: resolvedOrg, repo, path, ref: branch });
+    // Get current SHA for update (required by GitHub API) — only when the
+    // caller did NOT lock: expectedSha writes send the caller's sha directly
+    // so GitHub enforces it atomically (a second read here would adopt a
+    // concurrent write and defeat the lock — check-then-act, not CAS).
+    // createOnly writes send no sha, so GitHub itself enforces non-existence
+    // (422 when the file materialized concurrently).
+    const existing =
+      createOnly || expectedSha
+        ? null
+        : await this.getMeta({ gitOrganization: resolvedOrg, repo, path, ref: branch });
 
     let data;
     try {
@@ -514,7 +532,9 @@ export class ContentService {
         path,
         message: message || `Update ${path}`,
         content: Buffer.from(content).toString('base64'),
-        sha: existing?.sha, // Required for updates, undefined for creates
+        // expectedSha is the atomic precondition; otherwise the fresh read's
+        // sha (required for updates), undefined for creates.
+        sha: expectedSha ?? existing?.sha,
         ...(branch ? { branch } : {}),
       }));
     } catch (error: unknown) {
@@ -524,6 +544,16 @@ export class ContentService {
         const conflict = new Error(
           `File already exists: ${path} (create-only write refused)`
         ) as Error & { status: number };
+        conflict.status = 409;
+        throw conflict;
+      }
+      // GitHub rejected the expectedSha precondition (409 Conflict): the file
+      // moved between the pre-check and the PUT. Same conflict semantics and
+      // message as the pre-check, now race-free.
+      if (expectedSha && hasStatus(error, 409)) {
+        const conflict = new Error('File was modified by someone else') as Error & {
+          status: number;
+        };
         conflict.status = 409;
         throw conflict;
       }

--- a/packages/services/src/content/ContentService.ts
+++ b/packages/services/src/content/ContentService.ts
@@ -572,9 +572,9 @@ export class ContentService {
         ? null
         : await this.getMeta({ gitOrganization: resolvedOrg, repo, path, ref: branch });
 
-    let data;
+    let response;
     try {
-      ({ data } = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+      response = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
         owner: resolvedOrg.login,
         repo,
         path,
@@ -584,7 +584,7 @@ export class ContentService {
         // sha (required for updates), undefined for creates.
         sha: expectedSha ?? existing?.sha,
         ...(branch ? { branch } : {}),
-      }));
+      });
     } catch (error: unknown) {
       // Sha-less create against an existing file → GitHub 422. For createOnly
       // callers that's the existence race, surfaced with conflict semantics.
@@ -595,10 +595,15 @@ export class ContentService {
         conflict.status = 409;
         throw conflict;
       }
-      // GitHub rejected the expectedSha precondition (409 Conflict): the file
-      // moved between the pre-check and the PUT. Same conflict semantics and
-      // message as the pre-check, now race-free.
-      if (expectedSha && hasStatus(error, 409)) {
+      // GitHub rejected the expectedSha precondition: the file moved between
+      // the pre-check and the PUT. It answers 409 Conflict, and (observed in
+      // practice) 422 "sha … does not match" for the SAME mismatch — map both
+      // to the same conflict so the caller never gets a raw 422.
+      if (
+        expectedSha &&
+        (hasStatus(error, 409) ||
+          (hasStatus(error, 422) && /does not match|sha/i.test(getErrorMessage(error))))
+      ) {
         const conflict = new Error('File was modified by someone else') as Error & {
           status: number;
         };
@@ -607,6 +612,24 @@ export class ContentService {
       }
       throw error;
     }
+
+    // Concurrent-delete race (live-probed): with an expectedSha the pre-check
+    // saw the file present, but it was DELETED before this PUT landed. GitHub
+    // has no "update-only" mode — a sha-bearing PUT on a now-missing path
+    // CREATES the file (HTTP 201) instead of conflicting, silently resurrecting
+    // content the deleter removed. The create cannot be cheaply prevented (no
+    // compare-and-swap-on-delete API), so we surface the delete as the same
+    // conflict AFTER the unwanted create; the caller reloads and the stray file
+    // is reconciled (overwritten/removed) on the next write.
+    if (expectedSha && response.status === 201) {
+      const conflict = new Error('File was deleted since it was read') as Error & {
+        status: number;
+      };
+      conflict.status = 409;
+      throw conflict;
+    }
+
+    const { data } = response;
 
     // Invalidate cache for this path (and parent folder).
     // Branch writes don't touch the default branch's content, so they must

--- a/packages/services/src/content/ContentService.ts
+++ b/packages/services/src/content/ContentService.ts
@@ -434,6 +434,54 @@ export class ContentService {
   }
 
   /**
+   * Fetch a blob's decoded utf-8 content by its blob sha (Git Blobs API).
+   * Blob shas are content-addressed — no ref is needed and the content can
+   * never change under the sha, so this is the canonical way to read "the
+   * file as it was when a conflict token was handed out" (content-tools plan
+   * §3b Phase 7.5: the editor's stale token IS the 3-way merge base).
+   *
+   * Never cached (immutable content, read once per stale save).
+   *
+   * @param {Object} options
+   * @param {Object} [options.gitOrganization] - GitOrganization record from database
+   * @param {string} [options.orgLogin] - Organization login (fallback, assumes GITHUB)
+   * @param {string} options.repo - Repository name
+   * @param {string} options.sha - The blob sha to fetch
+   * @returns {Promise<{ content: string, sha: string } | null>} - null when the
+   *   blob does not exist in the repo (404, or GitHub's 422 for a malformed sha)
+   */
+  static async getBlobContent({
+    gitOrganization,
+    orgLogin,
+    repo,
+    sha,
+  }: {
+    gitOrganization?: GitOrganizationRecord;
+    orgLogin?: string;
+    repo: string;
+    sha: string;
+  }): Promise<{ content: string; sha: string } | null> {
+    try {
+      const resolvedOrg = await resolveGitOrganization(gitOrganization, orgLogin);
+      const octokit = await getOctokit(resolvedOrg);
+      const { data } = await octokit.request('GET /repos/{owner}/{repo}/git/blobs/{file_sha}', {
+        owner: resolvedOrg.login,
+        repo,
+        file_sha: sha,
+      });
+      return {
+        content: Buffer.from(data.content, 'base64').toString('utf-8'),
+        sha,
+      };
+    } catch (error: unknown) {
+      if (hasStatus(error, 404) || hasStatus(error, 422)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Create or update a text file
    * @param {Object} options
    * @param {Object} [options.gitOrganization] - GitOrganization record from database

--- a/packages/services/src/content/__tests__/ContentService.test.ts
+++ b/packages/services/src/content/__tests__/ContentService.test.ts
@@ -742,3 +742,73 @@ describe('compareBranches', () => {
     ).rejects.toThrow('Server error');
   });
 });
+
+describe('getBlobContent', () => {
+  it('fetches a blob by sha via the Git Blobs API and decodes utf-8', async () => {
+    requestMock.mockImplementation(async (route: string, params: RequestParams) => {
+      expect(route).toBe('GET /repos/{owner}/{repo}/git/blobs/{file_sha}');
+      expect(params).toMatchObject({
+        owner: 'test-org',
+        repo: 'repo-blob',
+        file_sha: 'abc123',
+      });
+      // GitHub returns base64 with embedded newlines
+      const base64 = Buffer.from('{"version":1,"slides":[]}', 'utf-8').toString('base64');
+      return { data: { content: `${base64.slice(0, 10)}\n${base64.slice(10)}`, sha: 'abc123' } };
+    });
+
+    const result = await ContentService.getBlobContent({
+      gitOrganization,
+      repo: 'repo-blob',
+      sha: 'abc123',
+    });
+
+    expect(result).toEqual({ content: '{"version":1,"slides":[]}', sha: 'abc123' });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never serves from or stores into the response cache (content-addressed, uncached)', async () => {
+    const base64 = Buffer.from('hello', 'utf-8').toString('base64');
+    requestMock.mockResolvedValue({ data: { content: base64, sha: 'blob-sha' } });
+
+    await ContentService.getBlobContent({ gitOrganization, repo: 'repo-blob-2', sha: 'blob-sha' });
+    await ContentService.getBlobContent({ gitOrganization, repo: 'repo-blob-2', sha: 'blob-sha' });
+
+    // Two reads → two API calls (no cache layer involved).
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null on 404 (blob not in the repo)', async () => {
+    requestMock.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }));
+
+    const result = await ContentService.getBlobContent({
+      gitOrganization,
+      repo: 'repo-blob',
+      sha: 'ffffffffffffffffffffffffffffffffffffffff',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on 422 (GitHub's malformed-sha answer)", async () => {
+    requestMock.mockRejectedValue(
+      Object.assign(new Error('The sha parameter must be exactly 40 characters'), { status: 422 })
+    );
+
+    const result = await ContentService.getBlobContent({
+      gitOrganization,
+      repo: 'repo-blob',
+      sha: 'not-a-sha',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('rethrows non-404/422 errors', async () => {
+    requestMock.mockRejectedValue(Object.assign(new Error('Server error'), { status: 500 }));
+
+    await expect(
+      ContentService.getBlobContent({ gitOrganization, repo: 'repo-blob', sha: 'abc123' })
+    ).rejects.toThrow('Server error');
+  });
+});

--- a/packages/services/src/content/__tests__/ContentService.test.ts
+++ b/packages/services/src/content/__tests__/ContentService.test.ts
@@ -384,6 +384,115 @@ describe('put with branch', () => {
   });
 });
 
+describe('put expectedSha: concurrent-delete race + 422 mismatch (plan §P6)', () => {
+  it('a sha-bearing PUT GitHub answers as a CREATE (201) → 409 deleted-since-read, not a silent resurrection', async () => {
+    const repo = 'repo-put-201';
+    const path = 'pages/racedelete/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        // Pre-check still sees the file present with the expected sha…
+        return { data: { content: Buffer.from('x').toString('base64'), sha: 'sha-live', size: 1 } };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        // …but it was DELETED before the PUT landed, so GitHub CREATED it (201).
+        return {
+          status: 201,
+          data: { content: { sha: 'sha-new' }, commit: { sha: 'commit-new' } },
+        };
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    await expect(
+      ContentService.put({
+        gitOrganization,
+        repo,
+        path,
+        content: 'resurrected?',
+        expectedSha: 'sha-live',
+      })
+    ).rejects.toMatchObject({ status: 409, message: expect.stringContaining('deleted') });
+  });
+
+  it('a 200 update under expectedSha is NOT mistaken for a create', async () => {
+    const repo = 'repo-put-200';
+    const path = 'pages/ok/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: Buffer.from('x').toString('base64'), sha: 'sha-live', size: 1 } };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        return {
+          status: 200,
+          data: { content: { sha: 'sha-new' }, commit: { sha: 'commit-new' } },
+        };
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    const result = await ContentService.put({
+      gitOrganization,
+      repo,
+      path,
+      content: 'updated',
+      expectedSha: 'sha-live',
+    });
+    expect(result).toMatchObject({ sha: 'sha-new', commit: 'commit-new' });
+  });
+
+  it("GitHub's 422 sha-mismatch variant under expectedSha maps to the same 409 conflict", async () => {
+    const repo = 'repo-put-422';
+    const path = 'pages/mismatch/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: Buffer.from('x').toString('base64'), sha: 'sha-live', size: 1 } };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        throw Object.assign(new Error('"sha" 111 does not match abc'), { status: 422 });
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    await expect(
+      ContentService.put({
+        gitOrganization,
+        repo,
+        path,
+        content: 'updated',
+        expectedSha: 'sha-live',
+      })
+    ).rejects.toMatchObject({ status: 409, message: 'File was modified by someone else' });
+  });
+
+  it('an unrelated 422 (not a sha mismatch) under expectedSha still propagates raw', async () => {
+    const repo = 'repo-put-422-other';
+    const path = 'pages/other/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: Buffer.from('x').toString('base64'), sha: 'sha-live', size: 1 } };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        throw Object.assign(new Error('content is too large'), { status: 422 });
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    await expect(
+      ContentService.put({
+        gitOrganization,
+        repo,
+        path,
+        content: 'updated',
+        expectedSha: 'sha-live',
+      })
+    ).rejects.toMatchObject({ status: 422, message: expect.stringContaining('too large') });
+  });
+});
+
 describe('put createOnly', () => {
   it('sends NO sha (no prior meta read) and creates the file', async () => {
     const repo = 'repo-createonly-ok';

--- a/packages/services/src/content/__tests__/ContentService.test.ts
+++ b/packages/services/src/content/__tests__/ContentService.test.ts
@@ -220,12 +220,14 @@ describe('put with branch', () => {
     });
     expect(result).toEqual({ sha: 'sha-new', commit: 'commit-new' });
 
-    // Both internal getMeta lookups must have read the BRANCH (ref set), not main
+    // ONE internal getMeta pre-check, reading the BRANCH (ref set), not main.
+    // No second read: the expectedSha write sends the caller's sha directly
+    // (true CAS — a second read would adopt a concurrent writer's sha).
     const afterPut = contentsGetCalls();
-    expect(afterPut.withRef).toBe(2);
+    expect(afterPut.withRef).toBe(1);
     expect(afterPut.withoutRef).toBe(1);
 
-    // The PUT itself must carry the branch
+    // The PUT itself must carry the branch and the CALLER'S expected sha
     const putCall = requestMock.mock.calls.find(
       ([route]) => route === 'PUT /repos/{owner}/{repo}/contents/{path}'
     );
@@ -263,6 +265,96 @@ describe('put with branch', () => {
     // Cache was invalidated by the default-branch write, so this refetches
     const after = await ContentService.getContent({ gitOrganization, repo, path });
     expect(after?.content).toBe('main-v2');
+  });
+
+  it('expectedSha put is a true CAS: uncached pre-check, PUT carries the CALLER sha, no second read', async () => {
+    const repo = 'repo-put-cas';
+    const path = 'pages/cas/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        const body = 'main-v1';
+        return {
+          data: { content: Buffer.from(body).toString('base64'), sha: 'sha-live', size: 1 },
+        };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: { sha: 'sha-new' }, commit: { sha: 'commit-new' } } };
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    // Seed the 60s cache — the pre-check must NOT be satisfied by it.
+    await ContentService.getContent({ gitOrganization, repo, path });
+    expect(contentsGetCalls().total).toBe(1);
+
+    await ContentService.put({
+      gitOrganization,
+      repo,
+      path,
+      content: 'updated',
+      expectedSha: 'sha-live',
+    });
+
+    // Exactly ONE more Contents GET: the uncached pre-check. No second
+    // "current sha" read — that read is what made the old flow check-then-act
+    // (it would adopt a concurrent writer's sha).
+    expect(contentsGetCalls().total).toBe(2);
+
+    // The PUT sends the CALLER'S expectedSha so GitHub enforces it atomically.
+    const putCall = requestMock.mock.calls.find(
+      ([route]) => route === 'PUT /repos/{owner}/{repo}/contents/{path}'
+    );
+    expect((putCall?.[1] as RequestParams).sha).toBe('sha-live');
+  });
+
+  it("a 409 from GitHub's sha precondition (lost race after the pre-check) maps to the same conflict", async () => {
+    const repo = 'repo-put-cas-race';
+    const path = 'pages/race/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        // Pre-check still sees the expected sha…
+        return { data: { content: Buffer.from('x').toString('base64'), sha: 'sha-live', size: 1 } };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        // …but a concurrent writer landed between the check and the PUT.
+        throw Object.assign(new Error('is at abc but expected sha-live'), { status: 409 });
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    await expect(
+      ContentService.put({
+        gitOrganization,
+        repo,
+        path,
+        content: 'updated',
+        expectedSha: 'sha-live',
+      })
+    ).rejects.toMatchObject({ status: 409, message: 'File was modified by someone else' });
+  });
+
+  it('a put WITHOUT expectedSha keeps the auto-sha update path (fresh read, its sha on the PUT)', async () => {
+    const repo = 'repo-put-nosha';
+    const path = 'pages/nosha/content.json';
+
+    requestMock.mockImplementation(async (route: string) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: Buffer.from('x').toString('base64'), sha: 'sha-auto', size: 1 } };
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: { sha: 'sha-new' }, commit: { sha: 'commit-new' } } };
+      }
+      throw new Error(`Unexpected route: ${route}`);
+    });
+
+    await ContentService.put({ gitOrganization, repo, path, content: 'updated' });
+
+    const putCall = requestMock.mock.calls.find(
+      ([route]) => route === 'PUT /repos/{owner}/{repo}/contents/{path}'
+    );
+    expect((putCall?.[1] as RequestParams).sha).toBe('sha-auto');
   });
 
   it('expectedSha + missing file → 409 (deleted since read), never a silent create', async () => {

--- a/packages/services/src/content/__tests__/merge3.test.ts
+++ b/packages/services/src/content/__tests__/merge3.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the shared 3-way merge primitives (merge3.ts):
+ * - indexResolutions element-shape validation (F5: malformed choices throw
+ *   INVALID_RESOLUTIONS everywhere, never a silent default to a side)
+ * - mergeIdSequence3's both-add tiebreak (pins the behavior the F6 comment
+ *   documents: theirs' additions land first at a shared anchor)
+ * - dedupeMergedTreeIds, the final id-uniqueness sweep both engines run
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  dedupeMergedTreeIds,
+  indexResolutions,
+  mergeIdSequence3,
+  PreviewResolutionError,
+  type MergeResolution,
+} from '../merge3.ts';
+
+describe('indexResolutions — element validation (F5)', () => {
+  it('indexes a well-formed array', () => {
+    expect(
+      indexResolutions([
+        { id: 'a', choose: 'ours' },
+        { id: '__order__', choose: 'theirs' },
+      ])
+    ).toEqual({ a: 'ours', __order__: 'theirs' });
+  });
+
+  it.each([
+    ['bad choose value', [{ id: 'a', choose: 'banana' }]],
+    ['missing choose', [{ id: 'a' }]],
+    ['empty id', [{ id: '', choose: 'ours' }]],
+    ['non-string id', [{ id: 42, choose: 'ours' }]],
+    ['null element', [null]],
+    ['string element', ['a:ours']],
+  ] as Array<[string, unknown[]]>)('throws INVALID_RESOLUTIONS on %s', (_label, resolutions) => {
+    let failure: unknown;
+    try {
+      indexResolutions(resolutions as MergeResolution[]);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect((failure as PreviewResolutionError).code).toBe('INVALID_RESOLUTIONS');
+  });
+
+  it('still throws DUPLICATE_RESOLUTIONS on repeated ids', () => {
+    let failure: unknown;
+    try {
+      indexResolutions([
+        { id: 'a', choose: 'ours' },
+        { id: 'a', choose: 'theirs' },
+      ]);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toMatchObject({ code: 'DUPLICATE_RESOLUTIONS', ids: ['a'] });
+  });
+});
+
+describe('mergeIdSequence3 — both-add tiebreak (F6 comment pin)', () => {
+  it("theirs' addition lands FIRST when both sides add at the same anchor of a base backbone", () => {
+    const base = ['a', 'b'];
+    const ours = ['a', 'o1', 'b'];
+    const theirs = ['a', 't1', 'b'];
+    const members = new Set(['a', 'b', 'o1', 't1']);
+
+    const result = mergeIdSequence3(base, ours, theirs, members);
+
+    expect(result.conflict).toBe(false);
+    if (!result.conflict) {
+      // Neither side reordered → base backbone; ours woven first, theirs
+      // woven second directly after the shared anchor — ahead of ours'.
+      expect(result.order).toEqual(['a', 't1', 'o1', 'b']);
+    }
+  });
+});
+
+describe('dedupeMergedTreeIds', () => {
+  const doc = () => [
+    { id: 'p', children: [{ id: 'c', text: 'edited' }] },
+    { id: 'q', children: [{ id: 'c', text: 'stale' }] },
+    { id: 'r' },
+  ];
+
+  it('is a no-op on unique ids', () => {
+    const nodes = [{ id: 'a' }, { id: 'b', children: [{ id: 'c' }] }];
+    expect(dedupeMergedTreeIds(nodes)).toEqual([]);
+    expect(nodes).toEqual([{ id: 'a' }, { id: 'b', children: [{ id: 'c' }] }]);
+  });
+
+  it('keeps the first occurrence by default and reports the duplicated id', () => {
+    const nodes = doc();
+    expect(dedupeMergedTreeIds(nodes)).toEqual(['c']);
+    expect(nodes).toEqual([
+      { id: 'p', children: [{ id: 'c', text: 'edited' }] },
+      { id: 'q', children: [] },
+      { id: 'r' },
+    ]);
+  });
+
+  it('prefers the copy inside a conflict-unit subtree even when it comes later', () => {
+    const nodes = doc();
+    dedupeMergedTreeIds(nodes, new Set(['q']));
+    expect(nodes).toEqual([
+      { id: 'p', children: [] },
+      { id: 'q', children: [{ id: 'c', text: 'stale' }] },
+      { id: 'r' },
+    ]);
+  });
+
+  it('drops a duplicated TOP-LEVEL copy in favor of the conflict copy', () => {
+    const nodes = [
+      { id: 'p', children: [{ id: 'c', text: 'kept' }] },
+      { id: 'c', text: 'stale' },
+    ];
+    dedupeMergedTreeIds(nodes, new Set(['p']));
+    expect(nodes).toEqual([{ id: 'p', children: [{ id: 'c', text: 'kept' }] }]);
+  });
+
+  it('dropEmptyChildren removes a children key the sweep emptied (deck shape)', () => {
+    const nodes = [
+      { id: 'p', children: [{ id: 'c' }] },
+      { id: 'q', children: [{ id: 'c' }] },
+    ];
+    dedupeMergedTreeIds(nodes, new Set(), { dropEmptyChildren: true });
+    expect(nodes).toEqual([{ id: 'p', children: [{ id: 'c' }] }, { id: 'q' }]);
+  });
+});

--- a/packages/services/src/content/merge3.ts
+++ b/packages/services/src/content/merge3.ts
@@ -1,0 +1,189 @@
+/**
+ * merge3.ts — shared primitives for the semantic 3-way content merge
+ * (content-tools plan §3b, Phase 7).
+ *
+ * Pure functions only: no service imports, no network, no database. Used by
+ * the deck merge engine (slides/deckMerge.ts) and the page block merge engine
+ * (classmoji/pageContent.service.ts merge3Blocks).
+ */
+
+// ─── Resolution types ────────────────────────────────────────────────────────
+
+/** A per-conflict choice: `ours` = the live (main) side, `theirs` = the preview side. */
+export type MergeChoice = 'ours' | 'theirs';
+
+/** One chooser decision, keyed by the conflict id from a prior conflict report. */
+export interface MergeResolution {
+  id: string;
+  choose: MergeChoice;
+}
+
+/**
+ * Typed failure for resolvePreviewConflicts: the supplied resolutions do not
+ * exactly cover the current conflict set (or there is nothing to resolve).
+ * Carries the offending ids so tools can name them.
+ */
+export class PreviewResolutionError extends Error {
+  code:
+    | 'NO_PREVIEW'
+    | 'NOTHING_TO_RESOLVE'
+    | 'UNRESOLVED_CONFLICTS'
+    | 'UNKNOWN_RESOLUTIONS'
+    | 'DUPLICATE_RESOLUTIONS';
+  ids: string[];
+
+  constructor(message: string, code: PreviewResolutionError['code'], ids: string[] = []) {
+    super(message);
+    this.name = 'PreviewResolutionError';
+    this.code = code;
+    this.ids = ids;
+  }
+}
+
+/**
+ * Validate a resolutions array (non-empty, no duplicate ids) and index it by
+ * conflict id. Throws PreviewResolutionError on duplicates.
+ */
+export function indexResolutions(resolutions: MergeResolution[]): Record<string, MergeChoice> {
+  const map: Record<string, MergeChoice> = {};
+  const dupes: string[] = [];
+  for (const { id, choose } of resolutions) {
+    if (id in map) dupes.push(id);
+    map[id] = choose;
+  }
+  if (dupes.length > 0) {
+    throw new PreviewResolutionError(
+      `Duplicate resolution ids: ${dupes.join(', ')} — pass each conflict id exactly once`,
+      'DUPLICATE_RESOLUTIONS',
+      dupes
+    );
+  }
+  return map;
+}
+
+// ─── Canonical JSON (order-insensitive deep comparison) ──────────────────────
+
+/**
+ * Deterministic serialization with object keys sorted at every level, so
+ * comparisons are stable regardless of key insertion order.
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'undefined';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${canonicalJson((value as Record<string, unknown>)[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
+// ─── 3-way id-sequence merge ─────────────────────────────────────────────────
+
+export type SequenceMerge3Result =
+  | { conflict: false; order: string[] }
+  | {
+      conflict: true;
+      base: string[];
+      ours: string[];
+      theirs: string[];
+      /** Theirs-backboned order, used while the conflict is pending resolution. */
+      provisional: string[];
+    };
+
+const restrictTo = (seq: string[], keep: ReadonlySet<string>): string[] =>
+  seq.filter(id => keep.has(id));
+
+const sameSeq = (a: string[], b: string[]): boolean =>
+  a.length === b.length && a.every((id, i) => id === b[i]);
+
+function intersect(a: string[], b: string[]): Set<string> {
+  const bSet = new Set(b);
+  return new Set(a.filter(id => bSet.has(id)));
+}
+
+/**
+ * Weave `members` from sideSeq that are missing from `result` into `result`,
+ * each inserted directly after the nearest preceding sideSeq element already
+ * present (runs of consecutive additions keep their side order; additions with
+ * no preceding anchor land at the start).
+ */
+function weave(result: string[], sideSeq: string[], members: ReadonlySet<string>): void {
+  let lastIdx = -1;
+  for (const id of sideSeq) {
+    const existing = result.indexOf(id);
+    if (existing !== -1) {
+      lastIdx = existing;
+      continue;
+    }
+    if (!members.has(id)) continue;
+    result.splice(lastIdx + 1, 0, id);
+    lastIdx += 1;
+  }
+}
+
+/**
+ * 3-way merge of an id sequence (one document "scope": the top level, or one
+ * stack's children).
+ *
+ * Reordering is detected on the ids each side SHARES with base (additions and
+ * deletions never count as a reorder). One side reordered → its order is the
+ * backbone; both reordered identically → that order; both reordered
+ * differently → conflict (unless `resolution` picks a backbone). The final
+ * sequence contains exactly `members`, with each side's additions woven in at
+ * their side-relative positions (backbone-side entries first at a shared
+ * anchor, ours before theirs when both add at the same anchor of a base
+ * backbone).
+ *
+ * @param members - the ids that must appear in the output (the surviving units
+ *   assigned to this scope by the unit-level merge).
+ * @param resolution - optional pre-resolved backbone for an order conflict.
+ */
+export function mergeIdSequence3(
+  base: string[],
+  ours: string[],
+  theirs: string[],
+  members: ReadonlySet<string>,
+  resolution?: MergeChoice
+): SequenceMerge3Result {
+  const oursShared = intersect(base, ours);
+  const theirsShared = intersect(base, theirs);
+  const oursReordered = !sameSeq(restrictTo(base, oursShared), restrictTo(ours, oursShared));
+  const theirsReordered = !sameSeq(
+    restrictTo(base, theirsShared),
+    restrictTo(theirs, theirsShared)
+  );
+
+  const bothShared = intersect(ours, theirs);
+  const agreeRelative = sameSeq(restrictTo(ours, bothShared), restrictTo(theirs, bothShared));
+
+  const build = (backbone: 'base' | 'ours' | 'theirs'): string[] => {
+    const spine = backbone === 'base' ? base : backbone === 'ours' ? ours : theirs;
+    const result = restrictTo(spine, members);
+    weave(result, ours, members);
+    weave(result, theirs, members);
+    return result;
+  };
+
+  const genuineOrderConflict = oursReordered && theirsReordered && !agreeRelative;
+  if (genuineOrderConflict && !resolution) {
+    return {
+      conflict: true,
+      base: [...base],
+      ours: [...ours],
+      theirs: [...theirs],
+      provisional: build('theirs'),
+    };
+  }
+
+  const backbone: 'base' | 'ours' | 'theirs' = genuineOrderConflict
+    ? (resolution as MergeChoice)
+    : oursReordered
+      ? 'ours'
+      : theirsReordered
+        ? 'theirs'
+        : 'base';
+  return { conflict: false, order: build(backbone) };
+}

--- a/packages/services/src/content/merge3.ts
+++ b/packages/services/src/content/merge3.ts
@@ -22,6 +22,16 @@ export interface MergeResolution {
  * Typed failure for resolvePreviewConflicts: the supplied resolutions do not
  * exactly cover the current conflict set (or there is nothing to resolve).
  * Carries the offending ids so tools can name them.
+ *
+ * Additional codes:
+ * - `INVALID_RESOLUTIONS` — a resolution element is malformed (id not a
+ *   non-empty string, or choose not 'ours'/'theirs'). Validated centrally in
+ *   indexResolutions so a malformed choice can never silently default.
+ * - `CONTENT_CONFLICT` — the caller pinned the resolution to a conflict
+ *   report (expected ours/theirs shas) and the content moved since; the
+ *   report is stale — re-run accept for a fresh one.
+ * - `MAIN_CONTENT_MISSING` — main's content file was deleted, so there is no
+ *   sha to CAS the merge commit on; discard the preview or re-apply it.
  */
 export class PreviewResolutionError extends Error {
   code:
@@ -29,7 +39,10 @@ export class PreviewResolutionError extends Error {
     | 'NOTHING_TO_RESOLVE'
     | 'UNRESOLVED_CONFLICTS'
     | 'UNKNOWN_RESOLUTIONS'
-    | 'DUPLICATE_RESOLUTIONS';
+    | 'DUPLICATE_RESOLUTIONS'
+    | 'INVALID_RESOLUTIONS'
+    | 'CONTENT_CONFLICT'
+    | 'MAIN_CONTENT_MISSING';
   ids: string[];
 
   constructor(message: string, code: PreviewResolutionError['code'], ids: string[] = []) {
@@ -41,13 +54,24 @@ export class PreviewResolutionError extends Error {
 }
 
 /**
- * Validate a resolutions array (non-empty, no duplicate ids) and index it by
- * conflict id. Throws PreviewResolutionError on duplicates.
+ * Validate a resolutions array (well-formed elements, no duplicate ids) and
+ * index it by conflict id. Every element must be `{id: non-empty string,
+ * choose: 'ours' | 'theirs'}` — anything else throws INVALID_RESOLUTIONS
+ * (never a silent default to one side). Duplicates throw
+ * DUPLICATE_RESOLUTIONS.
  */
 export function indexResolutions(resolutions: MergeResolution[]): Record<string, MergeChoice> {
   const map: Record<string, MergeChoice> = {};
   const dupes: string[] = [];
-  for (const { id, choose } of resolutions) {
+  for (const entry of resolutions) {
+    const { id, choose } = (entry ?? {}) as { id?: unknown; choose?: unknown };
+    if (typeof id !== 'string' || id.length === 0 || (choose !== 'ours' && choose !== 'theirs')) {
+      throw new PreviewResolutionError(
+        "Malformed resolution — every element must be {id: non-empty string, choose: 'ours'|'theirs'}",
+        'INVALID_RESOLUTIONS',
+        typeof id === 'string' && id ? [id] : []
+      );
+    }
     if (id in map) dupes.push(id);
     map[id] = choose;
   }
@@ -133,9 +157,10 @@ function weave(result: string[], sideSeq: string[], members: ReadonlySet<string>
  * backbone; both reordered identically → that order; both reordered
  * differently → conflict (unless `resolution` picks a backbone). The final
  * sequence contains exactly `members`, with each side's additions woven in at
- * their side-relative positions (backbone-side entries first at a shared
- * anchor, ours before theirs when both add at the same anchor of a base
- * backbone).
+ * their side-relative positions (runs of consecutive additions keep their
+ * side order; when both sides add at the same anchor of a base backbone,
+ * theirs' additions land first — ours is woven before theirs, so the later
+ * theirs weave inserts directly after the shared anchor, ahead of ours').
  *
  * @param members - the ids that must appear in the output (the surviving units
  *   assigned to this scope by the unit-level merge).
@@ -186,4 +211,85 @@ export function mergeIdSequence3(
         ? 'theirs'
         : 'base';
   return { conflict: false, order: build(backbone) };
+}
+
+// ─── Merged-document id uniqueness (final safety sweep) ──────────────────────
+
+interface DedupeTreeNode {
+  id?: unknown;
+  children?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Enforce id uniqueness on an assembled merged document — the final assertion
+ * both merge engines run before returning `merged`. Duplicate ids should be
+ * unreachable after the cross-scope-move handling, but deeply-nested
+ * cross-parent moves (an id nested under different parents on each side, both
+ * parents kept) can still smuggle two copies in.
+ *
+ * For each duplicated id, ONE copy is kept: the first copy that sits inside a
+ * conflict unit's subtree (`preferredRoots` — that copy is what the chooser
+ * card showed / the resolution produced), else the first in document order.
+ * Every other copy is removed, subtree included (it is by definition a stale
+ * duplicate). Mutates `nodes` in place; returns the duplicated ids for
+ * logging/telemetry.
+ *
+ * @param opts.dropEmptyChildren - delete a `children` key emptied by the
+ *   sweep (deck documents omit empty children; BlockNote keeps `[]`).
+ */
+export function dedupeMergedTreeIds(
+  nodes: unknown[],
+  preferredRoots: ReadonlySet<string> = new Set(),
+  opts: { dropEmptyChildren?: boolean } = {}
+): string[] {
+  const byId = new Map<string, Array<{ node: DedupeTreeNode; preferred: boolean }>>();
+
+  const scan = (list: DedupeTreeNode[], underPreferred: boolean): void => {
+    for (const node of list) {
+      if (!node || typeof node !== 'object') continue;
+      const id = typeof node.id === 'string' && node.id ? node.id : null;
+      const preferred = underPreferred || (id != null && preferredRoots.has(id));
+      if (id != null) {
+        const bucket = byId.get(id) ?? [];
+        bucket.push({ node, preferred });
+        byId.set(id, bucket);
+      }
+      if (Array.isArray(node.children)) {
+        scan(node.children as DedupeTreeNode[], preferred);
+      }
+    }
+  };
+  scan(nodes as DedupeTreeNode[], false);
+
+  const toDrop = new Set<DedupeTreeNode>();
+  const duplicated: string[] = [];
+  for (const [id, bucket] of byId) {
+    if (bucket.length < 2) continue;
+    duplicated.push(id);
+    const winner = bucket.find(occurrence => occurrence.preferred) ?? bucket[0];
+    for (const occurrence of bucket) {
+      if (occurrence !== winner) toDrop.add(occurrence.node);
+    }
+  }
+  if (toDrop.size === 0) return [];
+
+  const prune = (list: DedupeTreeNode[]): void => {
+    for (let i = list.length - 1; i >= 0; i--) {
+      const node = list[i];
+      if (node && typeof node === 'object' && toDrop.has(node)) {
+        list.splice(i, 1);
+        continue;
+      }
+      if (Array.isArray(node?.children)) {
+        prune(node.children as DedupeTreeNode[]);
+        if (opts.dropEmptyChildren && (node.children as unknown[]).length === 0) {
+          delete node.children;
+        }
+      }
+    }
+  };
+  prune(nodes as DedupeTreeNode[]);
+
+  return duplicated;
 }

--- a/packages/services/src/content/merge3.ts
+++ b/packages/services/src/content/merge3.ts
@@ -32,6 +32,12 @@ export interface MergeResolution {
  *   report is stale — re-run accept for a fresh one.
  * - `MAIN_CONTENT_MISSING` — main's content file was deleted, so there is no
  *   sha to CAS the merge commit on; discard the preview or re-apply it.
+ * - `MERGE_BASE_MISSING` — the 3-way merge base (the content file at the
+ *   preview's fork point) is missing (add/add: the file was created
+ *   independently on both sides) or unparseable, so there is no trustworthy
+ *   base to merge against — merging against an empty base silently resurrects
+ *   deletions and duplicates blocks. Discard the preview or re-apply it as a
+ *   fresh document.
  */
 export class PreviewResolutionError extends Error {
   code:
@@ -42,7 +48,8 @@ export class PreviewResolutionError extends Error {
     | 'DUPLICATE_RESOLUTIONS'
     | 'INVALID_RESOLUTIONS'
     | 'CONTENT_CONFLICT'
-    | 'MAIN_CONTENT_MISSING';
+    | 'MAIN_CONTENT_MISSING'
+    | 'MERGE_BASE_MISSING';
   ids: string[];
 
   constructor(message: string, code: PreviewResolutionError['code'], ids: string[] = []) {

--- a/packages/services/src/slides/__tests__/deckHtml.behaviors.test.ts
+++ b/packages/services/src/slides/__tests__/deckHtml.behaviors.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit behaviors: parseSlidesFragment, normalizeSlideHtml, diffDeckUnits,
- * and generator specifics (config emission, invalid attr names, includeNotes).
+ * Unit behaviors: parseSlidesFragment, normalizeSlideHtml, and generator
+ * specifics (config emission, invalid attr names, includeNotes).
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -8,7 +8,6 @@ import {
   generateDeckHtml,
   parseSlidesFragment,
   normalizeSlideHtml,
-  diffDeckUnits,
   DeckParseError,
   SlideHtmlError,
   mintSlideId,
@@ -66,6 +65,19 @@ describe('parseSlidesFragment', () => {
   it('throws DeckParseError on a fragment with zero sections', () => {
     expect(() => parseSlidesFragment('<div class="slides"></div>')).toThrow(DeckParseError);
   });
+
+  it('strips fragment runtime paint from a merely-viewed slide (no phantom edit persists)', () => {
+    const result = parseSlidesFragment(
+      '<div class="slides" data-theme="white" data-code-theme="github">' +
+        '<section data-cm-id="frag8888"><h2>Intro</h2>' +
+        '<p class="fragment visible">one</p>' +
+        '<p class="fragment visible current-fragment">two</p></section>' +
+        '</div>'
+    );
+    expect(result.slides[0].html).toBe(
+      '<h2>Intro</h2><p class="fragment">one</p><p class="fragment">two</p>'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -112,112 +124,28 @@ describe('normalizeSlideHtml', () => {
     const output = normalizeSlideHtml('<div><p>unclosed');
     expect(output).toBe('<div><p>unclosed</p></div>');
   });
+
+  it('strips Reveal fragment runtime paint (visible / current-fragment), keeping `fragment`', () => {
+    const output = normalizeSlideHtml(
+      '<p class="fragment visible">one</p><p class="fragment visible current-fragment">two</p>'
+    );
+    expect(output).toBe('<p class="fragment">one</p><p class="fragment">two</p>');
+  });
+
+  it('leaves a non-fragment `visible`/`current-fragment` class alone (only fragment paint is runtime)', () => {
+    const output = normalizeSlideHtml('<div class="visible">kept</div>');
+    expect(output).toBe('<div class="visible">kept</div>');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// diffDeckUnits
+// Shared deck helpers (generator specifics below)
 // ─────────────────────────────────────────────────────────────────────────────
-
-function makeDeck(slides: DeckSlide[]): DeckJson {
-  return { version: 1, theme: 'white', codeTheme: 'github', slides };
-}
 
 const s = (id: string, html: string, extra: Partial<DeckSlide> = {}): DeckSlide => ({
   id,
   html,
   ...extra,
-});
-
-describe('diffDeckUnits', () => {
-  const base = makeDeck([s('aaa11111', '<h1>One</h1>'), s('bbb22222', '<h2>Two</h2>')]);
-
-  it('reports no conflicts when the sides change different units', () => {
-    const ours = makeDeck([s('aaa11111', '<h1>One edited</h1>'), s('bbb22222', '<h2>Two</h2>')]);
-    const theirs = makeDeck([s('aaa11111', '<h1>One</h1>'), s('bbb22222', '<h2>Two edited</h2>')]);
-    const result = diffDeckUnits(base, ours, theirs);
-    expect(result.units).toEqual([]);
-    expect(result.orderConflict).toBeUndefined();
-  });
-
-  it('reports a conflict when both sides change the same unit differently', () => {
-    const ours = makeDeck([s('aaa11111', '<h1>Ours</h1>'), s('bbb22222', '<h2>Two</h2>')]);
-    const theirs = makeDeck([s('aaa11111', '<h1>Theirs</h1>'), s('bbb22222', '<h2>Two</h2>')]);
-    const result = diffDeckUnits(base, ours, theirs);
-    expect(result.units).toHaveLength(1);
-    expect(result.units[0]).toMatchObject({
-      id: 'aaa11111',
-      index: '1',
-      ours: { html: '<h1>Ours</h1>' },
-      theirs: { html: '<h1>Theirs</h1>' },
-    });
-    expect(result.units[0].base).toEqual(s('aaa11111', '<h1>One</h1>'));
-  });
-
-  it('does not report a conflict when both sides made the identical change', () => {
-    const same = makeDeck([s('aaa11111', '<h1>Same</h1>'), s('bbb22222', '<h2>Two</h2>')]);
-    const result = diffDeckUnits(base, same, makeDeck([...same.slides]));
-    expect(result.units).toEqual([]);
-  });
-
-  it('reports delete-vs-edit as a conflict with null for the deleted side', () => {
-    const ours = makeDeck([s('bbb22222', '<h2>Two</h2>')]); // deleted aaa
-    const theirs = makeDeck([s('aaa11111', '<h1>Edited</h1>'), s('bbb22222', '<h2>Two</h2>')]);
-    const result = diffDeckUnits(base, ours, theirs);
-    expect(result.units).toHaveLength(1);
-    expect(result.units[0].id).toBe('aaa11111');
-    expect(result.units[0].ours).toBeNull();
-    expect(result.units[0].theirs).toEqual(s('aaa11111', '<h1>Edited</h1>'));
-    // Order changed on ours only (deletion) — no order conflict
-    expect(result.orderConflict).toBeUndefined();
-  });
-
-  it('reports an order conflict only when both sides reordered differently', () => {
-    const ours = makeDeck([base.slides[1], base.slides[0]]);
-    const theirs = makeDeck([base.slides[0], base.slides[1]]);
-    expect(diffDeckUnits(base, ours, theirs).orderConflict).toBeUndefined();
-
-    const theirs2 = makeDeck([s('ccc33333', '<h3>New</h3>'), base.slides[0], base.slides[1]]);
-    const conflict = diffDeckUnits(base, ours, theirs2).orderConflict;
-    expect(conflict).toEqual({
-      base: ['aaa11111', 'bbb22222'],
-      ours: ['bbb22222', 'aaa11111'],
-      theirs: ['ccc33333', 'aaa11111', 'bbb22222'],
-    });
-  });
-
-  it('walks container children as their own units with dotted indexes', () => {
-    const containerBase = makeDeck([
-      s('flat0001', '<h1>Flat</h1>'),
-      { id: 'stack001', children: [s('leaf0001', '<p>a</p>'), s('leaf0002', '<p>b</p>')] },
-    ]);
-    const ours = makeDeck([
-      s('flat0001', '<h1>Flat</h1>'),
-      { id: 'stack001', children: [s('leaf0001', '<p>ours</p>'), s('leaf0002', '<p>b</p>')] },
-    ]);
-    const theirs = makeDeck([
-      s('flat0001', '<h1>Flat</h1>'),
-      { id: 'stack001', children: [s('leaf0001', '<p>theirs</p>'), s('leaf0002', '<p>b</p>')] },
-    ]);
-    const result = diffDeckUnits(containerBase, ours, theirs);
-    expect(result.units).toHaveLength(1);
-    expect(result.units[0].id).toBe('leaf0001');
-    expect(result.units[0].index).toBe('2.1');
-  });
-
-  it('treats attrs key order as irrelevant (sorted comparison)', () => {
-    const withAttrs = (order: 'ab' | 'ba') =>
-      makeDeck([
-        {
-          id: 'aaa11111',
-          html: '<h1>One</h1>',
-          attrs:
-            order === 'ab' ? { 'data-a': '1', 'data-b': '2' } : { 'data-b': '2', 'data-a': '1' },
-        },
-        s('bbb22222', '<h2>Two</h2>'),
-      ]);
-    const result = diffDeckUnits(withAttrs('ab'), withAttrs('ba'), withAttrs('ab'));
-    expect(result.units).toEqual([]);
-  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/services/src/slides/__tests__/deckHtml.browserEquiv.test.ts
+++ b/packages/services/src/slides/__tests__/deckHtml.browserEquiv.test.ts
@@ -1,0 +1,146 @@
+/**
+ * htmlEquivalentModuloBrowserSerialization contract (Phase 7.5 phantom-
+ * conflict fix).
+ *
+ * Positive cases are pinned by CAPTURED Chromium output (see
+ * fixtures/browserSerialization.ts for provenance): the stored form of a
+ * fragment, its pure innerHTML round-trip, and its CSSOM-restyled form must
+ * all be equivalent. Negative cases prove the equivalence stays conservative:
+ * genuinely different colors/numbers/text/code/attrs still differ.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { htmlEquivalentModuloBrowserSerialization as equivalent } from '../deckHtml.ts';
+import {
+  BROWSER_SERIALIZATION_FIXTURES,
+  TRUE_DIFFERENCE_CASES,
+} from './fixtures/browserSerialization.ts';
+
+describe('htmlEquivalentModuloBrowserSerialization — captured browser rewrites are equal', () => {
+  it.each(BROWSER_SERIALIZATION_FIXTURES)(
+    '$name: input ≡ pure innerHTML round-trip',
+    ({ input, roundtrip }) => {
+      expect(equivalent(input, roundtrip)).toBe(true);
+    }
+  );
+
+  it.each(BROWSER_SERIALIZATION_FIXTURES)(
+    '$name: input ≡ CSSOM-restyled read-back',
+    ({ input, cssom }) => {
+      expect(equivalent(input, cssom)).toBe(true);
+    }
+  );
+
+  it.each(BROWSER_SERIALIZATION_FIXTURES)(
+    '$name: round-trip ≡ CSSOM form (transitivity across browser variants)',
+    ({ roundtrip, cssom }) => {
+      expect(equivalent(roundtrip, cssom)).toBe(true);
+    }
+  );
+});
+
+describe('htmlEquivalentModuloBrowserSerialization — genuine differences still differ', () => {
+  it.each(TRUE_DIFFERENCE_CASES)('$name', ({ a, b }) => {
+    expect(equivalent(a, b)).toBe(false);
+    expect(equivalent(b, a)).toBe(false);
+  });
+});
+
+describe('htmlEquivalentModuloBrowserSerialization — style declaration semantics', () => {
+  it('declaration order is insignificant', () => {
+    expect(
+      equivalent(
+        '<div style="color: red; top: 1px">x</div>',
+        '<div style="top: 1px; color: red">x</div>'
+      )
+    ).toBe(true);
+  });
+
+  it('trailing semicolon and declaration spacing are insignificant', () => {
+    expect(
+      equivalent(
+        '<div style="color:red;top:1px">x</div>',
+        '<div style="color: red; top: 1px;">x</div>'
+      )
+    ).toBe(true);
+  });
+
+  it('duplicate properties resolve last-wins (browser behavior)', () => {
+    expect(
+      equivalent('<div style="color: red; color: blue">x</div>', '<div style="color: blue">x</div>')
+    ).toBe(true);
+    expect(
+      equivalent('<div style="color: red; color: blue">x</div>', '<div style="color: red">x</div>')
+    ).toBe(false);
+  });
+
+  it('4/8-digit hex (alpha) forms stay strict — never conflated with rgb()', () => {
+    expect(
+      equivalent(
+        '<div style="color:#e07b39aa">x</div>',
+        '<div style="color: rgb(224, 123, 57);">x</div>'
+      )
+    ).toBe(false);
+  });
+
+  it('named colors are never conflated with their rgb value (deliberately strict)', () => {
+    expect(
+      equivalent('<div style="color: red">x</div>', '<div style="color: rgb(255, 0, 0)">x</div>')
+    ).toBe(false);
+  });
+
+  it('data-URL url() args with semicolons survive declaration splitting', () => {
+    const dataUrl =
+      '<div style="background: url(data:image/png;base64,AAAA); color:#ffffff">x</div>';
+    const browserForm =
+      '<div style="background: url(&quot;data:image/png;base64,AAAA&quot;); color: rgb(255, 255, 255);">x</div>';
+    expect(equivalent(dataUrl, browserForm)).toBe(true);
+    expect(
+      equivalent(
+        dataUrl,
+        '<div style="background: url(&quot;data:image/png;base64,BBBB&quot;); color: rgb(255, 255, 255);">x</div>'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('htmlEquivalentModuloBrowserSerialization — field-level edges', () => {
+  it('null/undefined equal each other but never a string (absent ≠ empty)', () => {
+    expect(equivalent(null, undefined)).toBe(true);
+    expect(equivalent(null, '')).toBe(false);
+    expect(equivalent('', null)).toBe(false);
+    expect(equivalent('', '')).toBe(true);
+  });
+
+  it('boolean attr forms are equal (data-x vs data-x="")', () => {
+    expect(equivalent('<div data-x>x</div>', '<div data-x="">x</div>')).toBe(true);
+    expect(equivalent('<div data-x>x</div>', '<div data-x="1">x</div>')).toBe(false);
+  });
+
+  it('attribute order is insignificant, attribute presence is not', () => {
+    expect(equivalent('<div a="1" b="2">x</div>', '<div b="2" a="1">x</div>')).toBe(true);
+    expect(equivalent('<div a="1" b="2">x</div>', '<div a="1">x</div>')).toBe(false);
+  });
+
+  it('inter-element whitespace text stays significant', () => {
+    expect(equivalent('<p>a</p> <p>b</p>', '<p>a</p><p>b</p>')).toBe(false);
+  });
+
+  it('style attrs INSIDE pre/code get no loosening (code content is sacred)', () => {
+    expect(
+      equivalent(
+        '<pre><code><span style="color:#e07b39">x</span></code></pre>',
+        '<pre><code><span style="color: rgb(224, 123, 57);">x</span></code></pre>'
+      )
+    ).toBe(false);
+  });
+
+  it("the pre/code element's OWN chrome attrs still tolerate browser rewrites", () => {
+    expect(
+      equivalent(
+        '<pre style="width:600.50px"><code class="language-js">x</code></pre>',
+        '<pre style="width: 600.5px;"><code class="language-js">x</code></pre>'
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/services/src/slides/__tests__/deckHtml.browserEquiv.test.ts
+++ b/packages/services/src/slides/__tests__/deckHtml.browserEquiv.test.ts
@@ -47,13 +47,34 @@ describe('htmlEquivalentModuloBrowserSerialization — genuine differences still
 });
 
 describe('htmlEquivalentModuloBrowserSerialization — style declaration semantics', () => {
-  it('declaration order is insignificant', () => {
+  it('declaration order is SIGNIFICANT — browsers never reorder on a round-trip', () => {
+    // Independent properties reordered: still a genuine difference, because a
+    // DOM read-back never produces this reordering on its own (fixtures show
+    // order is preserved), so any reorder is a real edit.
     expect(
       equivalent(
         '<div style="color: red; top: 1px">x</div>',
         '<div style="top: 1px; color: red">x</div>'
       )
-    ).toBe(true);
+    ).toBe(false);
+  });
+
+  it('shorthand/longhand reorder changes the render — reported as a difference', () => {
+    // `margin-top: 5px; margin: 10px` renders margin-top 10px (shorthand last
+    // wins); the reverse renders margin-top 5px. The old order-insensitive
+    // canonicalization equated them and silently reverted one side's edit.
+    expect(
+      equivalent(
+        '<h2 style="margin-top: 5px; margin: 10px;">t</h2>',
+        '<h2 style="margin: 10px; margin-top: 5px;">t</h2>'
+      )
+    ).toBe(false);
+  });
+
+  it('a same-property value change is still detected (control)', () => {
+    expect(
+      equivalent('<h2 style="margin-top: 5px;">t</h2>', '<h2 style="margin-top: 9px;">t</h2>')
+    ).toBe(false);
   });
 
   it('trailing semicolon and declaration spacing are insignificant', () => {
@@ -72,6 +93,23 @@ describe('htmlEquivalentModuloBrowserSerialization — style declaration semanti
     expect(
       equivalent('<div style="color: red; color: blue">x</div>', '<div style="color: red">x</div>')
     ).toBe(false);
+  });
+
+  it('hex is NOT rewritten to rgb inside a custom property value (browser stores it verbatim)', () => {
+    expect(
+      equivalent(
+        '<div style="--brand: #fff">x</div>',
+        '<div style="--brand: rgb(255, 255, 255)">x</div>'
+      )
+    ).toBe(false);
+    // ...but a real edit to the same custom property is still a difference.
+    expect(
+      equivalent('<div style="--brand: #fff">x</div>', '<div style="--brand: #eee">x</div>')
+    ).toBe(false);
+    // An untouched custom property (only spacing differs) still matches.
+    expect(
+      equivalent('<div style="--brand:#fff">x</div>', '<div style="--brand: #fff">x</div>')
+    ).toBe(true);
   });
 
   it('4/8-digit hex (alpha) forms stay strict — never conflated with rgb()', () => {
@@ -101,6 +139,19 @@ describe('htmlEquivalentModuloBrowserSerialization — style declaration semanti
         '<div style="background: url(&quot;data:image/png;base64,BBBB&quot;); color: rgb(255, 255, 255);">x</div>'
       )
     ).toBe(false);
+  });
+});
+
+describe('htmlEquivalentModuloBrowserSerialization — class attribute is verbatim', () => {
+  it('class whitespace is significant — browsers preserve it byte-for-byte', () => {
+    // Fixture `class-whitespace` proves a DOM round-trip keeps repeated and
+    // leading/trailing spaces, so collapsing them would mask a real edit.
+    expect(equivalent('<div class="a  b">x</div>', '<div class="a b">x</div>')).toBe(false);
+    expect(equivalent('<div class=" a b ">x</div>', '<div class="a b">x</div>')).toBe(false);
+  });
+
+  it('identical class strings still match (no false difference)', () => {
+    expect(equivalent('<div class="a  b">x</div>', '<div class="a  b">x</div>')).toBe(true);
   });
 });
 

--- a/packages/services/src/slides/__tests__/deckMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckMerge.test.ts
@@ -17,6 +17,7 @@ import {
   deckChildOrderConflictId,
   merge3Units,
 } from '../deckMerge.ts';
+import { browserFixture } from './fixtures/browserSerialization.ts';
 import type { DeckJson, DeckSlide } from '../deckTypes.ts';
 
 const slide = (id: string, html = `<p>${id}</p>`, extra: Partial<DeckSlide> = {}): DeckSlide => ({
@@ -743,6 +744,107 @@ describe('merge3Units — cross-scope moves (confined view)', () => {
       assertUniqueIds(resolved);
     }
     expect(byId(keepTheirs.merged, 's').children?.map(child => child.id)).toEqual(['x']);
+  });
+});
+
+// ─── Browser-serialization tolerance (Phase 7.5 phantom conflicts) ───────────
+//
+// theirs in an editor save is a browser DOM read-back; base/ours come from
+// stored generator output. The fixture strings below are CAPTURED Chromium
+// output (fixtures/browserSerialization.ts) — the exact forms the user's
+// two-tab repro produced.
+
+describe('merge3Units — browser-serialization tolerance', () => {
+  const hexFixture = browserFixture('hex-color-style');
+  /** A third, byte-distinct but semantically identical browser variant. */
+  const hexVariant =
+    '<h2 style="color:rgb(224,123,57)">Warm heading</h2><p style="color:rgb(171,71,188)">purple</p>';
+
+  it('theirs = the REAL browser form of an untouched styled slide + ours = real edit → auto-merges to ours, zero conflicts', () => {
+    const edited = '<h2 style="color:#e07b39">Warm heading EDITED</h2>';
+    const base = deck([slide('a', hexFixture.input), slide('b')]);
+    const ours = deck([slide('a', edited), slide('b')]);
+    const theirs = deck([slide('a', hexFixture.cssom), slide('b')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'a').html).toBe(edited);
+    // Only ours' genuine edit counts — browser noise is not a change.
+    expect(result.autoMerged).toBe(1);
+  });
+
+  it('the inverse — theirs REALLY edited (a different color) against an ours edit → still a content conflict', () => {
+    const base = deck([slide('a', hexFixture.input)]);
+    const ours = deck([slide('a', '<h2 style="color:#e07b39">Warm heading EDITED</h2>')]);
+    // rgb(200, …) is NOT the browser serialization of #e07b39 (that is 224).
+    const theirs = deck([slide('a', '<h2 style="color: rgb(200, 123, 57);">Warm heading</h2>')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toMatchObject([{ id: 'a', reason: 'content' }]);
+  });
+
+  it('identical edits where one side is browser-serialized → auto-merge keeps ours (the clean stored form)', () => {
+    const base = deck([slide('a', '<p>old</p>')]);
+    const ours = deck([slide('a', hexFixture.input)]);
+    const theirs = deck([slide('a', hexFixture.cssom)]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'a').html).toBe(hexFixture.input);
+    expect(result.autoMerged).toBe(1);
+  });
+
+  it('browser noise on BOTH sides of an untouched slide → the unit stays at base verbatim', () => {
+    const base = deck([slide('a', hexFixture.input), slide('b')]);
+    const ours = deck([slide('a', hexFixture.cssom), slide('b')]);
+    const theirs = deck([slide('a', hexVariant), slide('b')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'a').html).toBe(hexFixture.input);
+    expect(result.autoMerged).toBe(0);
+  });
+
+  it('notes fields get the same tolerance', () => {
+    const base = deck([slide('a', '<p>a</p>', { notes: '<p style="color:#e07b39">note</p>' })]);
+    const ours = deck([
+      slide('a', '<p>a edited</p>', { notes: '<p style="color:#e07b39">note</p>' }),
+    ]);
+    const theirs = deck([
+      slide('a', '<p>a</p>', { notes: '<p style="color: rgb(224, 123, 57);">note</p>' }),
+    ]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'a').html).toBe('<p>a edited</p>');
+  });
+
+  it('section attrs (style) tolerate CSSOM re-serialization; genuine attr changes still conflict', () => {
+    // Captured: style="background-color:#123456" reads back as
+    // "background-color: rgb(18, 52, 86);" after any CSSOM style write.
+    const base = deck([slide('a', '<p>a</p>', { attrs: { style: 'background-color:#123456' } })]);
+    const ours = deck([
+      slide('a', '<p>a edited</p>', { attrs: { style: 'background-color:#123456' } }),
+    ]);
+    const theirs = deck([
+      slide('a', '<p>a</p>', { attrs: { style: 'background-color: rgb(18, 52, 86);' } }),
+    ]);
+
+    const tolerant = merge3Units(base, ours, theirs);
+    expect(tolerant.conflicts).toEqual([]);
+    expect(byId(tolerant.merged, 'a').html).toBe('<p>a edited</p>');
+
+    const genuine = merge3Units(
+      base,
+      ours,
+      deck([slide('a', '<p>a</p>', { attrs: { style: 'background-color: rgb(99, 52, 86);' } })])
+    );
+    expect(genuine.conflicts).toMatchObject([{ id: 'a', reason: 'content' }]);
   });
 });
 

--- a/packages/services/src/slides/__tests__/deckMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckMerge.test.ts
@@ -594,6 +594,158 @@ describe('merge3Units — resolutions', () => {
   });
 });
 
+// ─── Cross-scope moves (confined view) ───────────────────────────────────────
+//
+// Review-probe scenarios (Phase 7 fix batch F1): a preview that moves a
+// child OUT of its stack while main edits that child must NOT collapse into a
+// container conflict whose cards contradict what resolving produces. The
+// confined view merges the escaped child independently: the move and the
+// edit compose (auto-merge), and any remaining conflict on the container is
+// fields-only with truthful cards.
+
+describe('merge3Units — cross-scope moves (confined view)', () => {
+  const collectIds = (d: DeckJson): string[] => {
+    const out: string[] = [];
+    for (const s of d.slides) {
+      out.push(s.id);
+      for (const c of s.children ?? []) out.push(c.id);
+    }
+    return out;
+  };
+  const assertUniqueIds = (d: DeckJson) => {
+    const ids = collectIds(d);
+    expect(new Set(ids).size).toBe(ids.length);
+  };
+
+  it('preview moves the only child out of a stack + main edits it → clean auto-merge (probe dir 1)', () => {
+    const base = deck([stack('s', [slide('c')]), slide('a')]);
+    const ours = deck([stack('s', [slide('c', '<p>edited on main</p>')]), slide('a')]);
+    // theirs: c moved to the top level; s left as a childless husk.
+    const theirs = deck([{ id: 's' }, slide('a'), slide('c')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['s', 'a', 'c']);
+    // The edit followed the moved slide; the husk stayed childless.
+    expect(byId(result.merged, 'c').html).toBe('<p>edited on main</p>');
+    expect(result.merged.slides[0].children).toBeUndefined();
+    assertUniqueIds(result.merged);
+  });
+
+  it('main moves the only child out + preview edits it → clean auto-merge (probe dir 2)', () => {
+    const base = deck([stack('s', [slide('c')]), slide('a')]);
+    const ours = deck([{ id: 's' }, slide('a'), slide('c')]);
+    const theirs = deck([stack('s', [slide('c', '<p>edited on preview</p>')]), slide('a')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['s', 'a', 'c']);
+    expect(byId(result.merged, 'c').html).toBe('<p>edited on preview</p>');
+    expect(result.merged.slides[0].children).toBeUndefined();
+    assertUniqueIds(result.merged);
+  });
+
+  it('move-out + container-field collision → fields-only conflict whose resolutions DIFFER and match the cards', () => {
+    const base = deck([stack('s', [slide('c')], { attrs: { 'data-x': 'base' } }), slide('a')]);
+    const ours = deck([
+      stack('s', [slide('c', '<p>edited on main</p>')], { attrs: { 'data-x': 'main' } }),
+      slide('a'),
+    ]);
+    const theirs = deck([{ id: 's', attrs: { 'data-x': 'preview' } }, slide('a'), slide('c')]);
+
+    const report = merge3Units(base, ours, theirs);
+    expect(report.conflicts).toHaveLength(1);
+    const conflict = report.conflicts[0];
+    expect(conflict).toMatchObject({ id: 's', reason: 'content' });
+    // Cards are fields-only: the escaped child appears on NEITHER side.
+    expect((conflict.ours as DeckSlide).children).toBeUndefined();
+    expect((conflict.theirs as DeckSlide).children).toBeUndefined();
+
+    const keepOurs = merge3Units(base, ours, theirs, { resolutions: { s: 'ours' } });
+    const keepTheirs = merge3Units(base, ours, theirs, { resolutions: { s: 'theirs' } });
+    expect(keepOurs.conflicts).toEqual([]);
+    expect(keepTheirs.conflicts).toEqual([]);
+
+    // The choice is honored: the two documents DIFFER exactly where the
+    // cards differ (s's fields), and each matches its card.
+    expect(keepOurs.merged).not.toEqual(keepTheirs.merged);
+    expect(byId(keepOurs.merged, 's').attrs).toEqual({ 'data-x': 'main' });
+    expect(byId(keepOurs.merged, 's')).toEqual(conflict.ours);
+    expect(byId(keepTheirs.merged, 's').attrs).toEqual({ 'data-x': 'preview' });
+    expect(byId(keepTheirs.merged, 's')).toEqual(conflict.theirs);
+
+    // Either way the moved child lives once, at the root, carrying the edit.
+    for (const resolved of [keepOurs.merged, keepTheirs.merged]) {
+      expect(topIds(resolved)).toEqual(['s', 'a', 'c']);
+      expect(byId(resolved, 'c').html).toBe('<p>edited on main</p>');
+      assertUniqueIds(resolved);
+    }
+  });
+
+  it('delete-vs-edit on a stack with an escaped child: cards exclude it, resolutions differ', () => {
+    const base = deck([stack('s', [slide('c'), slide('d')]), slide('a')]);
+    const ours = deck([slide('a')]); // main deleted the whole stack
+    // theirs: d edited in place, c moved out (unedited).
+    const theirs = deck([stack('s', [slide('d', '<p>edited</p>')]), slide('a'), slide('c')]);
+
+    const report = merge3Units(base, ours, theirs);
+    expect(report.conflicts).toHaveLength(1);
+    const conflict = report.conflicts[0];
+    expect(conflict).toMatchObject({ id: 's', reason: 'delete_vs_edit', ours: null });
+    // The escaped child c is excluded from the theirs AND base cards — its
+    // fate (delete wins over the unedited move) is not the chooser's to make.
+    expect((conflict.theirs as DeckSlide).children?.map(child => child.id)).toEqual(['d']);
+    expect((conflict.base as DeckSlide).children?.map(child => child.id)).toEqual(['d']);
+
+    const keepTheirs = merge3Units(base, ours, theirs, { resolutions: { s: 'theirs' } });
+    expect(keepTheirs.conflicts).toEqual([]);
+    expect(topIds(keepTheirs.merged)).toEqual(['s', 'a']);
+    expect(byId(keepTheirs.merged, 's').children?.map(child => child.id)).toEqual(['d']);
+    expect(byId(keepTheirs.merged, 'd').html).toBe('<p>edited</p>');
+
+    const keepOurs = merge3Units(base, ours, theirs, { resolutions: { s: 'ours' } });
+    expect(keepOurs.conflicts).toEqual([]);
+    expect(topIds(keepOurs.merged)).toEqual(['a']);
+
+    expect(keepOurs.merged).not.toEqual(keepTheirs.merged);
+    assertUniqueIds(keepOurs.merged);
+    assertUniqueIds(keepTheirs.merged);
+  });
+
+  it('both-added stack where one side moved an EXISTING slide in: nothing lost, resolutions differ', () => {
+    const base = deck([slide('c'), slide('a')]);
+    // ours adds stack s and moves existing c into it.
+    const ours = deck([stack('s', [slide('c')]), slide('a')]);
+    // theirs adds stack s with a brand-new child x; c untouched at the root.
+    const theirs = deck([stack('s', [slide('x', '<p>new</p>')]), slide('c'), slide('a')]);
+
+    const report = merge3Units(base, ours, theirs);
+    expect(report.conflicts).toHaveLength(1);
+    expect(report.conflicts[0]).toMatchObject({ id: 's', reason: 'both_added' });
+    // c escaped (it exists at the root on base/theirs) → not in ours' card.
+    expect((report.conflicts[0].ours as DeckSlide).children).toBeUndefined();
+    expect((report.conflicts[0].theirs as DeckSlide).children?.map(child => child.id)).toEqual([
+      'x',
+    ]);
+
+    const keepOurs = merge3Units(base, ours, theirs, { resolutions: { s: 'ours' } });
+    const keepTheirs = merge3Units(base, ours, theirs, { resolutions: { s: 'theirs' } });
+    expect(keepOurs.conflicts).toEqual([]);
+    expect(keepTheirs.conflicts).toEqual([]);
+    expect(keepOurs.merged).not.toEqual(keepTheirs.merged);
+
+    // c survives exactly once in both outcomes (root fallback — a verbatim
+    // container cannot admit independent children).
+    for (const resolved of [keepOurs.merged, keepTheirs.merged]) {
+      expect(collectIds(resolved)).toContain('c');
+      assertUniqueIds(resolved);
+    }
+    expect(byId(keepTheirs.merged, 's').children?.map(child => child.id)).toEqual(['x']);
+  });
+});
+
 // ─── Hygiene ─────────────────────────────────────────────────────────────────
 
 describe('merge3Units — hygiene', () => {

--- a/packages/services/src/slides/__tests__/deckMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckMerge.test.ts
@@ -1,0 +1,621 @@
+/**
+ * merge3Units fixture matrix (content-tools plan §3b Phase 7).
+ *
+ * Pure engine tests — no mocks. The contract under test:
+ * one-side edits merge, identical edits merge, true collisions conflict,
+ * adds keep their side position, delete-vs-unchanged lets the delete win
+ * (moves do NOT protect), delete-vs-edit conflicts, order sequences 3-way
+ * merge per scope (top level + each stack), stack membership moves are
+ * sequence ops, deck meta merges per-field, and resolutions apply chooser
+ * decisions ('ours' = main, 'theirs' = preview).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DECK_META_CONFLICT_ID,
+  DECK_ORDER_CONFLICT_ID,
+  deckChildOrderConflictId,
+  merge3Units,
+} from '../deckMerge.ts';
+import type { DeckJson, DeckSlide } from '../deckTypes.ts';
+
+const slide = (id: string, html = `<p>${id}</p>`, extra: Partial<DeckSlide> = {}): DeckSlide => ({
+  id,
+  html,
+  ...extra,
+});
+const stack = (id: string, children: DeckSlide[], extra: Partial<DeckSlide> = {}): DeckSlide => ({
+  id,
+  children,
+  ...extra,
+});
+const deck = (slides: DeckSlide[], extra: Partial<DeckJson> = {}): DeckJson => ({
+  version: 1,
+  theme: 'white',
+  codeTheme: 'github',
+  slides,
+  ...extra,
+});
+const topIds = (d: DeckJson): string[] => d.slides.map(s => s.id);
+const byId = (d: DeckJson, id: string): DeckSlide => {
+  for (const s of d.slides) {
+    if (s.id === id) return s;
+    for (const c of s.children ?? []) if (c.id === id) return c;
+  }
+  throw new Error(`missing ${id}`);
+};
+
+// ─── One-side edits, every field type ────────────────────────────────────────
+
+describe('merge3Units — one-side edits', () => {
+  const mutations: Array<[string, (s: DeckSlide) => void]> = [
+    ['html', s => (s.html = '<h1>edited</h1>')],
+    ['notes', s => (s.notes = '<p>new notes</p>')],
+    ['hidden', s => (s.hidden = true)],
+    ['attrs', s => (s.attrs = { 'data-transition': 'fade' })],
+  ];
+
+  it.each(mutations)('an ours-only %s change is taken', (_field, mutate) => {
+    const base = deck([slide('a'), slide('b')]);
+    const ours = deck([slide('a'), slide('b')]);
+    mutate(ours.slides[0]);
+    const theirs = deck([slide('a'), slide('b')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.slides[0]).toEqual(ours.slides[0]);
+    expect(result.autoMerged).toBe(1);
+  });
+
+  it.each(mutations)('a theirs-only %s change is taken', (_field, mutate) => {
+    const base = deck([slide('a'), slide('b')]);
+    const ours = deck([slide('a'), slide('b')]);
+    const theirs = deck([slide('a'), slide('b')]);
+    mutate(theirs.slides[1]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.slides[1]).toEqual(theirs.slides[1]);
+  });
+
+  it('edits on DIFFERENT slides from each side both land', () => {
+    const base = deck([slide('a'), slide('b')]);
+    const ours = deck([slide('a', '<p>main edit</p>'), slide('b')]);
+    const theirs = deck([slide('a'), slide('b', '<p>preview edit</p>', { hidden: true })]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'a').html).toBe('<p>main edit</p>');
+    expect(byId(result.merged, 'b')).toEqual(slide('b', '<p>preview edit</p>', { hidden: true }));
+    expect(result.autoMerged).toBe(2);
+  });
+});
+
+// ─── Identical edits + true collisions ───────────────────────────────────────
+
+describe('merge3Units — identical edits and collisions', () => {
+  it('identical edits on both sides merge without conflict', () => {
+    const base = deck([slide('a')]);
+    const edited = deck([slide('a', '<p>same edit</p>', { hidden: true })]);
+
+    const result = merge3Units(base, edited, structuredClone(edited));
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'a')).toEqual(edited.slides[0]);
+    expect(result.autoMerged).toBe(1);
+  });
+
+  it('both-changed-differently is a content conflict carrying base/ours/theirs', () => {
+    const base = deck([slide('a', '<p>original</p>'), slide('b')]);
+    const ours = deck([slide('a', '<p>main version</p>'), slide('b')]);
+    const theirs = deck([slide('a', '<p>preview version</p>'), slide('b')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: 'a',
+        index: '1',
+        reason: 'content',
+        base: slide('a', '<p>original</p>'),
+        ours: slide('a', '<p>main version</p>'),
+        theirs: slide('a', '<p>preview version</p>'),
+      },
+    ]);
+    // Pending conflicts carry theirs provisionally.
+    expect(byId(result.merged, 'a').html).toBe('<p>preview version</p>');
+    expect(result.autoMerged).toBe(0);
+  });
+
+  it('different FIELDS of the same slide still collide (the slide is the unit)', () => {
+    const base = deck([slide('a', '<p>x</p>')]);
+    const ours = deck([slide('a', '<p>main html</p>')]);
+    const theirs = deck([slide('a', '<p>x</p>', { notes: '<p>preview notes</p>' })]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({ id: 'a', reason: 'content' });
+  });
+});
+
+// ─── Adds ────────────────────────────────────────────────────────────────────
+
+describe('merge3Units — adds', () => {
+  it('a slide added on one side keeps its position from that side', () => {
+    const base = deck([slide('a'), slide('b')]);
+    const ours = deck([slide('a'), slide('x', '<p>added on main</p>'), slide('b')]);
+    const theirs = deck([slide('a'), slide('b'), slide('y', '<p>added on preview</p>')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['a', 'x', 'b', 'y']);
+    expect(result.autoMerged).toBe(2);
+  });
+
+  it('the same id added identically on both sides is kept once', () => {
+    const base = deck([slide('a')]);
+    const withX = deck([slide('a'), slide('x', '<p>same add</p>')]);
+
+    const result = merge3Units(base, withX, structuredClone(withX));
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['a', 'x']);
+  });
+
+  it('the same id added differently on both sides is a both_added conflict (no base)', () => {
+    const base = deck([slide('a')]);
+    const ours = deck([slide('a'), slide('x', '<p>main add</p>')]);
+    const theirs = deck([slide('a'), slide('x', '<p>preview add</p>')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({
+      id: 'x',
+      reason: 'both_added',
+      ours: { html: '<p>main add</p>' },
+      theirs: { html: '<p>preview add</p>' },
+    });
+    expect('base' in result.conflicts[0]).toBe(false);
+  });
+});
+
+// ─── Deletes ─────────────────────────────────────────────────────────────────
+
+describe('merge3Units — deletes', () => {
+  it('delete vs unchanged: the delete wins (both directions)', () => {
+    const base = deck([slide('a'), slide('b')]);
+    const oursDeleted = deck([slide('b')]);
+    const untouched = deck([slide('a'), slide('b')]);
+
+    expect(topIds(merge3Units(base, oursDeleted, untouched).merged)).toEqual(['b']);
+    expect(topIds(merge3Units(base, untouched, oursDeleted).merged)).toEqual(['b']);
+    expect(merge3Units(base, oursDeleted, untouched).conflicts).toEqual([]);
+  });
+
+  it('deleted on both sides is simply gone', () => {
+    const base = deck([slide('a'), slide('b')]);
+    const both = deck([slide('b')]);
+
+    const result = merge3Units(base, both, structuredClone(both));
+    expect(topIds(result.merged)).toEqual(['b']);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('delete vs EDIT is a delete_vs_edit conflict with null on the deleted side', () => {
+    const base = deck([slide('a', '<p>original</p>'), slide('b')]);
+    const ours = deck([slide('b')]); // deleted on main
+    const theirs = deck([slide('a', '<p>edited on preview</p>'), slide('b')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: 'a',
+        index: '1',
+        reason: 'delete_vs_edit',
+        base: slide('a', '<p>original</p>'),
+        ours: null,
+        theirs: slide('a', '<p>edited on preview</p>'),
+      },
+    ]);
+    // The edited side survives provisionally.
+    expect(topIds(result.merged)).toEqual(['a', 'b']);
+  });
+
+  it('a move does NOT protect from a delete (delete wins over an unchanged moved slide)', () => {
+    const base = deck([stack('s', [slide('c1'), slide('c2')]), slide('a')]);
+    // theirs moves c1 out of the stack to the top level; ours deletes it.
+    const ours = deck([stack('s', [slide('c2')]), slide('a')]);
+    const theirs = deck([stack('s', [slide('c2')]), slide('a'), slide('c1')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['s', 'a']);
+    expect(byId(result.merged, 's').children?.map(c => c.id)).toEqual(['c2']);
+  });
+});
+
+// ─── Order (top level) ───────────────────────────────────────────────────────
+
+describe('merge3Units — top-level order', () => {
+  const abc = () => deck([slide('a'), slide('b'), slide('c')]);
+
+  it('a one-side reorder is taken (and the other side content edit still lands)', () => {
+    const base = abc();
+    const ours = deck([slide('c'), slide('a'), slide('b')]); // reordered on main
+    const theirs = deck([slide('a'), slide('b', '<p>edited</p>'), slide('c')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['c', 'a', 'b']);
+    expect(byId(result.merged, 'b').html).toBe('<p>edited</p>');
+  });
+
+  it('identical reorders on both sides are not a conflict', () => {
+    const swapped = deck([slide('b'), slide('a'), slide('c')]);
+    const result = merge3Units(abc(), swapped, structuredClone(swapped));
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('different reorders on both sides raise the __order__ conflict', () => {
+    const base = abc();
+    const ours = deck([slide('b'), slide('a'), slide('c')]);
+    const theirs = deck([slide('a'), slide('c'), slide('b')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: DECK_ORDER_CONFLICT_ID,
+        index: '',
+        reason: 'order',
+        base: ['a', 'b', 'c'],
+        ours: ['b', 'a', 'c'],
+        theirs: ['a', 'c', 'b'],
+      },
+    ]);
+    // Provisional order follows theirs.
+    expect(topIds(result.merged)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('a reorder on one side + an add on the other weave together', () => {
+    const base = abc();
+    const ours = deck([slide('c'), slide('a'), slide('b')]);
+    const theirs = deck([slide('a'), slide('b'), slide('c'), slide('d')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    // Ours' order is the backbone; theirs' d stays anchored after its
+    // predecessor c.
+    expect(topIds(result.merged)).toEqual(['c', 'd', 'a', 'b']);
+  });
+});
+
+// ─── Stacks ──────────────────────────────────────────────────────────────────
+
+describe('merge3Units — vertical stacks', () => {
+  const baseStack = () => deck([stack('s', [slide('c1'), slide('c2')]), slide('a')]);
+
+  it('different children edited on each side both merge', () => {
+    const ours = deck([stack('s', [slide('c1', '<p>main child</p>'), slide('c2')]), slide('a')]);
+    const theirs = deck([
+      stack('s', [slide('c1'), slide('c2', '<p>preview child</p>')]),
+      slide('a'),
+    ]);
+
+    const result = merge3Units(baseStack(), ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'c1').html).toBe('<p>main child</p>');
+    expect(byId(result.merged, 'c2').html).toBe('<p>preview child</p>');
+    expect(result.autoMerged).toBe(2);
+  });
+
+  it('the SAME child edited differently is a conflict on the child (dotted index)', () => {
+    const ours = deck([stack('s', [slide('c1', '<p>main</p>'), slide('c2')]), slide('a')]);
+    const theirs = deck([stack('s', [slide('c1', '<p>preview</p>'), slide('c2')]), slide('a')]);
+
+    const result = merge3Units(baseStack(), ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({ id: 'c1', index: '1.1', reason: 'content' });
+  });
+
+  it('a child added inside a stack on one side is kept in stack position', () => {
+    const theirs = deck([
+      stack('s', [slide('c1'), slide('c9', '<p>new child</p>'), slide('c2')]),
+      slide('a'),
+    ]);
+
+    const result = merge3Units(baseStack(), baseStack(), theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 's').children?.map(c => c.id)).toEqual(['c1', 'c9', 'c2']);
+  });
+
+  it("both sides reordering a stack's children differently raises __order__:<stackId>", () => {
+    const base = deck([stack('s', [slide('c1'), slide('c2'), slide('c3')])]);
+    const ours = deck([stack('s', [slide('c2'), slide('c1'), slide('c3')])]);
+    const theirs = deck([stack('s', [slide('c1'), slide('c3'), slide('c2')])]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: deckChildOrderConflictId('s'),
+        index: '1',
+        reason: 'child_order',
+        base: ['c1', 'c2', 'c3'],
+        ours: ['c2', 'c1', 'c3'],
+        theirs: ['c1', 'c3', 'c2'],
+      },
+    ]);
+  });
+
+  it('a one-side move out of a stack (membership change) merges as sequence ops', () => {
+    // theirs moves c1 to the top level; ours edits c1's content.
+    const ours = deck([
+      stack('s', [slide('c1', '<p>edited on main</p>'), slide('c2')]),
+      slide('a'),
+    ]);
+    const theirs = deck([stack('s', [slide('c2')]), slide('a'), slide('c1')]);
+
+    const result = merge3Units(baseStack(), ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    // theirs' placement + ours' content.
+    expect(topIds(result.merged)).toEqual(['s', 'a', 'c1']);
+    expect(byId(result.merged, 'c1').html).toBe('<p>edited on main</p>');
+    expect(byId(result.merged, 's').children?.map(c => c.id)).toEqual(['c2']);
+  });
+
+  it('moved to DIFFERENT parents on each side is a placement conflict', () => {
+    const base = deck([
+      stack('s', [slide('c1'), slide('c2')]),
+      stack('t', [slide('t1')]),
+      slide('a'),
+    ]);
+    // ours moves c1 to the top level; theirs moves it into stack t.
+    const ours = deck([
+      stack('s', [slide('c2')]),
+      stack('t', [slide('t1')]),
+      slide('a'),
+      slide('c1'),
+    ]);
+    const theirs = deck([
+      stack('s', [slide('c2')]),
+      stack('t', [slide('t1'), slide('c1')]),
+      slide('a'),
+    ]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({ id: 'c1', reason: 'placement' });
+    // Provisionally at theirs' position (inside t).
+    expect(byId(result.merged, 't').children?.map(c => c.id)).toEqual(['t1', 'c1']);
+  });
+
+  it('deleting a stack vs editing its child is ONE conflict on the container (children absorbed)', () => {
+    const base = baseStack();
+    const ours = deck([slide('a')]); // stack deleted on main
+    const theirs = deck([stack('s', [slide('c1', '<p>edited</p>'), slide('c2')]), slide('a')]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({
+      id: 's',
+      reason: 'delete_vs_edit',
+      ours: null,
+      theirs: { id: 's', children: [{ id: 'c1', html: '<p>edited</p>' }, { id: 'c2' }] },
+    });
+    // No separate conflict for c1 — it rides with the container decision.
+    expect(result.conflicts.some(c => c.id === 'c1')).toBe(false);
+  });
+
+  it('container FIELD collisions conflict sans children; the children still merge', () => {
+    const base = deck([stack('s', [slide('c1'), slide('c2')], { attrs: { 'data-x': 'base' } })]);
+    const ours = deck([stack('s', [slide('c1'), slide('c2')], { attrs: { 'data-x': 'main' } })]);
+    const theirs = deck([
+      stack('s', [slide('c1'), slide('c2', '<p>preview child</p>')], {
+        attrs: { 'data-x': 'preview' },
+      }),
+    ]);
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toHaveLength(1);
+    const conflict = result.conflicts[0];
+    expect(conflict).toMatchObject({ id: 's', reason: 'content' });
+    // Fields-only conflict: the displayed sides carry no children.
+    expect((conflict.ours as DeckSlide).children).toBeUndefined();
+    expect((conflict.theirs as DeckSlide).children).toBeUndefined();
+    // The clean child edit still merged underneath.
+    expect(byId(result.merged, 'c2').html).toBe('<p>preview child</p>');
+  });
+
+  it('a leaf turned into a stack on one side (structure change) rides verbatim', () => {
+    const base = deck([slide('l', '<p>leaf</p>'), slide('a')]);
+    const theirs = deck([stack('l', [slide('n1'), slide('n2')]), slide('a')]);
+
+    const result = merge3Units(base, structuredClone(base), theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 'l').children?.map(c => c.id)).toEqual(['n1', 'n2']);
+  });
+});
+
+// ─── Deck-level meta ─────────────────────────────────────────────────────────
+
+describe('merge3Units — deck meta', () => {
+  it('one-side meta changes are taken; different fields from each side both land', () => {
+    const base = deck([slide('a')], { customCss: '.x{}' });
+    const ours = deck([slide('a')], { customCss: '.y{}' });
+    const theirs = deck([slide('a')], { customCss: '.x{}', codeTheme: 'monokai' });
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.customCss).toBe('.y{}');
+    expect(result.merged.codeTheme).toBe('monokai');
+    expect(result.merged.theme).toBe('white');
+    expect(result.merged.version).toBe(1);
+  });
+
+  it('the same field changed differently raises the single __meta__ conflict', () => {
+    const base = deck([slide('a')]);
+    const ours = deck([slide('a')], { theme: 'night' });
+    const theirs = deck([slide('a')], { theme: 'dracula' });
+
+    const result = merge3Units(base, ours, theirs);
+
+    expect(result.conflicts).toEqual([
+      {
+        id: DECK_META_CONFLICT_ID,
+        index: '',
+        reason: 'meta',
+        base: { theme: 'white' },
+        ours: { theme: 'night' },
+        theirs: { theme: 'dracula' },
+      },
+    ]);
+    expect(result.merged.theme).toBe('dracula'); // theirs provisionally
+  });
+});
+
+// ─── Resolutions ─────────────────────────────────────────────────────────────
+
+describe('merge3Units — resolutions', () => {
+  it('a content conflict resolves to either side', () => {
+    const base = deck([slide('a', '<p>original</p>')]);
+    const ours = deck([slide('a', '<p>main</p>')]);
+    const theirs = deck([slide('a', '<p>preview</p>')]);
+
+    const keepOurs = merge3Units(base, ours, theirs, { resolutions: { a: 'ours' } });
+    expect(keepOurs.conflicts).toEqual([]);
+    expect(byId(keepOurs.merged, 'a').html).toBe('<p>main</p>');
+
+    const keepTheirs = merge3Units(base, ours, theirs, { resolutions: { a: 'theirs' } });
+    expect(keepTheirs.conflicts).toEqual([]);
+    expect(byId(keepTheirs.merged, 'a').html).toBe('<p>preview</p>');
+  });
+
+  it('a delete_vs_edit conflict resolves to the delete (gone) or the edit (kept)', () => {
+    const base = deck([slide('a', '<p>original</p>'), slide('b')]);
+    const ours = deck([slide('b')]);
+    const theirs = deck([slide('a', '<p>edited</p>'), slide('b')]);
+
+    const chooseDelete = merge3Units(base, ours, theirs, { resolutions: { a: 'ours' } });
+    expect(chooseDelete.conflicts).toEqual([]);
+    expect(topIds(chooseDelete.merged)).toEqual(['b']);
+
+    const chooseEdit = merge3Units(base, ours, theirs, { resolutions: { a: 'theirs' } });
+    expect(chooseEdit.conflicts).toEqual([]);
+    expect(topIds(chooseEdit.merged)).toEqual(['a', 'b']);
+    expect(byId(chooseEdit.merged, 'a').html).toBe('<p>edited</p>');
+  });
+
+  it("an __order__ resolution picks that side's backbone but keeps the other side's adds", () => {
+    const base = deck([slide('a'), slide('b'), slide('c')]);
+    const ours = deck([slide('b'), slide('a'), slide('c')]);
+    const theirs = deck([slide('a'), slide('c'), slide('b'), slide('d')]);
+
+    const result = merge3Units(base, ours, theirs, {
+      resolutions: { [DECK_ORDER_CONFLICT_ID]: 'ours' },
+    });
+
+    expect(result.conflicts).toEqual([]);
+    // Ours' order wins; theirs' added d is still woven in (after its
+    // predecessor b).
+    expect(topIds(result.merged)).toEqual(['b', 'd', 'a', 'c']);
+  });
+
+  it('a child-order resolution applies to just that stack', () => {
+    const base = deck([stack('s', [slide('c1'), slide('c2'), slide('c3')])]);
+    const ours = deck([stack('s', [slide('c2'), slide('c1'), slide('c3')])]);
+    const theirs = deck([stack('s', [slide('c1'), slide('c3'), slide('c2')])]);
+
+    const result = merge3Units(base, ours, theirs, {
+      resolutions: { [deckChildOrderConflictId('s')]: 'ours' },
+    });
+
+    expect(result.conflicts).toEqual([]);
+    expect(byId(result.merged, 's').children?.map(c => c.id)).toEqual(['c2', 'c1', 'c3']);
+  });
+
+  it('a __meta__ resolution applies the chosen side for the double-changed fields', () => {
+    const base = deck([slide('a')]);
+    const ours = deck([slide('a')], { theme: 'night', customCss: '.main{}' });
+    const theirs = deck([slide('a')], { theme: 'dracula' });
+
+    const result = merge3Units(base, ours, theirs, {
+      resolutions: { [DECK_META_CONFLICT_ID]: 'ours' },
+    });
+
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.theme).toBe('night');
+    expect(result.merged.customCss).toBe('.main{}'); // one-sided change, untouched by the choice
+  });
+
+  it('a placement conflict resolves to the chosen side verbatim (content + position)', () => {
+    const base = deck([
+      stack('s', [slide('c1'), slide('c2')]),
+      stack('t', [slide('t1')]),
+      slide('a'),
+    ]);
+    const ours = deck([
+      stack('s', [slide('c2')]),
+      stack('t', [slide('t1')]),
+      slide('a'),
+      slide('c1'),
+    ]);
+    const theirs = deck([
+      stack('s', [slide('c2')]),
+      stack('t', [slide('t1'), slide('c1')]),
+      slide('a'),
+    ]);
+
+    const result = merge3Units(base, ours, theirs, { resolutions: { c1: 'ours' } });
+
+    expect(result.conflicts).toEqual([]);
+    expect(topIds(result.merged)).toEqual(['s', 't', 'a', 'c1']);
+    expect(byId(result.merged, 't').children?.map(c => c.id)).toEqual(['t1']);
+  });
+});
+
+// ─── Hygiene ─────────────────────────────────────────────────────────────────
+
+describe('merge3Units — hygiene', () => {
+  it('never mutates its inputs', () => {
+    const base = deck([stack('s', [slide('c1')]), slide('a')], { customCss: '.x{}' });
+    const ours = deck([stack('s', [slide('c1', '<p>edit</p>')]), slide('a')]);
+    const theirs = deck([stack('s', [slide('c1')]), slide('a'), slide('z')]);
+    const snapshots = [structuredClone(base), structuredClone(ours), structuredClone(theirs)];
+
+    merge3Units(base, ours, theirs);
+
+    expect([base, ours, theirs]).toEqual(snapshots);
+  });
+
+  it('a merged result is independent of the inputs (deep-cloned)', () => {
+    const base = deck([slide('a')]);
+    const ours = deck([slide('a', '<p>edit</p>')]);
+    const theirs = deck([slide('a')]);
+
+    const result = merge3Units(base, ours, theirs);
+    byId(result.merged, 'a').html = '<p>tampered</p>';
+
+    expect(ours.slides[0].html).toBe('<p>edit</p>');
+  });
+});

--- a/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
@@ -468,4 +468,131 @@ describe('resolveDeckPreviewConflicts', () => {
 
     expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'NO_PREVIEW' });
   });
+
+  it('malformed resolution elements → INVALID_RESOLUTIONS, nothing written (never defaults to theirs)', async () => {
+    conflicted();
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'sideways' } as unknown as { id: string; choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'INVALID_RESOLUTIONS',
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  // ── Sha pinning (F3): resolutions apply only to the reviewed report ──
+
+  it('expected_ours_sha mismatch → CONTENT_CONFLICT, nothing written', async () => {
+    conflicted(); // fresh main reads as ours-sha
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+      expectedOursSha: 'sha-from-an-older-report',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'CONTENT_CONFLICT',
+      message: expect.stringContaining('re-run accept'),
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('expected_theirs_sha mismatch (preview stacked since the report) → CONTENT_CONFLICT', async () => {
+    conflicted(); // preview branch reads as theirs-sha
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+      expectedTheirsSha: 'sha-from-an-older-report',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'CONTENT_CONFLICT' });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('matching sha pins resolve normally', async () => {
+    conflicted();
+
+    const result = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+      expectedTheirsSha: 'theirs-sha',
+    });
+
+    expect(result).toMatchObject({ merged: true, semantic: true });
+    expect(batchCall().deck?.slides[0]).toEqual({ id: 'aaa', html: '<p>main</p>' });
+  });
+
+  it("main's deck.json deleted → MAIN_CONTENT_MISSING from the resolve flow", async () => {
+    conflicted();
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === BRANCH) {
+        return {
+          content: deckJson(deckWith([{ id: 'aaa', html: '<p>preview</p>' }])),
+          sha: 'theirs-sha',
+        };
+      }
+      if (ref === 'fork-point') {
+        return {
+          content: deckJson(deckWith([{ id: 'aaa', html: '<p>original</p>' }])),
+          sha: 'base-sha',
+        };
+      }
+      return null; // main's file is gone
+    });
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'MAIN_CONTENT_MISSING',
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Main-file-deleted degenerate on the accept path (F4) ────────────────────
+
+describe('acceptDeckPreview — main deck.json deleted', () => {
+  it('throws typed MAIN_CONTENT_MISSING instead of an empty-units conflict report', async () => {
+    primeThreeWay({
+      base: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      ours: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      theirs: deckWith([{ id: 'aaa', html: '<p>one PREVIEW</p>' }]),
+    });
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === BRANCH) {
+        return {
+          content: deckJson(deckWith([{ id: 'aaa', html: '<p>one PREVIEW</p>' }])),
+          sha: 'theirs-sha',
+        };
+      }
+      if (ref === 'fork-point') {
+        return {
+          content: deckJson(deckWith([{ id: 'aaa', html: '<p>one</p>' }])),
+          sha: 'base-sha',
+        };
+      }
+      return null; // main's file is gone
+    });
+
+    const failure = await acceptDeckPreview(slide).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({
+      code: 'MAIN_CONTENT_MISSING',
+      message: expect.stringContaining('deleted'),
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
@@ -596,3 +596,101 @@ describe('acceptDeckPreview — main deck.json deleted', () => {
     expect(deleteBranchMock).not.toHaveBeenCalled();
   });
 });
+
+// ─── Missing / unparseable merge base (S3): refuse, never merge against empty ─
+
+describe('accept/resolve — merge base unavailable', () => {
+  /** A conflicting 3-way whose fork-point deck.json read yields `base`. */
+  function primeBase(base: string | null, ours: DeckJson, theirs: DeckJson) {
+    mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
+    compareBranchesMock.mockResolvedValue({
+      ahead_by: 1,
+      behind_by: 1,
+      base_sha: 'main-head',
+      head_sha: 'preview-head',
+      merge_base_sha: 'fork-point',
+      commits: [],
+    });
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === BRANCH) return { content: deckJson(theirs), sha: 'theirs-sha' };
+      if (ref === 'fork-point') return base == null ? null : { content: base, sha: 'base-sha' };
+      return { content: deckJson(ours), sha: 'ours-sha' };
+    });
+  }
+
+  it('accept: base deck.json 404 (legacy add/add) → MAIN_CONTENT_MISSING, nothing committed', async () => {
+    // Preview deleted bbb; without a real base an empty-base merge would
+    // RESURRECT it. Refuse instead.
+    primeBase(
+      null,
+      deckWith([
+        { id: 'aaa', html: '<h1>Keep</h1>' },
+        { id: 'bbb', html: '<p>gone on preview</p>' },
+      ]),
+      deckWith([{ id: 'aaa', html: '<h1>Keep</h1>' }])
+    );
+
+    const failure = await acceptDeckPreview(slide).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'MAIN_CONTENT_MISSING' });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('accept: base deck.json unparseable → MAIN_CONTENT_MISSING, nothing committed', async () => {
+    primeBase(
+      '{ not valid json !!!',
+      deckWith([
+        { id: 'aaa', html: '<h1>Keep</h1>' },
+        { id: 'bbb', html: '<p>gone on preview</p>' },
+      ]),
+      deckWith([{ id: 'aaa', html: '<h1>Keep</h1>' }])
+    );
+
+    const failure = await acceptDeckPreview(slide).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'MAIN_CONTENT_MISSING' });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('resolve: base deck.json 404 → MAIN_CONTENT_MISSING, nothing committed', async () => {
+    primeBase(
+      null,
+      deckWith([{ id: 'aaa', html: '<h2>Racer</h2>' }]),
+      deckWith([{ id: 'aaa', html: '<h1>Preview</h1>' }])
+    );
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'MAIN_CONTENT_MISSING' });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: a present, parseable base still merges (deletion honored, no resurrection)', async () => {
+    primeBase(
+      deckJson(
+        deckWith([
+          { id: 'aaa', html: '<h1>Keep</h1>' },
+          { id: 'bbb', html: '<p>gone on preview</p>' },
+        ])
+      ),
+      deckWith([
+        { id: 'aaa', html: '<h1>Keep (main edited)</h1>' },
+        { id: 'bbb', html: '<p>gone on preview</p>' },
+      ]),
+      deckWith([{ id: 'aaa', html: '<h1>Keep</h1>' }])
+    );
+
+    const result = await acceptDeckPreview(slide);
+    expect(result).toMatchObject({ merged: true, semantic: true });
+    expect(batchCall().deck?.slides.map(s => s.id)).toEqual(['aaa']); // bbb stays deleted
+  });
+});

--- a/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
@@ -241,7 +241,7 @@ describe('acceptDeckPreview — semantic auto-merge on git conflict', () => {
   });
 
   it('a both-sides order collision surfaces as order_conflict (units empty)', async () => {
-    const a = { id: 'aaa', html: '<p>a</p>' };
+    const a = { id: 'aaa', html: '<h2>Alpha</h2>' };
     const b = { id: 'bbb', html: '<p>b</p>' };
     const c = { id: 'ccc', html: '<p>c</p>' };
     primeThreeWay({
@@ -259,6 +259,50 @@ describe('acceptDeckPreview — semantic auto-merge on git conflict', () => {
       ours: ['bbb', 'aaa', 'ccc'],
       theirs: ['aaa', 'ccc', 'bbb'],
     });
+    // Every id the ordering references carries a filmstrip preview built from
+    // the ours deck: dotted position IN OURS, title (first heading/text), html.
+    expect(result.unit_previews).toEqual({
+      aaa: { index: '2', title: 'Alpha', html: '<h2>Alpha</h2>' },
+      bbb: { index: '1', title: 'b', html: '<p>b</p>' },
+      ccc: { index: '3', title: 'c', html: '<p>c</p>' },
+    });
+  });
+
+  it('an order preview drops html for slides over ~50KB (title-only fallback)', async () => {
+    const bigHtml = `<h2>Huge slide</h2><p>${'x'.repeat(60 * 1024)}</p>`;
+    const a = { id: 'aaa', html: bigHtml };
+    const b = { id: 'bbb', html: '<p>b</p>' };
+    const c = { id: 'ccc', html: '<p>c</p>' };
+    // Both sides reorder the same three slides differently → an order conflict.
+    primeThreeWay({
+      base: deckWith([a, b, c]),
+      ours: deckWith([b, a, c]),
+      theirs: deckWith([a, c, b]),
+    });
+
+    const result = await acceptDeckPreview(slide);
+
+    if (result.merged) throw new Error('unreachable');
+    // Over-cap slide keeps index + title but omits html; small slides keep it.
+    // (index is the position IN OURS: ours = [bbb, aaa, ccc].)
+    expect(result.unit_previews?.aaa).toEqual({ index: '2', title: 'Huge slide' });
+    expect(result.unit_previews?.aaa.html).toBeUndefined();
+    expect(result.unit_previews?.bbb).toEqual({ index: '1', title: 'b', html: '<p>b</p>' });
+    expect(result.unit_previews?.ccc).toEqual({ index: '3', title: 'c', html: '<p>c</p>' });
+  });
+
+  it('a pure content collision has no unit_previews (no ordering conflict)', async () => {
+    primeThreeWay({
+      base: deckWith([{ id: 'aaa', html: '<p>original</p>' }]),
+      ours: deckWith([{ id: 'aaa', html: '<p>main</p>' }]),
+      theirs: deckWith([{ id: 'aaa', html: '<p>preview</p>' }]),
+    });
+
+    const result = await acceptDeckPreview(slide);
+
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toHaveLength(1);
+    expect(result.unit_previews).toBeUndefined();
   });
 
   it('a CAS loss on the semantic commit retries ONCE against fresh main', async () => {

--- a/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Semantic auto-merge on deck accept + per-unit conflict resolution
+ * (content-tools plan §3b Phase 7).
+ *
+ * Mocks mirror deckPreview.service.test.ts (ContentService + prisma mocked;
+ * the deck engine and saveDeck are REAL). Pins the upgraded contract:
+ * a git-conflicted accept that 3-way-merges cleanly commits the merged deck
+ * to main through saveDeck (ONE atomic batch: deck.json + regenerated
+ * index.html, CAS'd on main's pre-write deck.json sha via BOTH the pre-check
+ * and verifyBaseTree) and deletes the branch; true collisions return only the
+ * colliding units plus auto_merged with the branch kept; resolutions must
+ * exactly cover the current conflict set.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DeckJson } from '../deckTypes.ts';
+
+const slideUpdateMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    slide: { update: (...args: unknown[]) => slideUpdateMock(...args) },
+  }),
+}));
+
+const compareBranchesMock = vi.fn();
+const mergeBranchMock = vi.fn();
+const createBranchMock = vi.fn();
+const deleteBranchMock = vi.fn();
+const getContentMock = vi.fn();
+const getMetaMock = vi.fn();
+const uploadBatchMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    compareBranches: (...args: unknown[]) => compareBranchesMock(...args),
+    mergeBranch: (...args: unknown[]) => mergeBranchMock(...args),
+    createBranch: (...args: unknown[]) => createBranchMock(...args),
+    deleteBranch: (...args: unknown[]) => deleteBranchMock(...args),
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getMeta: (...args: unknown[]) => getMetaMock(...args),
+    uploadBatch: (...args: unknown[]) => uploadBatchMock(...args),
+  },
+}));
+
+const { acceptDeckPreview, resolveDeckPreviewConflicts } =
+  await import('../deckPreview.service.ts');
+const { PreviewResolutionError } = await import('../deckMerge.ts');
+
+const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
+const slide = {
+  id: 'slide-1',
+  title: 'My Deck',
+  content_path: 'slides/my-deck',
+  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+};
+
+const BRANCH = 'preview/slides/my-deck';
+const DECK_PATH = 'slides/my-deck/deck.json';
+const HTML_PATH = 'slides/my-deck/index.html';
+
+const deckWith = (slides: DeckJson['slides']): DeckJson => ({
+  version: 1,
+  theme: 'white',
+  codeTheme: 'github',
+  slides,
+});
+const deckJson = (deck: DeckJson) => JSON.stringify(deck, null, 2);
+
+/** Standard 3-way content reads: ours = fresh main, theirs = branch, base = fork-point. */
+function primeThreeWay({
+  base,
+  ours,
+  theirs,
+}: {
+  base: DeckJson;
+  ours: DeckJson;
+  theirs: DeckJson;
+}) {
+  mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
+  compareBranchesMock.mockResolvedValue({
+    ahead_by: 1,
+    behind_by: 1,
+    base_sha: 'main-head',
+    head_sha: 'preview-head',
+    merge_base_sha: 'fork-point',
+    commits: [],
+  });
+  getContentMock.mockImplementation(async (arg: unknown) => {
+    const { ref } = arg as { ref?: string };
+    if (ref === BRANCH) return { content: deckJson(theirs), sha: 'theirs-sha' };
+    if (ref === 'fork-point') return { content: deckJson(base), sha: 'base-sha' };
+    return { content: deckJson(ours), sha: 'ours-sha' };
+  });
+}
+
+/** The batch payloads saveDeck sent (deck.json parsed, html raw). */
+function batchCall(n = 0) {
+  const args = uploadBatchMock.mock.calls[n][0] as {
+    files: Array<{ path: string; content: string }>;
+    branch: string;
+    verifyBaseTree?: unknown;
+  };
+  const deckFile = args.files.find(f => f.path === DECK_PATH);
+  const htmlFile = args.files.find(f => f.path === HTML_PATH);
+  return {
+    args,
+    deck: deckFile ? (JSON.parse(deckFile.content) as DeckJson) : null,
+    html: htmlFile?.content ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  slideUpdateMock.mockResolvedValue({});
+  deleteBranchMock.mockResolvedValue({ deleted: true });
+  // getMeta: saveDeck's main pre-check sees main's pre-write sha; the
+  // post-commit guard (ref = the preview branch) sees the merged theirs sha.
+  getMetaMock.mockImplementation(async (arg: unknown) => {
+    const { ref } = arg as { ref?: string };
+    if (ref === BRANCH) return { sha: 'theirs-sha', size: 1 };
+    return { sha: 'ours-sha', size: 1 };
+  });
+  uploadBatchMock.mockImplementation(
+    async ({
+      files,
+      verifyBaseTree,
+    }: {
+      files: Array<{ path: string }>;
+      verifyBaseTree?: (ctx: {
+        getFileSha: (path: string) => Promise<string | null>;
+      }) => Promise<void>;
+    }) => {
+      if (verifyBaseTree) {
+        await verifyBaseTree({ getFileSha: async () => 'ours-sha' });
+      }
+      return {
+        commit: 'semantic-commit',
+        filesUploaded: files.length,
+        files: files.map(f => ({
+          path: f.path,
+          sha: f.path === DECK_PATH ? 'merged-deck-sha' : 'new-html-sha',
+        })),
+      };
+    }
+  );
+});
+
+// ─── acceptDeckPreview — semantic fallback ───────────────────────────────────
+
+describe('acceptDeckPreview — semantic auto-merge on git conflict', () => {
+  it('zero true collisions → ONE atomic saveDeck commit on main (deck.json + regenerated html), branch deleted', async () => {
+    primeThreeWay({
+      base: deckWith([
+        { id: 'aaa', html: '<p>one</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<h1>Main edit</h1>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      theirs: deckWith([
+        { id: 'aaa', html: '<p>one</p>' },
+        { id: 'bbb', html: '<h2>Preview edit</h2>' },
+      ]),
+    });
+
+    const result = await acceptDeckPreview(slide);
+
+    expect(result).toEqual({
+      merged: true,
+      semantic: true,
+      html_regenerated: true,
+      auto_merged: 2,
+      sha: 'merged-deck-sha',
+    });
+
+    // ONE atomic batch on main carrying BOTH the merged source and artifact.
+    expect(uploadBatchMock).toHaveBeenCalledTimes(1);
+    const { args, deck, html } = batchCall();
+    expect(args.branch).toBe('main');
+    expect(args.files).toHaveLength(2);
+    expect(args.verifyBaseTree).toBeTypeOf('function');
+    expect(deck?.slides).toEqual([
+      { id: 'aaa', html: '<h1>Main edit</h1>' },
+      { id: 'bbb', html: '<h2>Preview edit</h2>' },
+    ]);
+    expect(html).toContain('<h1>Main edit</h1>');
+    expect(html).toContain('<h2>Preview edit</h2>');
+    expect(html).toContain('data-cm-id="aaa"');
+
+    // Guard read the BRANCH's deck.json sha, then cleanup + updated_at bump.
+    expect(getMetaMock).toHaveBeenCalledWith(expect.objectContaining({ ref: BRANCH }));
+    expect(deleteBranchMock).toHaveBeenCalledWith(expect.objectContaining({ branch: BRANCH }));
+    expect(slideUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'slide-1' } })
+    );
+  });
+
+  it('true collisions → report with ONLY the colliding units + auto_merged, branch kept, nothing written', async () => {
+    primeThreeWay({
+      base: deckWith([
+        { id: 'aaa', html: '<p>original</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>main</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      theirs: deckWith([
+        { id: 'aaa', html: '<p>preview</p>' },
+        { id: 'bbb', html: '<p>two edited</p>' },
+      ]),
+    });
+
+    const result = await acceptDeckPreview(slide);
+
+    expect(result).toMatchObject({
+      merged: false,
+      conflict: true,
+      auto_merged: 1, // bbb's one-sided edit
+      ours_sha: 'ours-sha',
+      theirs_sha: 'theirs-sha',
+    });
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([
+      {
+        id: 'aaa',
+        index: '1',
+        reason: 'content',
+        base: { id: 'aaa', html: '<p>original</p>' },
+        ours: { id: 'aaa', html: '<p>main</p>' },
+        theirs: { id: 'aaa', html: '<p>preview</p>' },
+      },
+    ]);
+    expect(result.order_conflict).toBeUndefined();
+
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+    expect(slideUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('a both-sides order collision surfaces as order_conflict (units empty)', async () => {
+    const a = { id: 'aaa', html: '<p>a</p>' };
+    const b = { id: 'bbb', html: '<p>b</p>' };
+    const c = { id: 'ccc', html: '<p>c</p>' };
+    primeThreeWay({
+      base: deckWith([a, b, c]),
+      ours: deckWith([b, a, c]),
+      theirs: deckWith([a, c, b]),
+    });
+
+    const result = await acceptDeckPreview(slide);
+
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([]);
+    expect(result.order_conflict).toEqual({
+      base: ['aaa', 'bbb', 'ccc'],
+      ours: ['bbb', 'aaa', 'ccc'],
+      theirs: ['aaa', 'ccc', 'bbb'],
+    });
+  });
+
+  it('a CAS loss on the semantic commit retries ONCE against fresh main', async () => {
+    primeThreeWay({
+      base: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      ours: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      theirs: deckWith([{ id: 'aaa', html: '<p>preview</p>' }]),
+    });
+    // A racer moves main's deck.json to ours-sha-2 before the first commit
+    // lands: the pre-check and base tree serve the fresh sha once the first
+    // batch attempt has happened.
+    const mainSha = () => (uploadBatchMock.mock.calls.length > 0 ? 'ours-sha-2' : 'ours-sha');
+    getMetaMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === BRANCH) return { sha: 'theirs-sha', size: 1 };
+      return { sha: mainSha(), size: 1 };
+    });
+    const baseContent = getContentMock.getMockImplementation()!;
+    getContentMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === undefined && uploadBatchMock.mock.calls.length > 0) {
+        return {
+          content: deckJson(deckWith([{ id: 'aaa', html: '<p>one</p>' }])),
+          sha: 'ours-sha-2',
+        };
+      }
+      return baseContent(arg);
+    });
+    uploadBatchMock.mockImplementation(
+      async ({
+        files,
+        verifyBaseTree,
+      }: {
+        files: Array<{ path: string }>;
+        verifyBaseTree?: (ctx: {
+          getFileSha: (path: string) => Promise<string | null>;
+        }) => Promise<void>;
+      }) => {
+        // The base tree ALWAYS carries the racer's sha: attempt 1 (pinned to
+        // ours-sha) conflicts, attempt 2 (pinned to ours-sha-2) commits.
+        if (verifyBaseTree) {
+          await verifyBaseTree({ getFileSha: async () => 'ours-sha-2' });
+        }
+        return {
+          commit: 'semantic-commit-2',
+          filesUploaded: files.length,
+          files: files.map(f => ({
+            path: f.path,
+            sha: f.path === DECK_PATH ? 'merged-deck-sha-2' : 'new-html-sha',
+          })),
+        };
+      }
+    );
+
+    const result = await acceptDeckPreview(slide);
+
+    expect(uploadBatchMock).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ merged: true, semantic: true, sha: 'merged-deck-sha-2' });
+    expect(deleteBranchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the branch when it gained edits during the semantic accept', async () => {
+    primeThreeWay({
+      base: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      ours: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      theirs: deckWith([{ id: 'aaa', html: '<p>preview</p>' }]),
+    });
+    getMetaMock.mockImplementation(async (arg: unknown) => {
+      const { ref } = arg as { ref?: string };
+      if (ref === BRANCH) return { sha: 'newer-theirs-sha', size: 1 }; // stacked during accept
+      return { sha: 'ours-sha', size: 1 };
+    });
+
+    const result = await acceptDeckPreview(slide);
+
+    expect(result).toMatchObject({
+      merged: true,
+      semantic: true,
+      preview_kept: true,
+      reason: expect.stringContaining('retained'),
+    });
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── resolveDeckPreviewConflicts ─────────────────────────────────────────────
+
+describe('resolveDeckPreviewConflicts', () => {
+  const conflicted = () =>
+    primeThreeWay({
+      base: deckWith([
+        { id: 'aaa', html: '<p>original</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>main</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      theirs: deckWith([
+        { id: 'aaa', html: '<p>preview</p>' },
+        { id: 'bbb', html: '<p>two edited</p>' },
+      ]),
+    });
+
+  it('applies the choices, commits via saveDeck (CAS + artifact), deletes the branch', async () => {
+    conflicted();
+
+    const result = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    });
+
+    expect(result).toEqual({
+      merged: true,
+      semantic: true,
+      html_regenerated: true,
+      auto_merged: 1,
+      resolved: [{ id: 'aaa', choose: 'ours' }],
+      sha: 'merged-deck-sha',
+    });
+
+    const { args, deck, html } = batchCall();
+    expect(args.branch).toBe('main');
+    // The chosen side (ours) for the conflict + theirs' clean edit both landed.
+    expect(deck?.slides).toEqual([
+      { id: 'aaa', html: '<p>main</p>' },
+      { id: 'bbb', html: '<p>two edited</p>' },
+    ]);
+    expect(html).toContain('<p>main</p>');
+    expect(html).toContain('<p>two edited</p>');
+    expect(deleteBranchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("'theirs' keeps the preview's version", async () => {
+    conflicted();
+
+    await resolveDeckPreviewConflicts(slide, { resolutions: [{ id: 'aaa', choose: 'theirs' }] });
+
+    expect(batchCall().deck?.slides[0]).toEqual({ id: 'aaa', html: '<p>preview</p>' });
+  });
+
+  it('errors naming UNRESOLVED conflict ids — nothing written', async () => {
+    // Two content conflicts (aaa and bbb both double-edited).
+    primeThreeWay({
+      base: deckWith([
+        { id: 'aaa', html: '<p>a0</p>' },
+        { id: 'bbb', html: '<p>b0</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>a-main</p>' },
+        { id: 'bbb', html: '<p>b-main</p>' },
+      ]),
+      theirs: deckWith([
+        { id: 'aaa', html: '<p>a-preview</p>' },
+        { id: 'bbb', html: '<p>b-preview</p>' },
+      ]),
+    });
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'UNRESOLVED_CONFLICTS', ids: ['bbb'] });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(deleteBranchMock).not.toHaveBeenCalled();
+  });
+
+  it('errors on UNKNOWN resolution ids', async () => {
+    conflicted();
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [
+        { id: 'aaa', choose: 'ours' },
+        { id: 'ghost', choose: 'theirs' },
+      ],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'UNKNOWN_RESOLUTIONS',
+      ids: ['ghost'],
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('errors with NOTHING_TO_RESOLVE when the merge is now clean', async () => {
+    primeThreeWay({
+      base: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      ours: deckWith([{ id: 'aaa', html: '<p>one</p>' }]),
+      theirs: deckWith([{ id: 'aaa', html: '<p>preview</p>' }]),
+    });
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'NOTHING_TO_RESOLVE' });
+  });
+
+  it('errors with NO_PREVIEW when the branch is gone', async () => {
+    compareBranchesMock.mockResolvedValue(null);
+    getContentMock.mockResolvedValue(null);
+
+    const failure = await resolveDeckPreviewConflicts(slide, {
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'NO_PREVIEW' });
+  });
+});

--- a/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
@@ -619,7 +619,7 @@ describe('accept/resolve — merge base unavailable', () => {
     });
   }
 
-  it('accept: base deck.json 404 (legacy add/add) → MAIN_CONTENT_MISSING, nothing committed', async () => {
+  it('accept: base deck.json 404 (legacy add/add) → MERGE_BASE_MISSING, nothing committed', async () => {
     // Preview deleted bbb; without a real base an empty-base merge would
     // RESURRECT it. Refuse instead.
     primeBase(
@@ -634,12 +634,12 @@ describe('accept/resolve — merge base unavailable', () => {
     const failure = await acceptDeckPreview(slide).catch((e: unknown) => e);
 
     expect(failure).toBeInstanceOf(PreviewResolutionError);
-    expect(failure).toMatchObject({ code: 'MAIN_CONTENT_MISSING' });
+    expect(failure).toMatchObject({ code: 'MERGE_BASE_MISSING' });
     expect(uploadBatchMock).not.toHaveBeenCalled();
     expect(deleteBranchMock).not.toHaveBeenCalled();
   });
 
-  it('accept: base deck.json unparseable → MAIN_CONTENT_MISSING, nothing committed', async () => {
+  it('accept: base deck.json unparseable → MERGE_BASE_MISSING, nothing committed', async () => {
     primeBase(
       '{ not valid json !!!',
       deckWith([
@@ -652,12 +652,12 @@ describe('accept/resolve — merge base unavailable', () => {
     const failure = await acceptDeckPreview(slide).catch((e: unknown) => e);
 
     expect(failure).toBeInstanceOf(PreviewResolutionError);
-    expect(failure).toMatchObject({ code: 'MAIN_CONTENT_MISSING' });
+    expect(failure).toMatchObject({ code: 'MERGE_BASE_MISSING' });
     expect(uploadBatchMock).not.toHaveBeenCalled();
     expect(deleteBranchMock).not.toHaveBeenCalled();
   });
 
-  it('resolve: base deck.json 404 → MAIN_CONTENT_MISSING, nothing committed', async () => {
+  it('resolve: base deck.json 404 → MERGE_BASE_MISSING, nothing committed', async () => {
     primeBase(
       null,
       deckWith([{ id: 'aaa', html: '<h2>Racer</h2>' }]),
@@ -669,7 +669,7 @@ describe('accept/resolve — merge base unavailable', () => {
     }).catch((e: unknown) => e);
 
     expect(failure).toBeInstanceOf(PreviewResolutionError);
-    expect(failure).toMatchObject({ code: 'MAIN_CONTENT_MISSING' });
+    expect(failure).toMatchObject({ code: 'MERGE_BASE_MISSING' });
     expect(uploadBatchMock).not.toHaveBeenCalled();
     expect(deleteBranchMock).not.toHaveBeenCalled();
   });

--- a/packages/services/src/slides/__tests__/deckPreview.service.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.service.test.ts
@@ -6,10 +6,10 @@
  * index.html on main FROM the merged deck.json via a single-file uploadBatch
  * whose verifyBaseTree hook pins the merged deck sha (a concurrent save skips
  * regeneration instead of clobbering); a conflicted merge builds the per-unit
- * report (real diffDeckUnits), keeps the branch, and NEVER regenerates.
+ * report (real merge3Units), keeps the branch, and NEVER regenerates.
  *
  * ContentService and prisma are mocked; the deck engine (generateDeckHtml,
- * diffDeckUnits) is real.
+ * merge3Units) is real.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -416,7 +416,7 @@ describe('acceptDeckPreview (clean merge)', () => {
 // ─── acceptDeckPreview — conflict ────────────────────────────────────────────
 
 describe('acceptDeckPreview (conflict)', () => {
-  it('builds the per-unit report (real diffDeckUnits), keeps the branch, never regenerates', async () => {
+  it('builds the per-unit report (real merge3Units), keeps the branch, never regenerates', async () => {
     mergeBranchMock.mockResolvedValue({ merged: false, conflict: true });
     compareBranchesMock.mockResolvedValue({
       ahead_by: 1,

--- a/packages/services/src/slides/__tests__/deckSaveFromOps.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveFromOps.test.ts
@@ -208,6 +208,126 @@ describe('saveDeckFromOps — clean commits', () => {
   });
 });
 
+describe('saveDeckFromOps — adoption signal (S1/S10) and merge commit messages', () => {
+  it('no concurrent change, no mint → adoption_required false (cursor preserved), plain commit message', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    primeSave({ base, ours: base });
+
+    const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>Mine</h1>' }];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true, concurrent: 0, adoption_required: false });
+    // A plain save (no fold, no resolution) is NOT marked '(merged)'.
+    expect(batchCall().args.message).toBe('Update slides: My Deck');
+  });
+
+  it('S1 reorder-only concurrent (counter 0) → adoption_required true, still remounts', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<h1>Alpha</h1>' },
+      { id: 'bbb', html: '<h1>Beta</h1>' },
+      { id: 'ccc', html: '<h1>Gamma</h1>' },
+    ]);
+    // Main reordered [A,B,C] → [C,A,B] with NO content edit (pure reorder).
+    const ours = deckWith([base.slides[2], base.slides[0], base.slides[1]]);
+    primeSave({ base, ours });
+
+    const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>Alpha EDITED</h1>' }];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    // The unit counter misses a pure reorder, but the committed order differs
+    // from base+ops so the client MUST remount (else the next save reverts it).
+    expect(result).toMatchObject({ merged: true, concurrent: 0, adoption_required: true });
+    expect(batchCall().deck?.slides.map(s => s.id)).toEqual(['ccc', 'aaa', 'bbb']);
+    // concurrent === 0 → the commit is still a plain save (no fold counted).
+    expect(batchCall().args.message).toBe('Update slides: My Deck');
+  });
+
+  it('S1 meta-only concurrent (theme changed on main) → adoption_required true', async () => {
+    const base = deckWith([{ id: 'aaa', html: '<p>one</p>' }]);
+    const ours: DeckJson = { ...deckWith([{ id: 'aaa', html: '<p>one</p>' }]), theme: 'moon' };
+    primeSave({ base, ours });
+
+    const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>Mine</h1>' }];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true, concurrent: 0, adoption_required: true });
+    // The concurrent theme change is folded into the committed deck.
+    expect(batchCall().deck?.theme).toBe('moon');
+  });
+
+  it('S10 an insert mints a server-side id → adoption_required true even with concurrent 0', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    primeSave({ base, ours: base });
+
+    // The id-less <section> the editor added diffs to a single insert; the
+    // server mints its id, which the live DOM never carries → force adoption
+    // so the next in-session save can't delete+re-insert (id churn).
+    const ops: DeckOp[] = [
+      { op: 'insert', slides: [{ html: '<p>new slide</p>' }], position: { after: 'bbb' } },
+    ];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true, concurrent: 0, adoption_required: true });
+    expect(batchCall().deck?.slides.map(s => s.html)).toEqual([
+      '<p>one</p>',
+      '<p>two</p>',
+      '<p>new slide</p>',
+    ]);
+    // A mint alone is not a concurrent fold — the commit stays a plain save.
+    expect(batchCall().args.message).toBe('Update slides: My Deck');
+  });
+
+  it('a concurrent fold marks the commit (merged); a resolution appends the summary', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    // Disjoint concurrent edit on main → clean fold, concurrent 1.
+    const ours = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<h2>Racer</h2>' },
+    ]);
+    primeSave({ base, ours });
+
+    const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>Mine</h1>' }];
+    const merged = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+    expect(merged).toMatchObject({ merged: true, concurrent: 1, adoption_required: true });
+    expect(batchCall().args.message).toBe('Update slides (merged): My Deck');
+
+    // Now a genuine same-slide collision resolved via the chooser.
+    vi.clearAllMocks();
+    getMetaMock.mockResolvedValue({ sha: 'ours-sha', size: 1 });
+    uploadBatchMock.mockImplementation(async ({ files }: { files: Array<{ path: string }> }) => ({
+      commit: 'ops-commit',
+      filesUploaded: files.length,
+      files: files.map(f => ({
+        path: f.path,
+        sha: f.path === DECK_PATH ? 'new-deck-sha' : 'new-html-sha',
+      })),
+    }));
+    const collidingOurs = deckWith([
+      { id: 'aaa', html: '<h2>Racer version</h2>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    primeSave({ base, ours: collidingOurs });
+    const resolved = await saveDeckFromOps({
+      slide,
+      ops,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'theirs' }],
+      expectedOursSha: 'ours-sha',
+    });
+    expect(resolved).toMatchObject({ merged: true });
+    expect(batchCall().args.message).toBe('Update slides (merged): My Deck — resolved 1 conflict');
+  });
+});
+
 describe('saveDeckFromOps — conflicts and resolutions', () => {
   const base = deckWith([
     { id: 'aaa', html: '<p>one</p>' },

--- a/packages/services/src/slides/__tests__/deckSaveFromOps.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveFromOps.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Ops-shaped editor saves (deckSaveMerge saveDeckFromOps).
+ *
+ * Harness mirrors deckSaveMerge.test.ts (ContentService + prisma mocked; the
+ * deck engine, op engine, and saveDeck are REAL). Pins the ops-save contract:
+ * theirs = applyDeckOps(base, ops) — op ids/anchors resolve against the BASE
+ * — then the existing 3-way merge → clean commit / conflict report /
+ * resolutions flow. Untouched slides never ride in the request, so
+ * concurrent saves to OTHER slides auto-merge by construction with STRICT
+ * content comparison only (no browser-serialization tolerance involved);
+ * ops that don't apply to the base throw the typed OPS_BASE_MISMATCH the
+ * client answers with a whole-document fallback save.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DeckJson } from '../deckTypes.ts';
+import type { DeckOp } from '../deckOps.ts';
+
+const slideUpdateMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    slide: { update: (...args: unknown[]) => slideUpdateMock(...args) },
+  }),
+}));
+
+const getContentMock = vi.fn();
+const getMetaMock = vi.fn();
+const getBlobContentMock = vi.fn();
+const uploadBatchMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getMeta: (...args: unknown[]) => getMetaMock(...args),
+    getBlobContent: (...args: unknown[]) => getBlobContentMock(...args),
+    uploadBatch: (...args: unknown[]) => uploadBatchMock(...args),
+  },
+}));
+
+const { saveDeckFromOps, DeckOpsBaseMismatchError } = await import('../deckSaveMerge.service.ts');
+const { DeckConflictError } = await import('../slideContent.service.ts');
+const { PreviewResolutionError } = await import('../deckMerge.ts');
+
+const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
+const slide = {
+  id: 'slide-1',
+  title: 'My Deck',
+  content_path: 'slides/my-deck',
+  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+};
+
+const DECK_PATH = 'slides/my-deck/deck.json';
+const HTML_PATH = 'slides/my-deck/index.html';
+const BASE_SHA = 'base-sha';
+
+const deckWith = (slides: DeckJson['slides']): DeckJson => ({
+  version: 1,
+  theme: 'white',
+  codeTheme: 'github',
+  slides,
+});
+const deckJson = (deck: DeckJson) => JSON.stringify(deck, null, 2);
+
+/** Prime the two save reads: base = blob at the token, ours = fresh main. */
+function primeSave({ base, ours }: { base: DeckJson; ours: DeckJson }) {
+  getBlobContentMock.mockImplementation(async (arg: unknown) => {
+    const { sha } = arg as { sha: string };
+    if (sha === BASE_SHA) return { content: deckJson(base), sha: BASE_SHA };
+    return null;
+  });
+  getContentMock.mockResolvedValue({ content: deckJson(ours), sha: 'ours-sha' });
+}
+
+/** The batch payload saveDeck sent (deck.json parsed, html raw). */
+function batchCall(n = 0) {
+  const args = uploadBatchMock.mock.calls[n][0] as {
+    files: Array<{ path: string; content: string }>;
+    branch: string;
+    message: string;
+  };
+  const deckFile = args.files.find(f => f.path === DECK_PATH);
+  const htmlFile = args.files.find(f => f.path === HTML_PATH);
+  return {
+    args,
+    deck: deckFile ? (JSON.parse(deckFile.content) as DeckJson) : null,
+    html: htmlFile?.content ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  slideUpdateMock.mockResolvedValue({});
+  getMetaMock.mockResolvedValue({ sha: 'ours-sha', size: 1 });
+  uploadBatchMock.mockImplementation(
+    async ({
+      files,
+      verifyBaseTree,
+    }: {
+      files: Array<{ path: string }>;
+      verifyBaseTree?: (ctx: {
+        getFileSha: (path: string) => Promise<string | null>;
+      }) => Promise<void>;
+    }) => {
+      if (verifyBaseTree) {
+        await verifyBaseTree({ getFileSha: async () => 'ours-sha' });
+      }
+      return {
+        commit: 'ops-commit',
+        filesUploaded: files.length,
+        files: files.map(f => ({
+          path: f.path,
+          sha: f.path === DECK_PATH ? 'new-deck-sha' : 'new-html-sha',
+        })),
+      };
+    }
+  );
+});
+
+describe('saveDeckFromOps — clean commits', () => {
+  it('fresh base (main unchanged): ops replay onto base and commit; concurrent = 0', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    primeSave({ base, ours: base });
+
+    const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>Mine</h1>' }];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true, sha: 'new-deck-sha', concurrent: 0 });
+    expect(batchCall().deck?.slides).toEqual([
+      { id: 'aaa', html: '<h1>Mine</h1>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+  });
+
+  it('disjoint slides: my op + a concurrent main edit to ANOTHER slide auto-merge (strict compare, zero tolerance involved)', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    // A GENUINE concurrent edit — plain-string different, so only the
+    // structural "untouched slides never transmitted" property (theirs.bbb is
+    // literally base.bbb) makes this merge clean.
+    const ours = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<h2>Racer edit</h2>' },
+    ]);
+    primeSave({ base, ours });
+
+    const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>Mine</h1>' }];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true, concurrent: 1, auto_merged: 2 });
+    expect(batchCall().deck?.slides).toEqual([
+      { id: 'aaa', html: '<h1>Mine</h1>' },
+      { id: 'bbb', html: '<h2>Racer edit</h2>' },
+    ]);
+  });
+
+  it('structural ops (delete + insert + reorder) replay through the merge and commit', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+      { id: 'ccc', html: '<p>three</p>' },
+    ]);
+    primeSave({ base, ours: base });
+
+    // Client planner ordering: deletes → reorder (existing ids only — minted
+    // insert ids are unknown client-side) → inserts anchored on final slots.
+    const ops: DeckOp[] = [
+      { op: 'delete', id: 'bbb' },
+      { op: 'reorder', order: ['ccc', 'aaa'] },
+      { op: 'insert', slides: [{ html: '<p>new</p>' }], position: { after: 'ccc' } },
+    ];
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true });
+    const committed = batchCall().deck;
+    expect(committed?.slides.map(s => s.html)).toEqual([
+      '<p>three</p>',
+      '<p>new</p>',
+      '<p>one</p>',
+    ]);
+    expect(committed?.slides[1].id).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('op html routes through normalizeSlideHtml (hljs stripped — same canonical form as whole-doc saves)', async () => {
+    const base = deckWith([{ id: 'aaa', html: '<p>one</p>' }]);
+    primeSave({ base, ours: base });
+
+    const ops: DeckOp[] = [
+      {
+        op: 'update',
+        id: 'aaa',
+        html: '<pre><code class="hljs language-js"><span class="hljs-keyword">const</span> x = 1;</code></pre>',
+        notes: '<pre><code class="hljs">a &lt; b</code></pre>',
+      },
+    ];
+    await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    const committed = batchCall().deck;
+    expect(committed?.slides[0].html).toBe(
+      '<pre><code class="language-js">const x = 1;</code></pre>'
+    );
+    expect(committed?.slides[0].notes).toBe('<pre><code>a &lt; b</code></pre>');
+  });
+});
+
+describe('saveDeckFromOps — conflicts and resolutions', () => {
+  const base = deckWith([
+    { id: 'aaa', html: '<p>one</p>' },
+    { id: 'bbb', html: '<p>two</p>' },
+  ]);
+  const ours = deckWith([
+    { id: 'aaa', html: '<h2>Racer version</h2>' },
+    { id: 'bbb', html: '<p>two</p>' },
+  ]);
+  const ops: DeckOp[] = [{ op: 'update', id: 'aaa', html: '<h1>My version</h1>' }];
+
+  it('same-slide collision → conflict report (units + ours_sha pin), nothing written', async () => {
+    primeSave({ base, ours });
+
+    const result = await saveDeckFromOps({ slide, ops, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: false, conflict: true, ours_sha: 'ours-sha' });
+    if (result.merged) throw new Error('expected a conflict report');
+    expect(result.units).toHaveLength(1);
+    expect(result.units[0]).toMatchObject({
+      id: 'aaa',
+      reason: 'content',
+      ours: { html: '<h2>Racer version</h2>' },
+      theirs: { html: '<h1>My version</h1>' },
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('re-submit with resolutions (same ops) commits the chosen side', async () => {
+    primeSave({ base, ours });
+
+    const result = await saveDeckFromOps({
+      slide,
+      ops,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'theirs' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(result).toMatchObject({ merged: true, sha: 'new-deck-sha' });
+    expect(batchCall().deck?.slides).toEqual([
+      { id: 'aaa', html: '<h1>My version</h1>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+  });
+
+  it('stale ours pin → CONTENT_CONFLICT, nothing written', async () => {
+    primeSave({ base, ours });
+
+    const failure = await saveDeckFromOps({
+      slide,
+      ops,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'theirs' }],
+      expectedOursSha: 'stale-report-sha',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'CONTENT_CONFLICT' });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveDeckFromOps — OPS_BASE_MISMATCH and fallbacks', () => {
+  const base = deckWith([
+    { id: 'aaa', html: '<p>one</p>' },
+    { id: 'bbb', html: '<p>two</p>' },
+  ]);
+
+  it('unknown op id → DeckOpsBaseMismatchError (client falls back to the whole-doc save)', async () => {
+    primeSave({ base, ours: base });
+
+    const failure = await saveDeckFromOps({
+      slide,
+      ops: [{ op: 'update', id: 'zzz', html: '<p>x</p>' }],
+      baseSha: BASE_SHA,
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(DeckOpsBaseMismatchError);
+    expect(failure).toMatchObject({ code: 'OPS_BASE_MISMATCH', status: 409 });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('insert anchor missing in base (anchor slide deleted) → OPS_BASE_MISMATCH', async () => {
+    primeSave({ base, ours: base });
+
+    const failure = await saveDeckFromOps({
+      slide,
+      ops: [{ op: 'insert', slides: [{ html: '<p>new</p>' }], position: { after: 'ghost' } }],
+      baseSha: BASE_SHA,
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(DeckOpsBaseMismatchError);
+    expect((failure as Error).message).toContain("Unknown slide id 'ghost'");
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('section tags in op html → OPS_BASE_MISMATCH (engine refusal), nothing written', async () => {
+    primeSave({ base, ours: base });
+
+    const failure = await saveDeckFromOps({
+      slide,
+      ops: [{ op: 'update', id: 'aaa', html: '<section>injected</section>' }],
+      baseSha: BASE_SHA,
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(DeckOpsBaseMismatchError);
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('base blob unreadable → DeckConflictError (plain reload flow), nothing written', async () => {
+    getBlobContentMock.mockResolvedValue(null);
+    getContentMock.mockResolvedValue({ content: deckJson(base), sha: 'ours-sha' });
+
+    const failure = await saveDeckFromOps({
+      slide,
+      ops: [{ op: 'update', id: 'aaa', html: '<p>x</p>' }],
+      baseSha: BASE_SHA,
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it("main's deck.json gone → DeckConflictError", async () => {
+    getBlobContentMock.mockResolvedValue({ content: deckJson(base), sha: BASE_SHA });
+    getContentMock.mockResolvedValue(null);
+
+    const failure = await saveDeckFromOps({
+      slide,
+      ops: [{ op: 'update', id: 'aaa', html: '<p>x</p>' }],
+      baseSha: BASE_SHA,
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
@@ -145,6 +145,8 @@ describe('saveDeckWithMerge — clean 3-way', () => {
       html: expect.stringContaining('<h1>My edit</h1>'),
       auto_merged: 2,
       concurrent: 1, // bbb — the one change main made that this editor never saw
+      // committed deck ≠ theirs (bbb's concurrent edit folded in) → remount
+      adoption_required: true,
     });
 
     // ONE atomic batch on main: merged deck.json + regenerated index.html,

--- a/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
@@ -439,15 +439,18 @@ describe('saveDeckWithMerge — resolutions', () => {
 describe('saveDeckWithMerge — fallbacks', () => {
   const theirs = deckWith([{ id: 'aaa', html: '<h1>Edited</h1>' }]);
 
-  it('base blob missing (getBlobContent null) → DeckConflictError, nothing read from main, nothing written', async () => {
+  it('base blob missing (getBlobContent null) → DeckConflictError, nothing written', async () => {
     getBlobContentMock.mockResolvedValue(null);
+    // The fresh-main read is prefetched in PARALLEL with the base blob (a
+    // latency win), so it may fire — but a missing base must abort before
+    // any merge or write.
+    getContentMock.mockResolvedValue(null);
 
     const failure = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA }).catch(
       (e: unknown) => e
     );
 
     expect(failure).toBeInstanceOf(DeckConflictError);
-    expect(getContentMock).not.toHaveBeenCalled();
     expect(uploadBatchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../content/ContentService.ts', () => ({
 const { saveDeckWithMerge } = await import('../deckSaveMerge.service.ts');
 const { DeckConflictError } = await import('../slideContent.service.ts');
 const { PreviewResolutionError } = await import('../deckMerge.ts');
+const { browserFixture } = await import('./fixtures/browserSerialization.ts');
 
 const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
 const slide = {
@@ -181,6 +182,74 @@ describe('saveDeckWithMerge — clean 3-way', () => {
 
     expect(result).toMatchObject({ merged: true, concurrent: 0 });
     expect(batchCall().deck?.slides).toEqual([{ id: 'aaa', html: '<h1>Edited</h1>' }]);
+  });
+});
+
+describe('saveDeckWithMerge — browser-serialization tolerance (the two-tab phantom conflict)', () => {
+  // The user's repro: two tabs editing DIFFERENT slides raised an
+  // 'Edited in both versions' card on a styled slide NEITHER touched, because
+  // each tab's browser re-serialized its inline styles (captured Chromium
+  // ground truth in fixtures/browserSerialization.ts).
+  const hexFixture = browserFixture('hex-color-style');
+
+  it('two tabs, different slides: the untouched styled slide auto-merges, save succeeds with the right concurrent count', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: hexFixture.input },
+      { id: 'bbb', html: '<p>two</p>' },
+      { id: 'ccc', html: '<p>three</p>' },
+    ]);
+    // Tab 1 saved first: edited bbb; its posted document carried aaa in ITS
+    // browser-serialized form, which is now on main.
+    primeSave({
+      base,
+      ours: deckWith([
+        { id: 'aaa', html: hexFixture.cssom },
+        { id: 'bbb', html: '<h2>Tab 1 edit</h2>' },
+        { id: 'ccc', html: '<p>three</p>' },
+      ]),
+    });
+    // Tab 2 (stale token) edited ccc; posts aaa in another equivalent browser
+    // form (byte-distinct from both base and main).
+    const theirs = deckWith([
+      {
+        id: 'aaa',
+        html: '<h2 style="color:rgb(224,123,57)">Warm heading</h2><p style="color:rgb(171,71,188)">purple</p>',
+      },
+      { id: 'bbb', html: '<p>two</p>' },
+      { id: 'ccc', html: '<p>Tab 2 edit</p>' },
+    ]);
+
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({
+      merged: true,
+      auto_merged: 2, // bbb (main's edit) + ccc (this save's edit)
+      concurrent: 1, // ONLY bbb — aaa's browser noise is not a concurrent change
+    });
+    // The untouched styled slide keeps its clean BASE form; both real edits land.
+    expect(batchCall().deck?.slides).toEqual([
+      { id: 'aaa', html: hexFixture.input },
+      { id: 'bbb', html: '<h2>Tab 1 edit</h2>' },
+      { id: 'ccc', html: '<p>Tab 2 edit</p>' },
+    ]);
+  });
+
+  it('a GENUINE double edit of the styled slide still reports a conflict', async () => {
+    const base = deckWith([{ id: 'aaa', html: hexFixture.input }]);
+    primeSave({
+      base,
+      ours: deckWith([{ id: 'aaa', html: '<h2 style="color:#e07b39">Main rewrote this</h2>' }]),
+    });
+    const theirs = deckWith([
+      { id: 'aaa', html: '<h2 style="color: rgb(200, 123, 57);">Tab 2 rewrote this</h2>' },
+    ]);
+
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: false, conflict: true });
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toMatchObject([{ id: 'aaa', reason: 'content' }]);
+    expect(uploadBatchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
@@ -1,0 +1,506 @@
+/**
+ * Semantic 3-way merge for EDITOR saves (content-tools plan §3b Phase 7.5).
+ *
+ * Mocks mirror deckPreview.semantic.test.ts (ContentService + prisma mocked;
+ * the deck engine and saveDeck are REAL). Pins the save-merge contract:
+ * a stale-token save whose 3-way merges cleanly commits through saveDeck (ONE
+ * atomic batch: deck.json + regenerated index.html, CAS'd on FRESH main's
+ * deck.json sha) and reports the concurrent-change count; true collisions
+ * return only the colliding units + auto_merged + the ours_sha pin with
+ * nothing written; resolutions must exactly cover the current conflict set;
+ * an unreadable base falls back to the plain DeckConflictError flow.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DeckJson } from '../deckTypes.ts';
+
+const slideUpdateMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    slide: { update: (...args: unknown[]) => slideUpdateMock(...args) },
+  }),
+}));
+
+const getContentMock = vi.fn();
+const getMetaMock = vi.fn();
+const getBlobContentMock = vi.fn();
+const uploadBatchMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getMeta: (...args: unknown[]) => getMetaMock(...args),
+    getBlobContent: (...args: unknown[]) => getBlobContentMock(...args),
+    uploadBatch: (...args: unknown[]) => uploadBatchMock(...args),
+  },
+}));
+
+const { saveDeckWithMerge } = await import('../deckSaveMerge.service.ts');
+const { DeckConflictError } = await import('../slideContent.service.ts');
+const { PreviewResolutionError } = await import('../deckMerge.ts');
+
+const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
+const slide = {
+  id: 'slide-1',
+  title: 'My Deck',
+  content_path: 'slides/my-deck',
+  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+};
+
+const DECK_PATH = 'slides/my-deck/deck.json';
+const HTML_PATH = 'slides/my-deck/index.html';
+const BASE_SHA = 'base-sha';
+
+const deckWith = (slides: DeckJson['slides']): DeckJson => ({
+  version: 1,
+  theme: 'white',
+  codeTheme: 'github',
+  slides,
+});
+const deckJson = (deck: DeckJson) => JSON.stringify(deck, null, 2);
+
+/** Prime the two save-merge reads: base = blob at the token, ours = fresh main. */
+function primeSave({ base, ours }: { base: DeckJson; ours: DeckJson }) {
+  getBlobContentMock.mockImplementation(async (arg: unknown) => {
+    const { sha } = arg as { sha: string };
+    if (sha === BASE_SHA) return { content: deckJson(base), sha: BASE_SHA };
+    return null;
+  });
+  getContentMock.mockResolvedValue({ content: deckJson(ours), sha: 'ours-sha' });
+}
+
+/** The batch payload saveDeck sent (deck.json parsed, html raw). */
+function batchCall(n = 0) {
+  const args = uploadBatchMock.mock.calls[n][0] as {
+    files: Array<{ path: string; content: string }>;
+    branch: string;
+    message: string;
+    verifyBaseTree?: unknown;
+  };
+  const deckFile = args.files.find(f => f.path === DECK_PATH);
+  const htmlFile = args.files.find(f => f.path === HTML_PATH);
+  return {
+    args,
+    deck: deckFile ? (JSON.parse(deckFile.content) as DeckJson) : null,
+    html: htmlFile?.content ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  slideUpdateMock.mockResolvedValue({});
+  // saveDeck's pre-check reads main's current deck.json sha.
+  getMetaMock.mockResolvedValue({ sha: 'ours-sha', size: 1 });
+  uploadBatchMock.mockImplementation(
+    async ({
+      files,
+      verifyBaseTree,
+    }: {
+      files: Array<{ path: string }>;
+      verifyBaseTree?: (ctx: {
+        getFileSha: (path: string) => Promise<string | null>;
+      }) => Promise<void>;
+    }) => {
+      if (verifyBaseTree) {
+        await verifyBaseTree({ getFileSha: async () => 'ours-sha' });
+      }
+      return {
+        commit: 'merge-commit',
+        filesUploaded: files.length,
+        files: files.map(f => ({
+          path: f.path,
+          sha: f.path === DECK_PATH ? 'merged-deck-sha' : 'new-html-sha',
+        })),
+      };
+    }
+  );
+});
+
+describe('saveDeckWithMerge — clean 3-way', () => {
+  it('folds a concurrent main edit into the save: ONE atomic CAS commit on fresh main', async () => {
+    primeSave({
+      base: deckWith([
+        { id: 'aaa', html: '<p>one</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>one</p>' },
+        { id: 'bbb', html: '<h2>Concurrent edit</h2>' },
+      ]),
+    });
+    // The editor's posted deck: edited slide aaa, never saw bbb's change.
+    const theirs = deckWith([
+      { id: 'aaa', html: '<h1>My edit</h1>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    expect(result).toEqual({
+      merged: true,
+      sha: 'merged-deck-sha',
+      commit: 'merge-commit',
+      html: expect.stringContaining('<h1>My edit</h1>'),
+      auto_merged: 2,
+      concurrent: 1, // bbb — the one change main made that this editor never saw
+    });
+
+    // ONE atomic batch on main: merged deck.json + regenerated index.html,
+    // CAS'd (verifyBaseTree) on FRESH main's sha — not the stale token.
+    expect(uploadBatchMock).toHaveBeenCalledTimes(1);
+    const { args, deck, html } = batchCall();
+    expect(args.branch).toBe('main');
+    expect(args.files).toHaveLength(2);
+    expect(args.message).toBe('Update slides (merged): My Deck');
+    expect(args.verifyBaseTree).toBeTypeOf('function');
+    expect(deck?.slides).toEqual([
+      { id: 'aaa', html: '<h1>My edit</h1>' },
+      { id: 'bbb', html: '<h2>Concurrent edit</h2>' },
+    ]);
+    expect(html).toContain('<h1>My edit</h1>');
+    expect(html).toContain('<h2>Concurrent edit</h2>');
+
+    // Base was fetched content-addressed by the token's blob sha.
+    expect(getBlobContentMock).toHaveBeenCalledWith(expect.objectContaining({ sha: BASE_SHA }));
+    // Fresh-main read bypassed the cache (it pins the CAS sha).
+    expect(getContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: DECK_PATH, skipCache: true })
+    );
+    expect(slideUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'slide-1' } })
+    );
+  });
+
+  it('main unchanged since the token (base == ours) → theirs commits verbatim, concurrent 0', async () => {
+    const base = deckWith([{ id: 'aaa', html: '<p>one</p>' }]);
+    primeSave({ base, ours: base });
+    const theirs = deckWith([{ id: 'aaa', html: '<h1>Edited</h1>' }]);
+
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({ merged: true, concurrent: 0 });
+    expect(batchCall().deck?.slides).toEqual([{ id: 'aaa', html: '<h1>Edited</h1>' }]);
+  });
+});
+
+describe('saveDeckWithMerge — collision report', () => {
+  it('a same-unit double edit → report with ONLY that unit + auto_merged + ours_sha, nothing written', async () => {
+    primeSave({
+      base: deckWith([
+        { id: 'aaa', html: '<p>original</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>main</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+    });
+    const theirs = deckWith([
+      { id: 'aaa', html: '<p>mine</p>' },
+      { id: 'bbb', html: '<p>two edited</p>' },
+    ]);
+
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    expect(result).toMatchObject({
+      merged: false,
+      conflict: true,
+      auto_merged: 1, // bbb's one-sided edit
+      ours_sha: 'ours-sha',
+    });
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([
+      {
+        id: 'aaa',
+        index: '1',
+        reason: 'content',
+        base: { id: 'aaa', html: '<p>original</p>' },
+        ours: { id: 'aaa', html: '<p>main</p>' },
+        theirs: { id: 'aaa', html: '<p>mine</p>' },
+      },
+    ]);
+    expect(result.order_conflict).toBeUndefined();
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+    expect(slideUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('a both-sides order collision surfaces as order_conflict (units empty)', async () => {
+    const a = { id: 'aaa', html: '<p>a</p>' };
+    const b = { id: 'bbb', html: '<p>b</p>' };
+    const c = { id: 'ccc', html: '<p>c</p>' };
+    primeSave({
+      base: deckWith([a, b, c]),
+      ours: deckWith([b, a, c]),
+    });
+    const theirs = deckWith([a, c, b]);
+
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    if (result.merged) throw new Error('unreachable');
+    expect(result.units).toEqual([]);
+    expect(result.order_conflict).toEqual({
+      base: ['aaa', 'bbb', 'ccc'],
+      ours: ['bbb', 'aaa', 'ccc'],
+      theirs: ['aaa', 'ccc', 'bbb'],
+    });
+  });
+});
+
+describe('saveDeckWithMerge — resolutions', () => {
+  const conflicted = () => {
+    primeSave({
+      base: deckWith([
+        { id: 'aaa', html: '<p>original</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>main</p>' },
+        { id: 'bbb', html: '<p>two</p>' },
+      ]),
+    });
+    return deckWith([
+      { id: 'aaa', html: '<p>mine</p>' },
+      { id: 'bbb', html: '<p>two edited</p>' },
+    ]);
+  };
+
+  it("applies the choices and commits: 'ours' keeps the server's version, clean edits still land", async () => {
+    const theirs = conflicted();
+
+    const result = await saveDeckWithMerge({
+      slide,
+      theirs,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(result).toMatchObject({ merged: true, sha: 'merged-deck-sha', auto_merged: 1 });
+    expect(batchCall().deck?.slides).toEqual([
+      { id: 'aaa', html: '<p>main</p>' },
+      { id: 'bbb', html: '<p>two edited</p>' },
+    ]);
+  });
+
+  it("'theirs' keeps the editor's version", async () => {
+    const theirs = conflicted();
+
+    await saveDeckWithMerge({
+      slide,
+      theirs,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'theirs' }],
+      expectedOursSha: 'ours-sha',
+    });
+
+    expect(batchCall().deck?.slides[0]).toEqual({ id: 'aaa', html: '<p>mine</p>' });
+  });
+
+  it('errors naming UNRESOLVED conflict ids — nothing written', async () => {
+    primeSave({
+      base: deckWith([
+        { id: 'aaa', html: '<p>a0</p>' },
+        { id: 'bbb', html: '<p>b0</p>' },
+      ]),
+      ours: deckWith([
+        { id: 'aaa', html: '<p>a-main</p>' },
+        { id: 'bbb', html: '<p>b-main</p>' },
+      ]),
+    });
+    const theirs = deckWith([
+      { id: 'aaa', html: '<p>a-mine</p>' },
+      { id: 'bbb', html: '<p>b-mine</p>' },
+    ]);
+
+    const failure = await saveDeckWithMerge({
+      slide,
+      theirs,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toBeInstanceOf(PreviewResolutionError);
+    expect(failure).toMatchObject({ code: 'UNRESOLVED_CONFLICTS', ids: ['bbb'] });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('errors on UNKNOWN resolution ids', async () => {
+    const theirs = conflicted();
+
+    const failure = await saveDeckWithMerge({
+      slide,
+      theirs,
+      baseSha: BASE_SHA,
+      resolutions: [
+        { id: 'aaa', choose: 'ours' },
+        { id: 'ghost', choose: 'theirs' },
+      ],
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({
+      name: 'PreviewResolutionError',
+      code: 'UNKNOWN_RESOLUTIONS',
+      ids: ['ghost'],
+    });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('the ours_sha pin refuses when main moved after the reviewed report (CONTENT_CONFLICT)', async () => {
+    const theirs = conflicted();
+    // Main moved: the fresh read serves a NEWER sha than the report's pin.
+    getContentMock.mockResolvedValue({
+      content: deckJson(deckWith([{ id: 'aaa', html: '<p>even newer</p>' }])),
+      sha: 'ours-sha-2',
+    });
+
+    const failure = await saveDeckWithMerge({
+      slide,
+      theirs,
+      baseSha: BASE_SHA,
+      resolutions: [{ id: 'aaa', choose: 'ours' }],
+      expectedOursSha: 'ours-sha',
+    }).catch((e: unknown) => e);
+
+    expect(failure).toMatchObject({ name: 'PreviewResolutionError', code: 'CONTENT_CONFLICT' });
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveDeckWithMerge — fallbacks', () => {
+  const theirs = deckWith([{ id: 'aaa', html: '<h1>Edited</h1>' }]);
+
+  it('base blob missing (getBlobContent null) → DeckConflictError, nothing read from main, nothing written', async () => {
+    getBlobContentMock.mockResolvedValue(null);
+
+    const failure = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+    expect(getContentMock).not.toHaveBeenCalled();
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('base blob read throwing → same DeckConflictError fallback', async () => {
+    getBlobContentMock.mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+
+    const failure = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+
+  it('base blob unparseable as a deck → DeckConflictError fallback', async () => {
+    getBlobContentMock.mockResolvedValue({ content: '<html>legacy</html>', sha: BASE_SHA });
+
+    const failure = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+  });
+
+  it("main's deck.json deleted → DeckConflictError, never an unguarded write", async () => {
+    getBlobContentMock.mockResolvedValue({
+      content: deckJson(deckWith([{ id: 'aaa', html: '<p>one</p>' }])),
+      sha: BASE_SHA,
+    });
+    getContentMock.mockResolvedValue(null);
+
+    const failure = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveDeckWithMerge — CAS retry', () => {
+  it('a CAS loss on the commit retries ONCE against fresh main (re-running the 3-way)', async () => {
+    const base = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    getBlobContentMock.mockResolvedValue({ content: deckJson(base), sha: BASE_SHA });
+
+    // Attempt 1 reads ours-v1; a racer then lands bbb's edit, so saveDeck's
+    // pre-check (getMeta) sees ours-sha-2 and 409s. Attempt 2 re-reads fresh
+    // main (ours-v2) and commits CAS'd on ours-sha-2.
+    const oursV1 = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    const oursV2 = deckWith([
+      { id: 'aaa', html: '<p>one</p>' },
+      { id: 'bbb', html: '<h2>Racer edit</h2>' },
+    ]);
+    let mainReads = 0;
+    getContentMock.mockImplementation(async () => {
+      mainReads += 1;
+      return mainReads === 1
+        ? { content: deckJson(oursV1), sha: 'ours-sha' }
+        : { content: deckJson(oursV2), sha: 'ours-sha-2' };
+    });
+    getMetaMock.mockResolvedValue({ sha: 'ours-sha-2', size: 1 });
+    uploadBatchMock.mockImplementation(
+      async ({
+        files,
+        verifyBaseTree,
+      }: {
+        files: Array<{ path: string }>;
+        verifyBaseTree?: (ctx: {
+          getFileSha: (path: string) => Promise<string | null>;
+        }) => Promise<void>;
+      }) => {
+        if (verifyBaseTree) {
+          await verifyBaseTree({ getFileSha: async () => 'ours-sha-2' });
+        }
+        return {
+          commit: 'merge-commit-2',
+          filesUploaded: files.length,
+          files: files.map(f => ({
+            path: f.path,
+            sha: f.path === DECK_PATH ? 'merged-deck-sha-2' : 'new-html-sha',
+          })),
+        };
+      }
+    );
+
+    const theirs = deckWith([
+      { id: 'aaa', html: '<h1>My edit</h1>' },
+      { id: 'bbb', html: '<p>two</p>' },
+    ]);
+    const result = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA });
+
+    // Attempt 1 died at saveDeck's pre-check (before the batch), attempt 2 committed.
+    expect(getContentMock).toHaveBeenCalledTimes(2);
+    expect(uploadBatchMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ merged: true, sha: 'merged-deck-sha-2', concurrent: 1 });
+    // The retry's merge folded the RACER's edit in (3-way re-ran against fresh ours).
+    expect(batchCall().deck?.slides).toEqual([
+      { id: 'aaa', html: '<h1>My edit</h1>' },
+      { id: 'bbb', html: '<h2>Racer edit</h2>' },
+    ]);
+  });
+
+  it('a second CAS loss rethrows DeckConflictError (the plain fallback)', async () => {
+    const base = deckWith([{ id: 'aaa', html: '<p>one</p>' }]);
+    getBlobContentMock.mockResolvedValue({ content: deckJson(base), sha: BASE_SHA });
+    getContentMock.mockResolvedValue({ content: deckJson(base), sha: 'ours-sha' });
+    // Main's sha never matches what we read — every saveDeck pre-check 409s.
+    getMetaMock.mockResolvedValue({ sha: 'always-moving', size: 1 });
+
+    const theirs = deckWith([{ id: 'aaa', html: '<h1>Edited</h1>' }]);
+    const failure = await saveDeckWithMerge({ slide, theirs, baseSha: BASE_SHA }).catch(
+      (e: unknown) => e
+    );
+
+    expect(failure).toBeInstanceOf(DeckConflictError);
+    expect(getContentMock).toHaveBeenCalledTimes(2); // one read per attempt
+    expect(uploadBatchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/slides/__tests__/fixtures/browserSerialization.ts
+++ b/packages/services/src/slides/__tests__/fixtures/browserSerialization.ts
@@ -1,0 +1,209 @@
+/**
+ * Browser-serialization ground truth for the editor-save merge equivalence
+ * (Phase 7.5 phantom-conflict fix).
+ *
+ * PROVENANCE: every `roundtrip`/`cssom` string below was captured verbatim
+ * from headless Chromium (Playwright 1.58.2 bundled chromium headless shell,
+ * build 1208) on 2026-08-04 by a scratch script that, for each `input`:
+ *
+ *   1. `div.innerHTML = input; roundtrip = div.innerHTML`
+ *      — the pure parse/serialize round-trip every posted slide goes through.
+ *   2. then `el.setAttribute('style', el.style.cssText)` for every `[style]`
+ *      element and read `div.innerHTML` again → `cssom`
+ *      — what the style attribute becomes after ANY CSSOM style mutation
+ *        (the Reveal editor mutates styles constantly: drag-positioning
+ *        sl-blocks, visibility toggles, …), which re-serializes the whole
+ *        declaration block in the browser's canonical form.
+ *
+ * Do not hand-edit the output strings — they are evidence, not style. If a
+ * future Chromium changes its serialization, re-capture rather than tweak.
+ *
+ * What the capture demonstrates:
+ * - pure round-trips keep style attrs byte-identical but rewrite valueless
+ *   attrs (`data-x` → `data-x=""`), re-quote single-quoted attrs, re-encode
+ *   entities (`&quot;` in text becomes `"` — including inside pre/code), and
+ *   drop self-closing slashes (`<br/>` → `<br>`);
+ * - CSSOM serialization converts 3/6-digit hex colors to `rgb(r, g, b)`
+ *   (named colors stay named), respaces `rgb(a,b,c)` to `rgb(a, b, c)`,
+ *   trims numeric noise (`600.50px` → `600.5px`, `.5px` → `0.5px`,
+ *   `-50.0%` → `-50%`), quotes url() args (`url(x)` → `url("x")`), double-
+ *   quotes font names, joins declarations with `; ` and a trailing `;`.
+ */
+
+export interface BrowserSerializationFixture {
+  name: string;
+  /** The markup as authored / stored in deck.json (generator-clean form). */
+  input: string;
+  /** Chromium's `div.innerHTML` read-back of `input` (pure round-trip). */
+  roundtrip: string;
+  /** Read-back after every `[style]` attr was re-serialized through the CSSOM. */
+  cssom: string;
+}
+
+export const BROWSER_SERIALIZATION_FIXTURES: BrowserSerializationFixture[] = [
+  {
+    name: 'hex-color-style',
+    input: '<h2 style="color:#e07b39">Warm heading</h2><p style="color: #AB47BC;">purple</p>',
+    roundtrip: '<h2 style="color:#e07b39">Warm heading</h2><p style="color: #AB47BC;">purple</p>',
+    cssom:
+      '<h2 style="color: rgb(224, 123, 57);">Warm heading</h2><p style="color: rgb(171, 71, 188);">purple</p>',
+  },
+  {
+    name: 'named-color-and-hex-bg',
+    input: '<span style="color: red; background-color:#FF5500">x</span>',
+    roundtrip: '<span style="color: red; background-color:#FF5500">x</span>',
+    cssom: '<span style="color: red; background-color: rgb(255, 85, 0);">x</span>',
+  },
+  {
+    name: 'sl-block-positioned-decimals',
+    input:
+      '<div class="sl-block" data-block-type="text" style="height: auto; width: 600.50px; left: 79.375px; top: .5px; z-index: 11"><div class="sl-block-content" style="text-align: left; font-size: 120%;"><p>Positioned</p></div></div>',
+    roundtrip:
+      '<div class="sl-block" data-block-type="text" style="height: auto; width: 600.50px; left: 79.375px; top: .5px; z-index: 11"><div class="sl-block-content" style="text-align: left; font-size: 120%;"><p>Positioned</p></div></div>',
+    cssom:
+      '<div class="sl-block" data-block-type="text" style="height: auto; width: 600.5px; left: 79.375px; top: 0.5px; z-index: 11;"><div class="sl-block-content" style="text-align: left; font-size: 120%;"><p>Positioned</p></div></div>',
+  },
+  {
+    name: 'rgb-no-spaces',
+    input: '<p style="color:rgb(224,123,57)">already rgb</p>',
+    roundtrip: '<p style="color:rgb(224,123,57)">already rgb</p>',
+    cssom: '<p style="color: rgb(224, 123, 57);">already rgb</p>',
+  },
+  {
+    name: 'transform-decimals',
+    input: '<div style="transform: translate(-50.0%, 20.25px) rotate(0.50deg);">t</div>',
+    roundtrip: '<div style="transform: translate(-50.0%, 20.25px) rotate(0.50deg);">t</div>',
+    cssom: '<div style="transform: translate(-50%, 20.25px) rotate(0.5deg);">t</div>',
+  },
+  {
+    name: 'url-unquoted',
+    input: '<div style="background-image:url(assets/img.png)">bg</div>',
+    roundtrip: '<div style="background-image:url(assets/img.png)">bg</div>',
+    cssom: '<div style="background-image: url(&quot;assets/img.png&quot;);">bg</div>',
+  },
+  {
+    name: 'font-family-single-quotes',
+    input: '<p style="font-family:\'Source Sans Pro\', Arial, sans-serif">type</p>',
+    roundtrip: '<p style="font-family:\'Source Sans Pro\', Arial, sans-serif">type</p>',
+    cssom: '<p style="font-family: &quot;Source Sans Pro&quot;, Arial, sans-serif;">type</p>',
+  },
+  {
+    name: 'data-attrs-valueless',
+    input:
+      '<div data-x data-y="" data-note="a &lt; b" data-caption="He said &quot;hi&quot;">d</div>',
+    roundtrip:
+      '<div data-x="" data-y="" data-note="a &lt; b" data-caption="He said &quot;hi&quot;">d</div>',
+    cssom:
+      '<div data-x="" data-y="" data-note="a &lt; b" data-caption="He said &quot;hi&quot;">d</div>',
+  },
+  {
+    name: 'class-whitespace',
+    input: '<div class=" sl-block   content ">c</div>',
+    roundtrip: '<div class=" sl-block   content ">c</div>',
+    cssom: '<div class=" sl-block   content ">c</div>',
+  },
+  {
+    name: 'pre-code-escaped-entities',
+    input:
+      '<pre><code class="language-html">&lt;div class=&quot;box&quot;&gt;\n  &lt;p&gt;Hello &amp;amp; welcome&lt;/p&gt;\n&lt;/div&gt;</code></pre>',
+    roundtrip:
+      '<pre><code class="language-html">&lt;div class="box"&gt;\n  &lt;p&gt;Hello &amp;amp; welcome&lt;/p&gt;\n&lt;/div&gt;</code></pre>',
+    cssom:
+      '<pre><code class="language-html">&lt;div class="box"&gt;\n  &lt;p&gt;Hello &amp;amp; welcome&lt;/p&gt;\n&lt;/div&gt;</code></pre>',
+  },
+  {
+    name: 'sandpack-embed',
+    input:
+      '<div class="sl-block" data-block-type="sandpack"><div class="sl-block-content"><div class="sandpack-embed" data-template="react" data-theme="auto" data-layout="preview-right"><script type="application/json" data-sandpack-files>{"/App.js":{"code":"const x = 1 < 2 && \'y\';","active":true}}</script></div></div></div>',
+    roundtrip:
+      '<div class="sl-block" data-block-type="sandpack"><div class="sl-block-content"><div class="sandpack-embed" data-template="react" data-theme="auto" data-layout="preview-right"><script type="application/json" data-sandpack-files="">{"/App.js":{"code":"const x = 1 < 2 && \'y\';","active":true}}</script></div></div></div>',
+    cssom:
+      '<div class="sl-block" data-block-type="sandpack"><div class="sl-block-content"><div class="sandpack-embed" data-template="react" data-theme="auto" data-layout="preview-right"><script type="application/json" data-sandpack-files="">{"/App.js":{"code":"const x = 1 < 2 && \'y\';","active":true}}</script></div></div></div>',
+  },
+  {
+    name: 'self-closing-and-entities-in-text',
+    input: '<p>Hello&nbsp;world &amp; more<br/></p><img src="x.png" alt="" />',
+    roundtrip: '<p>Hello&nbsp;world &amp; more<br></p><img src="x.png" alt="">',
+    cssom: '<p>Hello&nbsp;world &amp; more<br></p><img src="x.png" alt="">',
+  },
+  {
+    name: 'single-quoted-attrs',
+    input: '<div data-caption=\'He said "hi" &amp; left\'>q</div>',
+    roundtrip: '<div data-caption="He said &quot;hi&quot; &amp; left">q</div>',
+    cssom: '<div data-caption="He said &quot;hi&quot; &amp; left">q</div>',
+  },
+  {
+    name: 'section-with-style',
+    input:
+      '<section data-cm-id="sec00001" style="background-color:#123456" data-background-color="#ff5500"><h2>Sec</h2></section>',
+    roundtrip:
+      '<section data-cm-id="sec00001" style="background-color:#123456" data-background-color="#ff5500"><h2>Sec</h2></section>',
+    cssom:
+      '<section data-cm-id="sec00001" style="background-color: rgb(18, 52, 86);" data-background-color="#ff5500"><h2>Sec</h2></section>',
+  },
+];
+
+/** Fixture lookup by name (throws on a typo instead of silently vacuous tests). */
+export function browserFixture(name: string): BrowserSerializationFixture {
+  const fixture = BROWSER_SERIALIZATION_FIXTURES.find(f => f.name === name);
+  if (!fixture) throw new Error(`Unknown browser serialization fixture: ${name}`);
+  return fixture;
+}
+
+/**
+ * Pairs that look superficially similar but are GENUINELY different — the
+ * equivalence must stay conservative and report every one of these as a real
+ * difference (they would be real conflicts in a merge).
+ */
+export const TRUE_DIFFERENCE_CASES: Array<{ name: string; a: string; b: string }> = [
+  {
+    name: 'genuinely different color (not the hex↔rgb pair)',
+    a: '<h2 style="color:#e07b39">Warm heading</h2>',
+    b: '<h2 style="color: rgb(200, 123, 57);">Warm heading</h2>',
+  },
+  {
+    name: 'genuinely different numeric value',
+    a: '<div style="width: 600.5px">x</div>',
+    b: '<div style="width: 600px">x</div>',
+  },
+  {
+    name: 'text content change',
+    a: '<p>Hello world</p>',
+    b: '<p>Hello world!</p>',
+  },
+  {
+    name: 'class token order change',
+    a: '<div class="sl-block content">x</div>',
+    b: '<div class="content sl-block">x</div>',
+  },
+  {
+    name: 'code content change',
+    a: '<pre><code>a &lt; b</code></pre>',
+    b: '<pre><code>a &gt; b</code></pre>',
+  },
+  {
+    name: 'code whitespace change',
+    a: '<pre><code>if (x) {\n  y();\n}</code></pre>',
+    b: '<pre><code>if (x) { y(); }</code></pre>',
+  },
+  {
+    name: 'declaration removed',
+    a: '<div style="color: red; top: 1px">x</div>',
+    b: '<div style="color: red">x</div>',
+  },
+  {
+    name: 'tag change',
+    a: '<p>x</p>',
+    b: '<div>x</div>',
+  },
+  {
+    name: 'data attribute value change',
+    a: '<div data-note="a">x</div>',
+    b: '<div data-note="b">x</div>',
+  },
+  {
+    name: 'sandpack payload change',
+    a: '<div class="sandpack-embed"><script type="application/json" data-sandpack-files>{"/App.js":{"code":"const x = 1;"}}</script></div>',
+    b: '<div class="sandpack-embed"><script type="application/json" data-sandpack-files>{"/App.js":{"code":"const x = 2;"}}</script></div>',
+  },
+];

--- a/packages/services/src/slides/__tests__/slide.service.test.ts
+++ b/packages/services/src/slides/__tests__/slide.service.test.ts
@@ -68,6 +68,7 @@ const {
   updateSlide,
   SLIDE_CONTENT_PATH_CONFLICT,
   STARTER_CUSTOM_CSS,
+  buildEditorDeck,
 } = await import('../slide.service.ts');
 const { parseDeckHtml, generateDeckHtml } = await import('../deckHtml.ts');
 
@@ -552,5 +553,96 @@ describe('getSlideDeleteInfo', () => {
     getContentMock.mockResolvedValue(null);
     const info = await getSlideDeleteInfo('slide-1');
     expect(info.themeName).toBeNull();
+  });
+});
+
+describe('buildEditorDeck (editor save meta-merge, plan §5.1)', () => {
+  const slides = [{ id: 'aaa', html: '<h1>One</h1>' }];
+
+  it('carries config, customCss, extraCss, and dark themes from the current deck', () => {
+    const currentDeck = {
+      version: 1 as const,
+      theme: 'white',
+      codeTheme: 'github',
+      themeDark: 'black',
+      codeThemeDark: 'monokai',
+      config: { center: false },
+      customCss: '.reveal h1 { color: red; }',
+      extraCss: [{ href: 'https://cdn.example/extra.css', media: 'print' }],
+      slides: [],
+    };
+
+    const deck = buildEditorDeck({ theme: 'white', codeTheme: 'github', slides, currentDeck });
+
+    expect(deck).toEqual({
+      version: 1,
+      theme: 'white',
+      codeTheme: 'github',
+      themeDark: 'black',
+      codeThemeDark: 'monokai',
+      config: { center: false },
+      customCss: '.reveal h1 { color: red; }',
+      extraCss: [{ href: 'https://cdn.example/extra.css', media: 'print' }],
+      slides,
+    });
+  });
+
+  it('a theme change clears the paired dark theme; a codeTheme change clears codeThemeDark', () => {
+    const currentDeck = {
+      version: 1 as const,
+      theme: 'white',
+      codeTheme: 'github',
+      themeDark: 'black',
+      codeThemeDark: 'monokai',
+      slides: [],
+    };
+
+    const themeChanged = buildEditorDeck({
+      theme: 'night',
+      codeTheme: 'github',
+      slides,
+      currentDeck,
+    });
+    expect(themeChanged.themeDark).toBeUndefined();
+    expect(themeChanged.codeThemeDark).toBe('monokai');
+
+    const codeChanged = buildEditorDeck({
+      theme: 'white',
+      codeTheme: 'dracula',
+      slides,
+      currentDeck,
+    });
+    expect(codeChanged.themeDark).toBe('black');
+    expect(codeChanged.codeThemeDark).toBeUndefined();
+  });
+
+  it('a theme change drops starter-recognized customCss (exact match) but keeps custom edits', () => {
+    const starter = {
+      version: 1 as const,
+      theme: 'white',
+      codeTheme: 'monokai',
+      customCss: STARTER_CUSTOM_CSS,
+      slides: [],
+    };
+    expect(
+      buildEditorDeck({ theme: 'night', codeTheme: 'monokai', slides, currentDeck: starter })
+        .customCss
+    ).toBeUndefined();
+    // Same theme → the starter css stays.
+    expect(
+      buildEditorDeck({ theme: 'white', codeTheme: 'monokai', slides, currentDeck: starter })
+        .customCss
+    ).toBe(STARTER_CUSTOM_CSS);
+    // Hand-edited css survives a theme change.
+    const edited = { ...starter, customCss: '.reveal h1 { color: teal; }' };
+    expect(
+      buildEditorDeck({ theme: 'night', codeTheme: 'monokai', slides, currentDeck: edited })
+        .customCss
+    ).toBe('.reveal h1 { color: teal; }');
+  });
+
+  it('no current deck (legacy-unparseable or first write) → bare posted fields', () => {
+    const deck = buildEditorDeck({ theme: 'sky', codeTheme: 'github', slides, currentDeck: null });
+    expect(deck).toEqual({ version: 1, theme: 'sky', codeTheme: 'github', slides });
   });
 });

--- a/packages/services/src/slides/deckHtml.ts
+++ b/packages/services/src/slides/deckHtml.ts
@@ -19,7 +19,7 @@
 
 import * as cheerio from 'cheerio';
 import type { Cheerio, CheerioAPI } from 'cheerio';
-import type { Element } from 'domhandler';
+import type { AnyNode, Element } from 'domhandler';
 import { randomBytes } from 'node:crypto';
 import type { DeckConfig, DeckExtraCss, DeckJson, DeckSlide } from './deckTypes.ts';
 
@@ -737,6 +737,245 @@ export function normalizeSlideHtml(html: string): string {
   });
 
   return $.root().html() ?? '';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Browser-serialization-tolerant HTML equivalence (Phase 7.5 editor saves)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The editor-save merge compares the POSTED document (browser-serialized DOM)
+// against decks parsed from stored generator output. Browsers rewrite markup
+// they never semantically changed — the exact rewrites are pinned as captured
+// Chromium ground truth in __tests__/fixtures/browserSerialization.ts:
+//   - CSSOM style serialization: hex → rgb(r, g, b), rgb respacing, numeric
+//     noise trimmed (`.5px` → `0.5px`, `600.50px` → `600.5px`), url()/font
+//     quoting, `; ` joining + trailing `;`
+//   - valueless attrs gain `=""`, attr re-quoting, entity re-encoding,
+//     self-closing slashes dropped
+// The equivalence below treats exactly those rewrites as equal and NOTHING
+// else: tag structure and text-node data compare verbatim (the fragment
+// parser decodes entities, so `&quot;` vs `"` is the same text, never a
+// loosening), pre/code subtrees get no attribute loosening at all, and
+// genuinely different values (colors, numbers, class token order, code
+// content) still differ.
+
+/** Protects quoted strings / url() args during unquoted-css normalization. */
+const CSS_STRING_RE = /"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'/g;
+/** 3/6-digit hex colors only — 4/8-digit (alpha) forms stay verbatim. */
+const CSS_HEX_COLOR_RE = /#([0-9a-f]{6}|[0-9a-f]{3})(?![0-9a-f])/gi;
+const CSS_DECIMAL_RE = /(\d+\.\d*|\.\d+)/g;
+
+function hexToRgbTriplet(hex: string): string {
+  const full =
+    hex.length === 3
+      ? hex
+          .split('')
+          .map(c => c + c)
+          .join('')
+      : hex;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+/** `.5` → `0.5`, `600.50` → `600.5`, `-50.0` → `-50` (sign untouched). */
+function trimCssDecimal(digits: string): string {
+  let d = digits.startsWith('.') ? `0${digits}` : digits;
+  if (d.includes('.')) {
+    d = d.replace(/0+$/, '');
+    if (d.endsWith('.')) d = d.slice(0, -1);
+  }
+  return d;
+}
+
+/**
+ * Canonicalize one css declaration VALUE the way Chromium's CSSOM serializer
+ * would (fixture-pinned): quoted strings become double-quoted (content
+ * verbatim), unquoted url() args get quoted, whitespace/comma spacing
+ * collapses, 3/6-digit hex → rgb(r, g, b), decimal noise trimmed. Keyword
+ * case and everything inside quotes stay verbatim — deliberately strict.
+ */
+function canonicalCssValue(rawValue: string): string {
+  const protectedParts: string[] = [];
+  const protect = (part: string): string => {
+    protectedParts.push(part);
+    return `\u0000${protectedParts.length - 1}\u0000`;
+  };
+
+  // Quoted strings first: canonical double-quoted form, content verbatim.
+  let value = rawValue.replace(
+    CSS_STRING_RE,
+    (_m, dq: string | undefined, sq: string | undefined) => {
+      const content =
+        dq !== undefined ? dq : (sq as string).replace(/\\'/g, "'").replace(/"/g, '\\"');
+      return protect(`"${content}"`);
+    }
+  );
+  // Unquoted url() args (quoted ones are already placeholders): url(x) → url("x").
+  value = value.replace(
+    // eslint-disable-next-line no-control-regex -- \u0000 is the placeholder sentinel; parsed attr values can never contain NUL
+    /url\(\s*([^)\u0000]*?)\s*\)/gi,
+    (_m, arg: string) => `url(${protect(`"${arg}"`)})`
+  );
+
+  value = value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*/g, ', ')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .replace(CSS_HEX_COLOR_RE, (_m, hex: string) => hexToRgbTriplet(hex.toLowerCase()))
+    .replace(CSS_DECIMAL_RE, (_m, digits: string) => trimCssDecimal(digits));
+
+  // eslint-disable-next-line no-control-regex -- restoring the \u0000-delimited placeholders
+  return value.replace(/\u0000(\d+)\u0000/g, (_m, i: string) => protectedParts[Number(i)]);
+}
+
+/** Split a style attr on top-level `;` (quotes and parens respected). */
+function splitStyleDeclarations(style: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let depth = 0;
+  for (let i = 0; i < style.length; i++) {
+    const ch = style[i];
+    if (quote) {
+      current += ch;
+      if (ch === '\\' && i + 1 < style.length) {
+        current += style[++i];
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === ';' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim() !== '') parts.push(current);
+  return parts;
+}
+
+/**
+ * Canonical form of a style attr VALUE for equivalence: declarations parsed
+ * (property lowercased, value via canonicalCssValue), duplicates last-wins
+ * (browser behavior), compared order-insensitively (sorted), trailing `;`
+ * irrelevant by construction.
+ */
+function canonicalStyleAttr(style: string): string {
+  const decls = new Map<string, string>();
+  for (const raw of splitStyleDeclarations(style)) {
+    const idx = raw.indexOf(':');
+    if (idx === -1) {
+      const bare = raw.trim().toLowerCase();
+      if (bare) decls.set(bare, '');
+      continue;
+    }
+    const prop = raw.slice(0, idx).trim().toLowerCase();
+    if (!prop) continue;
+    decls.set(prop, canonicalCssValue(raw.slice(idx + 1)));
+  }
+  return [...decls.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([prop, val]) => `${prop}:${val}`)
+    .join(';');
+}
+
+/**
+ * Canonical form of one attribute value for browser-serialization-tolerant
+ * comparison: `style` via the CSSOM rules, `class` as its ordered token list
+ * with whitespace collapsed (token ORDER still matters), everything else
+ * verbatim (values are already entity-decoded by the parser; a valueless
+ * attr and `=""` are both the empty string).
+ */
+export function browserCanonicalAttrValue(name: string, value: string): string {
+  if (name === 'style') return canonicalStyleAttr(value);
+  if (name === 'class') return value.trim().split(/\s+/).filter(Boolean).join(' ');
+  return value;
+}
+
+function browserCanonicalNodeSig(node: AnyNode, verbatimAttrs: boolean): string {
+  if (node.type === 'text') {
+    // Parser-decoded data verbatim: entity re-encodings compare equal, any
+    // actual character change (including whitespace) does not.
+    return `T${JSON.stringify(node.data)}`;
+  }
+  if (node.type === 'comment') {
+    return `C${JSON.stringify(node.data)}`;
+  }
+  if (node.type === 'tag' || node.type === 'script' || node.type === 'style') {
+    const el = node as Element;
+    const name = el.tagName.toLowerCase();
+    // No attribute loosening anywhere inside pre/code — code content (and any
+    // markup riding in it) must never be loosened.
+    const childVerbatim = verbatimAttrs || name === 'pre' || name === 'code';
+    const attrs = Object.entries(el.attribs ?? {})
+      .map(([attrName, attrValue]): [string, string] => {
+        const lower = attrName.toLowerCase();
+        const raw = attrValue ?? '';
+        return [lower, verbatimAttrs ? raw : browserCanonicalAttrValue(lower, raw)];
+      })
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const children = (el.children as AnyNode[])
+      .map(child => browserCanonicalNodeSig(child, childVerbatim))
+      .join('');
+    return `<${name} ${JSON.stringify(attrs)}>${children}</${name}>`;
+  }
+  // Directives / CDATA / anything exotic: byte-strict.
+  return `O${JSON.stringify({ type: node.type, data: (node as { data?: string }).data ?? '' })}`;
+}
+
+const canonicalHtmlCache = new Map<string, string>();
+const CANONICAL_HTML_CACHE_MAX = 2000;
+
+/**
+ * Canonical signature of an html fragment under the browser-serialization
+ * equivalence. Two fragments are equivalent iff their signatures match —
+ * signature comparison is transitive, so merge decisions stay consistent
+ * across base/ours/theirs.
+ */
+export function browserCanonicalHtmlSig(html: string): string {
+  const cached = canonicalHtmlCache.get(html);
+  if (cached !== undefined) return cached;
+  let sig: string;
+  try {
+    const $ = cheerio.load(html, null, false);
+    sig = ($.root()[0].children as AnyNode[])
+      .map(child => browserCanonicalNodeSig(child, false))
+      .join('');
+  } catch {
+    // Unparseable → byte-strict (never loosen what we cannot model).
+    sig = `RAW${JSON.stringify(html)}`;
+  }
+  if (canonicalHtmlCache.size >= CANONICAL_HTML_CACHE_MAX) canonicalHtmlCache.clear();
+  canonicalHtmlCache.set(html, sig);
+  return sig;
+}
+
+/**
+ * True when two html/notes fragments differ only by browser serialization
+ * (DOM round-trip + CSSOM style re-serialization) — see the fixture file for
+ * the exact rewrites this absorbs. Conservative by design: any real content,
+ * structure, attribute, color, or numeric difference is NOT equivalent.
+ * null/undefined are equivalent only to each other (absent ≠ empty string).
+ */
+export function htmlEquivalentModuloBrowserSerialization(
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean {
+  if (a == null || b == null) return a == null && b == null;
+  if (a === b) return true;
+  return browserCanonicalHtmlSig(a) === browserCanonicalHtmlSig(b);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/services/src/slides/deckHtml.ts
+++ b/packages/services/src/slides/deckHtml.ts
@@ -358,8 +358,21 @@ function hasNotesClass(el: Element): boolean {
   return cls.split(/\s+/).includes('notes');
 }
 
+/**
+ * Reveal paints `visible` / `current-fragment` on `.fragment` descendants at
+ * runtime (as the presenter steps through fragments). They are never authored
+ * and must never persist — otherwise a merely-VIEWED slide's read-back html
+ * differs from its stored form and phantom-conflicts / phantom-diffs. Mirrors
+ * the client strips (deckOpsDiff cleanupContainer, RevealSlides
+ * getCurrentContent). `fragment` itself is authored content and stays.
+ */
+function stripFragmentRuntimeClasses($root: Cheerio<AnyNode>): void {
+  $root.find('.fragment').removeClass('visible').removeClass('current-fragment');
+}
+
 /** Strip runtime paint from a section element (plan §2 cruft list). */
 function stripRuntimeCruft($el: Cheerio<Element>): void {
+  stripFragmentRuntimeClasses($el);
   const cls = $el.attr('class');
   if (cls != null) {
     const kept = cls.split(/\s+/).filter(c => c !== '' && !CRUFT_CLASSES.has(c));
@@ -736,6 +749,9 @@ export function normalizeSlideHtml(html: string): string {
     }
   });
 
+  // Reveal fragment runtime paint (visible / current-fragment) never persists.
+  stripFragmentRuntimeClasses($.root());
+
   return $.root().html() ?? '';
 }
 
@@ -868,39 +884,57 @@ function splitStyleDeclarations(style: string): string[] {
 
 /**
  * Canonical form of a style attr VALUE for equivalence: declarations parsed
- * (property lowercased, value via canonicalCssValue), duplicates last-wins
- * (browser behavior), compared order-insensitively (sorted), trailing `;`
- * irrelevant by construction.
+ * (property lowercased, value via canonicalCssValue), trailing `;` irrelevant
+ * by construction.
+ *
+ * Declaration ORDER is PRESERVED — a browser DOM round-trip never reorders a
+ * style attr's declarations (captured Chromium ground truth in the fixtures),
+ * so two read-backs of untouched markup keep the same order, while a genuine
+ * shorthand/longhand reorder (`margin-top: 5px; margin: 10px` vs the reverse)
+ * changes the rendered result and MUST read as a difference. Sorting the
+ * declarations (the old behavior) masked exactly those semantic edits.
+ *
+ * An EXACT same-property repeat still collapses last-wins (the browser's own
+ * behavior), keeping the property at its first-seen position. Custom
+ * properties (`--x`) are stored verbatim by the browser — their value skips
+ * canonicalCssValue (no hex→rgb, no decimal trimming) and their name keeps its
+ * case.
  */
 function canonicalStyleAttr(style: string): string {
-  const decls = new Map<string, string>();
+  const order: string[] = [];
+  const values = new Map<string, string>();
+  const set = (prop: string, value: string): void => {
+    if (!values.has(prop)) order.push(prop);
+    values.set(prop, value);
+  };
   for (const raw of splitStyleDeclarations(style)) {
     const idx = raw.indexOf(':');
     if (idx === -1) {
       const bare = raw.trim().toLowerCase();
-      if (bare) decls.set(bare, '');
+      if (bare) set(bare, '');
       continue;
     }
-    const prop = raw.slice(0, idx).trim().toLowerCase();
-    if (!prop) continue;
-    decls.set(prop, canonicalCssValue(raw.slice(idx + 1)));
+    const rawProp = raw.slice(0, idx).trim();
+    if (!rawProp) continue;
+    const isCustom = rawProp.startsWith('--');
+    const prop = isCustom ? rawProp : rawProp.toLowerCase();
+    const value = isCustom ? raw.slice(idx + 1).trim() : canonicalCssValue(raw.slice(idx + 1));
+    set(prop, value);
   }
-  return [...decls.entries()]
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([prop, val]) => `${prop}:${val}`)
-    .join(';');
+  return order.map(prop => `${prop}:${values.get(prop)}`).join(';');
 }
 
 /**
  * Canonical form of one attribute value for browser-serialization-tolerant
- * comparison: `style` via the CSSOM rules, `class` as its ordered token list
- * with whitespace collapsed (token ORDER still matters), everything else
- * verbatim (values are already entity-decoded by the parser; a valueless
- * attr and `=""` are both the empty string).
+ * comparison: `style` via the CSSOM rules, everything else (including `class`)
+ * verbatim. Browsers preserve the class attribute string byte-for-byte on a
+ * DOM round-trip (fixture-pinned: leading/trailing and repeated whitespace all
+ * survive), so collapsing it would mask a real edit — compare it verbatim.
+ * Values are already entity-decoded by the parser; a valueless attr and `=""`
+ * are both the empty string.
  */
 export function browserCanonicalAttrValue(name: string, value: string): string {
   if (name === 'style') return canonicalStyleAttr(value);
-  if (name === 'class') return value.trim().split(/\s+/).filter(Boolean).join(' ');
   return value;
 }
 
@@ -976,113 +1010,4 @@ export function htmlEquivalentModuloBrowserSerialization(
   if (a == null || b == null) return a == null && b == null;
   if (a === b) return true;
   return browserCanonicalHtmlSig(a) === browserCanonicalHtmlSig(b);
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// diffDeckUnits — 3-way unit walk (powers §3b's structured conflict return)
-// ─────────────────────────────────────────────────────────────────────────────
-
-export interface DeckUnitConflict {
-  id: string;
-  /** Dotted position, '4' or '4.2' (position in ours, falling back to theirs/base). */
-  index: string;
-  /** The merge-base version of the unit; absent when the unit was added on both sides. */
-  base?: DeckSlide;
-  /** null = deleted/absent on that side. */
-  ours: DeckSlide | null;
-  theirs: DeckSlide | null;
-}
-
-export interface DeckUnitDiff {
-  /** Units changed on BOTH sides with differing results (deep-equal comparison). */
-  units: DeckUnitConflict[];
-  /** Present when both sides reordered the root sequence differently. */
-  orderConflict?: { base: string[]; ours: string[]; theirs: string[] };
-}
-
-interface FlatUnit {
-  unit: DeckSlide;
-  index: string;
-}
-
-function flattenUnits(deck: DeckJson): Map<string, FlatUnit> {
-  const map = new Map<string, FlatUnit>();
-  deck.slides.forEach((slide, i) => {
-    map.set(slide.id, { unit: slide, index: String(i + 1) });
-    slide.children?.forEach((child, j) => {
-      map.set(child.id, { unit: child, index: `${i + 1}.${j + 1}` });
-    });
-  });
-  return map;
-}
-
-/**
- * Comparable signature of a unit. Containers compare their own fields plus the
- * ORDER of their children (child ids) — child content changes are the child
- * unit's own diff. Attrs compared with sorted keys.
- */
-function unitSignature(entry: FlatUnit | undefined): string {
-  if (!entry) return ' absent';
-  const { unit } = entry;
-  const unitAttrs = unit.attrs ?? {};
-  const attrs = Object.keys(unitAttrs)
-    .sort()
-    .map(key => [key, unitAttrs[key]]);
-  return JSON.stringify({
-    html: unit.html ?? null,
-    notes: unit.notes ?? null,
-    hidden: unit.hidden ?? false,
-    attrs,
-    children: unit.children ? unit.children.map(c => c.id) : null,
-  });
-}
-
-/**
- * Report units changed on BOTH sides (base = merge-base, ours = main,
- * theirs = preview). Reports conflicts only — no auto-merge (Phase 7).
- */
-export function diffDeckUnits(base: DeckJson, ours: DeckJson, theirs: DeckJson): DeckUnitDiff {
-  const baseUnits = flattenUnits(base);
-  const ourUnits = flattenUnits(ours);
-  const theirUnits = flattenUnits(theirs);
-
-  const allIds = new Set<string>([...baseUnits.keys(), ...ourUnits.keys(), ...theirUnits.keys()]);
-  const units: DeckUnitConflict[] = [];
-
-  for (const id of allIds) {
-    const b = baseUnits.get(id);
-    const o = ourUnits.get(id);
-    const t = theirUnits.get(id);
-    const bSig = unitSignature(b);
-    const oSig = unitSignature(o);
-    const tSig = unitSignature(t);
-
-    const changedOurs = oSig !== bSig;
-    const changedTheirs = tSig !== bSig;
-    if (changedOurs && changedTheirs && oSig !== tSig) {
-      const index = o?.index ?? t?.index ?? b?.index ?? '';
-      const conflict: DeckUnitConflict = {
-        id,
-        index,
-        ours: o?.unit ?? null,
-        theirs: t?.unit ?? null,
-      };
-      if (b) conflict.base = b.unit;
-      units.push(conflict);
-    }
-  }
-
-  // Root order sequence compared as id arrays.
-  const baseOrder = base.slides.map(s => s.id);
-  const ourOrder = ours.slides.map(s => s.id);
-  const theirOrder = theirs.slides.map(s => s.id);
-  const sameAsBaseOurs = JSON.stringify(ourOrder) === JSON.stringify(baseOrder);
-  const sameAsBaseTheirs = JSON.stringify(theirOrder) === JSON.stringify(baseOrder);
-  const oursVsTheirs = JSON.stringify(ourOrder) === JSON.stringify(theirOrder);
-
-  const result: DeckUnitDiff = { units };
-  if (!sameAsBaseOurs && !sameAsBaseTheirs && !oursVsTheirs) {
-    result.orderConflict = { base: baseOrder, ours: ourOrder, theirs: theirOrder };
-  }
-  return result;
 }

--- a/packages/services/src/slides/deckMerge.ts
+++ b/packages/services/src/slides/deckMerge.ts
@@ -1,0 +1,596 @@
+/**
+ * deckMerge.ts — semantic 3-way merge of deck slides (content-tools plan §3b,
+ * Phase 7).
+ *
+ * Pure functions only: no service imports, no network, no database. Extends
+ * the Level-1 3-way walk (deckHtml diffDeckUnits) into a true auto-merge:
+ * non-conflicted units of a stale preview are rebased onto fresh main, so an
+ * accept only ever stops on genuine same-unit collisions.
+ *
+ * Merge semantics (a SLIDE is the unit — fields merge atomically per unit,
+ * never html-vs-notes within one slide):
+ * - changed on one side only → take that side
+ * - changed identically on both sides → take either
+ * - changed differently on both sides → conflict
+ * - added on one side → keep (position from that side's order)
+ * - deleted on one side + unchanged on the other → the delete wins
+ *   (a move on the other side does NOT protect from the delete — only edits do)
+ * - deleted on one side + edited on the other → conflict (null = deleted side)
+ * - order: the top-level id sequence and each stack's child sequence are
+ *   3-way merged (one side reordered → take it; both reordered differently →
+ *   order conflict); stack membership moves are sequence ops
+ * - containers (vertical stacks) recurse one level: their own fields merge as
+ *   a unit, child slides merge as units, the child sequence merges as a scope.
+ *   Delete-vs-edit tests for a container consider its whole subtree; a
+ *   container conflict that carries subtrees (delete-vs-edit / structure
+ *   change) absorbs its children — no nested conflicts.
+ * - deck-level meta (theme, codeTheme, dark pairs, config, customCss,
+ *   extraCss) merges per-field; a field changed differently on both sides
+ *   raises the single `__meta__` conflict carrying the double-changed fields.
+ *
+ * Conflict ids are addressable by the chooser / resolutions:
+ *   <slideId>              unit conflict (content / delete_vs_edit / both_added / placement)
+ *   __order__              top-level order conflict (id-array sides)
+ *   __order__:<stackId>    one stack's child-order conflict (id-array sides)
+ *   __meta__               deck-level field conflict (partial-meta sides)
+ * Resolving a unit conflict takes the chosen side's version of the unit
+ * verbatim (its content, its placement, and — for subtree-carrying conflicts —
+ * its children). Resolving an order conflict picks that side's sequence as the
+ * backbone (the other side's additions are still woven in).
+ */
+
+import { canonicalJson, mergeIdSequence3, type MergeChoice } from '../content/merge3.ts';
+import type { DeckJson, DeckSlide } from './deckTypes.ts';
+
+export { PreviewResolutionError, indexResolutions } from '../content/merge3.ts';
+export type { MergeChoice, MergeResolution } from '../content/merge3.ts';
+
+// ─── Conflict types ──────────────────────────────────────────────────────────
+
+/** Sentinel conflict id for the top-level order; stacks use `__order__:<id>`. */
+export const DECK_ORDER_CONFLICT_ID = '__order__';
+/** Sentinel conflict id for deck-level meta (theme/config/css) collisions. */
+export const DECK_META_CONFLICT_ID = '__meta__';
+
+/** Conflict-id for a stack's child-order conflict. */
+export function deckChildOrderConflictId(containerId: string): string {
+  return `${DECK_ORDER_CONFLICT_ID}:${containerId}`;
+}
+
+/** The deck-level fields merged per-field (everything but `version`/`slides`). */
+export type DeckMeta = Pick<
+  DeckJson,
+  'theme' | 'codeTheme' | 'themeDark' | 'codeThemeDark' | 'config' | 'customCss' | 'extraCss'
+>;
+
+const META_FIELDS = [
+  'theme',
+  'codeTheme',
+  'themeDark',
+  'codeThemeDark',
+  'config',
+  'customCss',
+  'extraCss',
+] as const;
+
+/** A slide changed incompatibly on both sides. null = deleted/absent on that side. */
+export interface DeckUnitMergeConflict {
+  id: string;
+  /** Dotted position, '4' or '4.2' (position in ours, falling back to theirs/base). */
+  index: string;
+  reason: 'content' | 'delete_vs_edit' | 'both_added' | 'placement';
+  base?: DeckSlide;
+  ours: DeckSlide | null;
+  theirs: DeckSlide | null;
+}
+
+/** Both sides reordered a sequence differently (top level or one stack). */
+export interface DeckOrderMergeConflict {
+  /** `__order__` (top level) or `__order__:<stackId>`. */
+  id: string;
+  /** '' for the top level; the stack's dotted position otherwise. */
+  index: string;
+  reason: 'order' | 'child_order';
+  base: string[];
+  ours: string[];
+  theirs: string[];
+}
+
+/** Both sides changed the same deck-level field(s) differently. */
+export interface DeckMetaMergeConflict {
+  id: typeof DECK_META_CONFLICT_ID;
+  index: '';
+  reason: 'meta';
+  /** Only the double-changed fields appear. */
+  base: Partial<DeckMeta>;
+  ours: Partial<DeckMeta>;
+  theirs: Partial<DeckMeta>;
+}
+
+export type DeckMergeConflict =
+  | DeckUnitMergeConflict
+  | DeckOrderMergeConflict
+  | DeckMetaMergeConflict;
+
+export interface DeckMergeResult {
+  /**
+   * The merged deck. Fully authoritative when `conflicts` is empty; while
+   * conflicts are pending, conflicted units carry the theirs side (or ours
+   * when theirs deleted) provisionally.
+   */
+  merged: DeckJson;
+  conflicts: DeckMergeConflict[];
+  /** Unit-level changes (edits/adds/deletes) that merged without a conflict. */
+  autoMerged: number;
+}
+
+// ─── Indexing / signatures ───────────────────────────────────────────────────
+
+const ROOT = '__root__';
+
+interface UnitEntry {
+  slide: DeckSlide;
+  parent: string; // ROOT or container id
+  index: string; // dotted position
+}
+
+interface SideIndex {
+  units: Map<string, UnitEntry>;
+  rootOrder: string[];
+  childOrder: Map<string, string[]>;
+}
+
+function indexDeck(deck: DeckJson): SideIndex {
+  const units = new Map<string, UnitEntry>();
+  const rootOrder: string[] = [];
+  const childOrder = new Map<string, string[]>();
+  deck.slides.forEach((slide, i) => {
+    rootOrder.push(slide.id);
+    units.set(slide.id, { slide, parent: ROOT, index: String(i + 1) });
+    if (slide.children && slide.children.length > 0) {
+      childOrder.set(
+        slide.id,
+        slide.children.map(child => child.id)
+      );
+      slide.children.forEach((child, j) => {
+        units.set(child.id, { slide: child, parent: slide.id, index: `${i + 1}.${j + 1}` });
+      });
+    }
+  });
+  return { units, rootOrder, childOrder };
+}
+
+const isContainer = (slide: DeckSlide | undefined): boolean => (slide?.children?.length ?? 0) > 0;
+
+/** A unit's own fields — children are the child units' / child scope's business. */
+function contentSig(slide: DeckSlide | undefined): string {
+  if (!slide) return 'absent';
+  const unitAttrs = slide.attrs ?? {};
+  const attrs = Object.keys(unitAttrs)
+    .sort()
+    .map(key => [key, unitAttrs[key]]);
+  return JSON.stringify({
+    html: slide.html ?? null,
+    notes: slide.notes ?? null,
+    hidden: slide.hidden ?? false,
+    attrs,
+  });
+}
+
+/** The whole subtree — used for delete tests on containers and atomic units. */
+function subtreeSig(slide: DeckSlide | undefined): string {
+  if (!slide) return 'absent';
+  const children = (slide.children ?? []).map(child => `${child.id}:${contentSig(child)}`);
+  return `${contentSig(slide)}|${children.join(',')}`;
+}
+
+/** Display copy of a container for a fields-only conflict: children stripped. */
+function sansChildren(slide: DeckSlide): DeckSlide {
+  const copy = structuredClone(slide);
+  delete copy.children;
+  return copy;
+}
+
+// ─── merge3Units ─────────────────────────────────────────────────────────────
+
+type Side = 'base' | 'ours' | 'theirs';
+
+interface UnitFate {
+  kind: 'drop' | 'keep' | 'conflict';
+  /** Which side's fields the merged unit carries ('keep', or provisional for 'conflict'). */
+  source?: Side;
+  /** Carry the source side's subtree verbatim (atomic / delete-vs-edit containers). */
+  verbatimSubtree?: boolean;
+  /** This fate contributed to the autoMerged counter (undone if it conflicts later). */
+  countedAuto?: boolean;
+  conflict?: DeckUnitMergeConflict;
+}
+
+/**
+ * Semantic 3-way merge of deck slides: base = merge-base, ours = main,
+ * theirs = preview. Pure. Zero conflicts ⇒ `merged` is fully auto-merged.
+ *
+ * @param opts.resolutions - chooser decisions keyed by conflict id; a resolved
+ *   conflict is applied (chosen side wins) and not reported.
+ */
+export function merge3Units(
+  base: DeckJson,
+  ours: DeckJson,
+  theirs: DeckJson,
+  opts: { resolutions?: Record<string, MergeChoice> } = {}
+): DeckMergeResult {
+  const resolutions = opts.resolutions ?? {};
+  const sides: Record<Side, SideIndex> = {
+    base: indexDeck(base),
+    ours: indexDeck(ours),
+    theirs: indexDeck(theirs),
+  };
+
+  const orderConflicts: DeckOrderMergeConflict[] = [];
+  let autoMerged = 0;
+
+  // Deterministic id walk: theirs order first, then ours, then base.
+  const seen = new Set<string>();
+  const allIds = [
+    ...sides.theirs.units.keys(),
+    ...sides.ours.units.keys(),
+    ...sides.base.units.keys(),
+  ].filter(id => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  const entryOf = (side: Side, id: string) => sides[side].units.get(id);
+  const positionOf = (id: string): string =>
+    entryOf('ours', id)?.index ?? entryOf('theirs', id)?.index ?? entryOf('base', id)?.index ?? '';
+
+  // ── Phase A: unit fates (content + membership) ──
+  const fates = new Map<string, UnitFate>();
+  /** Ids that ride verbatim inside a subtree-carrying unit — not independent units. */
+  const consumed = new Set<string>();
+
+  /** Child ids of `id` (across all sides) confined to `id` everywhere they exist. */
+  const confinedChildIds = (id: string): string[] => {
+    const childIds = new Set<string>();
+    for (const side of ['base', 'ours', 'theirs'] as const) {
+      for (const cid of entryOf(side, id)?.slide.children?.map(c => c.id) ?? []) {
+        childIds.add(cid);
+      }
+    }
+    return [...childIds].filter(cid =>
+      (['base', 'ours', 'theirs'] as const).every(side => {
+        const entry = entryOf(side, cid);
+        return !entry || entry.parent === id;
+      })
+    );
+  };
+
+  const makeConflict = (
+    id: string,
+    reason: DeckUnitMergeConflict['reason'],
+    oursSlide: DeckSlide | null,
+    theirsSlide: DeckSlide | null,
+    baseSlide: DeckSlide | undefined,
+    verbatimSubtree: boolean
+  ): UnitFate => {
+    const strip = (slide: DeckSlide | null): DeckSlide | null =>
+      slide == null
+        ? null
+        : verbatimSubtree
+          ? structuredClone(slide)
+          : isContainer(slide)
+            ? sansChildren(slide)
+            : structuredClone(slide);
+    const conflict: DeckUnitMergeConflict = {
+      id,
+      index: positionOf(id),
+      reason,
+      ours: strip(oursSlide),
+      theirs: strip(theirsSlide),
+    };
+    if (baseSlide) {
+      conflict.base = (
+        verbatimSubtree || !isContainer(baseSlide)
+          ? structuredClone(baseSlide)
+          : sansChildren(baseSlide)
+      ) as DeckSlide;
+    }
+    return {
+      kind: 'conflict',
+      source: theirsSlide != null ? 'theirs' : 'ours',
+      verbatimSubtree,
+      conflict,
+    };
+  };
+
+  for (const id of allIds) {
+    const b = entryOf('base', id);
+    const o = entryOf('ours', id);
+    const t = entryOf('theirs', id);
+
+    const presentFlags = [b, o, t].filter((e): e is UnitEntry => e != null);
+    const containerFlags = presentFlags.map(e => isContainer(e.slide));
+    const atomic = containerFlags.some(flag => flag !== containerFlags[0]);
+    const anyContainer = containerFlags.some(Boolean);
+
+    // Content comparisons: atomic units compare (and ride) whole subtrees;
+    // delete tests for containers consider the whole subtree.
+    const cSig = (e: UnitEntry | undefined) =>
+      atomic ? subtreeSig(e?.slide) : contentSig(e?.slide);
+    const dSig = (e: UnitEntry | undefined) =>
+      anyContainer || atomic ? subtreeSig(e?.slide) : contentSig(e?.slide);
+
+    const autoKeep = (source: Side): UnitFate => {
+      autoMerged++;
+      return { kind: 'keep', source, verbatimSubtree: atomic, countedAuto: true };
+    };
+    const autoDrop = (): UnitFate => {
+      autoMerged++;
+      return { kind: 'drop', countedAuto: true };
+    };
+
+    let fate: UnitFate;
+    if (b && o && t) {
+      const oursChanged = cSig(o) !== cSig(b);
+      const theirsChanged = cSig(t) !== cSig(b);
+      if (!oursChanged && !theirsChanged) {
+        fate = { kind: 'keep', source: 'base', verbatimSubtree: atomic };
+      } else if (oursChanged && !theirsChanged) {
+        fate = autoKeep('ours');
+      } else if (!oursChanged && theirsChanged) {
+        fate = autoKeep('theirs');
+      } else if (cSig(o) === cSig(t)) {
+        fate = autoKeep('ours'); // identical edits on both sides
+      } else {
+        fate = makeConflict(id, 'content', o.slide, t.slide, b.slide, atomic);
+      }
+    } else if (b && !o && !t) {
+      fate = autoDrop(); // deleted on both sides
+    } else if (b && !o && t) {
+      // Deleted on ours (main).
+      if (dSig(t) === dSig(b)) {
+        fate = autoDrop(); // the delete wins over an unchanged (or merely moved) unit
+      } else {
+        fate = makeConflict(id, 'delete_vs_edit', null, t.slide, b.slide, anyContainer || atomic);
+      }
+    } else if (b && o && !t) {
+      // Deleted on theirs (the preview).
+      if (dSig(o) === dSig(b)) {
+        fate = autoDrop();
+      } else {
+        fate = makeConflict(id, 'delete_vs_edit', o.slide, null, b.slide, anyContainer || atomic);
+      }
+    } else if (!b && o && !t) {
+      fate = autoKeep('ours'); // added on main
+    } else if (!b && !o && t) {
+      fate = autoKeep('theirs'); // added on the preview
+    } else {
+      // Added on both sides with the same id.
+      if (subtreeSig(o!.slide) === subtreeSig(t!.slide)) {
+        fate = autoKeep('ours');
+      } else {
+        fate = makeConflict(id, 'both_added', o!.slide, t!.slide, undefined, true);
+      }
+    }
+
+    // Apply a chooser resolution to a unit conflict. The verbatimSubtree flag
+    // survives the resolution (drops included) so the consumed sweep below
+    // still binds the unit's confined children to its fate.
+    const choice = resolutions[id];
+    if (fate.kind === 'conflict' && choice) {
+      const chosen = choice === 'ours' ? fate.conflict!.ours : fate.conflict!.theirs;
+      fate =
+        chosen == null
+          ? { kind: 'drop', verbatimSubtree: fate.verbatimSubtree }
+          : { kind: 'keep', source: choice, verbatimSubtree: fate.verbatimSubtree };
+    }
+
+    fates.set(id, fate);
+  }
+
+  // Subtree-carrying units (atomic structure changes, delete-vs-edit
+  // containers, both-added) absorb their confined children: no independent
+  // fates, no nested conflicts — the children's fate is the unit's fate.
+  for (const [id, fate] of fates) {
+    if (fate.verbatimSubtree !== true) continue;
+    for (const cid of confinedChildIds(id)) {
+      if (cid === id) continue;
+      consumed.add(cid);
+    }
+  }
+  for (const cid of consumed) fates.delete(cid);
+
+  // ── Phase B: placement (parent) per surviving unit ──
+  const parents = new Map<string, string>();
+  for (const [id, fate] of fates) {
+    if (fate.kind === 'drop') continue;
+
+    const pb = entryOf('base', id)?.parent;
+    const po = entryOf('ours', id)?.parent;
+    const pt = entryOf('theirs', id)?.parent;
+
+    if (fate.kind === 'conflict') {
+      // Pending conflicts sit at the provisional side's position.
+      parents.set(id, (fate.source === 'ours' ? po : pt) ?? pb ?? ROOT);
+      continue;
+    }
+
+    // Moved to different parents on each side → placement conflict
+    // (containers never nest, so this only happens to leaves). Detected
+    // before the resolution shortcut so a resolved placement conflict takes
+    // the chosen side's parent.
+    const bothMovedDifferently = po != null && pt != null && po !== pt && po !== pb && pt !== pb;
+    const choice = resolutions[id];
+
+    if (bothMovedDifferently) {
+      if (fate.countedAuto) autoMerged--; // its content change no longer counts as clean
+      if (choice) {
+        // Resolved placement conflict: the chosen side's unit verbatim —
+        // content AND position.
+        fates.set(id, { kind: 'keep', source: choice });
+        parents.set(id, (choice === 'ours' ? po : pt)!);
+      } else {
+        const o = entryOf('ours', id)!;
+        const t = entryOf('theirs', id)!;
+        const b = entryOf('base', id);
+        fates.set(id, makeConflict(id, 'placement', o.slide, t.slide, b?.slide, false));
+        parents.set(id, pt!);
+      }
+      continue;
+    }
+
+    if (choice) {
+      // A resolved conflict (content or delete-vs-edit) takes the chosen
+      // side's placement too.
+      parents.set(id, (choice === 'ours' ? po : pt) ?? po ?? pt ?? pb ?? ROOT);
+      continue;
+    }
+
+    if (po != null && pt != null) {
+      // po === pt → unmoved/moved identically; po === pb → theirs moved it;
+      // pt === pb → ours moved it.
+      parents.set(id, po === pt ? po : po === pb ? pt : po);
+    } else {
+      parents.set(id, po ?? pt ?? pb ?? ROOT);
+    }
+  }
+
+  // ── Phase C: sequence merges per scope (root + surviving stacks) ──
+  const survivors = new Set(
+    [...fates.entries()].filter(([, fate]) => fate.kind !== 'drop').map(([id]) => id)
+  );
+
+  // A surviving unit is a merged-doc container when any side has it as a
+  // container (stable, since atomic units ride verbatim and skip scopes).
+  const scopeContainers = [...survivors].filter(id => {
+    const fate = fates.get(id)!;
+    if (fate.verbatimSubtree) return false;
+    return (['base', 'ours', 'theirs'] as const).some(side =>
+      isContainer(entryOf(side, id)?.slide)
+    );
+  });
+
+  const scopeOrders = new Map<string, string[]>();
+  const scopes: string[] = [ROOT, ...scopeContainers];
+  for (const scope of scopes) {
+    const seqOf = (side: Side): string[] =>
+      scope === ROOT ? sides[side].rootOrder : (sides[side].childOrder.get(scope) ?? []);
+    const members = new Set([...survivors].filter(id => id !== scope && parents.get(id) === scope));
+    // A member whose parent no longer survives falls back to the root scope
+    // (rare: its container was resolved away) — appended at the end.
+    if (scope === ROOT) {
+      for (const id of survivors) {
+        const parent = parents.get(id);
+        if (parent !== ROOT && parent != null && !survivors.has(parent) && !members.has(id)) {
+          members.add(id);
+        }
+      }
+    }
+
+    const conflictId = scope === ROOT ? DECK_ORDER_CONFLICT_ID : deckChildOrderConflictId(scope);
+    const result = mergeIdSequence3(
+      seqOf('base'),
+      seqOf('ours'),
+      seqOf('theirs'),
+      members,
+      resolutions[conflictId]
+    );
+    const order = result.conflict ? result.provisional : result.order;
+    if (result.conflict) {
+      orderConflicts.push({
+        id: conflictId,
+        index: scope === ROOT ? '' : positionOf(scope),
+        reason: scope === ROOT ? 'order' : 'child_order',
+        base: result.base,
+        ours: result.ours,
+        theirs: result.theirs,
+      });
+    }
+    // Safety net: a member that appears in no side sequence for this scope
+    // (its container was resolved away) still must land somewhere — append.
+    for (const id of members) {
+      if (!order.includes(id)) order.push(id);
+    }
+    scopeOrders.set(scope, order);
+  }
+
+  // Unit conflicts in walk order, then order sentinels, then __meta__ (below).
+  const conflicts: DeckMergeConflict[] = [];
+  for (const id of allIds) {
+    const fate = fates.get(id);
+    if (fate?.kind === 'conflict' && fate.conflict) conflicts.push(fate.conflict);
+  }
+  conflicts.push(...orderConflicts);
+
+  // ── Phase D: assemble the merged deck ──
+  const buildUnit = (id: string): DeckSlide => {
+    const fate = fates.get(id)!;
+    const source: Side = fate.source ?? 'base';
+    const src = entryOf(source, id)?.slide ?? entryOf('base', id)!.slide;
+    const clone = structuredClone(src);
+    if (fate.verbatimSubtree) {
+      // Subtree rides verbatim, minus children that live independently.
+      if (clone.children) {
+        clone.children = clone.children.filter(child => consumed.has(child.id));
+        if (clone.children.length === 0) delete clone.children;
+      }
+      return clone;
+    }
+    delete clone.children;
+    const childOrder = scopeOrders.get(id);
+    if (childOrder && childOrder.length > 0) {
+      clone.children = childOrder.map(buildUnit);
+    }
+    return clone;
+  };
+
+  const rootOrder = scopeOrders.get(ROOT) ?? [];
+  const mergedSlides = rootOrder.map(buildUnit);
+
+  // ── Meta: per-field 3-way ──
+  const merged: DeckJson = {
+    version: 1,
+    theme: 'white',
+    codeTheme: 'github',
+    slides: mergedSlides,
+  };
+  const metaConflict: DeckMetaMergeConflict = {
+    id: DECK_META_CONFLICT_ID,
+    index: '',
+    reason: 'meta',
+    base: {},
+    ours: {},
+    theirs: {},
+  };
+  const metaChoice = resolutions[DECK_META_CONFLICT_ID];
+  for (const field of META_FIELDS) {
+    const bVal = base[field];
+    const oVal = ours[field];
+    const tVal = theirs[field];
+    const oursChanged = canonicalJson(oVal) !== canonicalJson(bVal);
+    const theirsChanged = canonicalJson(tVal) !== canonicalJson(bVal);
+    let value: DeckMeta[typeof field];
+    if (!oursChanged && !theirsChanged) value = bVal as DeckMeta[typeof field];
+    else if (oursChanged && !theirsChanged) value = oVal as DeckMeta[typeof field];
+    else if (!oursChanged && theirsChanged) value = tVal as DeckMeta[typeof field];
+    else if (canonicalJson(oVal) === canonicalJson(tVal)) value = oVal as DeckMeta[typeof field];
+    else if (metaChoice) {
+      value = (metaChoice === 'ours' ? oVal : tVal) as DeckMeta[typeof field];
+    } else {
+      // Double-changed → the single __meta__ conflict; theirs provisionally.
+      (metaConflict.base as Record<string, unknown>)[field] = bVal;
+      (metaConflict.ours as Record<string, unknown>)[field] = oVal;
+      (metaConflict.theirs as Record<string, unknown>)[field] = tVal;
+      value = tVal as DeckMeta[typeof field];
+    }
+    if (value !== undefined) {
+      (merged as unknown as Record<string, unknown>)[field] = structuredClone(value);
+    }
+  }
+  if (Object.keys(metaConflict.ours).length > 0) {
+    conflicts.push(metaConflict);
+  }
+
+  return { merged, conflicts, autoMerged };
+}

--- a/packages/services/src/slides/deckMerge.ts
+++ b/packages/services/src/slides/deckMerge.ts
@@ -9,6 +9,10 @@
  *
  * Merge semantics (a SLIDE is the unit — fields merge atomically per unit,
  * never html-vs-notes within one slide):
+ * - "changed" means changed MODULO BROWSER SERIALIZATION for html/notes/attrs
+ *   (deckHtml htmlEquivalentModuloBrowserSerialization): the editor's theirs
+ *   side is a browser DOM read-back, and browsers rewrite styled markup the
+ *   user never touched — those rewrites must not read as edits
  * - changed on one side only → take that side
  * - changed identically on both sides → take either
  * - changed differently on both sides → conflict
@@ -51,6 +55,7 @@ import {
   mergeIdSequence3,
   type MergeChoice,
 } from '../content/merge3.ts';
+import { browserCanonicalAttrValue, browserCanonicalHtmlSig } from './deckHtml.ts';
 import type { DeckJson, DeckSlide } from './deckTypes.ts';
 
 export { PreviewResolutionError, indexResolutions } from '../content/merge3.ts';
@@ -194,16 +199,30 @@ function indexDeck(deck: DeckJson): SideIndex {
 
 const isContainer = (slide: DeckSlide | undefined): boolean => (slide?.children?.length ?? 0) > 0;
 
-/** A unit's own fields — children are the child units' / child scope's business. */
+/**
+ * A unit's own fields — children are the child units' / child scope's business.
+ *
+ * html/notes/attrs enter the signature in browser-serialization-CANONICAL form
+ * (deckHtml browserCanonicalHtmlSig / browserCanonicalAttrValue): the editor's
+ * `theirs` side is a browser-serialized DOM read-back, and browsers rewrite
+ * markup the user never touched (CSSOM style re-serialization hex→rgb,
+ * numeric noise, valueless-attr `=""`, entity re-encoding — ground truth in
+ * __tests__/fixtures/browserSerialization.ts). Without canonicalization every
+ * styled slide reads as "edited in both versions" the moment two tabs race
+ * (phantom conflicts); with it, only genuine content differences count, in
+ * BOTH decisions that share this signature — unchanged detection (side vs
+ * base) and identical-edit detection (ours vs theirs). Signature comparison
+ * is transitive, so the three pairwise decisions can never disagree.
+ */
 function contentSig(slide: DeckSlide | undefined): string {
   if (!slide) return 'absent';
   const unitAttrs = slide.attrs ?? {};
   const attrs = Object.keys(unitAttrs)
     .sort()
-    .map(key => [key, unitAttrs[key]]);
+    .map(key => [key, browserCanonicalAttrValue(key, unitAttrs[key])]);
   return JSON.stringify({
-    html: slide.html ?? null,
-    notes: slide.notes ?? null,
+    html: slide.html != null ? browserCanonicalHtmlSig(slide.html) : null,
+    notes: slide.notes != null ? browserCanonicalHtmlSig(slide.notes) : null,
     hidden: slide.hidden ?? false,
     attrs,
   });

--- a/packages/services/src/slides/deckMerge.ts
+++ b/packages/services/src/slides/deckMerge.ts
@@ -2,17 +2,17 @@
  * deckMerge.ts — semantic 3-way merge of deck slides (content-tools plan §3b,
  * Phase 7).
  *
- * Pure functions only: no service imports, no network, no database. Extends
- * the Level-1 3-way walk (deckHtml diffDeckUnits) into a true auto-merge:
- * non-conflicted units of a stale preview are rebased onto fresh main, so an
- * accept only ever stops on genuine same-unit collisions.
+ * Pure functions only: no service imports, no network, no database. This is
+ * the live 3-way auto-merge (merge3Units): non-conflicted units of a stale
+ * preview are rebased onto fresh main, so an accept only ever stops on genuine
+ * same-unit collisions.
  *
  * Merge semantics (a SLIDE is the unit — fields merge atomically per unit,
  * never html-vs-notes within one slide):
  * - "changed" means changed MODULO BROWSER SERIALIZATION for html/notes/attrs
- *   (deckHtml htmlEquivalentModuloBrowserSerialization): the editor's theirs
- *   side is a browser DOM read-back, and browsers rewrite styled markup the
- *   user never touched — those rewrites must not read as edits
+ *   (deckHtml browserCanonicalHtmlSig / browserCanonicalAttrValue): the
+ *   editor's theirs side is a browser DOM read-back, and browsers rewrite
+ *   styled markup the user never touched — those rewrites must not read as edits
  * - changed on one side only → take that side
  * - changed identically on both sides → take either
  * - changed differently on both sides → conflict

--- a/packages/services/src/slides/deckMerge.ts
+++ b/packages/services/src/slides/deckMerge.ts
@@ -24,6 +24,12 @@
  *   Delete-vs-edit tests for a container consider its whole subtree; a
  *   container conflict that carries subtrees (delete-vs-edit / structure
  *   change) absorbs its children — no nested conflicts.
+ * - the container view is CONFINED: a child that escaped to a different
+ *   parent on some side (a cross-scope move) merges independently and is
+ *   excluded from its old container's structure detection, comparisons, and
+ *   conflict cards. A move-out on one side + a content edit on the other
+ *   auto-merges (the edit follows the moved slide); a card can never show a
+ *   child whose fate the chooser does not control.
  * - deck-level meta (theme, codeTheme, dark pairs, config, customCss,
  *   extraCss) merges per-field; a field changed differently on both sides
  *   raises the single `__meta__` conflict carrying the double-changed fields.
@@ -39,7 +45,12 @@
  * backbone (the other side's additions are still woven in).
  */
 
-import { canonicalJson, mergeIdSequence3, type MergeChoice } from '../content/merge3.ts';
+import {
+  canonicalJson,
+  dedupeMergedTreeIds,
+  mergeIdSequence3,
+  type MergeChoice,
+} from '../content/merge3.ts';
 import type { DeckJson, DeckSlide } from './deckTypes.ts';
 
 export { PreviewResolutionError, indexResolutions } from '../content/merge3.ts';
@@ -177,10 +188,18 @@ function contentSig(slide: DeckSlide | undefined): string {
   });
 }
 
-/** The whole subtree — used for delete tests on containers and atomic units. */
-function subtreeSig(slide: DeckSlide | undefined): string {
+/**
+ * The unit's subtree restricted to its CONFINED children — used for delete
+ * tests on containers and for atomic (structure-change) units. Children that
+ * escaped to another parent on some side are excluded: they merge
+ * independently, so they must not drag their old container into a conflict
+ * (or pad out its cards) on their behalf.
+ */
+function subtreeSig(slide: DeckSlide | undefined, confined?: ReadonlySet<string>): string {
   if (!slide) return 'absent';
-  const children = (slide.children ?? []).map(child => `${child.id}:${contentSig(child)}`);
+  const children = (slide.children ?? [])
+    .filter(child => !confined || confined.has(child.id))
+    .map(child => `${child.id}:${contentSig(child)}`);
   return `${contentSig(slide)}|${children.join(',')}`;
 }
 
@@ -188,6 +207,22 @@ function subtreeSig(slide: DeckSlide | undefined): string {
 function sansChildren(slide: DeckSlide): DeckSlide {
   const copy = structuredClone(slide);
   delete copy.children;
+  return copy;
+}
+
+/**
+ * Verbatim card/subtree copy restricted to confined children. What a
+ * subtree-carrying conflict card shows must be EXACTLY what resolving to that
+ * side commits — escaped children have independent fates, so they are
+ * stripped from the card just as buildUnit strips them from the resolved
+ * subtree.
+ */
+function cloneConfined(slide: DeckSlide, confined: ReadonlySet<string>): DeckSlide {
+  const copy = structuredClone(slide);
+  if (copy.children) {
+    copy.children = copy.children.filter(child => confined.has(child.id));
+    if (copy.children.length === 0) delete copy.children;
+  }
   return copy;
 }
 
@@ -249,22 +284,28 @@ export function merge3Units(
   const fates = new Map<string, UnitFate>();
   /** Ids that ride verbatim inside a subtree-carrying unit — not independent units. */
   const consumed = new Set<string>();
+  /** Ids that were (initially) conflicts — resolved or not (dedupe preference). */
+  const conflictedIds = new Set<string>();
 
-  /** Child ids of `id` (across all sides) confined to `id` everywhere they exist. */
-  const confinedChildIds = (id: string): string[] => {
+  /** Every child id of `id` across all sides. */
+  const childIdsOf = (id: string): Set<string> => {
     const childIds = new Set<string>();
     for (const side of ['base', 'ours', 'theirs'] as const) {
       for (const cid of entryOf(side, id)?.slide.children?.map(c => c.id) ?? []) {
         childIds.add(cid);
       }
     }
-    return [...childIds].filter(cid =>
+    return childIds;
+  };
+
+  /** Child ids of `id` (across all sides) confined to `id` everywhere they exist. */
+  const confinedChildIds = (id: string): string[] =>
+    [...childIdsOf(id)].filter(cid =>
       (['base', 'ours', 'theirs'] as const).every(side => {
         const entry = entryOf(side, cid);
         return !entry || entry.parent === id;
       })
     );
-  };
 
   const makeConflict = (
     id: string,
@@ -272,13 +313,14 @@ export function merge3Units(
     oursSlide: DeckSlide | null,
     theirsSlide: DeckSlide | null,
     baseSlide: DeckSlide | undefined,
-    verbatimSubtree: boolean
+    verbatimSubtree: boolean,
+    confinedSet: ReadonlySet<string>
   ): UnitFate => {
     const strip = (slide: DeckSlide | null): DeckSlide | null =>
       slide == null
         ? null
         : verbatimSubtree
-          ? structuredClone(slide)
+          ? cloneConfined(slide, confinedSet)
           : isContainer(slide)
             ? sansChildren(slide)
             : structuredClone(slide);
@@ -290,11 +332,7 @@ export function merge3Units(
       theirs: strip(theirsSlide),
     };
     if (baseSlide) {
-      conflict.base = (
-        verbatimSubtree || !isContainer(baseSlide)
-          ? structuredClone(baseSlide)
-          : sansChildren(baseSlide)
-      ) as DeckSlide;
+      conflict.base = strip(baseSlide) as DeckSlide;
     }
     return {
       kind: 'conflict',
@@ -309,17 +347,26 @@ export function merge3Units(
     const o = entryOf('ours', id);
     const t = entryOf('theirs', id);
 
+    // Confined view (cross-scope moves): a child that escaped to a different
+    // parent on some side is merged independently — it is invisible to this
+    // unit's structure detection, its comparisons, and its conflict cards.
+    // Without this, a moved-out child both rides inside the container's
+    // conflict subtree AND gets its own fate, so resolving either side of the
+    // container yields the same (card-contradicting) document.
+    const confinedSet = new Set(confinedChildIds(id));
     const presentFlags = [b, o, t].filter((e): e is UnitEntry => e != null);
-    const containerFlags = presentFlags.map(e => isContainer(e.slide));
+    const containerFlags = presentFlags.map(e =>
+      (e.slide.children ?? []).some(child => confinedSet.has(child.id))
+    );
     const atomic = containerFlags.some(flag => flag !== containerFlags[0]);
     const anyContainer = containerFlags.some(Boolean);
 
-    // Content comparisons: atomic units compare (and ride) whole subtrees;
-    // delete tests for containers consider the whole subtree.
+    // Content comparisons: atomic units compare (and ride) their confined
+    // subtrees; delete tests for containers consider the confined subtree.
     const cSig = (e: UnitEntry | undefined) =>
-      atomic ? subtreeSig(e?.slide) : contentSig(e?.slide);
+      atomic ? subtreeSig(e?.slide, confinedSet) : contentSig(e?.slide);
     const dSig = (e: UnitEntry | undefined) =>
-      anyContainer || atomic ? subtreeSig(e?.slide) : contentSig(e?.slide);
+      anyContainer || atomic ? subtreeSig(e?.slide, confinedSet) : contentSig(e?.slide);
 
     const autoKeep = (source: Side): UnitFate => {
       autoMerged++;
@@ -343,7 +390,7 @@ export function merge3Units(
       } else if (cSig(o) === cSig(t)) {
         fate = autoKeep('ours'); // identical edits on both sides
       } else {
-        fate = makeConflict(id, 'content', o.slide, t.slide, b.slide, atomic);
+        fate = makeConflict(id, 'content', o.slide, t.slide, b.slide, atomic, confinedSet);
       }
     } else if (b && !o && !t) {
       fate = autoDrop(); // deleted on both sides
@@ -352,14 +399,30 @@ export function merge3Units(
       if (dSig(t) === dSig(b)) {
         fate = autoDrop(); // the delete wins over an unchanged (or merely moved) unit
       } else {
-        fate = makeConflict(id, 'delete_vs_edit', null, t.slide, b.slide, anyContainer || atomic);
+        fate = makeConflict(
+          id,
+          'delete_vs_edit',
+          null,
+          t.slide,
+          b.slide,
+          anyContainer || atomic,
+          confinedSet
+        );
       }
     } else if (b && o && !t) {
       // Deleted on theirs (the preview).
       if (dSig(o) === dSig(b)) {
         fate = autoDrop();
       } else {
-        fate = makeConflict(id, 'delete_vs_edit', o.slide, null, b.slide, anyContainer || atomic);
+        fate = makeConflict(
+          id,
+          'delete_vs_edit',
+          o.slide,
+          null,
+          b.slide,
+          anyContainer || atomic,
+          confinedSet
+        );
       }
     } else if (!b && o && !t) {
       fate = autoKeep('ours'); // added on main
@@ -367,16 +430,17 @@ export function merge3Units(
       fate = autoKeep('theirs'); // added on the preview
     } else {
       // Added on both sides with the same id.
-      if (subtreeSig(o!.slide) === subtreeSig(t!.slide)) {
+      if (subtreeSig(o!.slide, confinedSet) === subtreeSig(t!.slide, confinedSet)) {
         fate = autoKeep('ours');
       } else {
-        fate = makeConflict(id, 'both_added', o!.slide, t!.slide, undefined, true);
+        fate = makeConflict(id, 'both_added', o!.slide, t!.slide, undefined, true, confinedSet);
       }
     }
 
     // Apply a chooser resolution to a unit conflict. The verbatimSubtree flag
     // survives the resolution (drops included) so the consumed sweep below
     // still binds the unit's confined children to its fate.
+    if (fate.kind === 'conflict') conflictedIds.add(id);
     const choice = resolutions[id];
     if (fate.kind === 'conflict' && choice) {
       const chosen = choice === 'ours' ? fate.conflict!.ours : fate.conflict!.theirs;
@@ -425,6 +489,7 @@ export function merge3Units(
 
     if (bothMovedDifferently) {
       if (fate.countedAuto) autoMerged--; // its content change no longer counts as clean
+      conflictedIds.add(id);
       if (choice) {
         // Resolved placement conflict: the chosen side's unit verbatim —
         // content AND position.
@@ -434,7 +499,9 @@ export function merge3Units(
         const o = entryOf('ours', id)!;
         const t = entryOf('theirs', id)!;
         const b = entryOf('base', id);
-        fates.set(id, makeConflict(id, 'placement', o.slide, t.slide, b?.slide, false));
+        // Placement conflicts only happen to leaves (containers never nest),
+        // so the confined set is irrelevant to the fields-only cards.
+        fates.set(id, makeConflict(id, 'placement', o.slide, t.slide, b?.slide, false, new Set()));
         parents.set(id, pt!);
       }
       continue;
@@ -472,17 +539,19 @@ export function merge3Units(
   });
 
   const scopeOrders = new Map<string, string[]>();
+  const scopeSet = new Set(scopeContainers);
   const scopes: string[] = [ROOT, ...scopeContainers];
   for (const scope of scopes) {
     const seqOf = (side: Side): string[] =>
       scope === ROOT ? sides[side].rootOrder : (sides[side].childOrder.get(scope) ?? []);
     const members = new Set([...survivors].filter(id => id !== scope && parents.get(id) === scope));
-    // A member whose parent no longer survives falls back to the root scope
-    // (rare: its container was resolved away) — appended at the end.
+    // A member whose parent is not an actual scope falls back to the root
+    // scope, appended at the end (rare: its container was resolved away, or
+    // rides verbatim and cannot admit independent children).
     if (scope === ROOT) {
       for (const id of survivors) {
         const parent = parents.get(id);
-        if (parent !== ROOT && parent != null && !survivors.has(parent) && !members.has(id)) {
+        if (parent !== ROOT && parent != null && !scopeSet.has(parent) && !members.has(id)) {
           members.add(id);
         }
       }
@@ -547,6 +616,21 @@ export function merge3Units(
 
   const rootOrder = scopeOrders.get(ROOT) ?? [];
   const mergedSlides = rootOrder.map(buildUnit);
+
+  // Final safety assertion: no id may appear twice in the assembled document.
+  // Unreachable through the confined-view machinery above, but kept as a
+  // cheap last line of defense (a duplicate committed to main corrupts the
+  // deck for every future merge). Preference goes to the copy inside a
+  // conflict unit's subtree — that copy is what the chooser card showed.
+  const duplicateIds = dedupeMergedTreeIds(mergedSlides, conflictedIds, {
+    dropEmptyChildren: true,
+  });
+  if (duplicateIds.length > 0) {
+    console.warn(
+      `[deckMerge] merged deck carried duplicate slide id(s) ${duplicateIds.join(', ')} — ` +
+        'kept the conflict-resolution copy and dropped the stale one(s)'
+    );
+  }
 
   // ── Meta: per-field 3-way ──
   const merged: DeckJson = {

--- a/packages/services/src/slides/deckMerge.ts
+++ b/packages/services/src/slides/deckMerge.ts
@@ -123,6 +123,27 @@ export type DeckMergeConflict =
   | DeckOrderMergeConflict
   | DeckMetaMergeConflict;
 
+/**
+ * Split an engine conflict list into the service report shape: the top-level
+ * `__order__` sentinel is pulled out as `orderConflict`; everything else
+ * (unit conflicts, per-stack `__order__:<id>` sentinels, `__meta__`) stays in
+ * `units`. Shared by the accept flow (deckPreview.service) and the editor
+ * save-merge flow (deckSaveMerge.service).
+ */
+export function splitDeckConflicts(conflicts: DeckMergeConflict[]): {
+  units: DeckMergeConflict[];
+  orderConflict?: { base: string[]; ours: string[]; theirs: string[] };
+} {
+  const root = conflicts.find(
+    (conflict): conflict is DeckOrderMergeConflict => conflict.id === DECK_ORDER_CONFLICT_ID
+  );
+  const units = conflicts.filter(conflict => conflict.id !== DECK_ORDER_CONFLICT_ID);
+  return {
+    units,
+    ...(root ? { orderConflict: { base: root.base, ours: root.ours, theirs: root.theirs } } : {}),
+  };
+}
+
 export interface DeckMergeResult {
   /**
    * The merged deck. Fully authoritative when `conflicts` is empty; while

--- a/packages/services/src/slides/deckOps.ts
+++ b/packages/services/src/slides/deckOps.ts
@@ -1,0 +1,466 @@
+/**
+ * deckOps.ts — the granular deck op engine (update / insert / move / delete /
+ * reorder / set_theme), extracted VERBATIM from apps/mcp/src/tools/deck.ts so
+ * the editor save path (deckSaveMerge saveDeckFromOps) and the MCP deck_apply
+ * tool share one implementation.
+ *
+ * Pure: no service imports, no network, no database. Every incoming html/notes
+ * fragment rounds through normalizeSlideHtml (deckHtml), so op-built documents
+ * carry the SAME canonical form as editor whole-document saves.
+ *
+ * The zod schemas here are the single source of truth for the op vocabulary —
+ * deck_apply's inputSchema and the slides editor action both validate against
+ * them.
+ *
+ * NOTE for the MCP suite: deck.ts imports this module via the
+ * `@classmoji/services/slides/ops` subpath (NOT `…/slides`), so the deck tool
+ * tests' module mock of `@classmoji/services/slides` leaves the real engine in
+ * place — op behavior in those tests is genuine, exactly as it was when the
+ * engine lived inline in deck.ts.
+ */
+
+import { z } from 'zod';
+import { BUILTIN_THEMES, mintSlideId, normalizeSlideHtml } from './deckHtml.ts';
+import type { DeckJson, DeckSlide } from './deckTypes.ts';
+
+// Re-exported so op-engine callers can catch the SAME class instance the
+// engine's normalizeSlideHtml throws (module-identity-safe instanceof).
+export { SlideHtmlError } from './deckHtml.ts';
+
+// ─── Op schemas ──────────────────────────────────────────────────────────────
+
+const attrsSchema = z.record(z.string());
+
+const positionSchema = z.union([
+  z.object({ after: z.string().min(1) }).strict(),
+  z.object({ at: z.enum(['start', 'end']) }).strict(),
+]);
+
+const newChildSlideSchema = z
+  .object({
+    html: z.string().max(200_000),
+    notes: z.string().max(50_000).optional(),
+    hidden: z.boolean().optional(),
+    attrs: attrsSchema.optional(),
+  })
+  .strict();
+
+const newSlideSchema = z
+  .object({
+    html: z.string().max(200_000).optional(),
+    notes: z.string().max(50_000).optional(),
+    hidden: z.boolean().optional(),
+    attrs: attrsSchema.optional(),
+    children: z
+      .array(newChildSlideSchema)
+      .min(1)
+      .max(20)
+      .optional()
+      .describe(
+        'Create a vertical stack: the slide becomes a container holding these child slides ' +
+          '(one nesting level — children cannot have children). Omit html on the container.'
+      ),
+  })
+  .strict()
+  .refine(s => (s.children?.length ? s.html === undefined : typeof s.html === 'string'), {
+    message:
+      'A new slide needs either html (regular slide) or children (vertical stack container) — ' +
+      'stack containers carry no html of their own',
+  });
+
+export const deckOpSchema = z.discriminatedUnion('op', [
+  z.object({
+    op: z.literal('update'),
+    id: z.string().min(1),
+    html: z.string().max(200_000).optional(),
+    notes: z
+      .string()
+      .max(50_000)
+      .nullable()
+      .optional()
+      .describe('Speaker notes HTML; null or empty string removes the notes'),
+    hidden: z.boolean().optional(),
+    attrs: attrsSchema
+      .nullable()
+      .optional()
+      .describe('Full replacement attrs record (null or {} clears all extra attributes)'),
+  }),
+  z.object({
+    op: z.literal('insert'),
+    slides: z.array(newSlideSchema).min(1).max(20),
+    position: positionSchema,
+  }),
+  z.object({
+    op: z.literal('move'),
+    id: z.string().min(1),
+    position: positionSchema,
+  }),
+  z.object({
+    op: z.literal('delete'),
+    id: z.string().min(1),
+  }),
+  z.object({
+    op: z.literal('reorder'),
+    order: z
+      .array(z.string().min(1))
+      .min(1)
+      .describe('The complete new top-level slide order (a permutation of current top-level ids)'),
+  }),
+  z.object({
+    op: z.literal('set_theme'),
+    theme: z.string().max(120).optional(),
+    code_theme: z
+      .string()
+      .max(50)
+      .regex(/^[\w.-]+$/)
+      .optional(),
+  }),
+]);
+
+export type DeckOp = z.infer<typeof deckOpSchema>;
+
+/**
+ * Payload schema for the slides editor's ops-shaped save (a JSON array of
+ * ops). More generous than deck_apply's 25-op cap — an editor session can
+ * touch many slides between saves.
+ */
+export const deckOpsPayloadSchema = z.array(deckOpSchema).min(1).max(400);
+
+// ─── Errors / lookup helpers ─────────────────────────────────────────────────
+
+/** Typed error for deck op failures (unknown ids, bad positions, bad values). */
+export class DeckOpError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeckOpError';
+  }
+}
+
+/** Find a slide by id (top level or one stack level down, per Reveal). */
+export function findSlide(
+  slides: DeckSlide[],
+  id: string
+): { parent: DeckSlide[]; index: number; slide: DeckSlide } | null {
+  for (let i = 0; i < slides.length; i++) {
+    if (slides[i].id === id) return { parent: slides, index: i, slide: slides[i] };
+    const children = slides[i].children;
+    if (children) {
+      for (let j = 0; j < children.length; j++) {
+        if (children[j].id === id) return { parent: children, index: j, slide: children[j] };
+      }
+    }
+  }
+  return null;
+}
+
+/** All slide ids in a deck (stack children included). */
+export function collectIds(slides: DeckSlide[], out = new Set<string>()): Set<string> {
+  for (const slide of slides) {
+    out.add(slide.id);
+    if (slide.children) collectIds(slide.children, out);
+  }
+  return out;
+}
+
+function mustFindSlide(slides: DeckSlide[], id: string, opName: string) {
+  const found = findSlide(slides, id);
+  if (!found) {
+    throw new DeckOpError(`Unknown slide id '${id}' in ${opName} op`);
+  }
+  return found;
+}
+
+function insertSlidesAt(
+  deck: DeckJson,
+  newSlides: DeckSlide[],
+  position: { after: string } | { at: 'start' | 'end' },
+  opName: string
+): void {
+  if ('after' in position) {
+    const target = mustFindSlide(deck.slides, position.after, opName);
+    target.parent.splice(target.index + 1, 0, ...newSlides);
+  } else if (position.at === 'start') {
+    deck.slides.unshift(...newSlides);
+  } else {
+    deck.slides.push(...newSlides);
+  }
+}
+
+/** shared:/custom: theme names: single path segment, no separators, no '..'. */
+const THEME_NAME_RE = /^[\w.-]+$/;
+
+/** Validate a set_theme theme value: builtin, 'custom:<file>.css', or 'shared:<name>'. */
+function assertValidTheme(theme: string): void {
+  if (theme.startsWith('shared:') || theme.startsWith('custom:')) {
+    // The suffix lands in repo paths (.slidesthemes/<name>/…) and generated
+    // link hrefs — refuse anything that could traverse ('/', '..').
+    const name = theme.slice(theme.indexOf(':') + 1);
+    if (!THEME_NAME_RE.test(name) || name.includes('..')) {
+      throw new DeckOpError(
+        `Invalid theme name '${theme}' — shared:/custom: names may only contain letters, ` +
+          "digits, '_', '-', and '.' (no path separators, no '..')"
+      );
+    }
+    return;
+  }
+  if ((BUILTIN_THEMES as readonly string[]).includes(theme)) return;
+  throw new DeckOpError(
+    `Unknown theme '${theme}' — use a builtin (${BUILTIN_THEMES.join(', ')}), ` +
+      "'custom:<file>.css', or 'shared:<name>'"
+  );
+}
+
+// ─── applyDeckOps ────────────────────────────────────────────────────────────
+
+export interface ApplyDeckOpsOptions {
+  /**
+   * The starter deck's recognized customCss (slideService.STARTER_CUSTOM_CSS).
+   * When provided, an explicit set_theme change drops it — mirroring the
+   * editor's buildEditorDeck merge rules. Callers that never route set_theme
+   * ops (the editor save path) may omit it.
+   */
+  starterCustomCss?: string;
+}
+
+/**
+ * Apply a sequence of deck operations. Pure — returns a new deck, input
+ * untouched. Ops are applied sequentially, so later ops see earlier ops'
+ * effects. Ids are matched at the top level and one stack level down.
+ * EVERY incoming html/notes fragment rounds through normalizeSlideHtml
+ * (SlideHtmlError propagates — stray <section> tags are rejected).
+ *
+ * @throws {DeckOpError} unknown ids/anchors, invalid positions or values.
+ * @throws {SlideHtmlError} html/notes fragments carrying <section> tags.
+ */
+export function applyDeckOps(
+  currentDeck: DeckJson,
+  ops: DeckOp[],
+  opts: ApplyDeckOpsOptions = {}
+): { deck: DeckJson; applied: Array<Record<string, unknown>> } {
+  const deck = structuredClone(currentDeck) as DeckJson;
+  const applied: Array<Record<string, unknown>> = [];
+
+  for (const op of ops) {
+    switch (op.op) {
+      case 'update': {
+        if (
+          op.html === undefined &&
+          op.notes === undefined &&
+          op.hidden === undefined &&
+          op.attrs === undefined
+        ) {
+          throw new DeckOpError(
+            `update op for '${op.id}' must set at least one of html, notes, hidden, attrs`
+          );
+        }
+        const target = mustFindSlide(deck.slides, op.id, 'update');
+        if (op.html !== undefined && target.slide.children?.length) {
+          throw new DeckOpError(
+            `Slide '${op.id}' is a vertical stack container and has no html — target its children`
+          );
+        }
+        if (op.html !== undefined) {
+          target.slide.html = normalizeSlideHtml(op.html);
+        }
+        if (op.notes !== undefined) {
+          if (op.notes == null || op.notes === '') {
+            delete target.slide.notes;
+          } else {
+            target.slide.notes = normalizeSlideHtml(op.notes);
+          }
+        }
+        if (op.hidden !== undefined) {
+          if (op.hidden) target.slide.hidden = true;
+          else delete target.slide.hidden;
+        }
+        if (op.attrs !== undefined) {
+          if (op.attrs == null || Object.keys(op.attrs).length === 0) {
+            delete target.slide.attrs;
+          } else {
+            target.slide.attrs = { ...op.attrs };
+          }
+        }
+        applied.push({ op: 'update', id: op.id });
+        break;
+      }
+
+      case 'insert': {
+        // Runtime mirrors of the schema rules (defense in depth — the test
+        // harness and any validation-bypassing client hit the handler direct).
+        for (const spec of op.slides) {
+          const hasChildren = Boolean(spec.children?.length);
+          if (hasChildren && spec.html !== undefined) {
+            throw new DeckOpError(
+              'A vertical stack container cannot carry html — put content on its children'
+            );
+          }
+          if (!hasChildren && typeof spec.html !== 'string') {
+            throw new DeckOpError(
+              'A new slide needs html (regular slide) or children (vertical stack container)'
+            );
+          }
+          if (
+            hasChildren &&
+            (spec.children ?? []).some(c => (c as { children?: unknown[] }).children?.length)
+          ) {
+            throw new DeckOpError(
+              'Nested stacks are not supported — child slides cannot have children'
+            );
+          }
+        }
+        // A stack container can never land inside another stack (Reveal
+        // supports one nesting level) — mirror the move-op guard BEFORE any
+        // building so the rejection is targeted.
+        if (op.slides.some(s => s.children?.length) && 'after' in op.position) {
+          const target = mustFindSlide(deck.slides, op.position.after, 'insert');
+          if (target.parent !== deck.slides) {
+            throw new DeckOpError(
+              `Cannot insert a vertical stack after '${op.position.after}' — that position is ` +
+                'inside another stack (nested stacks are not supported)'
+            );
+          }
+        }
+        const used = collectIds(deck.slides);
+        const mint = (): string => {
+          let id = mintSlideId();
+          while (used.has(id)) id = mintSlideId(); // re-mint collisions
+          used.add(id);
+          return id;
+        };
+        const buildLeaf = (spec: {
+          html: string;
+          notes?: string;
+          hidden?: boolean;
+          attrs?: Record<string, string>;
+        }): DeckSlide => {
+          const leaf: DeckSlide = { id: mint(), html: normalizeSlideHtml(spec.html) };
+          if (spec.notes != null && spec.notes !== '') {
+            leaf.notes = normalizeSlideHtml(spec.notes);
+          }
+          if (spec.hidden) leaf.hidden = true;
+          if (spec.attrs && Object.keys(spec.attrs).length > 0) leaf.attrs = { ...spec.attrs };
+          return leaf;
+        };
+        const childIdsByContainer: Record<string, string[]> = {};
+        const inserted: DeckSlide[] = op.slides.map(spec => {
+          if (spec.children?.length) {
+            const container: DeckSlide = { id: mint() };
+            container.children = spec.children.map(buildLeaf);
+            if (spec.notes != null && spec.notes !== '') {
+              container.notes = normalizeSlideHtml(spec.notes);
+            }
+            if (spec.hidden) container.hidden = true;
+            if (spec.attrs && Object.keys(spec.attrs).length > 0) {
+              container.attrs = { ...spec.attrs };
+            }
+            childIdsByContainer[container.id] = container.children.map(c => c.id);
+            return container;
+          }
+          // The schema refine guarantees html is present on non-containers.
+          return buildLeaf(
+            spec as {
+              html: string;
+              notes?: string;
+              hidden?: boolean;
+              attrs?: Record<string, string>;
+            }
+          );
+        });
+        insertSlidesAt(deck, inserted, op.position, 'insert');
+        const entry: Record<string, unknown> = {
+          op: 'insert',
+          count: inserted.length,
+          ids: inserted.map(s => s.id),
+        };
+        if (Object.keys(childIdsByContainer).length > 0) entry.children = childIdsByContainer;
+        applied.push(entry);
+        break;
+      }
+
+      case 'move': {
+        if ('after' in op.position && op.position.after === op.id) {
+          throw new DeckOpError(`Cannot move slide '${op.id}' relative to itself`);
+        }
+        const source = mustFindSlide(deck.slides, op.id, 'move');
+        // Reveal supports one level of nesting: a stack container can never
+        // land inside another container. Checked BEFORE the splice so the
+        // rejection is targeted (not a generic unknown-id error).
+        if (source.slide.children?.length && 'after' in op.position) {
+          const target = mustFindSlide(deck.slides, op.position.after, 'move');
+          if (target.parent !== deck.slides) {
+            throw new DeckOpError(
+              `Cannot move slide '${op.id}' after '${op.position.after}' — '${op.id}' is a ` +
+                'vertical stack container and that position is inside another stack ' +
+                '(nested stacks are not supported)'
+            );
+          }
+        }
+        const [moved] = source.parent.splice(source.index, 1);
+        insertSlidesAt(deck, [moved], op.position, 'move');
+        applied.push({ op: 'move', id: op.id });
+        break;
+      }
+
+      case 'delete': {
+        const target = mustFindSlide(deck.slides, op.id, 'delete');
+        if (target.parent === deck.slides && deck.slides.length === 1) {
+          throw new DeckOpError('A deck must keep at least one slide — cannot delete the last one');
+        }
+        target.parent.splice(target.index, 1);
+        applied.push({ op: 'delete', id: op.id });
+        break;
+      }
+
+      case 'reorder': {
+        const currentIds = deck.slides.map(s => s.id);
+        const sameLength = op.order.length === currentIds.length;
+        const currentSet = new Set(currentIds);
+        const isPermutation =
+          sameLength &&
+          new Set(op.order).size === op.order.length &&
+          op.order.every(id => currentSet.has(id));
+        if (!isPermutation) {
+          throw new DeckOpError(
+            'reorder order must be a permutation of the current top-level slide ids ' +
+              `(current: ${currentIds.join(', ')})`
+          );
+        }
+        const byId = new Map(deck.slides.map(s => [s.id, s]));
+        deck.slides = op.order.flatMap(id => {
+          const found = byId.get(id);
+          return found ? [found] : []; // unreachable — permutation verified above
+        });
+        applied.push({ op: 'reorder', count: op.order.length });
+        break;
+      }
+
+      case 'set_theme': {
+        if (op.theme === undefined && op.code_theme === undefined) {
+          throw new DeckOpError('set_theme op must set theme and/or code_theme');
+        }
+        if (op.theme !== undefined && op.theme !== deck.theme) {
+          assertValidTheme(op.theme);
+          deck.theme = op.theme;
+          // Mirror the editor's merge rules: an explicit theme change clears
+          // the paired dark theme and drops starter-recognized customCss.
+          delete deck.themeDark;
+          if (opts.starterCustomCss !== undefined && deck.customCss === opts.starterCustomCss) {
+            delete deck.customCss;
+          }
+        }
+        if (op.code_theme !== undefined && op.code_theme !== deck.codeTheme) {
+          deck.codeTheme = op.code_theme;
+          delete deck.codeThemeDark;
+        }
+        applied.push({
+          op: 'set_theme',
+          ...(op.theme !== undefined ? { theme: op.theme } : {}),
+          ...(op.code_theme !== undefined ? { code_theme: op.code_theme } : {}),
+        });
+        break;
+      }
+    }
+  }
+
+  return { deck, applied };
+}

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -36,7 +36,7 @@ import {
   saveDeck,
   type SlideContentTarget,
 } from './slideContent.service.ts';
-import type { DeckJson } from './deckTypes.ts';
+import type { DeckJson, DeckSlide } from './deckTypes.ts';
 
 const THEMES_FOLDER = '.slidesthemes';
 
@@ -159,11 +159,40 @@ export type AcceptDeckPreviewResult =
       units: DeckMergeConflict[];
       /** Present when both sides reordered the root slide sequence differently (conflict id `__order__`). */
       order_conflict?: { base: string[]; ours: string[]; theirs: string[] };
+      /**
+       * Lightweight render of every slide referenced by an order / child-order
+       * (and placement) conflict, keyed by slide id — lets the chooser draw the
+       * two orderings as visual filmstrips instead of raw id lists. In a pure
+       * ordering conflict a slide's CONTENT is identical on both sides, so it is
+       * rendered ONCE here and shown in both orderings. Absent when no ordering
+       * conflict is present. See DeckUnitPreview for the per-slide shape.
+       */
+      unit_previews?: Record<string, DeckUnitPreview>;
       /** Changes the semantic layer can merge without a decision. */
       auto_merged: number;
       ours_sha: string | null;
       theirs_sha: string | null;
     };
+
+/**
+ * A slide as the order-conflict filmstrip renders it (built from the ours deck,
+ * falling back to theirs for ids only present there).
+ */
+export interface DeckUnitPreview {
+  /** Dotted position in the source deck ('4' or '4.2'). */
+  index: string;
+  /** First heading / text, ≤60 chars (empty when the slide carries no text). */
+  title: string;
+  /**
+   * Renderable slide html (stack containers: children joined like the chooser's
+   * SlideFrame). OMITTED for slides whose html exceeds ~50KB — the card falls
+   * back to the index + title so the payload never balloons.
+   */
+  html?: string;
+}
+
+/** Slides whose rendered html exceeds this drop `html` (title-only fallback). */
+const UNIT_PREVIEW_HTML_CAP = 50 * 1024;
 
 /** Result of resolveDeckPreviewConflicts: the resolved merge committed to main. */
 export interface ResolveDeckPreviewResult {
@@ -557,6 +586,81 @@ function baseDeckUnavailable(): PreviewResolutionError {
   );
 }
 
+/** Renderable html for one slide side: its own html, or a stack's children
+ * joined with the same dashed separator the chooser's SlideFrame uses. */
+function deckPreviewHtml(slide: DeckSlide): string {
+  if (typeof slide.html === 'string' && slide.html.trim()) return slide.html;
+  if (Array.isArray(slide.children) && slide.children.length > 0) {
+    return slide.children
+      .map(child => (typeof child?.html === 'string' ? child.html : ''))
+      .filter(Boolean)
+      .join('\n<hr style="border:none;border-top:1px dashed #bbb;margin:12px 0">\n');
+  }
+  return '';
+}
+
+/** First heading (else first text), tags stripped, ≤60 chars. */
+function deckPreviewTitle(html: string): string {
+  if (!html) return '';
+  const heading = html.match(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i)?.[1] ?? html;
+  const text = heading
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
+}
+
+/** Index a deck's slides AND their stack children by id → { slide, dotted index }. */
+function indexDeckUnits(...decks: DeckJson[]): Map<string, { slide: DeckSlide; index: string }> {
+  const map = new Map<string, { slide: DeckSlide; index: string }>();
+  for (const deck of decks) {
+    deck.slides.forEach((slide, i) => {
+      if (slide?.id && !map.has(slide.id)) map.set(slide.id, { slide, index: String(i + 1) });
+      slide?.children?.forEach((child, j) => {
+        if (child?.id && !map.has(child.id))
+          map.set(child.id, { slide: child, index: `${i + 1}.${j + 1}` });
+      });
+    });
+  }
+  return map;
+}
+
+/**
+ * Build the `unit_previews` map for an order/child-order/placement conflict
+ * report: every slide id those conflicts reference, rendered ONCE from the ours
+ * deck (falling back to theirs for ids only present there). Returns undefined
+ * when no ordering/placement conflict is present so the field stays absent.
+ */
+function buildDeckUnitPreviews(
+  conflicts: DeckMergeConflict[],
+  oursDeck: DeckJson,
+  theirsDeck: DeckJson
+): Record<string, DeckUnitPreview> | undefined {
+  const ids = new Set<string>();
+  for (const conflict of conflicts) {
+    if (conflict.reason === 'order' || conflict.reason === 'child_order') {
+      for (const list of [conflict.ours, conflict.theirs, conflict.base]) {
+        if (Array.isArray(list)) for (const id of list) if (typeof id === 'string') ids.add(id);
+      }
+    } else if (conflict.reason === 'placement') {
+      ids.add(conflict.id);
+    }
+  }
+  if (ids.size === 0) return undefined;
+
+  const index = indexDeckUnits(oursDeck, theirsDeck);
+  const previews: Record<string, DeckUnitPreview> = {};
+  for (const id of ids) {
+    const entry = index.get(id);
+    if (!entry) continue;
+    const html = deckPreviewHtml(entry.slide);
+    const preview: DeckUnitPreview = { index: entry.index, title: deckPreviewTitle(html) };
+    if (html && html.length <= UNIT_PREVIEW_HTML_CAP) preview.html = html;
+    previews[id] = preview;
+  }
+  return Object.keys(previews).length > 0 ? previews : undefined;
+}
+
 /** The accept path taken when the git merge reports a conflict. */
 async function acceptDeckSemanticFallback(
   slide: SlideContentTarget,
@@ -573,11 +677,17 @@ async function acceptDeckSemanticFallback(
 
   const report = (merge: ReturnType<typeof merge3Units>): AcceptDeckPreviewResult => {
     const { units, orderConflict } = splitDeckConflicts(merge.conflicts);
+    const unitPreviews = buildDeckUnitPreviews(
+      merge.conflicts,
+      parseDeckForDiff(ours?.content),
+      theirsDeck
+    );
     return {
       merged: false,
       conflict: true,
       units,
       ...(orderConflict ? { order_conflict: orderConflict } : {}),
+      ...(unitPreviews ? { unit_previews: unitPreviews } : {}),
       auto_merged: merge.autoMerged,
       ours_sha: ours?.sha ?? null,
       theirs_sha: theirs?.sha ?? null,

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -484,6 +484,13 @@ async function commitSemanticDeckMerge(
     ...(themeUrls ? { themeUrls } : {}),
   });
 
+  // TOCTOU note: this guard is a compare-THEN-delete — a stacking apply can
+  // still land on the branch between the getMeta read and the deleteBranch
+  // call below, and would be discarded with the branch. Accepted: GitHub's
+  // refs DELETE has no precondition (no CAS delete), so the window cannot be
+  // closed API-side; the guard shrinks it from the whole merge duration to
+  // one request round-trip, and an apply racing an in-flight accept has no
+  // ordering guarantee either way.
   let previewKept = false;
   let reason: string | undefined;
   try {
@@ -517,6 +524,19 @@ async function commitSemanticDeckMerge(
   return { sha: saved.sha, ...(previewKept ? { preview_kept: true, reason } : {}) };
 }
 
+/**
+ * Typed refusal for the main-file-deleted degenerate: without main's
+ * deck.json there is no sha to CAS the commit on, so committing would be an
+ * unguarded write over whatever deleted it.
+ */
+function mainDeckMissing(): PreviewResolutionError {
+  return new PreviewResolutionError(
+    "Main's deck.json was deleted while this preview was pending — discard the preview " +
+      'or re-apply it as a fresh deck',
+    'MAIN_CONTENT_MISSING'
+  );
+}
+
 /** The accept path taken when the git merge reports a conflict. */
 async function acceptDeckSemanticFallback(
   slide: SlideContentTarget,
@@ -542,11 +562,13 @@ async function acceptDeckSemanticFallback(
   };
 
   for (let attempt = 0; attempt < 2; attempt++) {
-    const merge = merge3Units(baseDeck, parseDeckForDiff(ours?.content), theirsDeck);
-    // Without main's deck.json sha there is nothing to CAS the commit on —
-    // report instead of writing (degenerate: a git conflict implies both
-    // sides changed deck.json, so ours should always exist).
-    if (merge.conflicts.length > 0 || !ours?.sha) {
+    // Main's deck.json vanished (deleted while the preview was pending):
+    // never commit without a CAS precondition, and never return an empty
+    // conflict report the caller cannot act on — refuse with a typed error.
+    if (!ours?.sha) throw mainDeckMissing();
+
+    const merge = merge3Units(baseDeck, parseDeckForDiff(ours.content), theirsDeck);
+    if (merge.conflicts.length > 0) {
       return report(merge);
     }
     try {
@@ -587,15 +609,30 @@ async function acceptDeckSemanticFallback(
  * the resolved merge to main exactly like a semantic accept (saveDeck: CAS +
  * artifact regeneration), and deletes the branch.
  *
+ * @param options.expectedOursSha - pin the resolution to the conflict report
+ *   the choices were made against (the report's `ours_sha`). When provided
+ *   and main's deck.json no longer matches, the resolve fails with
+ *   CONTENT_CONFLICT instead of applying reviewed choices to unseen content.
+ * @param options.expectedTheirsSha - same pin for the preview side
+ *   (the report's `theirs_sha`).
+ *
  * @throws {PreviewResolutionError} NO_PREVIEW / NOTHING_TO_RESOLVE /
- *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS.
+ *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS /
+ *   INVALID_RESOLUTIONS / CONTENT_CONFLICT / MAIN_CONTENT_MISSING.
  */
 export async function resolveDeckPreviewConflicts(
   slide: SlideContentTarget,
   {
     resolutions,
     resolveThemeUrls,
-  }: { resolutions: MergeResolution[]; resolveThemeUrls?: ThemeUrlResolver }
+    expectedOursSha,
+    expectedTheirsSha,
+  }: {
+    resolutions: MergeResolution[];
+    resolveThemeUrls?: ThemeUrlResolver;
+    expectedOursSha?: string;
+    expectedTheirsSha?: string;
+  }
 ): Promise<ResolveDeckPreviewResult> {
   if (!resolutions?.length) {
     throw new PreviewResolutionError(
@@ -617,8 +654,27 @@ export async function resolveDeckPreviewConflicts(
   const baseDeck = parseDeckForDiff(base?.content);
   const theirsDeck = parseDeckForDiff(theirs?.content);
 
+  if (expectedTheirsSha && (theirs?.sha ?? null) !== expectedTheirsSha) {
+    throw new PreviewResolutionError(
+      'The preview changed since the conflict report these choices were made against — ' +
+        're-run accept for a fresh report',
+      'CONTENT_CONFLICT'
+    );
+  }
+
   for (let attempt = 0; attempt < 2; attempt++) {
-    const oursDeck = parseDeckForDiff(ours?.content);
+    // Re-checked every attempt: a CAS-loss retry re-reads main, and choices
+    // pinned to the reviewed report must not silently apply to newer content.
+    if (expectedOursSha && (ours?.sha ?? null) !== expectedOursSha) {
+      throw new PreviewResolutionError(
+        'The live deck changed since the conflict report these choices were made against — ' +
+          're-run accept for a fresh report',
+        'CONTENT_CONFLICT'
+      );
+    }
+    if (!ours?.sha) throw mainDeckMissing();
+
+    const oursDeck = parseDeckForDiff(ours.content);
     const current = merge3Units(baseDeck, oursDeck, theirsDeck);
     const conflictIds = new Set(current.conflicts.map(conflict => conflict.id));
     if (conflictIds.size === 0) {
@@ -641,12 +697,6 @@ export async function resolveDeckPreviewConflicts(
         `Not current conflict ids: ${unknown.join(', ')} — re-run accept for the current report`,
         'UNKNOWN_RESOLUTIONS',
         unknown
-      );
-    }
-    if (!ours?.sha) {
-      throw new PreviewResolutionError(
-        'Main has no deck.json to lock the commit on — re-run accept',
-        'NOTHING_TO_RESOLVE'
       );
     }
 

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -22,12 +22,11 @@ import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
 import { generateDeckHtml, type DeckThemeUrls } from './deckHtml.ts';
 import {
-  DECK_ORDER_CONFLICT_ID,
   indexResolutions,
   merge3Units,
   PreviewResolutionError,
+  splitDeckConflicts,
   type DeckMergeConflict,
-  type DeckOrderMergeConflict,
   type MergeResolution,
 } from './deckMerge.ts';
 import {
@@ -434,21 +433,6 @@ async function readDeckThreeWay(slide: SlideContentTarget): Promise<DeckThreeWay
       : Promise.resolve(null),
   ]);
   return { comparison, ours, theirs, base };
-}
-
-/** Split the engine's conflicts into the service report shape (root order separated). */
-function splitDeckConflicts(conflicts: DeckMergeConflict[]): {
-  units: DeckMergeConflict[];
-  orderConflict?: { base: string[]; ours: string[]; theirs: string[] };
-} {
-  const root = conflicts.find(
-    (conflict): conflict is DeckOrderMergeConflict => conflict.id === DECK_ORDER_CONFLICT_ID
-  );
-  const units = conflicts.filter(conflict => conflict.id !== DECK_ORDER_CONFLICT_ID);
-  return {
-    units,
-    ...(root ? { orderConflict: { base: root.base, ours: root.ours, theirs: root.theirs } } : {}),
-  };
 }
 
 /**

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -193,6 +193,22 @@ function parseDeckForDiff(content: string | null | undefined): DeckJson {
 }
 
 /**
+ * STRICT parse for the merge BASE: null when the deck.json is missing or
+ * unparseable. Unlike parseDeckForDiff, the base is NEVER degraded to an empty
+ * deck — see baseDeckUnavailable for why.
+ */
+function parseBaseDeckStrict(content: string | null | undefined): DeckJson | null {
+  if (!content) return null;
+  try {
+    const parsed = JSON.parse(content) as DeckJson;
+    if (parsed?.version === 1 && Array.isArray(parsed.slides)) return parsed;
+  } catch {
+    // Malformed — reported as unavailable by the caller.
+  }
+  return null;
+}
+
+/**
  * Accept the deck's preview: merge the preview branch into main via the
  * GitHub merge API, regenerate the index.html artifact on main from the
  * MERGED deck.json, then delete the branch — unless a concurrent stacking
@@ -521,6 +537,25 @@ function mainDeckMissing(): PreviewResolutionError {
   );
 }
 
+/**
+ * Typed refusal for a missing/unparseable merge BASE. Preview branches always
+ * fork from main, so a git-conflicting accept has a real merge base with a
+ * real deck.json — if that read is empty or malformed, degrading it to an
+ * empty deck would treat every slide as "added on both sides": the preview's
+ * deletions get resurrected and legacy add/add decks (both sides materialized
+ * deck.json after the fork point) duplicate wholesale. There is no trustworthy
+ * 3-way, so refuse rather than commit — mirroring the 7.5 editor-save
+ * readBaseDeck refusal. Reuses MAIN_CONTENT_MISSING (the existing "content the
+ * merge needs is gone → re-apply or discard" code); no new code is invented.
+ */
+function baseDeckUnavailable(): PreviewResolutionError {
+  return new PreviewResolutionError(
+    'The merge base is unavailable (deck.json was missing or unreadable at the fork point) — ' +
+      're-apply your changes onto the current deck or discard the preview',
+    'MAIN_CONTENT_MISSING'
+  );
+}
+
 /** The accept path taken when the git merge reports a conflict. */
 async function acceptDeckSemanticFallback(
   slide: SlideContentTarget,
@@ -529,7 +564,10 @@ async function acceptDeckSemanticFallback(
   const threeWay = await readDeckThreeWay(slide);
   const { theirs, base } = threeWay;
   let ours = threeWay.ours;
-  const baseDeck = parseDeckForDiff(base?.content);
+  // A trustworthy 3-way needs a real merge base — never degrade a missing or
+  // unparseable base to an empty deck and commit (S3).
+  const baseDeck = parseBaseDeckStrict(base?.content);
+  if (!baseDeck) throw baseDeckUnavailable();
   const theirsDeck = parseDeckForDiff(theirs?.content);
 
   const report = (merge: ReturnType<typeof merge3Units>): AcceptDeckPreviewResult => {
@@ -635,7 +673,10 @@ export async function resolveDeckPreviewConflicts(
   }
   const { theirs, base } = threeWay;
   let ours = threeWay.ours;
-  const baseDeck = parseDeckForDiff(base?.content);
+  // Same base-availability guard as the accept path (S3): no trustworthy 3-way
+  // without a real merge base — refuse instead of resolving against an empty one.
+  const baseDeck = parseBaseDeckStrict(base?.content);
+  if (!baseDeck) throw baseDeckUnavailable();
   const theirsDeck = parseDeckForDiff(theirs?.content);
 
   if (expectedTheirsSha && (theirs?.sha ?? null) !== expectedTheirsSha) {

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -545,14 +545,15 @@ function mainDeckMissing(): PreviewResolutionError {
  * deletions get resurrected and legacy add/add decks (both sides materialized
  * deck.json after the fork point) duplicate wholesale. There is no trustworthy
  * 3-way, so refuse rather than commit — mirroring the 7.5 editor-save
- * readBaseDeck refusal. Reuses MAIN_CONTENT_MISSING (the existing "content the
- * merge needs is gone → re-apply or discard" code); no new code is invented.
+ * readBaseDeck refusal. Uses the shared MERGE_BASE_MISSING code (aligned with
+ * the pages twin, which raises the same code for the identical add/add
+ * merge-base degenerate).
  */
 function baseDeckUnavailable(): PreviewResolutionError {
   return new PreviewResolutionError(
     'The merge base is unavailable (deck.json was missing or unreadable at the fork point) — ' +
       're-apply your changes onto the current deck or discard the preview',
-    'MAIN_CONTENT_MISSING'
+    'MERGE_BASE_MISSING'
   );
 }
 
@@ -640,7 +641,8 @@ async function acceptDeckSemanticFallback(
  *
  * @throws {PreviewResolutionError} NO_PREVIEW / NOTHING_TO_RESOLVE /
  *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS /
- *   INVALID_RESOLUTIONS / CONTENT_CONFLICT / MAIN_CONTENT_MISSING.
+ *   INVALID_RESOLUTIONS / CONTENT_CONFLICT / MAIN_CONTENT_MISSING /
+ *   MERGE_BASE_MISSING.
  */
 export async function resolveDeckPreviewConflicts(
   slide: SlideContentTarget,

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -9,25 +9,32 @@
  * Accept = GitHub merge (main ← preview) → on a clean merge, regenerate
  * index.html on main FROM THE MERGED deck.json (CAS'd on its sha via
  * uploadBatch verifyBaseTree) → delete the branch. On a git-level conflict,
- * nothing merges, the branch is kept, and a structured per-unit report is
- * built by 3-way-walking deck slides (diffDeckUnits: base = merge-base,
- * ours = main, theirs = preview) so the caller resolves semantically.
+ * the semantic 3-way merge takes over (merge3Units: base = merge-base,
+ * ours = main, theirs = preview): zero true collisions → the auto-merged deck
+ * is committed to main via saveDeck and the branch deleted; genuine
+ * collisions → structured per-unit report (branch kept) that the caller
+ * resolves via resolveDeckPreviewConflicts or by re-applying.
  *
  * Discard = delete the branch; main untouched.
  */
 
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
+import { generateDeckHtml, type DeckThemeUrls } from './deckHtml.ts';
 import {
-  generateDeckHtml,
-  diffDeckUnits,
-  type DeckThemeUrls,
-  type DeckUnitConflict,
-} from './deckHtml.ts';
+  DECK_ORDER_CONFLICT_ID,
+  indexResolutions,
+  merge3Units,
+  PreviewResolutionError,
+  type DeckMergeConflict,
+  type DeckOrderMergeConflict,
+  type MergeResolution,
+} from './deckMerge.ts';
 import {
   DeckConflictError,
   previewBranchName,
   resolveSlideRepoContext,
+  saveDeck,
   type SlideContentTarget,
 } from './slideContent.service.ts';
 import type { DeckJson } from './deckTypes.ts';
@@ -133,6 +140,10 @@ export type AcceptDeckPreviewResult =
       sha: string | null;
       /** false when regeneration was skipped (concurrent writer already regenerated, or merged deck unreadable). */
       html_regenerated: boolean;
+      /** Present when the git merge conflicted but the semantic 3-way auto-merge committed the result. */
+      semantic?: true;
+      /** Changes auto-merged by the semantic layer (present iff semantic). */
+      auto_merged?: number;
       /** true when a concurrent stacking apply landed after the merge snapshot — the branch was kept, not deleted. */
       preview_kept?: boolean;
       /** Why the preview branch was retained (present iff preview_kept). */
@@ -141,13 +152,33 @@ export type AcceptDeckPreviewResult =
   | {
       merged: false;
       conflict: true;
-      /** Slides changed on BOTH sides with differing results (deck-unit 3-way walk). */
-      units: DeckUnitConflict[];
-      /** Present when both sides reordered the root slide sequence differently. */
+      /**
+       * ONLY the true collisions (everything else auto-merges on accept):
+       * per-slide conflicts, per-stack child-order conflicts
+       * (`__order__:<stackId>`), and the `__meta__` sentinel.
+       */
+      units: DeckMergeConflict[];
+      /** Present when both sides reordered the root slide sequence differently (conflict id `__order__`). */
       order_conflict?: { base: string[]; ours: string[]; theirs: string[] };
+      /** Changes the semantic layer can merge without a decision. */
+      auto_merged: number;
       ours_sha: string | null;
       theirs_sha: string | null;
     };
+
+/** Result of resolveDeckPreviewConflicts: the resolved merge committed to main. */
+export interface ResolveDeckPreviewResult {
+  merged: true;
+  semantic: true;
+  /** The new deck.json blob sha on main — the fresh expected_sha. */
+  sha: string | null;
+  html_regenerated: true;
+  auto_merged: number;
+  /** The applied choices, echoed for auditing. */
+  resolved: MergeResolution[];
+  preview_kept?: boolean;
+  reason?: string;
+}
 
 /** Parse a deck.json body into a DeckJson; malformed/missing → empty deck (diff-only use). */
 function parseDeckForDiff(content: string | null | undefined): DeckJson {
@@ -178,10 +209,11 @@ function parseDeckForDiff(content: string | null | undefined): DeckJson {
  * a conflict instead of clobbering, and since that concurrent save already
  * regenerated the artifact itself, the accept simply skips regeneration.
  *
- * On a git-level conflict, nothing is merged and nothing is deleted; instead
- * a structured per-unit report is built with diffDeckUnits (base = merge-base
- * deck, ours = main, theirs = preview) so the caller can resolve semantically
- * and re-apply.
+ * On a git-level conflict, the semantic 3-way merge (merge3Units) takes over:
+ * zero true collisions → the auto-merged deck is committed to main and the
+ * branch deleted (result carries `semantic: true`); genuine collisions →
+ * structured per-unit report (branch kept) with ONLY the units needing a
+ * decision plus the auto_merged count.
  */
 export async function acceptDeckPreview(
   slide: SlideContentTarget,
@@ -206,41 +238,12 @@ export async function acceptDeckPreview(
   });
 
   if (!result.merged) {
-    // Conflict: build the per-unit report. The branch is left alone so the
-    // caller can inspect, re-apply on fresh main, or discard explicitly.
-    const comparison = await ContentService.compareBranches({
-      gitOrganization,
-      repo,
-      base: 'main',
-      head: branch,
-    });
-    const [ours, theirs, base] = await Promise.all([
-      ContentService.getContent({ gitOrganization, repo, path: deckPath, skipCache: true }),
-      ContentService.getContent({ gitOrganization, repo, path: deckPath, ref: branch }),
-      comparison?.merge_base_sha
-        ? ContentService.getContent({
-            gitOrganization,
-            repo,
-            path: deckPath,
-            ref: comparison.merge_base_sha,
-          })
-        : Promise.resolve(null),
-    ]);
-
-    const diff = diffDeckUnits(
-      parseDeckForDiff(base?.content),
-      parseDeckForDiff(ours?.content),
-      parseDeckForDiff(theirs?.content)
-    );
-
-    return {
-      merged: false,
-      conflict: true,
-      units: diff.units,
-      ...(diff.orderConflict ? { order_conflict: diff.orderConflict } : {}),
-      ours_sha: ours?.sha ?? null,
-      theirs_sha: theirs?.sha ?? null,
-    };
+    // Git-level conflict: run the semantic 3-way merge (Phase 7). Zero true
+    // collisions → the auto-merged deck is committed to main (saveDeck: CAS'd
+    // on main's pre-write deck.json sha, artifact regenerated in the same
+    // atomic batch) and the branch is deleted; genuine collisions →
+    // structured report with only the units that need a decision, branch kept.
+    return acceptDeckSemanticFallback(slide, resolveThemeUrls);
   }
 
   // Clean merge: regenerate the artifact on main from the merged deck.json.
@@ -390,6 +393,298 @@ export async function acceptDeckPreview(
     html_regenerated: htmlRegenerated,
     ...(previewKept ? { preview_kept: true, reason: keptReason } : {}),
   };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Semantic merge on accept (Phase 7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ThemeUrlResolver = (deck: DeckJson) => Promise<DeckThemeUrls | undefined>;
+type ContentRead = Awaited<ReturnType<typeof ContentService.getContent>>;
+
+interface DeckThreeWay {
+  comparison: Awaited<ReturnType<typeof ContentService.compareBranches>>;
+  ours: ContentRead;
+  theirs: ContentRead;
+  base: ContentRead;
+}
+
+/** Read the 3-way (ours = fresh main, theirs = the preview branch, base = merge-base). */
+async function readDeckThreeWay(slide: SlideContentTarget): Promise<DeckThreeWay> {
+  const { gitOrganization, repo } = resolveSlideRepoContext(slide);
+  const branch = previewBranchName(slide.content_path);
+  const deckPath = `${slide.content_path}/deck.json`;
+
+  const comparison = await ContentService.compareBranches({
+    gitOrganization,
+    repo,
+    base: 'main',
+    head: branch,
+  });
+  const [ours, theirs, base] = await Promise.all([
+    ContentService.getContent({ gitOrganization, repo, path: deckPath, skipCache: true }),
+    ContentService.getContent({ gitOrganization, repo, path: deckPath, ref: branch }),
+    comparison?.merge_base_sha
+      ? ContentService.getContent({
+          gitOrganization,
+          repo,
+          path: deckPath,
+          ref: comparison.merge_base_sha,
+        })
+      : Promise.resolve(null),
+  ]);
+  return { comparison, ours, theirs, base };
+}
+
+/** Split the engine's conflicts into the service report shape (root order separated). */
+function splitDeckConflicts(conflicts: DeckMergeConflict[]): {
+  units: DeckMergeConflict[];
+  orderConflict?: { base: string[]; ours: string[]; theirs: string[] };
+} {
+  const root = conflicts.find(
+    (conflict): conflict is DeckOrderMergeConflict => conflict.id === DECK_ORDER_CONFLICT_ID
+  );
+  const units = conflicts.filter(conflict => conflict.id !== DECK_ORDER_CONFLICT_ID);
+  return {
+    units,
+    ...(root ? { orderConflict: { base: root.base, ours: root.ours, theirs: root.theirs } } : {}),
+  };
+}
+
+/**
+ * Commit a semantically merged deck to main via saveDeck (ONE atomic commit:
+ * deck.json + regenerated index.html, CAS'd on main's pre-write deck.json sha
+ * through both the pre-check and the verifyBaseTree hook), then delete the
+ * preview branch — unless the branch's deck.json moved past the `theirs` we
+ * merged (a concurrent stacking apply), in which case it is kept. Note:
+ * `compareBranches.ahead_by` cannot make that call here — the semantic commit
+ * is a NEW commit on main, so the branch's commits are never git-ancestors;
+ * the branch's blob sha vs the merged theirs sha is the reliable signal.
+ */
+async function commitSemanticDeckMerge(
+  slide: SlideContentTarget,
+  deck: DeckJson,
+  {
+    oursSha,
+    theirsSha,
+    resolveThemeUrls,
+  }: { oursSha: string; theirsSha: string | null; resolveThemeUrls?: ThemeUrlResolver }
+): Promise<{ sha: string; preview_kept?: boolean; reason?: string }> {
+  const { gitOrganization, repo } = resolveSlideRepoContext(slide);
+  const branch = previewBranchName(slide.content_path);
+  const deckPath = `${slide.content_path}/deck.json`;
+
+  const themeUrls = await resolveThemeUrls?.(deck);
+  const saved = await saveDeck({
+    slide,
+    deck,
+    expectedSha: oursSha,
+    shaSource: 'deck',
+    message: `Accept slides preview (auto-merged): ${slide.title}`,
+    ...(themeUrls ? { themeUrls } : {}),
+  });
+
+  let previewKept = false;
+  let reason: string | undefined;
+  try {
+    const branchMeta = await ContentService.getMeta({
+      gitOrganization,
+      repo,
+      path: deckPath,
+      ref: branch,
+      skipCache: true,
+    });
+    if (branchMeta && theirsSha && branchMeta.sha !== theirsSha) {
+      previewKept = true;
+      reason = 'Preview branch gained new edits during accept — retained with the newer changes';
+    } else {
+      try {
+        await ContentService.deleteBranch({ gitOrganization, repo, branch });
+      } catch (error: unknown) {
+        const status = (error as { status?: number }).status;
+        if (status !== 404 && status !== 422) throw error; // already gone is fine
+      }
+    }
+  } catch (error: unknown) {
+    previewKept = true;
+    reason = 'Could not verify the preview branch was unchanged — retained for safety';
+    console.warn(
+      `[deckPreview] Post-merge branch check failed for ${repo}/${branch}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  return { sha: saved.sha, ...(previewKept ? { preview_kept: true, reason } : {}) };
+}
+
+/** The accept path taken when the git merge reports a conflict. */
+async function acceptDeckSemanticFallback(
+  slide: SlideContentTarget,
+  resolveThemeUrls?: ThemeUrlResolver
+): Promise<AcceptDeckPreviewResult> {
+  const threeWay = await readDeckThreeWay(slide);
+  const { theirs, base } = threeWay;
+  let ours = threeWay.ours;
+  const baseDeck = parseDeckForDiff(base?.content);
+  const theirsDeck = parseDeckForDiff(theirs?.content);
+
+  const report = (merge: ReturnType<typeof merge3Units>): AcceptDeckPreviewResult => {
+    const { units, orderConflict } = splitDeckConflicts(merge.conflicts);
+    return {
+      merged: false,
+      conflict: true,
+      units,
+      ...(orderConflict ? { order_conflict: orderConflict } : {}),
+      auto_merged: merge.autoMerged,
+      ours_sha: ours?.sha ?? null,
+      theirs_sha: theirs?.sha ?? null,
+    };
+  };
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const merge = merge3Units(baseDeck, parseDeckForDiff(ours?.content), theirsDeck);
+    // Without main's deck.json sha there is nothing to CAS the commit on —
+    // report instead of writing (degenerate: a git conflict implies both
+    // sides changed deck.json, so ours should always exist).
+    if (merge.conflicts.length > 0 || !ours?.sha) {
+      return report(merge);
+    }
+    try {
+      const committed = await commitSemanticDeckMerge(slide, merge.merged, {
+        oursSha: ours.sha,
+        theirsSha: theirs?.sha ?? null,
+        resolveThemeUrls,
+      });
+      return {
+        merged: true,
+        semantic: true,
+        html_regenerated: true,
+        auto_merged: merge.autoMerged,
+        ...committed,
+      };
+    } catch (error: unknown) {
+      if (!(error instanceof DeckConflictError) || attempt === 1) throw error;
+      // Main moved while we were auto-merging — one retry against fresh main.
+      const { gitOrganization, repo } = resolveSlideRepoContext(slide);
+      ours = await ContentService.getContent({
+        gitOrganization,
+        repo,
+        path: `${slide.content_path}/deck.json`,
+        skipCache: true,
+      });
+    }
+  }
+  /* c8 ignore next */
+  throw new Error('unreachable');
+}
+
+/**
+ * Apply chooser decisions to a conflicted deck accept: re-runs the 3-way
+ * merge, requires the resolutions to exactly cover the current conflict set
+ * (`ours` = keep main's version, `theirs` = keep the preview's; sentinels:
+ * `__order__` for the top-level order, `__order__:<stackId>` for a stack's
+ * child order, `__meta__` for deck-level theme/config collisions), commits
+ * the resolved merge to main exactly like a semantic accept (saveDeck: CAS +
+ * artifact regeneration), and deletes the branch.
+ *
+ * @throws {PreviewResolutionError} NO_PREVIEW / NOTHING_TO_RESOLVE /
+ *   UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS / DUPLICATE_RESOLUTIONS.
+ */
+export async function resolveDeckPreviewConflicts(
+  slide: SlideContentTarget,
+  {
+    resolutions,
+    resolveThemeUrls,
+  }: { resolutions: MergeResolution[]; resolveThemeUrls?: ThemeUrlResolver }
+): Promise<ResolveDeckPreviewResult> {
+  if (!resolutions?.length) {
+    throw new PreviewResolutionError(
+      'No resolutions supplied — pass one {id, choose} per conflict',
+      'UNRESOLVED_CONFLICTS'
+    );
+  }
+  const chosen = indexResolutions(resolutions);
+
+  const threeWay = await readDeckThreeWay(slide);
+  if (!threeWay.comparison) {
+    throw new PreviewResolutionError(
+      'No pending preview for this deck — nothing to resolve',
+      'NO_PREVIEW'
+    );
+  }
+  const { theirs, base } = threeWay;
+  let ours = threeWay.ours;
+  const baseDeck = parseDeckForDiff(base?.content);
+  const theirsDeck = parseDeckForDiff(theirs?.content);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const oursDeck = parseDeckForDiff(ours?.content);
+    const current = merge3Units(baseDeck, oursDeck, theirsDeck);
+    const conflictIds = new Set(current.conflicts.map(conflict => conflict.id));
+    if (conflictIds.size === 0) {
+      throw new PreviewResolutionError(
+        'Nothing to resolve — the preview now merges cleanly; accept it without resolutions',
+        'NOTHING_TO_RESOLVE'
+      );
+    }
+    const missing = [...conflictIds].filter(id => !(id in chosen));
+    if (missing.length > 0) {
+      throw new PreviewResolutionError(
+        `Every conflict needs a choice — missing: ${missing.join(', ')}`,
+        'UNRESOLVED_CONFLICTS',
+        missing
+      );
+    }
+    const unknown = Object.keys(chosen).filter(id => !conflictIds.has(id));
+    if (unknown.length > 0) {
+      throw new PreviewResolutionError(
+        `Not current conflict ids: ${unknown.join(', ')} — re-run accept for the current report`,
+        'UNKNOWN_RESOLUTIONS',
+        unknown
+      );
+    }
+    if (!ours?.sha) {
+      throw new PreviewResolutionError(
+        'Main has no deck.json to lock the commit on — re-run accept',
+        'NOTHING_TO_RESOLVE'
+      );
+    }
+
+    const resolved = merge3Units(baseDeck, oursDeck, theirsDeck, { resolutions: chosen });
+    if (resolved.conflicts.length > 0) {
+      throw new Error(
+        `Resolution pass left conflicts standing (${resolved.conflicts.map(c => c.id).join(', ')}) — this is a bug`
+      );
+    }
+
+    try {
+      const committed = await commitSemanticDeckMerge(slide, resolved.merged, {
+        oursSha: ours.sha,
+        theirsSha: theirs?.sha ?? null,
+        resolveThemeUrls,
+      });
+      return {
+        merged: true,
+        semantic: true,
+        html_regenerated: true,
+        auto_merged: resolved.autoMerged,
+        resolved: resolutions,
+        ...committed,
+      };
+    } catch (error: unknown) {
+      if (!(error instanceof DeckConflictError) || attempt === 1) throw error;
+      // Main moved under us — re-read, re-validate the conflict set, retry once.
+      const { gitOrganization, repo } = resolveSlideRepoContext(slide);
+      ours = await ContentService.getContent({
+        gitOrganization,
+        repo,
+        path: `${slide.content_path}/deck.json`,
+        skipCache: true,
+      });
+    }
+  }
+  /* c8 ignore next */
+  throw new Error('unreachable');
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/services/src/slides/deckSaveMerge.service.ts
+++ b/packages/services/src/slides/deckSaveMerge.service.ts
@@ -13,6 +13,12 @@
  *   theirs = the POSTED document (the editor wrapper parsed + carried meta,
  *            constructed by the caller via slide.service buildEditorDeck)
  *
+ * theirs is a BROWSER-serialized DOM read-back while base/ours come from
+ * stored generator output, so the engine's equality is tolerant of pure
+ * browser serialization (hex→rgb style rewrites, numeric noise, attr
+ * requoting — see deckMerge/deckHtml). Slides the editor never touched merge
+ * clean instead of raising phantom "edited in both versions" conflicts.
+ *
  * Zero true collisions → the merged deck is committed through saveDeck (ONE
  * atomic CAS'd commit: deck.json + regenerated index.html) and the save
  * SUCCEEDS, reporting how many concurrent (main-side) changes were folded in.

--- a/packages/services/src/slides/deckSaveMerge.service.ts
+++ b/packages/services/src/slides/deckSaveMerge.service.ts
@@ -1,0 +1,247 @@
+/**
+ * deckSaveMerge.service.ts — semantic 3-way merge for EDITOR saves
+ * (content-tools plan §3b, Phase 7.5).
+ *
+ * When an editor save's conflict token is stale, the token IS the merge base:
+ * it is deck.json's blob sha at the time the editor read the deck, and blob
+ * shas are content-addressed (ContentService.getBlobContent — no ref needed).
+ * Instead of refusing with "reload, discard your work", the save runs the
+ * SAME 3-way semantic merge the preview-accept flow uses:
+ *
+ *   base   = the deck at the token's blob sha
+ *   ours   = current main (fresh read)
+ *   theirs = the POSTED document (the editor wrapper parsed + carried meta,
+ *            constructed by the caller via slide.service buildEditorDeck)
+ *
+ * Zero true collisions → the merged deck is committed through saveDeck (ONE
+ * atomic CAS'd commit: deck.json + regenerated index.html) and the save
+ * SUCCEEDS, reporting how many concurrent (main-side) changes were folded in.
+ * Genuine same-unit collisions → a structured per-unit report the editor
+ * renders in the existing conflict chooser; the client re-submits the same
+ * posted content plus per-unit resolutions and the report's ours_sha pin.
+ *
+ * Fallbacks (throw DeckConflictError → the caller's plain 409 reload flow):
+ * base blob unreadable/unparseable, main's deck.json deleted/unreadable, or
+ * the CAS retry losing twice. Resolution-validation failures throw
+ * PreviewResolutionError with the same codes as the accept flows.
+ */
+
+import { ContentService } from '../content/ContentService.ts';
+import type { DeckThemeUrls } from './deckHtml.ts';
+import {
+  indexResolutions,
+  merge3Units,
+  PreviewResolutionError,
+  splitDeckConflicts,
+  type DeckMergeConflict,
+  type MergeResolution,
+} from './deckMerge.ts';
+import {
+  DeckConflictError,
+  resolveSlideRepoContext,
+  saveDeck,
+  type SlideContentTarget,
+} from './slideContent.service.ts';
+import type { DeckJson } from './deckTypes.ts';
+
+export interface SaveDeckMergeArgs {
+  slide: SlideContentTarget;
+  /** The document this save wants to write (posted wrapper + carried meta). */
+  theirs: DeckJson;
+  /** The editor's conflict token — deck.json's blob sha when the editor read it (the 3-way base). */
+  baseSha: string;
+  /** Chooser decisions from a prior conflict report (save re-submit). */
+  resolutions?: MergeResolution[];
+  /**
+   * Pin to the conflict report the resolutions were reviewed against (its
+   * `ours_sha`). When main's deck.json no longer matches, the save fails with
+   * CONTENT_CONFLICT instead of applying reviewed choices to unseen content.
+   */
+  expectedOursSha?: string;
+  message?: string;
+  /** Resolver for shared:/custom: theme URLs, called with the MERGED deck. */
+  resolveThemeUrls?: (deck: DeckJson) => Promise<DeckThemeUrls | undefined>;
+}
+
+export type SaveDeckMergeResult =
+  | {
+      merged: true;
+      /** deck.json's new blob sha — the editor's fresh conflict token. */
+      sha: string;
+      commit: string;
+      /** The regenerated index.html (the editor's savedContent CDN-lag workaround). */
+      html: string;
+      /** Unit-level changes (both sides) that merged without a conflict. */
+      auto_merged: number;
+      /** Concurrent (main-side) unit changes folded into this save — the toast count. */
+      concurrent: number;
+    }
+  | {
+      merged: false;
+      conflict: true;
+      /**
+       * ONLY the true collisions: per-slide conflicts, per-stack child-order
+       * sentinels (`__order__:<stackId>`), and `__meta__`.
+       */
+      units: DeckMergeConflict[];
+      /** Present when both sides reordered the root slide sequence differently. */
+      order_conflict?: { base: string[]; ours: string[]; theirs: string[] };
+      auto_merged: number;
+      /** Main's deck.json sha the report was built from — the resolution pin. */
+      ours_sha: string;
+    };
+
+/** Strict deck.json parse — anything unusable is null (callers fall back). */
+function parseDeckStrict(content: string): DeckJson | null {
+  try {
+    const parsed = JSON.parse(content) as DeckJson;
+    if (parsed?.version === 1 && Array.isArray(parsed.slides)) return parsed;
+  } catch {
+    // Malformed — the caller falls back to the plain conflict flow.
+  }
+  return null;
+}
+
+/**
+ * Save an editor's posted deck over a stale conflict token by 3-way semantic
+ * merge (see the module doc for the full contract).
+ *
+ * @throws {DeckConflictError} fallback to the plain 409 reload flow (base
+ *   unreadable, main's deck.json gone, or the CAS retry lost twice).
+ * @throws {PreviewResolutionError} CONTENT_CONFLICT (ours pin stale) /
+ *   NOTHING_TO_RESOLVE / UNRESOLVED_CONFLICTS / UNKNOWN_RESOLUTIONS /
+ *   DUPLICATE_RESOLUTIONS / INVALID_RESOLUTIONS.
+ */
+export async function saveDeckWithMerge({
+  slide,
+  theirs,
+  baseSha,
+  resolutions,
+  expectedOursSha,
+  message,
+  resolveThemeUrls,
+}: SaveDeckMergeArgs): Promise<SaveDeckMergeResult> {
+  const { gitOrganization, repo } = resolveSlideRepoContext(slide);
+  const deckPath = `${slide.content_path}/deck.json`;
+
+  // Base = the deck at the editor's token. A failed or unparseable base read
+  // means no trustworthy 3-way exists — fall back to the plain conflict flow
+  // rather than merging against a guessed base.
+  let baseFile: { content: string } | null = null;
+  try {
+    baseFile = await ContentService.getBlobContent({ gitOrganization, repo, sha: baseSha });
+  } catch (error: unknown) {
+    console.warn(
+      `[deckSaveMerge] Base blob read failed for ${repo}@${baseSha}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+  const baseDeck = baseFile ? parseDeckStrict(baseFile.content) : null;
+  if (!baseDeck) {
+    throw new DeckConflictError('Deck changed since it was read — re-read before saving');
+  }
+
+  const chosen = resolutions ? indexResolutions(resolutions) : null;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    // Ours = fresh main. skipCache REQUIRED — this read pins the CAS sha.
+    const ours = await ContentService.getContent({
+      gitOrganization,
+      repo,
+      path: deckPath,
+      skipCache: true,
+    });
+
+    // Re-checked every attempt: a CAS-loss retry re-reads main, and choices
+    // reviewed against one report must not silently apply to newer content.
+    if (expectedOursSha && (ours?.sha ?? null) !== expectedOursSha) {
+      throw new PreviewResolutionError(
+        'The deck changed since the conflict report these choices were made against — ' +
+          'save again for a fresh report',
+        'CONTENT_CONFLICT'
+      );
+    }
+
+    const oursDeck = ours ? parseDeckStrict(ours.content) : null;
+    if (!ours || !oursDeck) {
+      // deck.json deleted or unreadable on main: no CAS anchor, no 3-way.
+      throw new DeckConflictError('deck.json no longer exists — re-read the deck before saving');
+    }
+
+    if (chosen) {
+      // The resolutions must exactly cover the CURRENT conflict set (same
+      // validation as resolveDeckPreviewConflicts).
+      const current = merge3Units(baseDeck, oursDeck, theirs);
+      const conflictIds = new Set(current.conflicts.map(conflict => conflict.id));
+      if (conflictIds.size === 0) {
+        throw new PreviewResolutionError(
+          'Nothing to resolve — the save now merges cleanly; save again without resolutions',
+          'NOTHING_TO_RESOLVE'
+        );
+      }
+      const missing = [...conflictIds].filter(id => !(id in chosen));
+      if (missing.length > 0) {
+        throw new PreviewResolutionError(
+          `Every conflict needs a choice — missing: ${missing.join(', ')}`,
+          'UNRESOLVED_CONFLICTS',
+          missing
+        );
+      }
+      const unknown = Object.keys(chosen).filter(id => !conflictIds.has(id));
+      if (unknown.length > 0) {
+        throw new PreviewResolutionError(
+          `Not current conflict ids: ${unknown.join(', ')} — save again for the current report`,
+          'UNKNOWN_RESOLUTIONS',
+          unknown
+        );
+      }
+    }
+
+    const merge = merge3Units(baseDeck, oursDeck, theirs, chosen ? { resolutions: chosen } : {});
+    if (merge.conflicts.length > 0) {
+      if (chosen) {
+        throw new Error(
+          `Resolution pass left conflicts standing (${merge.conflicts.map(c => c.id).join(', ')}) — this is a bug`
+        );
+      }
+      const { units, orderConflict } = splitDeckConflicts(merge.conflicts);
+      return {
+        merged: false,
+        conflict: true,
+        units,
+        ...(orderConflict ? { order_conflict: orderConflict } : {}),
+        auto_merged: merge.autoMerged,
+        ours_sha: ours.sha,
+      };
+    }
+
+    // Concurrent (main-side) changes folded into this save: a theirs-less
+    // merge (theirs = base) counts exactly the units ours changed vs base.
+    const concurrent = merge3Units(baseDeck, oursDeck, baseDeck).autoMerged;
+
+    const themeUrls = await resolveThemeUrls?.(merge.merged);
+    try {
+      const saved = await saveDeck({
+        slide,
+        deck: merge.merged,
+        expectedSha: ours.sha,
+        shaSource: 'deck',
+        message: message ?? `Update slides (merged): ${slide.title}`,
+        ...(themeUrls ? { themeUrls } : {}),
+      });
+      return {
+        merged: true,
+        sha: saved.sha,
+        commit: saved.commit,
+        html: saved.html,
+        auto_merged: merge.autoMerged,
+        concurrent,
+      };
+    } catch (error: unknown) {
+      if (!(error instanceof DeckConflictError) || attempt === 1) throw error;
+      // Main moved mid-commit — one retry re-runs the 3-way against fresh ours.
+    }
+  }
+  /* c8 ignore next */
+  throw new Error('unreachable');
+}

--- a/packages/services/src/slides/deckSaveMerge.service.ts
+++ b/packages/services/src/slides/deckSaveMerge.service.ts
@@ -33,7 +33,7 @@
  */
 
 import { ContentService } from '../content/ContentService.ts';
-import type { DeckThemeUrls } from './deckHtml.ts';
+import { SlideHtmlError, type DeckThemeUrls } from './deckHtml.ts';
 import {
   indexResolutions,
   merge3Units,
@@ -42,6 +42,7 @@ import {
   type DeckMergeConflict,
   type MergeResolution,
 } from './deckMerge.ts';
+import { applyDeckOps, DeckOpError, type DeckOp } from './deckOps.ts';
 import {
   DeckConflictError,
   resolveSlideRepoContext,
@@ -108,6 +109,56 @@ function parseDeckStrict(content: string): DeckJson | null {
   return null;
 }
 
+type SlideRepoContext = ReturnType<typeof resolveSlideRepoContext>;
+type OursRead = Awaited<ReturnType<typeof ContentService.getContent>>;
+
+/**
+ * Base = the deck at the editor's token (content-addressed blob read). A
+ * failed or unparseable base read means no trustworthy 3-way exists — the
+ * caller falls back to the plain conflict flow rather than merging against a
+ * guessed base.
+ */
+async function readBaseDeck(ctx: SlideRepoContext, baseSha: string): Promise<DeckJson | null> {
+  let baseFile: { content: string } | null = null;
+  try {
+    baseFile = await ContentService.getBlobContent({
+      gitOrganization: ctx.gitOrganization,
+      repo: ctx.repo,
+      sha: baseSha,
+    });
+  } catch (error: unknown) {
+    console.warn(
+      `[deckSaveMerge] Base blob read failed for ${ctx.repo}@${baseSha}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+  return baseFile ? parseDeckStrict(baseFile.content) : null;
+}
+
+/** Fresh-main deck.json read. skipCache REQUIRED — this read pins the CAS sha. */
+function readOursDeckFile(ctx: SlideRepoContext, deckPath: string): Promise<OursRead> {
+  return ContentService.getContent({
+    gitOrganization: ctx.gitOrganization,
+    repo: ctx.repo,
+    path: deckPath,
+    skipCache: true,
+  });
+}
+
+interface RunDeckMergeSaveArgs {
+  slide: SlideContentTarget;
+  deckPath: string;
+  ctx: SlideRepoContext;
+  baseDeck: DeckJson;
+  theirs: DeckJson;
+  chosen: ReturnType<typeof indexResolutions> | null;
+  expectedOursSha?: string;
+  message?: string;
+  resolveThemeUrls?: (deck: DeckJson) => Promise<DeckThemeUrls | undefined>;
+  /** Attempt-0 read of main's deck.json (prefetched in parallel with the base). */
+  firstOurs: OursRead;
+}
+
 /**
  * Save an editor's posted deck over a stale conflict token by 3-way semantic
  * merge (see the module doc for the full contract).
@@ -127,36 +178,55 @@ export async function saveDeckWithMerge({
   message,
   resolveThemeUrls,
 }: SaveDeckMergeArgs): Promise<SaveDeckMergeResult> {
-  const { gitOrganization, repo } = resolveSlideRepoContext(slide);
+  const ctx = resolveSlideRepoContext(slide);
   const deckPath = `${slide.content_path}/deck.json`;
 
-  // Base = the deck at the editor's token. A failed or unparseable base read
-  // means no trustworthy 3-way exists — fall back to the plain conflict flow
-  // rather than merging against a guessed base.
-  let baseFile: { content: string } | null = null;
-  try {
-    baseFile = await ContentService.getBlobContent({ gitOrganization, repo, sha: baseSha });
-  } catch (error: unknown) {
-    console.warn(
-      `[deckSaveMerge] Base blob read failed for ${repo}@${baseSha}:`,
-      error instanceof Error ? error.message : String(error)
-    );
-  }
-  const baseDeck = baseFile ? parseDeckStrict(baseFile.content) : null;
+  // The base blob and the first fresh-main read are independent GitHub
+  // round-trips — fetched in parallel (save-latency win).
+  const [baseDeck, firstOurs] = await Promise.all([
+    readBaseDeck(ctx, baseSha),
+    readOursDeckFile(ctx, deckPath),
+  ]);
   if (!baseDeck) {
     throw new DeckConflictError('Deck changed since it was read — re-read before saving');
   }
 
   const chosen = resolutions ? indexResolutions(resolutions) : null;
+  return runDeckMergeSave({
+    slide,
+    deckPath,
+    ctx,
+    baseDeck,
+    theirs,
+    chosen,
+    expectedOursSha,
+    message,
+    resolveThemeUrls,
+    firstOurs,
+  });
+}
 
+/**
+ * The shared merge→commit loop: 3-way merge against fresh main, resolution
+ * validation, conflict reporting, and the CAS'd saveDeck commit with ONE
+ * retry on a mid-commit race. `firstOurs` (prefetched by the entry points)
+ * serves attempt 0; a retry re-reads main.
+ */
+async function runDeckMergeSave({
+  slide,
+  deckPath,
+  ctx,
+  baseDeck,
+  theirs,
+  chosen,
+  expectedOursSha,
+  message,
+  resolveThemeUrls,
+  firstOurs,
+}: RunDeckMergeSaveArgs): Promise<SaveDeckMergeResult> {
   for (let attempt = 0; attempt < 2; attempt++) {
-    // Ours = fresh main. skipCache REQUIRED — this read pins the CAS sha.
-    const ours = await ContentService.getContent({
-      gitOrganization,
-      repo,
-      path: deckPath,
-      skipCache: true,
-    });
+    // Ours = fresh main (attempt 0 uses the prefetched parallel read).
+    const ours = attempt === 0 ? firstOurs : await readOursDeckFile(ctx, deckPath);
 
     // Re-checked every attempt: a CAS-loss retry re-reads main, and choices
     // reviewed against one report must not silently apply to newer content.
@@ -250,4 +320,110 @@ export async function saveDeckWithMerge({
   }
   /* c8 ignore next */
   throw new Error('unreachable');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// saveDeckFromOps — the editor's ops-shaped save (diff-at-save client)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 409 — the posted ops do not apply to the deck at the base token (an unknown
+ * slide id, an insert/move anchor that does not exist in the base — e.g. the
+ * anchor slide was never in that base — or an op the engine refuses). The
+ * client's contract: fall back to the whole-document 7.5 save ONCE; nothing
+ * was written.
+ */
+export class DeckOpsBaseMismatchError extends Error {
+  status = 409 as const;
+  code = 'OPS_BASE_MISMATCH' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeckOpsBaseMismatchError';
+  }
+}
+
+export interface SaveDeckFromOpsArgs {
+  slide: SlideContentTarget;
+  /** Granular ops the editor derived by diffing its DOM against its base snapshot. */
+  ops: DeckOp[];
+  /** The editor's conflict token — deck.json's blob sha the ops were diffed against. */
+  baseSha: string;
+  /** Chooser decisions from a prior conflict report (save re-submit with the SAME ops). */
+  resolutions?: MergeResolution[];
+  /** Pin to the conflict report the resolutions were reviewed against (its `ours_sha`). */
+  expectedOursSha?: string;
+  message?: string;
+  /** Resolver for shared:/custom: theme URLs, called with the MERGED deck. */
+  resolveThemeUrls?: (deck: DeckJson) => Promise<DeckThemeUrls | undefined>;
+}
+
+/**
+ * Save an editor's OPS over its base token: `theirs = applyDeckOps(base, ops)`
+ * — op ids and anchors resolve against the BASE deck — then the exact same
+ * 3-way merge → clean commit / conflict report / resolutions flow as
+ * saveDeckWithMerge. Untouched slides never ride in the request, so they can
+ * never phantom-conflict: a concurrent save to OTHER slides auto-merges by
+ * construction, with no equality tolerance involved.
+ *
+ * Op html/notes route through the same normalizeSlideHtml canonicalization
+ * the MCP deck_apply path uses (inside applyDeckOps), so ops-built documents
+ * match editor whole-document saves byte-for-byte.
+ *
+ * @throws {DeckOpsBaseMismatchError} the ops don't apply to the base (unknown
+ *   id/anchor, engine-refused op) — the client falls back to the whole-doc save.
+ * @throws {DeckConflictError} fallback to the plain 409 reload flow (base
+ *   blob unreadable/unparseable, main's deck.json gone, CAS retry lost twice).
+ * @throws {PreviewResolutionError} same codes as saveDeckWithMerge.
+ */
+export async function saveDeckFromOps({
+  slide,
+  ops,
+  baseSha,
+  resolutions,
+  expectedOursSha,
+  message,
+  resolveThemeUrls,
+}: SaveDeckFromOpsArgs): Promise<SaveDeckMergeResult> {
+  const ctx = resolveSlideRepoContext(slide);
+  const deckPath = `${slide.content_path}/deck.json`;
+
+  // Same parallel reads as saveDeckWithMerge (base blob + first fresh main).
+  const [baseDeck, firstOurs] = await Promise.all([
+    readBaseDeck(ctx, baseSha),
+    readOursDeckFile(ctx, deckPath),
+  ]);
+  if (!baseDeck) {
+    throw new DeckConflictError('Deck changed since it was read — re-read before saving');
+  }
+
+  // Materialize theirs by replaying the ops on the base. Anything the engine
+  // cannot resolve against THIS base (unknown ids, missing anchors, refused
+  // ops) is a base mismatch — the client retries as a whole-document save.
+  // NOTE: editor diffs never emit set_theme (theme changes take the whole-doc
+  // path, which owns the buildEditorDeck merge rules), so no starterCustomCss
+  // option is passed here.
+  let theirs: DeckJson;
+  try {
+    theirs = applyDeckOps(baseDeck, ops).deck;
+  } catch (error: unknown) {
+    if (error instanceof DeckOpError || error instanceof SlideHtmlError) {
+      throw new DeckOpsBaseMismatchError(`Ops do not apply to the base deck: ${error.message}`);
+    }
+    throw error;
+  }
+
+  const chosen = resolutions ? indexResolutions(resolutions) : null;
+  return runDeckMergeSave({
+    slide,
+    deckPath,
+    ctx,
+    baseDeck,
+    theirs,
+    chosen,
+    expectedOursSha,
+    message,
+    resolveThemeUrls,
+    firstOurs,
+  });
 }

--- a/packages/services/src/slides/deckSaveMerge.service.ts
+++ b/packages/services/src/slides/deckSaveMerge.service.ts
@@ -33,6 +33,7 @@
  */
 
 import { ContentService } from '../content/ContentService.ts';
+import { canonicalJson } from '../content/merge3.ts';
 import { SlideHtmlError, type DeckThemeUrls } from './deckHtml.ts';
 import {
   indexResolutions,
@@ -82,6 +83,16 @@ export type SaveDeckMergeResult =
       auto_merged: number;
       /** Concurrent (main-side) unit changes folded into this save — the toast count. */
       concurrent: number;
+      /**
+       * The client must remount its live editor from `html` (adopt the
+       * committed document). True whenever the committed deck differs from the
+       * client's intended document (base+ops) — concurrent reorders / cross-
+       * stack moves / deck-meta changes fold in with `concurrent === 0` — OR
+       * the server minted new insert ids the id-less DOM never carried. Gates
+       * the remount on a FULL comparison, not the unit counter (mirrors the
+       * pages twin's `document`-adoption rule).
+       */
+      adoption_required: boolean;
     }
   | {
       merged: false;
@@ -157,6 +168,20 @@ interface RunDeckMergeSaveArgs {
   resolveThemeUrls?: (deck: DeckJson) => Promise<DeckThemeUrls | undefined>;
   /** Attempt-0 read of main's deck.json (prefetched in parallel with the base). */
   firstOurs: OursRead;
+  /**
+   * The server minted new slide ids while materializing `theirs` (an insert
+   * op). Those ids never appear in the editor's id-less DOM, so the client
+   * MUST adopt the committed document even when the canonical compare matches
+   * (base == ours). Mirrors the pages twin forcing adoption on any re-mint.
+   */
+  forceAdoption?: boolean;
+}
+
+/** Compact human summary of applied chooser choices, appended to a merge commit. */
+function resolutionSummary(chosen: ReturnType<typeof indexResolutions>): string {
+  const count = Object.keys(chosen).length;
+  if (count === 0) return '';
+  return ` — resolved ${count} conflict${count === 1 ? '' : 's'}`;
 }
 
 /**
@@ -223,6 +248,7 @@ async function runDeckMergeSave({
   message,
   resolveThemeUrls,
   firstOurs,
+  forceAdoption,
 }: RunDeckMergeSaveArgs): Promise<SaveDeckMergeResult> {
   for (let attempt = 0; attempt < 2; attempt++) {
     // Ours = fresh main (attempt 0 uses the prefetched parallel read).
@@ -295,6 +321,28 @@ async function runDeckMergeSave({
     // merge (theirs = base) counts exactly the units ours changed vs base.
     const concurrent = merge3Units(baseDeck, oursDeck, baseDeck).autoMerged;
 
+    // Adoption signal (the client's remount gate): the committed document must
+    // replace whatever the editor DOM holds whenever it differs from the
+    // client's intended document (theirs = base+ops) — NOT merely when the
+    // `concurrent` unit-content counter is nonzero. A main-side reorder, a
+    // cross-stack move, or a deck-meta change folds in with concurrent 0, and
+    // server-minted insert ids (forceAdoption) never appear in the id-less DOM
+    // at all. A FULL canonical compare (order, children placement, meta, ids)
+    // catches every one; the counter stays only for the toast.
+    const adoptionRequired =
+      forceAdoption === true || canonicalJson(merge.merged) !== canonicalJson(theirs);
+
+    // Commit message: mark the git record when this save actually folded a
+    // concurrent change or applied a chooser resolution (the routes no longer
+    // override the default, so a plain save stays 'Update slides: <title>').
+    const commitMessage =
+      message ??
+      (chosen
+        ? `Update slides (merged): ${slide.title}${resolutionSummary(chosen)}`
+        : concurrent > 0
+          ? `Update slides (merged): ${slide.title}`
+          : `Update slides: ${slide.title}`);
+
     const themeUrls = await resolveThemeUrls?.(merge.merged);
     try {
       const saved = await saveDeck({
@@ -302,7 +350,7 @@ async function runDeckMergeSave({
         deck: merge.merged,
         expectedSha: ours.sha,
         shaSource: 'deck',
-        message: message ?? `Update slides (merged): ${slide.title}`,
+        message: commitMessage,
         ...(themeUrls ? { themeUrls } : {}),
       });
       return {
@@ -312,6 +360,7 @@ async function runDeckMergeSave({
         html: saved.html,
         auto_merged: merge.autoMerged,
         concurrent,
+        adoption_required: adoptionRequired,
       };
     } catch (error: unknown) {
       if (!(error instanceof DeckConflictError) || attempt === 1) throw error;
@@ -404,8 +453,20 @@ export async function saveDeckFromOps({
   // path, which owns the buildEditorDeck merge rules), so no starterCustomCss
   // option is passed here.
   let theirs: DeckJson;
+  // Any insert op mints fresh server-side ids the editor's DOM never carried
+  // (SlideToolbar.createNewSlide emits id-less <section>s); the client must
+  // then adopt the committed document or its next diff re-deletes+re-inserts
+  // the slide, churning the id and manufacturing bogus delete_vs_edit
+  // conflicts. Count the mints so runDeckMergeSave can force adoption.
+  let mintedIds = 0;
   try {
-    theirs = applyDeckOps(baseDeck, ops).deck;
+    const result = applyDeckOps(baseDeck, ops);
+    theirs = result.deck;
+    mintedIds = result.applied.reduce(
+      (n, entry) =>
+        entry.op === 'insert' ? n + ((entry.ids as string[] | undefined)?.length ?? 0) : n,
+      0
+    );
   } catch (error: unknown) {
     if (error instanceof DeckOpError || error instanceof SlideHtmlError) {
       throw new DeckOpsBaseMismatchError(`Ops do not apply to the base deck: ${error.message}`);
@@ -425,5 +486,6 @@ export async function saveDeckFromOps({
     message,
     resolveThemeUrls,
     firstOurs,
+    forceAdoption: mintedIds > 0,
   });
 }

--- a/packages/services/src/slides/index.ts
+++ b/packages/services/src/slides/index.ts
@@ -11,6 +11,7 @@
 export * from './deckTypes.ts';
 export * from './deckHtml.ts';
 export * from './deckMerge.ts';
+export * from './deckOps.ts';
 export * from './slideContent.service.ts';
 export * from './deckPreview.service.ts';
 export * from './deckSaveMerge.service.ts';

--- a/packages/services/src/slides/index.ts
+++ b/packages/services/src/slides/index.ts
@@ -13,4 +13,5 @@ export * from './deckHtml.ts';
 export * from './deckMerge.ts';
 export * from './slideContent.service.ts';
 export * from './deckPreview.service.ts';
+export * from './deckSaveMerge.service.ts';
 export * as slideService from './slide.service.ts';

--- a/packages/services/src/slides/index.ts
+++ b/packages/services/src/slides/index.ts
@@ -10,6 +10,7 @@
 
 export * from './deckTypes.ts';
 export * from './deckHtml.ts';
+export * from './deckMerge.ts';
 export * from './slideContent.service.ts';
 export * from './deckPreview.service.ts';
 export * as slideService from './slide.service.ts';

--- a/packages/services/src/slides/slide.service.ts
+++ b/packages/services/src/slides/slide.service.ts
@@ -206,6 +206,53 @@ export function starterDeck(title: string, idGen: IdGenerator = mintSlideId): De
 }
 
 /**
+ * Build the DeckJson an editor save writes: the posted wrapper's parsed
+ * fields (theme/codeTheme/slides) merged with the meta the thin editor
+ * wrapper doesn't round-trip, carried from the CURRENT deck (plan §5.1,
+ * review-hardened):
+ * - an explicit theme change clears the paired dark theme (same for
+ *   codeTheme) and drops starter-recognized customCss (exact match) so
+ *   switching a starter deck to a dark theme doesn't keep #333 headings;
+ * - all other customCss, the Reveal config, and extraCss carry over verbatim.
+ *
+ * Pure — theme resolution (shared: URL lookup, white fallback) happens in the
+ * caller BEFORE this runs; `theme` is the resolved value. Shared by the plain
+ * save path and the semantic save-merge path (Phase 7.5 theirs-construction).
+ */
+export function buildEditorDeck({
+  theme,
+  codeTheme,
+  slides,
+  currentDeck,
+}: {
+  theme: string;
+  codeTheme: string;
+  slides: DeckJson['slides'];
+  currentDeck: DeckJson | null;
+}): DeckJson {
+  const themeChanged = currentDeck != null && theme !== currentDeck.theme;
+  const codeThemeChanged = currentDeck != null && codeTheme !== currentDeck.codeTheme;
+  let customCss = currentDeck?.customCss;
+  if (themeChanged && customCss === STARTER_CUSTOM_CSS) {
+    customCss = undefined;
+  }
+
+  return {
+    version: 1,
+    theme,
+    codeTheme,
+    ...(!themeChanged && currentDeck?.themeDark ? { themeDark: currentDeck.themeDark } : {}),
+    ...(!codeThemeChanged && currentDeck?.codeThemeDark
+      ? { codeThemeDark: currentDeck.codeThemeDark }
+      : {}),
+    ...(currentDeck?.config ? { config: currentDeck.config } : {}),
+    ...(customCss != null ? { customCss } : {}),
+    ...(currentDeck?.extraCss ? { extraCss: currentDeck.extraCss } : {}),
+    slides,
+  };
+}
+
+/**
  * Orchestrated slide creation: content-path collision check → ensure the
  * shared content repo exists → starter deck via saveDeck (deck.json +
  * index.html in one commit) → DB row → manifest refresh.


### PR DESCRIPTION
## Summary

Phase 7 + 7.5 of the content tools: semantic 3-way merge for deck slides and page blocks, a side-by-side conflict chooser in both apps, and a unified op-based write pipeline shared by the MCP tools and both web editors.

### Semantic merge (Phase 7)
- Preview-branch accepts no longer fail on git-level conflicts: a semantic engine merges per unit (slide / block), auto-merging one-side changes and surfacing only true collisions (same unit changed on both sides).
- Conflict scopes: per-slide/per-block content, top-level order (`__order__`), per-stack child order (`__order__:<stackId>`), and deck meta (`__meta__`), with placement and delete-vs-edit detection.
- Accept tools (MCP + web) take per-unit `resolutions`, sha-pinned to the reviewed report so a resolution can never land on content that moved after review.

### Conflict chooser UI (both apps)
- Side-by-side cards per conflict with auto-merged count; Apply requires a choice for every card and publishes atomically.
- Slides: sandboxed slide-render cards; order conflicts render as filmstrips (horizontal for top-level order, vertical for a stack's child order) with moved-slide highlighting.
- Pages: block-type + text-summary cards; order conflicts as numbered block summaries.
- Save variant (7.5): stale editor saves 3-way merge server-side; true collisions open the same chooser ("Saved on the server" vs "Your unsaved version").

### Editor ops pipeline
- Both editors diff-at-save and post granular ops + base sha; the server materializes and merges. Whole-document save remains the fallback.
- Op engine extracted to `@classmoji/services` so MCP and editors share one implementation.

### UX hardening from live testing
- Save flow: saving-hold (no stale-view flash), merge progress overlay, Reveal recenter fix.
- Staff view reads are API-first (CDN lag no longer shows stale content to editors).
- Pages editor adopts the merged document after a preview accept (no manual reload).
- Editing is blocked while a chooser is open so edits can't be silently discarded.

## Testing
- services 665 + mcp 306 unit tests, 12/12 workspace typechecks, pages 44 + slides unit specs, Playwright suites green.
- Live Chrome verification on both surfaces: composite conflicts (content + order + auto-merges) staged on real GitHub-backed classrooms; full resolution round-trips verified against ground truth on the content repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
