### PR TITLE
fix(webapp): delete-cleanup uses the requester's GitHub token (user-to-server), never the app token

### DIFF
--- a/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router';
 
 import { useGlobalFetcher, useDisclosure } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
+import { getAuthSession } from '@classmoji/auth/server';
 import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
@@ -107,21 +108,32 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   const formData = await request.clone().formData();
   const deleteGitHub = formData.get('delete_github') === 'true';
 
+  // The REQUESTER's GitHub token drives the cleanup (user-to-server: GitHub
+  // enforces the human's own permissions per call). Never the app token.
+  const authData = deleteGitHub ? await getAuthSession(request) : null;
+
   return namedAction(request, {
     async removeClassroom() {
-      return removeClassroomHandler(classroom, deleteGitHub);
+      return removeClassroomHandler(classroom, deleteGitHub, authData?.token ?? null);
     },
   });
 };
 
-const removeClassroomHandler = async (classroom: { id: string }, deleteGitHub: boolean) => {
+const removeClassroomHandler = async (
+  classroom: { id: string },
+  deleteGitHub: boolean,
+  userToken: string | null
+) => {
   // GitHub cleanup MUST precede the DB delete: the cascade destroys the rows
   // that name the artifacts (content repo, team slugs, git repo names).
   // Best-effort — failures are reported, never block the classroom removal.
   let cleanupNote = '';
   if (deleteGitHub) {
     try {
-      const summary = await ClassmojiService.classroom.deleteGitHubArtifacts(classroom.id);
+      const summary = await ClassmojiService.classroom.deleteGitHubArtifacts(
+        classroom.id,
+        userToken ?? ''
+      );
       const bits: string[] = [];
       if (summary.deleted_repos > 0)
         bits.push(`${summary.deleted_repos} repo${summary.deleted_repos === 1 ? '' : 's'}`);

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -1,6 +1,6 @@
 import getPrisma from '@classmoji/database';
 import { classroomContentRepoName } from '@classmoji/utils';
-import { getGitProvider } from '../git/index.ts';
+import { GitHubProvider } from '../git/index.ts';
 import type { Prisma, Role } from '@prisma/client';
 
 /**
@@ -298,13 +298,33 @@ export interface GitHubCleanupSummary {
  * "also delete from GitHub" option. MUST run BEFORE the DB delete — the
  * cascade destroys the rows that name these artifacts.
  *
+ * Deletions run with the REQUESTING USER's token, never the app installation
+ * token — deliberately. Classmoji user tokens are GitHub App user-to-server
+ * tokens, so GitHub enforces the intersection of the app's permissions AND the
+ * human's own: anything the requesting owner couldn't delete on GitHub
+ * themselves fails with a 403 here, regardless of what the app installation
+ * could do. There is no app-token fallback.
+ *
  * Every deletion is independent and best-effort: a 404 counts as skipped
- * (already gone), any other failure is recorded and the rest proceed. The
- * classroom rows are never touched here.
+ * (already gone), any other failure (incl. permission 403s) is recorded and
+ * the rest proceed. The classroom rows are never touched here.
+ *
+ * @param {string} classroomId - Classroom whose artifacts to delete
+ * @param {string} userToken - The requesting user's GitHub token (required)
  */
 export const deleteGitHubArtifacts = async (
-  classroomId: string
+  classroomId: string,
+  userToken: string
 ): Promise<GitHubCleanupSummary> => {
+  if (!userToken) {
+    return {
+      deleted_repos: 0,
+      deleted_teams: 0,
+      skipped: 0,
+      failures: ['no GitHub user token — nothing deleted'],
+    };
+  }
+
   const classroom = await getPrisma().classroom.findUnique({
     where: { id: classroomId },
     include: {
@@ -319,6 +339,14 @@ export const deleteGitHubArtifacts = async (
   if (!classroom?.git_organization?.login) {
     return { deleted_repos: 0, deleted_teams: 0, skipped: 0, failures: ['no git organization'] };
   }
+  if (classroom.git_organization.provider !== 'GITHUB') {
+    return {
+      deleted_repos: 0,
+      deleted_teams: 0,
+      skipped: 0,
+      failures: ['provider not supported for cleanup — artifacts left in place'],
+    };
+  }
 
   const plan = classroomGitHubArtifactPlan({
     orgLogin: classroom.git_organization.login,
@@ -328,7 +356,8 @@ export const deleteGitHubArtifacts = async (
     teamSlugs: classroom.teams.map(t => t.slug),
   });
 
-  const provider = getGitProvider(classroom.git_organization);
+  // User-to-server octokit: GitHub checks the HUMAN's authority per call.
+  const octokit = GitHubProvider.getUserOctokit(userToken);
   const summary: GitHubCleanupSummary = {
     deleted_repos: 0,
     deleted_teams: 0,
@@ -339,10 +368,16 @@ export const deleteGitHubArtifacts = async (
   for (const artifact of plan) {
     try {
       if (artifact.kind === 'repo') {
-        await provider.deleteRepository(artifact.org, artifact.name);
+        await octokit.request('DELETE /repos/{owner}/{repo}', {
+          owner: artifact.org,
+          repo: artifact.name,
+        });
         summary.deleted_repos += 1;
       } else {
-        await provider.deleteTeam(artifact.org, artifact.name);
+        await octokit.request('DELETE /orgs/{org}/teams/{team_slug}', {
+          org: artifact.org,
+          team_slug: artifact.name,
+        });
         summary.deleted_teams += 1;
       }
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Hardens #188: the optional GitHub artifact cleanup on classroom delete now executes with the requesting owner's user-to-server token instead of the app installation token — GitHub enforces the human's own permissions per call, so the cleanup can never delete anything the requester couldn't delete themselves. No app-token fallback; missing token = nothing deleted, reported in the summary.

## Testing
- Typechecks clean; artifact-plan unit tests unchanged and green
- Live-verified on dev: deleted a test classroom with cleanup under the owner's token — content repo and both classroom teams removed from the GitHub org, DB cascade intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw