### PR TITLE
feat(webapp): content namespace field in classroom creation

### DIFF
--- a/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
@@ -17,6 +17,9 @@ interface StepBasicInfoProps {
   githubAppName?: string | null;
   availability?: AvailabilityResponse;
   availabilityLoading?: boolean;
+  selectedOrgLogin: string;
+  namespaceSuggestion: string;
+  effectiveNamespace: string;
 }
 
 const StepBasicInfo = ({
@@ -25,6 +28,9 @@ const StepBasicInfo = ({
   githubAppName,
   availability,
   availabilityLoading,
+  selectedOrgLogin,
+  namespaceSuggestion,
+  effectiveNamespace,
 }: StepBasicInfoProps) => {
   const {
     control,
@@ -38,6 +44,7 @@ const StepBasicInfo = ({
   const effectiveSlug = slugOverride && slugOverride.length > 0 ? slugOverride : slugPreview;
 
   const [editingSlug, setEditingSlug] = useState(false);
+  const [editingNamespace, setEditingNamespace] = useState(false);
 
   const showResult = !!effectiveSlug && !availabilityLoading && !!availability;
   const slugTaken = showResult && availability!.slug_available === false;
@@ -138,6 +145,11 @@ const StepBasicInfo = ({
                   if (!editingSlug) {
                     setValue('slug', '', { shouldDirty: false });
                   }
+                  // Same for the content-namespace override: re-derive from the
+                  // fresh slug unless the user is editing it right now.
+                  if (!editingNamespace) {
+                    setValue('content_namespace', '', { shouldDirty: false });
+                  }
                 }}
               />
             )}
@@ -223,6 +235,62 @@ const StepBasicInfo = ({
                   )}
                 </span>
               )}
+            </div>
+          </div>
+        )}
+
+        {/* Content repo name: content-{orgLogin}-{namespace}, namespace editable.
+            Shown once an org is selected and a slug exists to derive from. */}
+        {(slugPreview || slugOverride) && selectedOrgLogin && (
+          <div>
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 flex-wrap">
+              <span>Content repo:</span>
+              {editingNamespace ? (
+                <Controller
+                  name="content_namespace"
+                  control={control}
+                  render={({ field }) => (
+                    <Input
+                      {...field}
+                      size="small"
+                      style={{ width: 340 }}
+                      addonBefore={`content-${selectedOrgLogin}-`}
+                      value={(field.value as string) || namespaceSuggestion}
+                      onChange={e => field.onChange(slugify(e.target.value))}
+                      onBlur={() => {
+                        field.onBlur();
+                        // An override equal to the suggestion is not an override.
+                        if ((field.value as string) === namespaceSuggestion) {
+                          setValue('content_namespace', '', { shouldDirty: false });
+                        }
+                        setEditingNamespace(false);
+                      }}
+                      autoFocus
+                    />
+                  )}
+                />
+              ) : (
+                <>
+                  <code className="bg-stone-100 dark:bg-neutral-800 text-gray-700 dark:text-gray-300 px-2 py-1 rounded">
+                    content-{selectedOrgLogin}-
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">
+                      {effectiveNamespace}
+                    </span>
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => setEditingNamespace(true)}
+                    className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                    aria-label="Edit content namespace"
+                  >
+                    <EditOutlined /> edit
+                  </button>
+                </>
+              )}
+            </div>
+            <div className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              The GitHub repository that will store this classroom&rsquo;s pages &amp; slides
+              content.
             </div>
           </div>
         )}

--- a/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
@@ -16,6 +16,7 @@ interface StepReviewProps {
   formValues: CreateClassroomFormValues;
   gitOrgs: GitOrganizationOption[];
   slugPreview: string;
+  contentRepoName?: string | null;
   importEnabled: boolean;
   sourceClassroom?: OwnedClassroom;
   selectedModules: Map<string, ModuleConfig>;
@@ -25,6 +26,7 @@ const StepReview = ({
   formValues,
   gitOrgs,
   slugPreview,
+  contentRepoName,
   importEnabled,
   sourceClassroom,
   selectedModules,
@@ -77,6 +79,14 @@ const StepReview = ({
               {slugPreview}
             </code>
           </div>
+          {contentRepoName && (
+            <div className="flex justify-between">
+              <span className="text-gray-500">Content repo</span>
+              <code className="bg-stone-100 dark:bg-neutral-800 text-gray-700 dark:text-gray-300 px-2 py-0.5 rounded text-sm">
+                {contentRepoName}
+              </code>
+            </div>
+          )}
         </div>
       </Card>
 

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -8,6 +8,7 @@ import {
 } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import getPrisma from '@classmoji/database';
+import { maxContentNamespaceLength, suggestContentNamespace } from '@classmoji/utils';
 import { slugify } from './utils';
 
 export const action = checkAuth(async ({ request }: { request: Request }) => {
@@ -22,7 +23,13 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     return { error: 'Unauthorized' };
   }
 
-  const { git_org_id, name, slug: slugInput, importConfig } = await request.json();
+  const {
+    git_org_id,
+    name,
+    slug: slugInput,
+    content_namespace: namespaceInput,
+    importConfig,
+  } = await request.json();
 
   if (!name) {
     return { error: 'Classroom name is required' };
@@ -68,6 +75,21 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   // Slug: prefer client-provided (user override / suggestion) when present, else derive from name.
   const slug = slugInput && typeof slugInput === 'string' ? slugify(slugInput) : slugify(name);
 
+  // Content namespace (names the classroom's content repo,
+  // `content-{orgLogin}-{namespace}`): client-provided override when present,
+  // else the org-prefix-stripped slug — never the raw slug, which doubles the
+  // org name in the repo whenever the slug starts with the course/org name.
+  const contentNamespace =
+    namespaceInput && typeof namespaceInput === 'string' && slugify(namespaceInput).length > 0
+      ? slugify(namespaceInput)
+      : suggestContentNamespace({ orgLogin: gitOrg.login, slug });
+
+  if (contentNamespace.length > maxContentNamespaceLength(gitOrg.login)) {
+    return {
+      error: `Content namespace is too long — keep it under ${maxContentNamespaceLength(gitOrg.login)} characters so the content repo name fits GitHub's limit`,
+    };
+  }
+
   // Create Classroom, Settings, and Membership in transaction
   const classroom = await getPrisma().$transaction(async tx => {
     const classroom = await tx.classroom.create({
@@ -75,7 +97,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
         git_org_id,
         slug,
         name,
-        content_namespace: slug,
+        content_namespace: contentNamespace,
       },
     });
 

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -8,6 +8,7 @@ import { useGlobalFetcher, useGitHubAppInstallPopup } from '~/hooks';
 import { ClassmojiService, GitHubProvider } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import getPrisma from '@classmoji/database';
+import { classroomContentRepoName, suggestContentNamespace } from '@classmoji/utils';
 
 import StepBasicInfo from './StepBasicInfo';
 import StepImportModules from './StepImportModules';
@@ -273,6 +274,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
       git_org_id: '',
       name: '',
       slug: '',
+      content_namespace: '',
     },
   });
 
@@ -301,6 +303,18 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
   const slugPreview = formValues.name ? slugify(formValues.name) : '';
   const slugOverride = (formValues as { slug?: string }).slug;
   const effectiveSlug = slugOverride && slugOverride.length > 0 ? slugOverride : slugPreview;
+
+  // Content namespace: manual override when set, else the org-prefix-stripped
+  // slug (mirrors the server's fallback so the preview always shows what an
+  // untouched submit would create).
+  const selectedOrgLogin = gitOrgs.find(o => o.id === formValues.git_org_id)?.login ?? '';
+  const namespaceSuggestion =
+    effectiveSlug && selectedOrgLogin
+      ? suggestContentNamespace({ orgLogin: selectedOrgLogin, slug: effectiveSlug })
+      : effectiveSlug;
+  const namespaceOverride = (formValues as { content_namespace?: string }).content_namespace;
+  const effectiveNamespace =
+    namespaceOverride && namespaceOverride.length > 0 ? namespaceOverride : namespaceSuggestion;
 
   // Debounced availability check (shared with StepBasicInfo via props)
   const availabilityFetcher = useFetcher<{
@@ -362,7 +376,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     notify(ActionTypes.CREATE_CLASSROOM, 'Creating classroom...');
 
     fetcher!.submit(
-      { ...values, slug: effectiveSlug, importConfig },
+      { ...values, slug: effectiveSlug, content_namespace: effectiveNamespace, importConfig },
       {
         method: 'post',
         action: '/create-classroom',
@@ -420,6 +434,9 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                 githubAppName={githubAppName}
                 availability={availabilityFetcher.data}
                 availabilityLoading={availabilityFetcher.state !== 'idle'}
+                selectedOrgLogin={selectedOrgLogin}
+                namespaceSuggestion={namespaceSuggestion}
+                effectiveNamespace={effectiveNamespace}
               />
             )}
 
@@ -439,7 +456,15 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
               <StepReview
                 formValues={formValues}
                 gitOrgs={gitOrgs}
-                slugPreview={slugPreview}
+                slugPreview={effectiveSlug}
+                contentRepoName={
+                  selectedOrgLogin
+                    ? classroomContentRepoName({
+                        login: selectedOrgLogin,
+                        namespace: effectiveNamespace,
+                      })
+                    : null
+                }
                 importEnabled={importEnabled}
                 sourceClassroom={sourceClassroom}
                 selectedModules={selectedModules}

--- a/apps/webapp/app/routes/_user.create-classroom/types.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/types.ts
@@ -41,4 +41,7 @@ export interface ModuleConfig {
 export interface CreateClassroomFormValues {
   git_org_id: string;
   name: string;
+  slug: string;
+  /** Manual content-namespace override; '' = derive from org login + slug. */
+  content_namespace: string;
 }

--- a/packages/utils/src/__tests__/repoNames.test.ts
+++ b/packages/utils/src/__tests__/repoNames.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { classroomContentRepoName } from '../repoNames.ts';
+import {
+  classroomContentRepoName,
+  maxContentNamespaceLength,
+  suggestContentNamespace,
+  GITHUB_REPO_NAME_MAX,
+} from '../repoNames.ts';
 import { getContentRepoName } from '../content.ts';
 
 describe('classroomContentRepoName', () => {
@@ -23,5 +28,50 @@ describe('classroomContentRepoName', () => {
     expect(classroomContentRepoName({ login: 'dali', namespace: '26w' })).not.toBe(
       getContentRepoName({ login: 'dali' })
     );
+  });
+});
+
+describe('suggestContentNamespace', () => {
+  it('strips the org login prefix from the slug', () => {
+    expect(suggestContentNamespace({ orgLogin: 'dartmouth-cs52', slug: 'dartmouth-cs52-26f' })).toBe(
+      '26f'
+    );
+  });
+
+  it('matches the login case-insensitively (logins can be mixed-case, slugs are lowercase)', () => {
+    expect(suggestContentNamespace({ orgLogin: 'LindblomMSA', slug: 'lindblommsa-26f' })).toBe(
+      '26f'
+    );
+  });
+
+  it('returns the full slug when it does not start with the login', () => {
+    expect(
+      suggestContentNamespace({ orgLogin: 'classmoji-development', slug: 'classmoji-dev-winter-2025' })
+    ).toBe('classmoji-dev-winter-2025');
+  });
+
+  it('returns the full slug when stripping would leave nothing', () => {
+    expect(suggestContentNamespace({ orgLogin: 'dartmouth-cs52', slug: 'dartmouth-cs52' })).toBe(
+      'dartmouth-cs52'
+    );
+  });
+
+  it('does not strip on partial word overlap (prefix must end at a hyphen boundary)', () => {
+    expect(suggestContentNamespace({ orgLogin: 'dartmouth-cs5', slug: 'dartmouth-cs52-26f' })).toBe(
+      'dartmouth-cs52-26f'
+    );
+  });
+});
+
+describe('maxContentNamespaceLength', () => {
+  it('leaves room for content-{login}- within the GitHub repo-name cap', () => {
+    const login = 'dartmouth-cs52';
+    const max = maxContentNamespaceLength(login);
+    expect(
+      classroomContentRepoName({ login, namespace: 'x'.repeat(max) }).length
+    ).toBe(GITHUB_REPO_NAME_MAX);
+    expect(
+      classroomContentRepoName({ login, namespace: 'x'.repeat(max + 1) }).length
+    ).toBeGreaterThan(GITHUB_REPO_NAME_MAX);
   });
 });

--- a/packages/utils/src/repoNames.ts
+++ b/packages/utils/src/repoNames.ts
@@ -19,3 +19,41 @@ export function classroomContentRepoName({
 }): string {
   return `content-${login}-${namespace}`;
 }
+
+/** GitHub caps repository names at 100 characters. */
+export const GITHUB_REPO_NAME_MAX = 100;
+
+/**
+ * Longest content namespace that keeps `content-{login}-{namespace}` within
+ * GitHub's repo-name limit for the given org login.
+ */
+export function maxContentNamespaceLength(login: string): number {
+  return GITHUB_REPO_NAME_MAX - 'content-'.length - login.length - 1;
+}
+
+/**
+ * Suggested content namespace for a new classroom: the classroom slug with the
+ * git org's login stripped off the front, so the derived repo name
+ * `content-{login}-{namespace}` doesn't repeat the org (classroom slugs
+ * conventionally start with the course/org name — `dartmouth-cs52-26f` under
+ * org `dartmouth-cs52` would otherwise mint
+ * `content-dartmouth-cs52-dartmouth-cs52-26f`).
+ *
+ * Falls back to the full slug when stripping wouldn't help: no prefix overlap,
+ * or nothing meaningful left after the strip (slug === login).
+ */
+export function suggestContentNamespace({
+  orgLogin,
+  slug,
+}: {
+  orgLogin: string;
+  slug: string;
+}): string {
+  const login = orgLogin.toLowerCase();
+  const prefix = `${login}-`;
+  if (slug.startsWith(prefix)) {
+    const rest = slug.slice(prefix.length);
+    if (rest.length > 0) return rest;
+  }
+  return slug;
+}


### PR DESCRIPTION
## Summary

Classroom creation silently defaulted `content_namespace` to the full classroom slug, so the derived content repo name (`content-{orgLogin}-{namespace}`) doubled the org whenever the slug starts with the course name — e.g. `content-dartmouth-cs52-dartmouth-cs52-26f`.

- New `suggestContentNamespace` helper strips the org-login prefix from the slug (`dartmouth-cs52-26f` → `26f`); used as the server-side default AND the live suggestion in the form
- Create form (Basic Info) now shows the resulting content repo name with the namespace segment editable, matching the slug row's chip + edit pattern
- Review step lists the final repo name, and now shows the effective slug (manual overrides included) instead of always the name-derived preview
- Server validates the combined repo name against GitHub's 100-char limit

## Testing
- 9 unit tests on the new helpers (`packages/utils`), webapp typecheck clean
- Live E2E on the dev stack: created "Classmoji Development Demo 26X" with namespace overridden to `26x` → DB row has `content_namespace = '26x'`; suggestion, manual edit, review display, and server fallback all exercised in Chrome

Screenshots in the linked session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
