### PR TITLE
feat(webapp): optional GitHub artifact cleanup on classroom delete

### DIFF
--- a/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
@@ -1,4 +1,5 @@
-import { Button, Modal } from 'antd';
+import { useEffect, useState } from 'react';
+import { Button, Checkbox, Modal } from 'antd';
 
 import { namedAction } from 'remix-utils/named-action';
 import { useNavigate, useParams } from 'react-router';
@@ -14,19 +15,38 @@ const DangerZone = () => {
   const { show, close, visible } = useDisclosure();
   const { class: classSlug } = useParams();
   const navigate = useNavigate();
+  const [deleteGitHub, setDeleteGitHub] = useState(false);
+  const [removing, setRemoving] = useState(false);
 
   const onRemoveClassroom = () => {
-    notify(ActionTypes.REMOVE_CLASSROOM, 'Removing classroom...');
+    setRemoving(true);
+    notify(
+      ActionTypes.REMOVE_CLASSROOM,
+      deleteGitHub ? 'Removing classroom and GitHub artifacts...' : 'Removing classroom...'
+    );
     fetcher!.submit(
-      {},
+      { delete_github: deleteGitHub ? 'true' : 'false' },
       {
         method: 'delete',
         action: `?/removeClassroom`,
       }
     );
-
-    navigate('/select-organization');
   };
+
+  // Navigate only after the server confirms — a fire-and-forget navigate hid
+  // failures entirely (the classroom would silently still exist). The success
+  // toast (incl. the GitHub cleanup summary) comes from the global fetcher.
+  const fetcherData = fetcher?.data as { success?: string; error?: string } | undefined;
+  useEffect(() => {
+    if (!removing) return;
+    if (fetcher?.state !== 'idle') return;
+    if (fetcherData?.success) {
+      navigate('/select-organization');
+    } else if (fetcherData?.error) {
+      setRemoving(false);
+      close();
+    }
+  }, [removing, fetcher?.state, fetcherData, navigate, close]);
 
   return (
     <>
@@ -36,12 +56,27 @@ const DangerZone = () => {
         onOk={onRemoveClassroom}
         onCancel={() => close()}
         okText="Remove"
-        okButtonProps={{ danger: true }}
+        okButtonProps={{ danger: true, loading: removing }}
+        cancelButtonProps={{ disabled: removing }}
       >
         <p>
-          The following data will be removed: repositories, student enrollments, grades, quizzes, and
-          classroom settings.
+          Everything stored in Classmoji for this classroom will be permanently removed:
+          repositories, assignments, quizzes, pages, slide decks, modules, student enrollments,
+          grades, and settings. There is no undo.
         </p>
+        <div className="pt-3">
+          <Checkbox
+            checked={deleteGitHub}
+            disabled={removing}
+            onChange={e => setDeleteGitHub(e.target.checked)}
+          >
+            Also delete this classroom&rsquo;s GitHub artifacts
+            <div className="text-xs text-gray-500">
+              The content repository, the classroom teams, and all student assignment repositories
+              in the GitHub organization. Leave unchecked to keep everything on GitHub.
+            </div>
+          </Checkbox>
+        </div>
         <p className="pt-3">Are you sure you want to proceed?</p>
       </Modal>
       <div>
@@ -67,20 +102,49 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
+  // namedAction consumes the request body for the action name lookup only when
+  // using search-param naming (?/removeClassroom) — the form data stays readable.
+  const formData = await request.clone().formData();
+  const deleteGitHub = formData.get('delete_github') === 'true';
+
   return namedAction(request, {
     async removeClassroom() {
-      return removeClassroomHandler(classroom);
+      return removeClassroomHandler(classroom, deleteGitHub);
     },
   });
 };
 
-const removeClassroomHandler = async (classroom: { id: string }) => {
-  // Only delete the classroom data - don't remove the GitHub installation
-  // since multiple classrooms can share the same git organization
+const removeClassroomHandler = async (classroom: { id: string }, deleteGitHub: boolean) => {
+  // GitHub cleanup MUST precede the DB delete: the cascade destroys the rows
+  // that name the artifacts (content repo, team slugs, git repo names).
+  // Best-effort — failures are reported, never block the classroom removal.
+  let cleanupNote = '';
+  if (deleteGitHub) {
+    try {
+      const summary = await ClassmojiService.classroom.deleteGitHubArtifacts(classroom.id);
+      const bits: string[] = [];
+      if (summary.deleted_repos > 0)
+        bits.push(`${summary.deleted_repos} repo${summary.deleted_repos === 1 ? '' : 's'}`);
+      if (summary.deleted_teams > 0)
+        bits.push(`${summary.deleted_teams} team${summary.deleted_teams === 1 ? '' : 's'}`);
+      if (bits.length > 0) cleanupNote = ` GitHub: deleted ${bits.join(', ')}.`;
+      if (summary.failures.length > 0) {
+        console.error('GitHub cleanup failures on classroom delete:', summary.failures);
+        cleanupNote += ` ${summary.failures.length} GitHub item${
+          summary.failures.length === 1 ? '' : 's'
+        } could not be deleted (see server logs).`;
+      }
+    } catch (error: unknown) {
+      console.error('GitHub cleanup failed on classroom delete:', error);
+      cleanupNote = ' GitHub cleanup failed — artifacts left in place (see server logs).';
+    }
+  }
+
+  // The GitHub installation is never touched — multiple classrooms share it.
   await ClassmojiService.classroom.deleteById(classroom.id);
   return {
     action: ActionTypes.REMOVE_CLASSROOM,
-    success: 'Classroom removed successfully!',
+    success: `Classroom removed successfully!${cleanupNote}`,
   };
 };
 

--- a/packages/services/src/classmoji/__tests__/classroom.deleteArtifacts.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroom.deleteArtifacts.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { classroomGitHubArtifactPlan } from '../classroom.service.ts';
+
+const base = {
+  orgLogin: 'dartmouth-cs52',
+  slug: 'dartmouth-cs52-26f',
+  contentNamespace: 'dartmouth-cs52-26f',
+  gitRepoNames: [] as string[],
+  teamSlugs: [] as string[],
+};
+
+describe('classroomGitHubArtifactPlan', () => {
+  it('names the content repo from org login + namespace and the two conventional teams', () => {
+    const plan = classroomGitHubArtifactPlan(base);
+    expect(plan).toEqual([
+      {
+        kind: 'repo',
+        org: 'dartmouth-cs52',
+        name: 'content-dartmouth-cs52-dartmouth-cs52-26f',
+        label: 'content repo',
+      },
+      { kind: 'team', org: 'dartmouth-cs52', name: 'dartmouth-cs52-26f-students', label: 'classroom team' },
+      { kind: 'team', org: 'dartmouth-cs52', name: 'dartmouth-cs52-26f-assistants', label: 'classroom team' },
+    ]);
+  });
+
+  it('omits the content repo when the namespace is null', () => {
+    const plan = classroomGitHubArtifactPlan({ ...base, contentNamespace: null });
+    expect(plan.filter(a => a.label === 'content repo')).toHaveLength(0);
+    expect(plan.filter(a => a.kind === 'team')).toHaveLength(2);
+  });
+
+  it('includes assignment repos and project teams by their exact recorded names, de-duplicated', () => {
+    const plan = classroomGitHubArtifactPlan({
+      ...base,
+      gitRepoNames: ['hw1-alice', 'hw1-alice', 'hw1-bob'],
+      teamSlugs: ['team-rocket', 'team-rocket'],
+    });
+    expect(plan.filter(a => a.label === 'assignment repo').map(a => a.name)).toEqual([
+      'hw1-alice',
+      'hw1-bob',
+    ]);
+    expect(plan.filter(a => a.label === 'project team').map(a => a.name)).toEqual(['team-rocket']);
+  });
+
+  it('never invents artifacts: empty inputs yield only the derived content repo + conventional teams', () => {
+    const plan = classroomGitHubArtifactPlan(base);
+    expect(plan).toHaveLength(3);
+  });
+});

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -1,4 +1,6 @@
 import getPrisma from '@classmoji/database';
+import { classroomContentRepoName } from '@classmoji/utils';
+import { getGitProvider } from '../git/index.ts';
 import type { Prisma, Role } from '@prisma/client';
 
 /**
@@ -226,6 +228,134 @@ export const deleteById = async (id: string) => {
   return getPrisma().classroom.delete({
     where: { id },
   });
+};
+
+/** One GitHub artifact the optional delete-cleanup will remove. */
+export interface GitHubArtifact {
+  kind: 'repo' | 'team';
+  org: string;
+  /** Repo name or team slug. */
+  name: string;
+  /** Human label for summaries ('content repo', 'classroom team', …). */
+  label: string;
+}
+
+/**
+ * Pure helper: enumerate the GitHub artifacts a classroom owns, from DB-known
+ * facts ONLY — the content repo (derived from org login + content namespace),
+ * the two conventional classroom teams ({slug}-students / {slug}-assistants),
+ * any provider-backed project-team slugs, and the classroom's git repos by
+ * exact recorded name. Nothing is pattern-matched or discovered live: if the
+ * DB doesn't name it, it is not in the plan.
+ */
+export function classroomGitHubArtifactPlan({
+  orgLogin,
+  slug,
+  contentNamespace,
+  gitRepoNames,
+  teamSlugs,
+}: {
+  orgLogin: string;
+  slug: string;
+  contentNamespace: string | null;
+  gitRepoNames: string[];
+  teamSlugs: string[];
+}): GitHubArtifact[] {
+  const plan: GitHubArtifact[] = [];
+  if (contentNamespace) {
+    plan.push({
+      kind: 'repo',
+      org: orgLogin,
+      name: classroomContentRepoName({ login: orgLogin, namespace: contentNamespace }),
+      label: 'content repo',
+    });
+  }
+  for (const name of [...new Set(gitRepoNames)]) {
+    plan.push({ kind: 'repo', org: orgLogin, name, label: 'assignment repo' });
+  }
+  for (const suffix of ['students', 'assistants']) {
+    plan.push({ kind: 'team', org: orgLogin, name: `${slug}-${suffix}`, label: 'classroom team' });
+  }
+  for (const teamSlug of [...new Set(teamSlugs)]) {
+    plan.push({ kind: 'team', org: orgLogin, name: teamSlug, label: 'project team' });
+  }
+  return plan;
+}
+
+/** Result of the optional GitHub cleanup that precedes a classroom delete. */
+export interface GitHubCleanupSummary {
+  deleted_repos: number;
+  deleted_teams: number;
+  /** Artifacts that no longer existed on GitHub (already gone — not an error). */
+  skipped: number;
+  /** 'label name: reason' entries for artifacts that could not be deleted. */
+  failures: string[];
+}
+
+/**
+ * Best-effort deletion of a classroom's GitHub artifacts (content repo,
+ * classroom + project teams, student assignment repos), for the danger-zone
+ * "also delete from GitHub" option. MUST run BEFORE the DB delete — the
+ * cascade destroys the rows that name these artifacts.
+ *
+ * Every deletion is independent and best-effort: a 404 counts as skipped
+ * (already gone), any other failure is recorded and the rest proceed. The
+ * classroom rows are never touched here.
+ */
+export const deleteGitHubArtifacts = async (
+  classroomId: string
+): Promise<GitHubCleanupSummary> => {
+  const classroom = await getPrisma().classroom.findUnique({
+    where: { id: classroomId },
+    include: {
+      git_organization: true,
+      git_repos: { select: { name: true } },
+      teams: {
+        where: { provider: 'GITHUB', provider_id: { not: null } },
+        select: { slug: true },
+      },
+    },
+  });
+  if (!classroom?.git_organization?.login) {
+    return { deleted_repos: 0, deleted_teams: 0, skipped: 0, failures: ['no git organization'] };
+  }
+
+  const plan = classroomGitHubArtifactPlan({
+    orgLogin: classroom.git_organization.login,
+    slug: classroom.slug,
+    contentNamespace: classroom.content_namespace,
+    gitRepoNames: classroom.git_repos.map(r => r.name),
+    teamSlugs: classroom.teams.map(t => t.slug),
+  });
+
+  const provider = getGitProvider(classroom.git_organization);
+  const summary: GitHubCleanupSummary = {
+    deleted_repos: 0,
+    deleted_teams: 0,
+    skipped: 0,
+    failures: [],
+  };
+
+  for (const artifact of plan) {
+    try {
+      if (artifact.kind === 'repo') {
+        await provider.deleteRepository(artifact.org, artifact.name);
+        summary.deleted_repos += 1;
+      } else {
+        await provider.deleteTeam(artifact.org, artifact.name);
+        summary.deleted_teams += 1;
+      }
+    } catch (error: unknown) {
+      if ((error as { status?: number })?.status === 404) {
+        summary.skipped += 1;
+        continue;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      summary.failures.push(`${artifact.label} ${artifact.name}: ${message}`);
+    }
+  }
+
+  return summary;
 };
 
 /**


### PR DESCRIPTION
## Summary

Classroom delete was DB-only: the cascade wiped every row atomically but always left the content repo, classroom teams, and student assignment repos behind on GitHub. The danger-zone modal now offers an opt-in **"Also delete this classroom's GitHub artifacts"** checkbox (default off).

- Artifacts are enumerated from DB-known facts only — the derived content-repo name, the conventional `{slug}-students`/`{slug}-assistants` teams, provider-backed project teams, and exact recorded assignment-repo names. Nothing is pattern-matched or discovered live.
- Cleanup runs **before** the DB delete (the cascade destroys the rows that name the artifacts) and is best-effort per artifact: already-gone items count as skipped, failures are summarized in the toast and logged, and never block the classroom removal.
- Modal copy now lists what's actually removed (including pages and slide decks) and states that GitHub is untouched unless opted in.
- The delete now navigates away only after the server confirms — previously a fire-and-forget navigate hid any failure entirely.

## Testing
- 4 unit tests on the artifact plan; webapp + services typecheck clean
- Live-verified on a dev classroom: both conventional GitHub teams deleted from the org, nonexistent content repo correctly skipped, DB cascade intact, success toast carries the cleanup summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
