### PR TITLE
feat(webapp): full-featured classroom import (settings, scales, calendar, content, modules)

### DIFF
--- a/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Select, Switch, Avatar, Empty, Button, Tag } from 'antd';
+import { Select, Switch, Avatar, Empty, Button, Tag, Checkbox } from 'antd';
 import {
   EditOutlined,
   BookOutlined,
@@ -7,7 +7,7 @@ import {
   QuestionCircleOutlined,
 } from '@ant-design/icons';
 import ModuleSelectionDrawer from './ModuleSelectionDrawer';
-import type { ClassroomModule, OwnedClassroom } from './types';
+import type { ClassroomModule, ImportSelections, OwnedClassroom } from './types';
 
 interface ModuleConfig {
   includeQuizzes: boolean;
@@ -21,6 +21,17 @@ interface StepImportModulesProps {
   setSourceClassroomId: (id: string | null) => void;
   selectedModules: Map<string, ModuleConfig>;
   setSelectedModules: (repositories: Map<string, ModuleConfig>) => void;
+  importSelections: ImportSelections;
+  setImportSelections: (selections: ImportSelections) => void;
+}
+
+/** One "Also copy" toggle row: key, label, sublabel, and an item count that
+ * disables the row at zero (null count = settings groups, always available). */
+interface CopyGroupRow {
+  key: keyof ImportSelections;
+  label: string;
+  sublabel?: string;
+  count?: number | null;
 }
 
 const StepImportModules = ({
@@ -31,6 +42,8 @@ const StepImportModules = ({
   setSourceClassroomId,
   selectedModules,
   setSelectedModules,
+  importSelections,
+  setImportSelections,
 }: StepImportModulesProps) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -200,6 +213,105 @@ const StepImportModules = ({
                       Deadlines will be removed. Repositories and quizzes will start unpublished.
                     </div>
                   )}
+                </div>
+              )}
+
+              {sourceClassroomId && (
+                <div className="p-4 border border-gray-200 dark:border-neutral-700 rounded-lg">
+                  <div className="font-medium mb-1">Also copy</div>
+                  <div className="text-sm text-gray-500 mb-3">
+                    Settings and content to bring over from{' '}
+                    {sourceClassroom?.name ?? 'the source classroom'}. Pages, slide decks, and
+                    modules arrive as drafts.
+                  </div>
+                  <div className="grid sm:grid-cols-2 gap-x-6 gap-y-2">
+                    {(
+                      [
+                        {
+                          key: 'grading',
+                          label: 'Grading & late penalty',
+                          sublabel: 'late penalty rate, grade visibility',
+                        },
+                        {
+                          key: 'gradeScales',
+                          label: 'Grade scales',
+                          count:
+                            (sourceClassroom?._count?.emoji_mappings ?? 0) +
+                            (sourceClassroom?._count?.letter_grade_mappings ?? 0),
+                          sublabel: 'emoji + letter-grade mappings',
+                        },
+                        {
+                          key: 'tokens',
+                          label: 'Tokens & extensions',
+                          sublabel: 'default token rate',
+                        },
+                        {
+                          key: 'features',
+                          label: 'Features & appearance',
+                          sublabel: 'feature toggles, navigation, theme',
+                        },
+                        {
+                          key: 'aiConfig',
+                          label: 'AI & quiz config',
+                          sublabel: 'models, temperature, syllabus bot',
+                        },
+                        {
+                          key: 'apiKeys',
+                          label: 'AI API keys',
+                          sublabel: 'secrets — copy only if you mean to',
+                        },
+                        {
+                          key: 'pages',
+                          label: 'Pages',
+                          count: sourceClassroom?._count?.pages ?? 0,
+                          sublabel: 'imported as drafts',
+                        },
+                        {
+                          key: 'slides',
+                          label: 'Slide decks',
+                          count: sourceClassroom?._count?.slides ?? 0,
+                          sublabel: 'imported as drafts',
+                        },
+                        {
+                          key: 'modules',
+                          label: 'Modules',
+                          count: sourceClassroom?._count?.modules ?? 0,
+                          sublabel: 'items link only to content you import',
+                        },
+                        {
+                          key: 'calendar',
+                          label: 'Calendar events',
+                          count: sourceClassroom?._count?.calendar_events ?? 0,
+                          sublabel: 'dates copied as-is — edit after import',
+                        },
+                      ] as CopyGroupRow[]
+                    ).map(row => {
+                      const disabled = row.count !== undefined && (row.count ?? 0) === 0;
+                      return (
+                        <Checkbox
+                          key={row.key}
+                          checked={!disabled && importSelections[row.key]}
+                          disabled={disabled}
+                          onChange={e =>
+                            setImportSelections({
+                              ...importSelections,
+                              [row.key]: e.target.checked,
+                            })
+                          }
+                        >
+                          <span className="text-sm">
+                            {row.label}
+                            {row.count !== undefined && (
+                              <span className="text-gray-400"> ({row.count})</span>
+                            )}
+                          </span>
+                          {row.sublabel && (
+                            <div className="text-xs text-gray-500">{row.sublabel}</div>
+                          )}
+                        </Checkbox>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
 

--- a/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
@@ -8,6 +8,7 @@ import {
 import type {
   CreateClassroomFormValues,
   GitOrganizationOption,
+  ImportSelections,
   ModuleConfig,
   OwnedClassroom,
 } from './types';
@@ -20,7 +21,31 @@ interface StepReviewProps {
   importEnabled: boolean;
   sourceClassroom?: OwnedClassroom;
   selectedModules: Map<string, ModuleConfig>;
+  importSelections?: ImportSelections;
 }
+
+/** Human labels for the enabled "Also copy" groups, with counts where known. */
+const copySummaryParts = (
+  selections: ImportSelections,
+  counts?: OwnedClassroom['_count']
+): string[] => {
+  const parts: string[] = [];
+  if (selections.grading) parts.push('grading & late penalty');
+  const scaleCount = (counts?.emoji_mappings ?? 0) + (counts?.letter_grade_mappings ?? 0);
+  if (selections.gradeScales && scaleCount > 0) parts.push(`grade scales (${scaleCount})`);
+  if (selections.tokens) parts.push('tokens');
+  if (selections.features) parts.push('features & appearance');
+  if (selections.aiConfig) parts.push('AI config');
+  if (selections.apiKeys) parts.push('API keys');
+  if (selections.pages && (counts?.pages ?? 0) > 0) parts.push(`pages (${counts?.pages})`);
+  if (selections.slides && (counts?.slides ?? 0) > 0)
+    parts.push(`slide decks (${counts?.slides})`);
+  if (selections.modules && (counts?.modules ?? 0) > 0)
+    parts.push(`modules (${counts?.modules})`);
+  if (selections.calendar && (counts?.calendar_events ?? 0) > 0)
+    parts.push(`calendar events (${counts?.calendar_events})`);
+  return parts;
+};
 
 const StepReview = ({
   formValues,
@@ -30,6 +55,7 @@ const StepReview = ({
   importEnabled,
   sourceClassroom,
   selectedModules,
+  importSelections,
 }: StepReviewProps) => {
   const { git_org_id, name } = formValues;
   const selectedOrg = gitOrgs.find(o => o.id === git_org_id);
@@ -89,6 +115,32 @@ const StepReview = ({
           )}
         </div>
       </Card>
+
+      {importEnabled && sourceClassroom && importSelections && (
+        <Card
+          title={
+            <div className="flex items-center gap-2">
+              <CheckCircleOutlined className="text-blue-500" />
+              <span>Settings &amp; Content Copy</span>
+            </div>
+          }
+          size="small"
+        >
+          {(() => {
+            const parts = copySummaryParts(importSelections, sourceClassroom._count);
+            return parts.length > 0 ? (
+              <div className="text-sm text-gray-700 dark:text-gray-300">
+                Copying from {sourceClassroom.name}: {parts.join(', ')}.
+                <div className="mt-1 text-xs text-gray-500">
+                  Pages, slide decks, and modules arrive as drafts.
+                </div>
+              </div>
+            ) : (
+              <div className="text-gray-500">No settings or content selected.</div>
+            );
+          })()}
+        </Card>
+      )}
 
       {importEnabled && selectedModules.size > 0 ? (
         <Card

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -117,18 +117,120 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     return classroom;
   });
 
-  // Import repositories if configured
+  // Import from a source classroom if configured. Phases (each best-effort,
+  // logged, never fails classroom creation): 1 settings/scales/calendar,
+  // 2 repositories(+assignments/quizzes), 3 pages/slides content,
+  // 4 module containers last (they remap onto the ids minted in 2 and 3).
   let importResult = null;
-  if (importConfig?.repositories?.length > 0) {
-    try {
-      importResult = await ClassmojiService.repositoryImport.cloneModulesWithRelations(
-        classroom.id,
-        importConfig.repositories,
-        { stripDeadlines: true }
+  let configSummary: {
+    settings_fields: string[];
+    emoji_mappings: number;
+    letter_grade_mappings: number;
+    calendar_events: number;
+  } | null = null;
+  let contentSummary: {
+    pages: number;
+    slides: number;
+    page_id_map: Record<string, string>;
+    slide_id_map: Record<string, string>;
+    warnings: string[];
+  } | null = null;
+  let modulesSummary: { modules: number; items: number; skipped_items: number } | null = null;
+  const importWarnings: string[] = [];
+
+  const sourceClassroomId: string | undefined = importConfig?.sourceClassroomId;
+  const configSelections = importConfig?.config ?? {};
+  const contentSelections = importConfig?.content ?? {};
+  const anyConfigSelected = Object.values(configSelections).some(Boolean);
+  const anyContentSelected = Object.values(contentSelections).some(Boolean);
+  const requestedRepos: Array<{ id: string; includeQuizzes?: boolean }> =
+    importConfig?.repositories ?? [];
+
+  if (sourceClassroomId && (requestedRepos.length > 0 || anyConfigSelected || anyContentSelected)) {
+    // The picker only OFFERS owned classrooms, but every id here arrives from
+    // the request body — re-verify ownership server-side before copying
+    // anything (settings can carry API keys; content must not be exfiltrated
+    // from classrooms the requester doesn't own).
+    const sourceMembership = await getPrisma().classroomMembership.findFirst({
+      where: { classroom_id: sourceClassroomId, user_id: user.id, role: 'OWNER' },
+    });
+    if (!sourceMembership) {
+      return { error: 'You must own the source classroom to import from it' };
+    }
+
+    if (anyConfigSelected) {
+      try {
+        configSummary = await ClassmojiService.classroomConfigImport.importClassroomConfig(
+          sourceClassroomId,
+          classroom.id,
+          user.id,
+          configSelections
+        );
+      } catch (error: unknown) {
+        console.error('Error importing classroom settings:', error);
+        importWarnings.push('settings copy failed');
+      }
+    }
+
+    if (requestedRepos.length > 0) {
+      // Repositories must belong to the (ownership-verified) source classroom.
+      const sourceRepoIds = new Set(
+        (
+          await getPrisma().repository.findMany({
+            where: { classroom_id: sourceClassroomId },
+            select: { id: true },
+          })
+        ).map(r => r.id)
       );
-    } catch (error: unknown) {
-      console.error('Error importing repositories:', error);
-      // Don't fail classroom creation, just log the error
+      const repoConfigs = requestedRepos.filter(r => sourceRepoIds.has(r.id));
+      if (repoConfigs.length !== requestedRepos.length) {
+        importWarnings.push('repositories outside the source classroom were skipped');
+      }
+      if (repoConfigs.length > 0) {
+        try {
+          importResult = await ClassmojiService.repositoryImport.cloneModulesWithRelations(
+            classroom.id,
+            repoConfigs,
+            { stripDeadlines: true }
+          );
+        } catch (error: unknown) {
+          console.error('Error importing repositories:', error);
+          importWarnings.push('repository copy failed');
+        }
+      }
+    }
+
+    if (contentSelections.pages || contentSelections.slides) {
+      try {
+        contentSummary = await ClassmojiService.contentImport.importClassroomContent(
+          sourceClassroomId,
+          classroom.id,
+          user.id,
+          { pages: !!contentSelections.pages, slides: !!contentSelections.slides }
+        );
+        importWarnings.push(...(contentSummary?.warnings ?? []));
+      } catch (error: unknown) {
+        console.error('Error importing pages/slides content:', error);
+        importWarnings.push('page/slide content copy failed');
+      }
+    }
+
+    if (contentSelections.modules) {
+      try {
+        modulesSummary = await ClassmojiService.classroomConfigImport.importModules(
+          sourceClassroomId,
+          classroom.id,
+          {
+            repositories: importResult?.idMaps?.repositories ?? {},
+            quizzes: importResult?.idMaps?.quizzes ?? {},
+            pages: contentSummary?.page_id_map ?? {},
+            slides: contentSummary?.slide_id_map ?? {},
+          }
+        );
+      } catch (error: unknown) {
+        console.error('Error importing modules:', error);
+        importWarnings.push('module copy failed');
+      }
     }
   }
 
@@ -153,25 +255,37 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
 
   // Build success message
   let successMessage = 'Classroom created successfully!';
-  if (importResult) {
-    const parts = [];
-    if (importResult.repositories.length > 0) {
-      parts.push(
-        `${importResult.repositories.length} repository${importResult.repositories.length !== 1 ? 's' : ''}`
-      );
+  {
+    const plural = (n: number, singular: string, pluralForm = `${singular}s`) =>
+      `${n} ${n === 1 ? singular : pluralForm}`;
+    const parts: string[] = [];
+    if (importResult) {
+      if (importResult.repositories.length > 0)
+        parts.push(plural(importResult.repositories.length, 'repository', 'repositories'));
+      if (importResult.assignments.length > 0)
+        parts.push(plural(importResult.assignments.length, 'assignment'));
+      if (importResult.quizzes.length > 0)
+        parts.push(plural(importResult.quizzes.length, 'quiz', 'quizzes'));
     }
-    if (importResult.assignments.length > 0) {
-      parts.push(
-        `${importResult.assignments.length} assignment${importResult.assignments.length !== 1 ? 's' : ''}`
-      );
+    if (configSummary) {
+      if (configSummary.settings_fields.length > 0) parts.push('settings');
+      const scales = configSummary.emoji_mappings + configSummary.letter_grade_mappings;
+      if (scales > 0) parts.push(plural(scales, 'grade mapping'));
+      if (configSummary.calendar_events > 0)
+        parts.push(plural(configSummary.calendar_events, 'calendar event'));
     }
-    if (importResult.quizzes.length > 0) {
-      parts.push(
-        `${importResult.quizzes.length} quiz${importResult.quizzes.length !== 1 ? 'zes' : ''}`
-      );
+    if (contentSummary) {
+      if (contentSummary.pages > 0) parts.push(plural(contentSummary.pages, 'page'));
+      if (contentSummary.slides > 0) parts.push(plural(contentSummary.slides, 'slide deck'));
+    }
+    if (modulesSummary && modulesSummary.modules > 0) {
+      parts.push(plural(modulesSummary.modules, 'module'));
     }
     if (parts.length > 0) {
       successMessage = `Classroom created with ${parts.join(', ')} imported!`;
+    }
+    if (importWarnings.length > 0) {
+      successMessage += ` (${importWarnings.length} item${importWarnings.length === 1 ? '' : 's'} skipped — see server logs)`;
     }
   }
 
@@ -179,5 +293,6 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     success: successMessage,
     action: ActionTypes.CREATE_CLASSROOM,
     classroomSlug: classroom.slug,
+    import_warnings: importWarnings,
   };
 });

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -14,6 +14,7 @@ import StepBasicInfo from './StepBasicInfo';
 import StepImportModules from './StepImportModules';
 import StepReview from './StepReview';
 import { slugify, STEPS } from './utils';
+import type { ImportSelections } from './types';
 import type { Route } from './+types/route';
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
@@ -178,6 +179,17 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
             login: true,
           },
         },
+        // Counts drive the "Also copy" checkboxes on the import step.
+        _count: {
+          select: {
+            pages: true,
+            slides: true,
+            modules: true,
+            calendar_events: true,
+            emoji_mappings: true,
+            letter_grade_mappings: true,
+          },
+        },
         repositories: {
           select: {
             id: true,
@@ -290,6 +302,21 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
   const [selectedModules, setSelectedModules] = useState(
     new Map<string, { includeQuizzes: boolean }>()
   );
+  // Settings/content copy groups. Config + drafts-only content default ON
+  // (the point of importing is reuse); the two exceptions are secrets
+  // (API keys) and calendar events (dates copy as-is), which are opt-in.
+  const [importSelections, setImportSelections] = useState<ImportSelections>({
+    grading: true,
+    gradeScales: true,
+    tokens: true,
+    features: true,
+    aiConfig: true,
+    apiKeys: false,
+    calendar: false,
+    pages: true,
+    slides: true,
+    modules: true,
+  });
 
   // Navigate to new classroom on success
   useEffect(() => {
@@ -363,13 +390,18 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
 
     // Build import config if applicable
     let importConfig = null;
-    if (importEnabled && sourceClassroomId && selectedModules.size > 0) {
+    const anySelection =
+      selectedModules.size > 0 || Object.values(importSelections).some(Boolean);
+    if (importEnabled && sourceClassroomId && anySelection) {
+      const { pages, slides, modules, ...config } = importSelections;
       importConfig = {
         sourceClassroomId,
-        repositories: Array.from(selectedModules.entries()).map(([id, config]) => ({
+        repositories: Array.from(selectedModules.entries()).map(([id, cfg]) => ({
           id,
-          includeQuizzes: config.includeQuizzes || false,
+          includeQuizzes: cfg.includeQuizzes || false,
         })),
+        config,
+        content: { pages, slides, modules },
       };
     }
 
@@ -449,6 +481,8 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                 setSourceClassroomId={setSourceClassroomId}
                 selectedModules={selectedModules}
                 setSelectedModules={setSelectedModules}
+                importSelections={importSelections}
+                setImportSelections={setImportSelections}
               />
             )}
 
@@ -468,6 +502,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                 importEnabled={importEnabled}
                 sourceClassroom={sourceClassroom}
                 selectedModules={selectedModules}
+                importSelections={importSelections}
               />
             )}
 

--- a/apps/webapp/app/routes/_user.create-classroom/types.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/types.ts
@@ -32,6 +32,32 @@ export interface OwnedClassroom {
     [key: string]: unknown;
   } | null;
   repositories?: ClassroomModule[];
+  _count?: {
+    pages: number;
+    slides: number;
+    modules: number;
+    calendar_events: number;
+    emoji_mappings: number;
+    letter_grade_mappings: number;
+  };
+}
+
+/**
+ * The "Also copy" toggles on the import step. Settings groups mirror the
+ * server's ConfigImportSelections; pages/slides/modules are the content
+ * copiers. apiKeys (secrets) and calendar (verbatim dates) are opt-in.
+ */
+export interface ImportSelections {
+  grading: boolean;
+  gradeScales: boolean;
+  tokens: boolean;
+  features: boolean;
+  aiConfig: boolean;
+  apiKeys: boolean;
+  calendar: boolean;
+  pages: boolean;
+  slides: boolean;
+  modules: boolean;
 }
 
 export interface ModuleConfig {

--- a/packages/services/src/classmoji/__tests__/classroomConfigImport.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroomConfigImport.service.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectedSettingsFields,
+  remapModuleItem,
+  SETTINGS_FIELD_GROUPS,
+} from '../classroomConfigImport.service.ts';
+import type {
+  ModuleImportIdMaps,
+  SourceModuleItemShape,
+} from '../classroomConfigImport.service.ts';
+
+const emptyMaps = (over: Partial<ModuleImportIdMaps> = {}): ModuleImportIdMaps => ({
+  repositories: {},
+  quizzes: {},
+  pages: {},
+  slides: {},
+  ...over,
+});
+
+const item = (over: Partial<SourceModuleItemShape> = {}): SourceModuleItemShape => ({
+  item_type: 'PAGE',
+  position: 0,
+  page_id: null,
+  repository_id: null,
+  quiz_id: null,
+  slide_id: null,
+  ...over,
+});
+
+describe('selectedSettingsFields', () => {
+  it('returns an empty list when nothing is selected', () => {
+    expect(selectedSettingsFields({})).toEqual([]);
+  });
+
+  it('returns exactly the grading group when only grading is selected', () => {
+    expect(selectedSettingsFields({ grading: true })).toEqual([
+      'late_penalty_points_per_hour',
+      'show_grades_to_students',
+    ]);
+  });
+
+  it('returns exactly the tokens group when only tokens is selected', () => {
+    expect(selectedSettingsFields({ tokens: true })).toEqual(['default_tokens_per_hour']);
+  });
+
+  it('returns the features group verbatim', () => {
+    expect(selectedSettingsFields({ features: true })).toEqual([
+      'quizzes_enabled',
+      'slides_enabled',
+      'syllabus_bot_enabled',
+      'recent_viewers_enabled',
+      'show_modules',
+      'show_pages',
+      'show_repos',
+      'default_student_page',
+      'theme',
+    ]);
+  });
+
+  it('returns the aiConfig group verbatim', () => {
+    expect(selectedSettingsFields({ aiConfig: true })).toEqual([
+      'llm_provider',
+      'llm_model',
+      'llm_temperature',
+      'llm_max_tokens',
+      'code_aware_model',
+      'syllabus_bot_model',
+    ]);
+  });
+
+  it('excludes apiKeys unless explicitly opted in', () => {
+    const withoutKeys = selectedSettingsFields({
+      grading: true,
+      tokens: true,
+      features: true,
+      aiConfig: true,
+    });
+    expect(withoutKeys).not.toContain('openai_api_key');
+    expect(withoutKeys).not.toContain('anthropic_api_key');
+  });
+
+  it('includes apiKeys only when opted in', () => {
+    expect(selectedSettingsFields({ apiKeys: true })).toEqual([
+      'openai_api_key',
+      'anthropic_api_key',
+    ]);
+  });
+
+  it('unions enabled groups in stable group order with no duplicates', () => {
+    const fields = selectedSettingsFields({
+      grading: true,
+      tokens: true,
+      features: true,
+      aiConfig: true,
+      apiKeys: true,
+    });
+    const expected = [
+      ...SETTINGS_FIELD_GROUPS.grading,
+      ...SETTINGS_FIELD_GROUPS.tokens,
+      ...SETTINGS_FIELD_GROUPS.features,
+      ...SETTINGS_FIELD_GROUPS.aiConfig,
+      ...SETTINGS_FIELD_GROUPS.apiKeys,
+    ];
+    expect(fields).toEqual(expected);
+    expect(new Set(fields).size).toBe(fields.length);
+  });
+
+  it('ignores gradeScales and calendar (not settings groups)', () => {
+    expect(selectedSettingsFields({ gradeScales: true, calendar: true })).toEqual([]);
+    // They also add nothing on top of a real settings group.
+    expect(selectedSettingsFields({ grading: true, gradeScales: true, calendar: true })).toEqual(
+      selectedSettingsFields({ grading: true })
+    );
+  });
+});
+
+describe('remapModuleItem', () => {
+  it('remaps a PAGE item and preserves position', () => {
+    const result = remapModuleItem(
+      item({ item_type: 'PAGE', position: 3, page_id: 'p-src' }),
+      emptyMaps({ pages: { 'p-src': 'p-dst' } })
+    );
+    expect(result).toEqual({
+      item_type: 'PAGE',
+      position: 3,
+      page_id: 'p-dst',
+      repository_id: null,
+      quiz_id: null,
+      slide_id: null,
+    });
+  });
+
+  it('remaps a REPOSITORY item', () => {
+    const result = remapModuleItem(
+      item({ item_type: 'REPOSITORY', position: 1, repository_id: 'r-src' }),
+      emptyMaps({ repositories: { 'r-src': 'r-dst' } })
+    );
+    expect(result).toMatchObject({
+      item_type: 'REPOSITORY',
+      position: 1,
+      repository_id: 'r-dst',
+      page_id: null,
+      quiz_id: null,
+      slide_id: null,
+    });
+  });
+
+  it('remaps a QUIZ item', () => {
+    const result = remapModuleItem(
+      item({ item_type: 'QUIZ', quiz_id: 'q-src' }),
+      emptyMaps({ quizzes: { 'q-src': 'q-dst' } })
+    );
+    expect(result).toMatchObject({ item_type: 'QUIZ', quiz_id: 'q-dst' });
+  });
+
+  it('remaps a SLIDE item', () => {
+    const result = remapModuleItem(
+      item({ item_type: 'SLIDE', slide_id: 's-src' }),
+      emptyMaps({ slides: { 's-src': 's-dst' } })
+    );
+    expect(result).toMatchObject({ item_type: 'SLIDE', slide_id: 's-dst' });
+  });
+
+  it('returns null when the referenced resource was not imported (missing map)', () => {
+    expect(
+      remapModuleItem(item({ item_type: 'PAGE', page_id: 'p-src' }), emptyMaps())
+    ).toBeNull();
+    expect(
+      remapModuleItem(
+        item({ item_type: 'REPOSITORY', repository_id: 'r-src' }),
+        emptyMaps({ repositories: { other: 'x' } })
+      )
+    ).toBeNull();
+    expect(
+      remapModuleItem(item({ item_type: 'QUIZ', quiz_id: 'q-src' }), emptyMaps())
+    ).toBeNull();
+    expect(
+      remapModuleItem(item({ item_type: 'SLIDE', slide_id: 's-src' }), emptyMaps())
+    ).toBeNull();
+  });
+
+  it('returns null when the source id for the item type is null', () => {
+    expect(remapModuleItem(item({ item_type: 'PAGE', page_id: null }), emptyMaps())).toBeNull();
+    expect(
+      remapModuleItem(item({ item_type: 'SLIDE', slide_id: null }), emptyMaps())
+    ).toBeNull();
+  });
+
+  it('only consults the map matching the item type', () => {
+    // A PAGE item whose page_id is unmapped is skipped even if other maps are full.
+    const result = remapModuleItem(
+      item({ item_type: 'PAGE', page_id: 'p-src', repository_id: 'r-src' }),
+      emptyMaps({ repositories: { 'r-src': 'r-dst' } })
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/contentImport.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.service.test.ts
@@ -1,0 +1,129 @@
+/**
+ * contentImport.service pure helpers: routeSlug, dedupe (slug/title suffixing),
+ * remapFilePath, formatWarning. No DB/GitHub — the orchestrator's IO paths are
+ * out of scope here (repo pure-only test convention). The runtime-heavy imports
+ * the service pulls in at module load are stubbed so importing it is cheap.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+vi.mock('../../content/ContentService.ts', () => ({ ContentService: {} }));
+vi.mock('../../git/index.ts', () => ({ getGitProvider: vi.fn() }));
+vi.mock('../page.service.ts', () => ({ ensureContentRepo: vi.fn() }));
+vi.mock('../contentManifest.service.ts', () => ({ saveManifest: vi.fn() }));
+
+const { routeSlug, dedupe, slugSuffix, titleSuffix, remapFilePath, formatWarning } = await import(
+  '../contentImport.service.ts'
+);
+
+describe('routeSlug', () => {
+  it('matches the page/slide content-path slug computation', () => {
+    expect(routeSlug('Hello World!')).toBe('hello-world');
+    expect(routeSlug('  Lab 3: Pointers & Arrays ')).toBe('lab-3-pointers-arrays');
+    expect(routeSlug('Intro---to___CS')).toBe('intro-to-cs');
+  });
+
+  it('collapses runs of non-alphanumerics and trims edge dashes', () => {
+    expect(routeSlug('___abc___')).toBe('abc');
+    expect(routeSlug('a  b\tc')).toBe('a-b-c');
+  });
+
+  it('returns empty for a title with no slug-able characters', () => {
+    expect(routeSlug('')).toBe('');
+    expect(routeSlug('!!!')).toBe('');
+    expect(routeSlug('日本語')).toBe('');
+  });
+});
+
+describe('dedupe with slugSuffix', () => {
+  it('returns the base untouched when it is free', () => {
+    expect(dedupe('lab-1', new Set<string>(), slugSuffix)).toBe('lab-1');
+    expect(dedupe('lab-1', new Set(['other']), slugSuffix)).toBe('lab-1');
+  });
+
+  it('suffixes -2, then -3, on collisions', () => {
+    expect(dedupe('lab-1', new Set(['lab-1']), slugSuffix)).toBe('lab-1-2');
+    expect(dedupe('lab-1', new Set(['lab-1', 'lab-1-2']), slugSuffix)).toBe('lab-1-3');
+  });
+
+  it('skips already-taken suffixes to the next free one', () => {
+    expect(dedupe('lab-1', new Set(['lab-1', 'lab-1-2', 'lab-1-3']), slugSuffix)).toBe('lab-1-4');
+  });
+
+  it('does not mutate the taken set', () => {
+    const taken = new Set(['lab-1']);
+    dedupe('lab-1', taken, slugSuffix);
+    expect(taken.has('lab-1-2')).toBe(false);
+    expect(taken.size).toBe(1);
+  });
+
+  it('deterministically walks a run of imported collisions when the caller accumulates', () => {
+    const taken = new Set(['lab-1']);
+    const a = dedupe('lab-1', taken, slugSuffix);
+    taken.add(a);
+    const b = dedupe('lab-1', taken, slugSuffix);
+    taken.add(b);
+    expect([a, b]).toEqual(['lab-1-2', 'lab-1-3']);
+  });
+});
+
+describe('dedupe with titleSuffix', () => {
+  it('leaves a free title unchanged', () => {
+    expect(dedupe('Lab 1', new Set<string>(), titleSuffix)).toBe('Lab 1');
+  });
+
+  it('appends " (N)" on collisions', () => {
+    expect(dedupe('Lab 1', new Set(['Lab 1']), titleSuffix)).toBe('Lab 1 (2)');
+    expect(dedupe('Lab 1', new Set(['Lab 1', 'Lab 1 (2)']), titleSuffix)).toBe('Lab 1 (3)');
+  });
+});
+
+describe('remapFilePath', () => {
+  it('maps a top-level file into the target folder', () => {
+    expect(remapFilePath('pages/lab-1/index.html', 'pages/lab-1', 'pages/lab-1-2')).toBe(
+      'pages/lab-1-2/index.html'
+    );
+  });
+
+  it('preserves nested sub-paths (assets, images)', () => {
+    expect(
+      remapFilePath('pages/lab-1/assets/diagram.png', 'pages/lab-1', 'pages/intro')
+    ).toBe('pages/intro/assets/diagram.png');
+    expect(remapFilePath('slides/deck/deck.json', 'slides/deck', 'slides/deck-2')).toBe(
+      'slides/deck-2/deck.json'
+    );
+  });
+
+  it('maps the folder path itself to the target folder', () => {
+    expect(remapFilePath('pages/lab-1', 'pages/lab-1', 'pages/lab-1-2')).toBe('pages/lab-1-2');
+  });
+
+  it('defensively keeps only the basename for a path outside the source prefix', () => {
+    expect(remapFilePath('other/thing.txt', 'pages/lab-1', 'pages/lab-1-2')).toBe(
+      'pages/lab-1-2/thing.txt'
+    );
+  });
+});
+
+describe('formatWarning', () => {
+  it('prefixes the scope and passes short detail through', () => {
+    expect(formatWarning('pages', 'no files at pages/lab-1')).toBe(
+      'pages: no files at pages/lab-1'
+    );
+  });
+
+  it('truncates over-long detail with an ellipsis', () => {
+    const detail = 'x'.repeat(500);
+    const out = formatWarning('slides', detail);
+    expect(out.startsWith('slides: ')).toBe(true);
+    // scope + ': ' + 200 chars of detail + '…'
+    expect(out).toBe(`slides: ${'x'.repeat(200)}…`);
+    expect(out.length).toBe('slides: '.length + 201);
+  });
+
+  it('leaves detail exactly at the limit untouched', () => {
+    const detail = 'y'.repeat(200);
+    expect(formatWarning('manifest', detail)).toBe(`manifest: ${detail}`);
+  });
+});

--- a/packages/services/src/classmoji/classroomConfigImport.service.ts
+++ b/packages/services/src/classmoji/classroomConfigImport.service.ts
@@ -1,0 +1,402 @@
+import getPrisma from '@classmoji/database';
+import type { Prisma } from '@prisma/client';
+import { ModuleItemType } from '@prisma/client';
+
+type RepositoryImportClient = Prisma.TransactionClient | ReturnType<typeof getPrisma>;
+
+/**
+ * Selections describing which slices of a source classroom's configuration to
+ * copy into a target classroom. Each flag is independent; omitting/false skips
+ * that slice entirely.
+ */
+export interface ConfigImportSelections {
+  /** late_penalty_points_per_hour, show_grades_to_students */
+  grading?: boolean;
+  /** EmojiMapping + LetterGradeMapping rows (grade scales) */
+  gradeScales?: boolean;
+  /** default_tokens_per_hour */
+  tokens?: boolean;
+  /**
+   * quizzes_enabled, slides_enabled, syllabus_bot_enabled,
+   * recent_viewers_enabled, show_modules, show_pages, show_repos,
+   * default_student_page, theme
+   */
+  features?: boolean;
+  /** llm_provider, llm_model, llm_temperature, llm_max_tokens, code_aware_model, syllabus_bot_model */
+  aiConfig?: boolean;
+  /** openai_api_key, anthropic_api_key — OPT-IN secrets, never copied unless enabled */
+  apiKeys?: boolean;
+  /** CalendarEvent rows, dates copied verbatim */
+  calendar?: boolean;
+}
+
+/**
+ * Summary of what `importClassroomConfig` actually wrote to the target.
+ */
+export interface ConfigImportSummary {
+  /** Which ClassroomSettings fields were written (post null/undefined filtering). */
+  settings_fields: string[];
+  /** Number of EmojiMapping rows inserted (skipDuplicates applied). */
+  emoji_mappings: number;
+  /** Number of LetterGradeMapping rows inserted (skipDuplicates applied). */
+  letter_grade_mappings: number;
+  /** Number of CalendarEvent rows inserted. */
+  calendar_events: number;
+}
+
+/**
+ * ClassroomSettings field membership per selectable group. gradeScales and
+ * calendar are intentionally NOT here — they map to separate tables, not to
+ * columns on classroom_settings.
+ *
+ * NEVER included: content_repo_name, classroom_id (PK), created_at, updated_at.
+ */
+export const SETTINGS_FIELD_GROUPS: Record<
+  'grading' | 'tokens' | 'features' | 'aiConfig' | 'apiKeys',
+  readonly string[]
+> = {
+  grading: ['late_penalty_points_per_hour', 'show_grades_to_students'],
+  tokens: ['default_tokens_per_hour'],
+  features: [
+    'quizzes_enabled',
+    'slides_enabled',
+    'syllabus_bot_enabled',
+    'recent_viewers_enabled',
+    'show_modules',
+    'show_pages',
+    'show_repos',
+    'default_student_page',
+    'theme',
+  ],
+  aiConfig: [
+    'llm_provider',
+    'llm_model',
+    'llm_temperature',
+    'llm_max_tokens',
+    'code_aware_model',
+    'syllabus_bot_model',
+  ],
+  apiKeys: ['openai_api_key', 'anthropic_api_key'],
+};
+
+/**
+ * Pure helper: the union (in stable group order, de-duplicated) of
+ * classroom_settings field names implied by the enabled selection groups.
+ * apiKeys is included only when explicitly opted in. gradeScales/calendar are
+ * not settings groups and never contribute fields here.
+ *
+ * @param {ConfigImportSelections} selections - Enabled import groups
+ * @returns {string[]} - Ordered, de-duplicated settings field names
+ */
+export function selectedSettingsFields(selections: ConfigImportSelections): string[] {
+  const order: Array<keyof typeof SETTINGS_FIELD_GROUPS> = [
+    'grading',
+    'tokens',
+    'features',
+    'aiConfig',
+    'apiKeys',
+  ];
+  const fields: string[] = [];
+  const seen = new Set<string>();
+  for (const group of order) {
+    if (!selections[group]) continue;
+    for (const field of SETTINGS_FIELD_GROUPS[group]) {
+      if (seen.has(field)) continue;
+      seen.add(field);
+      fields.push(field);
+    }
+  }
+  return fields;
+}
+
+/**
+ * Copy selected configuration from a source classroom into an existing target
+ * classroom.
+ *
+ * Settings: builds a patch of ONLY the fields implied by the enabled groups
+ * (via `selectedSettingsFields`). A source field is skipped when it is null or
+ * undefined; booleans/numbers copy verbatim including false/0 (they are never
+ * null/undefined for the non-nullable columns). The target's settings row is
+ * assumed to already exist and is updated by classroom_id. Never copies
+ * content_repo_name, classroom_id, id, or timestamps.
+ *
+ * gradeScales: copies all source EmojiMapping and LetterGradeMapping rows via
+ * createMany({ skipDuplicates: true }).
+ *
+ * calendar: copies CalendarEvent rows verbatim (dates included), re-pointing
+ * classroom_id to the target and created_by to `createdByUserId`. Does not copy
+ * ids/timestamps or related override/link rows.
+ *
+ * @param {string} sourceClassroomId - Classroom to copy configuration from
+ * @param {string} targetClassroomId - Classroom to copy configuration into
+ * @param {string} createdByUserId - User id used as created_by for calendar events
+ * @param {ConfigImportSelections} selections - Which slices to import
+ * @param {Object} [tx] - Optional Prisma transaction client
+ * @returns {Promise<ConfigImportSummary>} - What was written
+ */
+export const importClassroomConfig = async (
+  sourceClassroomId: string,
+  targetClassroomId: string,
+  createdByUserId: string,
+  selections: ConfigImportSelections,
+  tx: RepositoryImportClient = getPrisma()
+): Promise<ConfigImportSummary> => {
+  const summary: ConfigImportSummary = {
+    settings_fields: [],
+    emoji_mappings: 0,
+    letter_grade_mappings: 0,
+    calendar_events: 0,
+  };
+
+  // --- ClassroomSettings patch -------------------------------------------
+  const fields = selectedSettingsFields(selections);
+  if (fields.length > 0) {
+    const source = await tx.classroomSettings.findUnique({
+      where: { classroom_id: sourceClassroomId },
+    });
+    if (!source) {
+      throw new Error(`Source classroom settings not found: ${sourceClassroomId}`);
+    }
+
+    const sourceRecord = source as unknown as Record<string, unknown>;
+    const patch: Record<string, unknown> = {};
+    const written: string[] = [];
+    for (const field of fields) {
+      const value = sourceRecord[field];
+      // Skip null/undefined; false/0 are not null/undefined so they copy verbatim.
+      if (value === null || value === undefined) continue;
+      patch[field] = value;
+      written.push(field);
+    }
+
+    if (written.length > 0) {
+      await tx.classroomSettings.update({
+        where: { classroom_id: targetClassroomId },
+        data: patch as Prisma.ClassroomSettingsUpdateInput,
+      });
+    }
+    summary.settings_fields = written;
+  }
+
+  // --- Grade scales (emoji + letter grade mappings) ----------------------
+  if (selections.gradeScales) {
+    const emojiMappings = await tx.emojiMapping.findMany({
+      where: { classroom_id: sourceClassroomId },
+    });
+    if (emojiMappings.length > 0) {
+      const result = await tx.emojiMapping.createMany({
+        data: emojiMappings.map(row => ({
+          classroom_id: targetClassroomId,
+          emoji: row.emoji,
+          grade: row.grade,
+          extra_tokens: row.extra_tokens,
+          description: row.description,
+        })),
+        skipDuplicates: true,
+      });
+      summary.emoji_mappings = result.count;
+    }
+
+    const letterMappings = await tx.letterGradeMapping.findMany({
+      where: { classroom_id: sourceClassroomId },
+    });
+    if (letterMappings.length > 0) {
+      const result = await tx.letterGradeMapping.createMany({
+        data: letterMappings.map(row => ({
+          classroom_id: targetClassroomId,
+          letter_grade: row.letter_grade,
+          min_grade: row.min_grade,
+        })),
+        skipDuplicates: true,
+      });
+      summary.letter_grade_mappings = result.count;
+    }
+  }
+
+  // --- Calendar events ---------------------------------------------------
+  if (selections.calendar) {
+    const events = await tx.calendarEvent.findMany({
+      where: { classroom_id: sourceClassroomId },
+    });
+    if (events.length > 0) {
+      const data: Prisma.CalendarEventCreateManyInput[] = events.map(event => ({
+        classroom_id: targetClassroomId,
+        created_by: createdByUserId,
+        title: event.title,
+        description: event.description,
+        event_type: event.event_type,
+        start_time: event.start_time,
+        end_time: event.end_time,
+        location: event.location,
+        meeting_link: event.meeting_link,
+        is_recurring: event.is_recurring,
+        // Nullable Json: omit when null to sidestep Prisma DbNull/JsonNull typing.
+        ...(event.recurrence_rule === null
+          ? {}
+          : { recurrence_rule: event.recurrence_rule as Prisma.InputJsonValue }),
+      }));
+      const result = await tx.calendarEvent.createMany({ data });
+      summary.calendar_events = result.count;
+    }
+  }
+
+  return summary;
+};
+
+// ============================================================================
+// Module (container) import with resource id remapping
+// ============================================================================
+
+/**
+ * Maps of source resource id → cloned/target resource id, one per resource kind
+ * a ModuleItem can point at. Filled by the various import passes (repositories
+ * and quizzes come from repositoryImport; pages/slides from content import).
+ */
+export interface ModuleImportIdMaps {
+  repositories: Record<string, string>;
+  quizzes: Record<string, string>;
+  pages: Record<string, string>;
+  slides: Record<string, string>;
+}
+
+/**
+ * The subset of a source ModuleItem needed to remap it. Exactly one of the
+ * *_id fields is set on any real row (matching item_type).
+ */
+export interface SourceModuleItemShape {
+  item_type: ModuleItemType;
+  position: number;
+  page_id: string | null;
+  repository_id: string | null;
+  quiz_id: string | null;
+  slide_id: string | null;
+}
+
+/**
+ * A ModuleItem remapped onto target resource ids, ready to be written under a
+ * new module. Exactly one *_id is non-null (the one matching item_type).
+ */
+export interface RemappedItem {
+  item_type: ModuleItemType;
+  position: number;
+  page_id: string | null;
+  repository_id: string | null;
+  quiz_id: string | null;
+  slide_id: string | null;
+}
+
+/**
+ * Pure helper: remap a source ModuleItem's resource reference onto the target
+ * ids. Returns null when the referenced resource was not imported (missing map
+ * entry, or a null source id for the item's type) — the caller SKIPS such
+ * items. The ModuleItemType enum is PAGE/REPOSITORY/QUIZ/SLIDE only; every item
+ * references an imported resource, so there is no verbatim/no-remap case.
+ *
+ * @param {SourceModuleItemShape} item - Source module item
+ * @param {ModuleImportIdMaps} idMaps - Source→target resource id maps
+ * @returns {RemappedItem | null} - Remapped item, or null to skip
+ */
+export function remapModuleItem(
+  item: SourceModuleItemShape,
+  idMaps: ModuleImportIdMaps
+): RemappedItem | null {
+  const base: RemappedItem = {
+    item_type: item.item_type,
+    position: item.position,
+    page_id: null,
+    repository_id: null,
+    quiz_id: null,
+    slide_id: null,
+  };
+
+  switch (item.item_type) {
+    case ModuleItemType.PAGE: {
+      const mapped = item.page_id ? idMaps.pages[item.page_id] : undefined;
+      if (!mapped) return null;
+      return { ...base, page_id: mapped };
+    }
+    case ModuleItemType.REPOSITORY: {
+      const mapped = item.repository_id ? idMaps.repositories[item.repository_id] : undefined;
+      if (!mapped) return null;
+      return { ...base, repository_id: mapped };
+    }
+    case ModuleItemType.QUIZ: {
+      const mapped = item.quiz_id ? idMaps.quizzes[item.quiz_id] : undefined;
+      if (!mapped) return null;
+      return { ...base, quiz_id: mapped };
+    }
+    case ModuleItemType.SLIDE: {
+      const mapped = item.slide_id ? idMaps.slides[item.slide_id] : undefined;
+      if (!mapped) return null;
+      return { ...base, slide_id: mapped };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Copy Module containers (and their items) from a source classroom into a
+ * target classroom, remapping each item's resource reference through the
+ * provided id maps. Modules are forced unpublished. Item ordering (position) is
+ * preserved. Items whose referenced resource was not imported are skipped and
+ * counted.
+ *
+ * @param {string} sourceClassroomId - Classroom to copy modules from
+ * @param {string} targetClassroomId - Classroom to copy modules into
+ * @param {ModuleImportIdMaps} idMaps - Source→target resource id maps
+ * @param {Object} [tx] - Optional Prisma transaction client
+ * @returns {Promise<{ modules: number; items: number; skipped_items: number }>}
+ */
+export const importModules = async (
+  sourceClassroomId: string,
+  targetClassroomId: string,
+  idMaps: ModuleImportIdMaps,
+  tx: RepositoryImportClient = getPrisma()
+): Promise<{ modules: number; items: number; skipped_items: number }> => {
+  const sourceModules = await tx.module.findMany({
+    where: { classroom_id: sourceClassroomId },
+    include: { items: { orderBy: { position: 'asc' } } },
+    orderBy: { position: 'asc' },
+  });
+
+  let modules = 0;
+  let items = 0;
+  let skipped_items = 0;
+
+  for (const sourceModule of sourceModules) {
+    const newModule = await tx.module.create({
+      data: {
+        classroom_id: targetClassroomId,
+        title: sourceModule.title,
+        slug: sourceModule.slug,
+        description: sourceModule.description,
+        position: sourceModule.position,
+        is_published: false,
+      },
+    });
+    modules += 1;
+
+    for (const item of sourceModule.items) {
+      const remapped = remapModuleItem(item, idMaps);
+      if (!remapped) {
+        skipped_items += 1;
+        continue;
+      }
+      await tx.moduleItem.create({
+        data: {
+          module_id: newModule.id,
+          item_type: remapped.item_type,
+          position: remapped.position,
+          page_id: remapped.page_id,
+          repository_id: remapped.repository_id,
+          quiz_id: remapped.quiz_id,
+          slide_id: remapped.slide_id,
+        },
+      });
+      items += 1;
+    }
+  }
+
+  return { modules, items, skipped_items };
+};

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -1,0 +1,592 @@
+/**
+ * contentImport.service.ts — copy a source classroom's page + slide-deck
+ * content into a target classroom, as DRAFTS (full-featured classroom import).
+ *
+ * Composes existing machinery rather than hand-rolling GitHub/DB plumbing:
+ *  - target content repo is provisioned by page.service.ensureContentRepo
+ *    (the same lazy repo-ensure the page/slide create flows use);
+ *  - files are read verbatim from the source repo's MAIN branch and re-committed
+ *    with ContentService.uploadBatch (ONE commit per content type);
+ *  - the target manifest is refreshed the same way create/delete flows do
+ *    (contentManifest.saveManifest, which rebuilds it wholesale from the DB).
+ *
+ * Verbatim copy: every source file is read as raw base64 and written back as
+ * base64, so text (deck.json / index.html / content.json) and binary assets are
+ * byte-perfect. In particular the deck's generated index.html is copied as-is —
+ * never regenerated — so the deck.json/index.html pair stays consistent.
+ *
+ * Preview branches (`preview/<content_path>`) are never read, written, or
+ * cleaned: reads target MAIN only.
+ */
+
+import getPrisma from '@classmoji/database';
+import { classroomContentRepoName, titleToIdentifier } from '@classmoji/utils';
+import { ContentService } from '../content/ContentService.ts';
+import { getGitProvider } from '../git/index.ts';
+import * as contentManifestService from './contentManifest.service.ts';
+import { ensureContentRepo } from './page.service.ts';
+import type { Prisma } from '@prisma/client';
+
+// GitHub Contents API caps single-file reads at 1MB; larger files return no
+// usable content, so they are skipped with a warning (task requirement).
+const ONE_MB = 1024 * 1024;
+
+/** Cap on retained warnings and on per-warning detail length (bounded output). */
+const MAX_WARNINGS = 50;
+const WARNING_DETAIL_MAX = 200;
+
+export interface ContentImportOptions {
+  pages?: boolean;
+  slides?: boolean;
+}
+
+export interface ContentImportSummary {
+  pages: number;
+  slides: number;
+  /** source Page id → new Page id */
+  page_id_map: Record<string, string>;
+  /** source Slide id → new Slide id */
+  slide_id_map: Record<string, string>;
+  /** per-item failures, capped detail */
+  warnings: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers (unit-tested — no DB/GitHub)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Route-slug for a title: lowercase, every run of non-alphanumerics → '-',
+ * leading/trailing '-' trimmed. This is the IDENTICAL computation page.service
+ * (`pageContentPath`) and slide.service (`slideSlug`) use for the content-path
+ * segment; duplicated locally so this file never imports the slides subtree
+ * (which pulls cheerio through the root barrel).
+ */
+export function routeSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * First of `base`, then `suffix(base, 2)`, `suffix(base, 3)`, … that is not in
+ * `taken`. Pure: does not mutate `taken` (the caller adds the winner).
+ */
+export function dedupe(
+  base: string,
+  taken: ReadonlySet<string>,
+  suffix: (base: string, n: number) => string
+): string {
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(suffix(base, n))) n++;
+  return suffix(base, n);
+}
+
+/** Slug collision suffix: `lab-1` → `lab-1-2`. */
+export const slugSuffix = (base: string, n: number): string => `${base}-${n}`;
+
+/** Title collision suffix: `Lab 1` → `Lab 1 (2)`. */
+export const titleSuffix = (base: string, n: number): string => `${base} (${n})`;
+
+/**
+ * Rewrite a source file path (which lives under `sourcePrefix`) to sit under
+ * `targetPrefix`, preserving any nested sub-path (e.g. `assets/x.png`).
+ */
+export function remapFilePath(
+  filePath: string,
+  sourcePrefix: string,
+  targetPrefix: string
+): string {
+  if (!filePath.startsWith(sourcePrefix)) {
+    // Defensive: a path outside the folder keeps only its basename.
+    const name = filePath.split('/').pop() ?? filePath;
+    return `${targetPrefix}/${name}`;
+  }
+  const rest = filePath.slice(sourcePrefix.length).replace(/^\//, '');
+  return rest ? `${targetPrefix}/${rest}` : targetPrefix;
+}
+
+/** Format one warning with truncated detail: `scope: detail…`. */
+export function formatWarning(scope: string, detail: string): string {
+  const trimmed =
+    detail.length > WARNING_DETAIL_MAX ? `${detail.slice(0, WARNING_DETAIL_MAX)}…` : detail;
+  return `${scope}: ${trimmed}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Impl helpers (touch DB/GitHub — not unit-tested)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Structural git-org shape ContentService + the git provider accept.
+interface GitOrgRecord {
+  id: string;
+  provider: string;
+  login: string;
+  github_installation_id?: string | null;
+  access_token?: string | null;
+  base_url?: string | null;
+  gitlab_group_id?: string | null;
+}
+
+interface RepoContext {
+  classroomId: string;
+  gitOrganization: GitOrgRecord;
+  login: string;
+  repo: string;
+  slug: string;
+}
+
+type WarnFn = (scope: string, detail: string) => void;
+
+function errText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Load a classroom's content-repo coordinates. Returns null when the classroom
+ * (or its git org / content namespace) is not configured — the caller turns
+ * that into a zeros+warning result for the SOURCE side, or a throw for TARGET.
+ */
+async function loadRepoContext(classroomId: string): Promise<RepoContext | null> {
+  const classroom = await getPrisma().classroom.findUnique({
+    where: { id: classroomId },
+    include: { git_organization: true },
+  });
+  const gitOrganization = classroom?.git_organization as GitOrgRecord | null | undefined;
+  if (!classroom || !gitOrganization?.login || !classroom.content_namespace) {
+    return null;
+  }
+  return {
+    classroomId,
+    gitOrganization,
+    login: gitOrganization.login,
+    repo: classroomContentRepoName({
+      login: gitOrganization.login,
+      namespace: classroom.content_namespace,
+    }),
+    slug: classroom.slug,
+  };
+}
+
+type BatchFile = { path: string; content: string; encoding: 'base64' };
+
+/**
+ * Recursively read every file under `sourcePath` on the source repo's MAIN
+ * branch, remapping each path to sit under `targetPath`. Files >1MB are skipped
+ * with a warning. Returns the base64 file writes for a later batch commit.
+ * Reads are ref-pinned to 'main' (also bypasses the per-process response cache).
+ */
+async function collectFolderFiles({
+  source,
+  sourcePath,
+  targetPath,
+  scope,
+  warn,
+}: {
+  source: RepoContext;
+  sourcePath: string;
+  targetPath: string;
+  scope: string;
+  warn: WarnFn;
+}): Promise<BatchFile[]> {
+  const collected: BatchFile[] = [];
+
+  const walk = async (dirPath: string): Promise<void> => {
+    const entries = await ContentService.listFolder({
+      gitOrganization: source.gitOrganization,
+      repo: source.repo,
+      path: dirPath,
+      ref: 'main',
+    });
+    for (const entry of entries) {
+      if (entry.type === 'dir') {
+        await walk(entry.path);
+        continue;
+      }
+      const meta = await ContentService.getMeta({
+        gitOrganization: source.gitOrganization,
+        repo: source.repo,
+        path: entry.path,
+        ref: 'main',
+      });
+      if (meta && meta.size > ONE_MB) {
+        warn(scope, `skipped ${entry.path} (>1MB, ${meta.size} bytes)`);
+        continue;
+      }
+      const file = await ContentService.getContent({
+        gitOrganization: source.gitOrganization,
+        repo: source.repo,
+        path: entry.path,
+        ref: 'main',
+        raw: true,
+      });
+      if (!file) {
+        warn(scope, `could not read ${entry.path}`);
+        continue;
+      }
+      collected.push({
+        path: remapFilePath(entry.path, sourcePath, targetPath),
+        content: file.content,
+        encoding: 'base64',
+      });
+    }
+  };
+
+  await walk(sourcePath);
+  return collected;
+}
+
+/** A source content row staged for import after its files were read. */
+interface StagedItem<Source> {
+  source: Source;
+  files: BatchFile[];
+  targetTitle: string;
+  targetSlug: string;
+  targetContentPath: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Copy all pages and/or all slide decks from `sourceClassroomId` into
+ * `targetClassroomId` as drafts, byte-perfect, returning id maps for
+ * module-item remapping.
+ *
+ * Resilience:
+ *  - a source with no configured content repo → zeros + a warning;
+ *  - a target that cannot be provisioned (missing org/namespace, repo-create
+ *    failure) THROWS — an unwritable target is a caller error, not per-item;
+ *  - per-item read/DB failures and a per-type commit failure → warning + skip.
+ */
+export const importClassroomContent = async (
+  sourceClassroomId: string,
+  targetClassroomId: string,
+  createdByUserId: string,
+  opts: ContentImportOptions
+): Promise<ContentImportSummary> => {
+  const warnings: string[] = [];
+  const warn: WarnFn = (scope, detail) => {
+    if (warnings.length >= MAX_WARNINGS) return;
+    warnings.push(formatWarning(scope, detail));
+  };
+
+  const summary: ContentImportSummary = {
+    pages: 0,
+    slides: 0,
+    page_id_map: {},
+    slide_id_map: {},
+    warnings,
+  };
+
+  const wantPages = opts.pages === true;
+  const wantSlides = opts.slides === true;
+  if (!wantPages && !wantSlides) {
+    return summary;
+  }
+
+  // ── Source side: resolve coordinates and confirm the content repo exists ──
+  const source = await loadRepoContext(sourceClassroomId);
+  if (!source) {
+    warn('source', 'source classroom has no configured content repository');
+    return summary;
+  }
+  let sourceRepoExists = false;
+  try {
+    const provider = getGitProvider(source.gitOrganization);
+    sourceRepoExists = await provider.repositoryExists(source.login, source.repo);
+  } catch (error: unknown) {
+    warn('source', `could not check source content repo: ${errText(error)}`);
+    return summary;
+  }
+  if (!sourceRepoExists) {
+    warn('source', `source content repository ${source.repo} does not exist`);
+    return summary;
+  }
+
+  // ── Target side: ensure the content repo exists (THROWS if unprovisionable) ──
+  const target = await loadRepoContext(targetClassroomId);
+  if (!target) {
+    // Mirror ensureContentRepo's own error surface for an unconfigured target.
+    throw new Error('Target classroom content repository is not configured');
+  }
+  await ensureContentRepo(targetClassroomId);
+
+  const commitMessage = `Import content from ${source.slug}`;
+  let createdAny = false;
+
+  // ── Pages ──
+  if (wantPages) {
+    try {
+      const created = await importPages({
+        source,
+        target,
+        createdByUserId,
+        commitMessage,
+        warn,
+        idMap: summary.page_id_map,
+      });
+      summary.pages = created;
+      if (created > 0) createdAny = true;
+    } catch (error: unknown) {
+      warn('pages', `page import failed: ${errText(error)}`);
+    }
+  }
+
+  // ── Slides ──
+  if (wantSlides) {
+    try {
+      const created = await importSlides({
+        source,
+        target,
+        createdByUserId,
+        commitMessage,
+        warn,
+        idMap: summary.slide_id_map,
+      });
+      summary.slides = created;
+      if (created > 0) createdAny = true;
+    } catch (error: unknown) {
+      warn('slides', `slide import failed: ${errText(error)}`);
+    }
+  }
+
+  // ── Manifest refresh (once, non-fatal — mirrors create/delete flows) ──
+  if (createdAny) {
+    try {
+      await contentManifestService.saveManifest(targetClassroomId);
+    } catch (error: unknown) {
+      warn('manifest', `failed to refresh target manifest: ${errText(error)}`);
+    }
+  }
+
+  return summary;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-type import passes
+// ─────────────────────────────────────────────────────────────────────────────
+
+type SourcePage = Prisma.PageGetPayload<Record<string, never>>;
+
+async function importPages({
+  source,
+  target,
+  createdByUserId,
+  commitMessage,
+  warn,
+  idMap,
+}: {
+  source: RepoContext;
+  target: RepoContext;
+  createdByUserId: string;
+  commitMessage: string;
+  warn: WarnFn;
+  idMap: Record<string, string>;
+}): Promise<number> {
+  const sourcePages = await getPrisma().page.findMany({
+    where: { classroom_id: source.classroomId },
+    orderBy: { created_at: 'asc' },
+  });
+  if (sourcePages.length === 0) return 0;
+
+  // Seed collision sets from existing TARGET rows.
+  const targetPages = await getPrisma().page.findMany({
+    where: { classroom_id: target.classroomId },
+    select: { title: true, content_path: true },
+  });
+  const takenTitles = new Set(targetPages.map(p => p.title));
+  const takenSlugs = new Set(targetPages.map(p => p.content_path.replace(/^pages\//, '')));
+
+  const staged: StagedItem<SourcePage>[] = [];
+
+  for (const page of sourcePages) {
+    const base = routeSlug(page.title);
+    if (!base) {
+      warn('pages', `skipped "${page.title}" — title has no slug-able characters`);
+      continue;
+    }
+    const targetSlug = dedupe(base, takenSlugs, slugSuffix);
+    takenSlugs.add(targetSlug);
+    const targetTitle = dedupe(page.title, takenTitles, titleSuffix);
+    takenTitles.add(targetTitle);
+    const targetContentPath = `pages/${targetSlug}`;
+
+    let files: BatchFile[];
+    try {
+      files = await collectFolderFiles({
+        source,
+        sourcePath: page.content_path,
+        targetPath: targetContentPath,
+        scope: 'pages',
+        warn,
+      });
+    } catch (error: unknown) {
+      warn('pages', `skipped "${page.title}" — read failed: ${errText(error)}`);
+      continue;
+    }
+    if (files.length === 0) {
+      warn('pages', `skipped "${page.title}" — no files at ${page.content_path}`);
+      continue;
+    }
+    staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath });
+  }
+
+  if (staged.length === 0) return 0;
+
+  // ONE commit for all page files.
+  try {
+    await ContentService.uploadBatch({
+      gitOrganization: target.gitOrganization,
+      repo: target.repo,
+      files: staged.flatMap(s => s.files),
+      branch: 'main',
+      message: commitMessage,
+    });
+  } catch (error: unknown) {
+    warn('pages', `page content commit failed: ${errText(error)}`);
+    return 0;
+  }
+
+  // DB rows AFTER the commit (GitHub-first, mirroring createPage).
+  let created = 0;
+  for (const item of staged) {
+    try {
+      const row = await getPrisma().page.create({
+        data: {
+          classroom_id: target.classroomId,
+          title: item.targetTitle,
+          slug: titleToIdentifier(item.targetTitle),
+          content_path: item.targetContentPath,
+          created_by: createdByUserId,
+          is_draft: true,
+          is_public: false,
+          width: item.source.width,
+          show_in_student_menu: item.source.show_in_student_menu,
+          menu_order: item.source.menu_order,
+          header_image_url: item.source.header_image_url,
+          header_image_position: item.source.header_image_position,
+        } satisfies Prisma.PageUncheckedCreateInput,
+      });
+      idMap[item.source.id] = row.id;
+      created++;
+    } catch (error: unknown) {
+      warn('pages', `DB row failed for "${item.targetTitle}": ${errText(error)}`);
+    }
+  }
+  return created;
+}
+
+type SourceSlide = Prisma.SlideGetPayload<Record<string, never>>;
+
+async function importSlides({
+  source,
+  target,
+  createdByUserId,
+  commitMessage,
+  warn,
+  idMap,
+}: {
+  source: RepoContext;
+  target: RepoContext;
+  createdByUserId: string;
+  commitMessage: string;
+  warn: WarnFn;
+  idMap: Record<string, string>;
+}): Promise<number> {
+  const sourceSlides = await getPrisma().slide.findMany({
+    where: { classroom_id: source.classroomId },
+    orderBy: { created_at: 'asc' },
+  });
+  if (sourceSlides.length === 0) return 0;
+
+  // Slides carry a [classroom_id, slug] unique constraint — slug drives both the
+  // constraint and the content path, so one dedupe set covers both.
+  const targetSlides = await getPrisma().slide.findMany({
+    where: { classroom_id: target.classroomId },
+    select: { slug: true },
+  });
+  const takenSlugs = new Set(targetSlides.map(s => s.slug));
+
+  const staged: StagedItem<SourceSlide>[] = [];
+
+  for (const slide of sourceSlides) {
+    const base = routeSlug(slide.title);
+    if (!base) {
+      warn('slides', `skipped "${slide.title}" — title has no slug-able characters`);
+      continue;
+    }
+    const targetSlug = dedupe(base, takenSlugs, slugSuffix);
+    takenSlugs.add(targetSlug);
+    const targetContentPath = `slides/${targetSlug}`;
+
+    let files: BatchFile[];
+    try {
+      files = await collectFolderFiles({
+        source,
+        sourcePath: slide.content_path,
+        targetPath: targetContentPath,
+        scope: 'slides',
+        warn,
+      });
+    } catch (error: unknown) {
+      warn('slides', `skipped "${slide.title}" — read failed: ${errText(error)}`);
+      continue;
+    }
+    if (files.length === 0) {
+      warn('slides', `skipped "${slide.title}" — no files at ${slide.content_path}`);
+      continue;
+    }
+    staged.push({
+      source: slide,
+      files,
+      targetTitle: slide.title,
+      targetSlug,
+      targetContentPath,
+    });
+  }
+
+  if (staged.length === 0) return 0;
+
+  // ONE commit for all slide files (deck.json + generated index.html copied
+  // verbatim — never regenerated).
+  try {
+    await ContentService.uploadBatch({
+      gitOrganization: target.gitOrganization,
+      repo: target.repo,
+      files: staged.flatMap(s => s.files),
+      branch: 'main',
+      message: commitMessage,
+    });
+  } catch (error: unknown) {
+    warn('slides', `slide content commit failed: ${errText(error)}`);
+    return 0;
+  }
+
+  let created = 0;
+  for (const item of staged) {
+    try {
+      const row = await getPrisma().slide.create({
+        data: {
+          classroom_id: target.classroomId,
+          title: item.targetTitle,
+          slug: item.targetSlug,
+          content_path: item.targetContentPath,
+          created_by: createdByUserId,
+          is_draft: true,
+          is_public: false,
+          allow_team_edit: item.source.allow_team_edit,
+          show_speaker_notes: item.source.show_speaker_notes,
+        } satisfies Prisma.SlideUncheckedCreateInput,
+      });
+      idMap[item.source.id] = row.id;
+      created++;
+    } catch (error: unknown) {
+      warn('slides', `DB row failed for "${item.targetTitle}": ${errText(error)}`);
+    }
+  }
+  return created;
+}

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -33,6 +33,8 @@ import * as userService from './user.service.ts';
 import * as quizService from './quiz.service.ts';
 import * as quizAttemptService from './quizAttempt.service.ts';
 import * as repositoryImportService from './repositoryImport.service.ts';
+import * as contentImportService from './contentImport.service.ts';
+import * as classroomConfigImportService from './classroomConfigImport.service.ts';
 import * as githubClassroomImportService from './githubClassroomImport.service.ts';
 import * as githubClassroomApiService from './githubClassroomApi.service.ts';
 import * as githubUserTokenService from './githubUserToken.service.ts';
@@ -78,6 +80,8 @@ const ClassmojiService = {
   quiz: quizService,
   quizAttempt: quizAttemptService,
   repositoryImport: repositoryImportService,
+  contentImport: contentImportService,
+  classroomConfigImport: classroomConfigImportService,
   githubClassroomImport: githubClassroomImportService,
   githubClassroomApi: githubClassroomApiService,
   githubUserToken: githubUserTokenService,
@@ -129,6 +133,8 @@ export {
   quizService,
   quizAttemptService,
   repositoryImportService,
+  contentImportService,
+  classroomConfigImportService,
   githubClassroomImportService,
   githubClassroomApiService,
   githubUserTokenService,

--- a/packages/services/src/classmoji/repositoryImport.service.ts
+++ b/packages/services/src/classmoji/repositoryImport.service.ts
@@ -216,10 +216,19 @@ export const cloneModule = async (
     repository: typeof newModule;
     assignments: Awaited<ReturnType<typeof cloneAssignment>>[];
     quizzes: Awaited<ReturnType<typeof cloneQuiz>>[];
+    idMaps: {
+      repositories: Record<string, string>;
+      quizzes: Record<string, string>;
+    };
   } = {
     repository: newModule,
     assignments: [],
     quizzes: [],
+    idMaps: {
+      // Source repository id → newly cloned repository id.
+      repositories: { [sourceRepositoryId]: newModule.id },
+      quizzes: {},
+    },
   };
 
   // Clone assignments
@@ -246,6 +255,7 @@ export const cloneModule = async (
         tx
       );
       results.quizzes.push(clonedQuiz);
+      results.idMaps.quizzes[quiz.id] = clonedQuiz.id;
     }
   }
 
@@ -275,11 +285,19 @@ export const cloneModulesWithRelations = async (
       assignments: Awaited<ReturnType<typeof cloneAssignment>>[];
       quizzes: Awaited<ReturnType<typeof cloneQuiz>>[];
       tags: Prisma.TagUncheckedCreateInput[];
+      idMaps: {
+        repositories: Record<string, string>;
+        quizzes: Record<string, string>;
+      };
     } = {
       repositories: [],
       assignments: [],
       quizzes: [],
       tags: [],
+      idMaps: {
+        repositories: {},
+        quizzes: {},
+      },
     };
 
     for (const config of moduleConfigs) {
@@ -297,6 +315,8 @@ export const cloneModulesWithRelations = async (
       results.repositories.push(cloneResult.repository);
       results.assignments.push(...cloneResult.assignments);
       results.quizzes.push(...cloneResult.quizzes);
+      Object.assign(results.idMaps.repositories, cloneResult.idMaps.repositories);
+      Object.assign(results.idMaps.quizzes, cloneResult.idMaps.quizzes);
     }
 
     return results;


### PR DESCRIPTION
## Summary

Classroom import previously copied only repositories + assignments. The import step now offers per-group selection of everything a returning instructor actually wants to carry over:

- **Grading & late penalty**, **grade scales** (emoji + letter mappings), **tokens**, **features & appearance**, **AI/quiz config** — all default ON
- **AI API keys** — explicit opt-in (secrets)
- **Calendar events** — opt-in, dates copied as-is
- **Pages** and **slide decks** — byte-perfect folder copies into the target's content repo (one batch commit per type, GitHub-first ordering, slug/title collision suffixing, manifest refresh), always arriving as drafts
- **Modules** — copied with per-item id remapping onto the imported repos/quizzes/pages/decks; items whose resource wasn't imported are skipped and counted

Hardening that rides along: the action now verifies server-side that the requester **owns the source classroom** and that requested repository ids belong to it (previously the loader offered only owned classrooms but the action never re-checked).

Never copied: memberships, teams, student repos, grades, submissions, tokens, attempts. Everything imported starts unpublished/draft.

## Testing
- 33 new unit tests (settings-group math, item remapping, slug/title dedupe, path remap, warning formatting); services suite 698 passed / 12 skipped; webapp + services typecheck clean
- Live E2E on dev: imported the full dev classroom (24 pages, 19 decks, 2 repos, 4+5 grade mappings, 3 calendar events, 1 module with PAGE/REPOSITORY/SLIDE items) into a fresh classroom — verified via DB (all drafts, module items remapped to new ids, settings fields copied), GitHub (content repo created with the import commits), and the webapp/pages-app UI

## Notes
- Large classrooms take a few minutes (sequential GitHub reads per file); follow-up candidate: Git Data API tree reads or a background job with progress
- Shared slide themes and absolute URLs inside copied files still reference the source repo (documented limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
