### PR TITLE
fix: adversarial-review fixes for the promotion batch (namespace uniqueness + import/delete hardening)

### DIFF
--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -90,32 +90,84 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     };
   }
 
-  // Create Classroom, Settings, and Membership in transaction
-  const classroom = await getPrisma().$transaction(async tx => {
-    const classroom = await tx.classroom.create({
-      data: {
-        git_org_id,
-        slug,
-        name,
-        content_namespace: contentNamespace,
-      },
-    });
-
-    await tx.classroomSettings.create({
-      data: { classroom_id: classroom.id },
-    });
-
-    await tx.classroomMembership.create({
-      data: {
-        classroom_id: classroom.id,
-        user_id: user.id,
-        role: 'OWNER',
-        has_accepted_invite: true,
-      },
-    });
-
-    return classroom;
+  // The namespace names the content repo (content-{org}-{namespace}); a
+  // collision would make two classrooms share one repo. The DB unique
+  // constraint backstops the race; this check gives a friendly error.
+  const namespaceTaken = await getPrisma().classroom.findFirst({
+    where: { git_org_id, content_namespace: contentNamespace },
+    select: { slug: true },
   });
+  if (namespaceTaken) {
+    return {
+      error: `Content namespace '${contentNamespace}' is already used by classroom '${namespaceTaken.slug}' in this organization — pick a different one`,
+    };
+  }
+
+  // ALL validation that can refuse creation must run BEFORE the transaction —
+  // returning an error after it leaves an orphaned classroom that also blocks
+  // a same-slug retry. Source-ownership for imports is part of that gate.
+  const sourceClassroomId: string | undefined = importConfig?.sourceClassroomId;
+  const configSelections = importConfig?.config ?? {};
+  const contentSelections = importConfig?.content ?? {};
+  const anyConfigSelected = Object.values(configSelections).some(Boolean);
+  const anyContentSelected = Object.values(contentSelections).some(Boolean);
+  const requestedRepos: Array<{ id: string; includeQuizzes?: boolean }> =
+    importConfig?.repositories ?? [];
+  const importRequested =
+    !!sourceClassroomId && (requestedRepos.length > 0 || anyConfigSelected || anyContentSelected);
+
+  if (importRequested) {
+    // The picker only OFFERS owned classrooms, but every id here arrives from
+    // the request body — re-verify ownership server-side before copying
+    // anything (settings can carry API keys; content must not be exfiltrated
+    // from classrooms the requester doesn't own).
+    const sourceMembership = await getPrisma().classroomMembership.findFirst({
+      where: { classroom_id: sourceClassroomId, user_id: user.id, role: 'OWNER' },
+    });
+    if (!sourceMembership) {
+      return { error: 'You must own the source classroom to import from it' };
+    }
+  }
+
+  // Create Classroom, Settings, and Membership in transaction
+  let classroom;
+  try {
+    classroom = await getPrisma().$transaction(async tx => {
+      const created = await tx.classroom.create({
+        data: {
+          git_org_id,
+          slug,
+          name,
+          content_namespace: contentNamespace,
+        },
+      });
+
+      await tx.classroomSettings.create({
+        data: { classroom_id: created.id },
+      });
+
+      await tx.classroomMembership.create({
+        data: {
+          classroom_id: created.id,
+          user_id: user.id,
+          role: 'OWNER',
+          has_accepted_invite: true,
+        },
+      });
+
+      return created;
+    });
+  } catch (error: unknown) {
+    // Unique-constraint race (slug or content namespace claimed between the
+    // pre-checks and the insert) — refuse cleanly instead of a 500.
+    if ((error as { code?: string })?.code === 'P2002') {
+      return {
+        error:
+          'That classroom slug or content namespace was just taken in this organization — adjust and try again',
+      };
+    }
+    throw error;
+  }
 
   // Import from a source classroom if configured. Phases (each best-effort,
   // logged, never fails classroom creation): 1 settings/scales/calendar,
@@ -138,26 +190,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   let modulesSummary: { modules: number; items: number; skipped_items: number } | null = null;
   const importWarnings: string[] = [];
 
-  const sourceClassroomId: string | undefined = importConfig?.sourceClassroomId;
-  const configSelections = importConfig?.config ?? {};
-  const contentSelections = importConfig?.content ?? {};
-  const anyConfigSelected = Object.values(configSelections).some(Boolean);
-  const anyContentSelected = Object.values(contentSelections).some(Boolean);
-  const requestedRepos: Array<{ id: string; includeQuizzes?: boolean }> =
-    importConfig?.repositories ?? [];
-
-  if (sourceClassroomId && (requestedRepos.length > 0 || anyConfigSelected || anyContentSelected)) {
-    // The picker only OFFERS owned classrooms, but every id here arrives from
-    // the request body — re-verify ownership server-side before copying
-    // anything (settings can carry API keys; content must not be exfiltrated
-    // from classrooms the requester doesn't own).
-    const sourceMembership = await getPrisma().classroomMembership.findFirst({
-      where: { classroom_id: sourceClassroomId, user_id: user.id, role: 'OWNER' },
-    });
-    if (!sourceMembership) {
-      return { error: 'You must own the source classroom to import from it' };
-    }
-
+  if (importRequested && sourceClassroomId) {
     if (anyConfigSelected) {
       try {
         configSummary = await ClassmojiService.classroomConfigImport.importClassroomConfig(

--- a/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Checkbox, Modal } from 'antd';
 
 import { namedAction } from 'remix-utils/named-action';
@@ -18,8 +18,15 @@ const DangerZone = () => {
   const navigate = useNavigate();
   const [deleteGitHub, setDeleteGitHub] = useState(false);
   const [removing, setRemoving] = useState(false);
+  // Round-trip latch. The global fetcher is SHARED and self-resets to null data
+  // right after it toasts a result, so "idle with no data" is ambiguous on its
+  // own: it is the aborted case only once this submission has been seen in
+  // flight, and only before its result was handled ('settled' — otherwise the
+  // post-success reset would re-enter the effect and reopen the button).
+  const phaseRef = useRef<'idle' | 'inflight' | 'settled'>('idle');
 
   const onRemoveClassroom = () => {
+    phaseRef.current = 'idle';
     setRemoving(true);
     notify(
       ActionTypes.REMOVE_CLASSROOM,
@@ -40,12 +47,23 @@ const DangerZone = () => {
   const fetcherData = fetcher?.data as { success?: string; error?: string } | undefined;
   useEffect(() => {
     if (!removing) return;
-    if (fetcher?.state !== 'idle') return;
+    if (phaseRef.current === 'settled') return;
+    if (fetcher?.state !== 'idle') {
+      phaseRef.current = 'inflight';
+      return;
+    }
+    if (phaseRef.current !== 'inflight') return;
+    phaseRef.current = 'settled';
     if (fetcherData?.success) {
       navigate('/select-organization');
     } else if (fetcherData?.error) {
       setRemoving(false);
       close();
+    } else {
+      // Settled with neither outcome: the action never returned (aborted or
+      // timed out). Un-stick the button but KEEP the modal open — the delete's
+      // fate is unknown, so the user must decide whether to retry.
+      setRemoving(false);
     }
   }, [removing, fetcher?.state, fetcherData, navigate, close]);
 
@@ -126,29 +144,56 @@ const removeClassroomHandler = async (
 ) => {
   // GitHub cleanup MUST precede the DB delete: the cascade destroys the rows
   // that name the artifacts (content repo, team slugs, git repo names).
-  // Best-effort — failures are reported, never block the classroom removal.
+  // A FAILED cleanup therefore ABORTS the delete — deleting anyway would strand
+  // the surviving GitHub artifacts with nothing left in Classmoji naming them,
+  // leaving manual cleanup as the only recourse. The user can fix permissions
+  // and retry, or opt out of the GitHub cleanup entirely.
   let cleanupNote = '';
   if (deleteGitHub) {
+    const retryHint =
+      'Fix the GitHub permissions and try again, or uncheck the GitHub option to remove the classroom only.';
+    let summary;
     try {
-      const summary = await ClassmojiService.classroom.deleteGitHubArtifacts(
+      summary = await ClassmojiService.classroom.deleteGitHubArtifacts(
         classroom.id,
         userToken ?? ''
       );
-      const bits: string[] = [];
-      if (summary.deleted_repos > 0)
-        bits.push(`${summary.deleted_repos} repo${summary.deleted_repos === 1 ? '' : 's'}`);
-      if (summary.deleted_teams > 0)
-        bits.push(`${summary.deleted_teams} team${summary.deleted_teams === 1 ? '' : 's'}`);
-      if (bits.length > 0) cleanupNote = ` GitHub: deleted ${bits.join(', ')}.`;
-      if (summary.failures.length > 0) {
-        console.error('GitHub cleanup failures on classroom delete:', summary.failures);
-        cleanupNote += ` ${summary.failures.length} GitHub item${
-          summary.failures.length === 1 ? '' : 's'
-        } could not be deleted (see server logs).`;
-      }
     } catch (error: unknown) {
       console.error('GitHub cleanup failed on classroom delete:', error);
-      cleanupNote = ' GitHub cleanup failed — artifacts left in place (see server logs).';
+      return {
+        action: ActionTypes.REMOVE_CLASSROOM,
+        error: `Classroom NOT deleted: GitHub cleanup failed (see server logs). ${retryHint}`,
+      };
+    }
+
+    const bits: string[] = [];
+    if (summary.deleted_repos > 0)
+      bits.push(`${summary.deleted_repos} repo${summary.deleted_repos === 1 ? '' : 's'}`);
+    if (summary.deleted_teams > 0)
+      bits.push(`${summary.deleted_teams} team${summary.deleted_teams === 1 ? '' : 's'}`);
+    const deletedNote = bits.length > 0 ? ` GitHub: deleted ${bits.join(', ')}.` : '';
+
+    if (summary.failures.length > 0) {
+      console.error('GitHub cleanup failures on classroom delete:', summary.failures);
+      const failedNote = `${summary.failures.length} GitHub item${
+        summary.failures.length === 1 ? '' : 's'
+      } could not be deleted (see server logs).`;
+      const progressNote =
+        bits.length > 0
+          ? ` Deleted before the failure: ${bits.join(', ')}.`
+          : ' Nothing was deleted on GitHub.';
+      return {
+        action: ActionTypes.REMOVE_CLASSROOM,
+        error: `Classroom NOT deleted: ${failedNote}${progressNote} ${retryHint}`,
+      };
+    }
+
+    // `skipped` is already-gone / not-visible — never a reason to abort.
+    cleanupNote = deletedNote;
+    if (summary.skipped > 0) {
+      cleanupNote += ` ${summary.skipped} item${
+        summary.skipped === 1 ? ' was' : 's were'
+      } already gone or not visible to your GitHub account.`;
     }
   }
 

--- a/packages/database/migrations/20260811232306_classroom_content_namespace_unique/migration.sql
+++ b/packages/database/migrations/20260811232306_classroom_content_namespace_unique/migration.sql
@@ -1,0 +1,32 @@
+-- The content repo name is content-{orgLogin}-{content_namespace}: two
+-- classrooms in one org sharing a namespace would share (and could adopt,
+-- overwrite, or delete) each other's content repo. Enforce per-org uniqueness.
+
+-- Repair pre-existing duplicates first: keep the OLDEST row in each
+-- [git_org_id, content_namespace] group, repoint newer rows to their slug
+-- (slug is already unique per org). Verified: all duplicate rows in prod have
+-- zero pages/slides, so no content repo exists for them and repointing is safe.
+UPDATE "classrooms" c SET "content_namespace" = c."slug"
+WHERE EXISTS (
+  SELECT 1 FROM "classrooms" other
+  WHERE other."git_org_id" = c."git_org_id"
+    AND other."content_namespace" = c."content_namespace"
+    AND other."id" <> c."id"
+    AND (other."created_at" < c."created_at"
+         OR (other."created_at" = c."created_at" AND other."id" < c."id"))
+);
+
+-- Defensive second pass: if a repointed namespace still collides (another
+-- classroom already used this slug as its namespace), suffix with the id prefix.
+UPDATE "classrooms" c SET "content_namespace" = c."content_namespace" || '-' || substr(c."id", 1, 8)
+WHERE EXISTS (
+  SELECT 1 FROM "classrooms" other
+  WHERE other."git_org_id" = c."git_org_id"
+    AND other."content_namespace" = c."content_namespace"
+    AND other."id" <> c."id"
+    AND (other."created_at" < c."created_at"
+         OR (other."created_at" = c."created_at" AND other."id" < c."id"))
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "classrooms_git_org_id_content_namespace_key" ON "classrooms"("git_org_id", "content_namespace");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -379,6 +379,10 @@ model Classroom {
   notifications         Notification[]
 
   @@unique([git_org_id, slug])
+  // The content repo name is content-{orgLogin}-{content_namespace}: two
+  // classrooms in one org sharing a namespace would share (and could adopt,
+  // overwrite, or delete) each other's content repo. Uniqueness is per-org.
+  @@unique([git_org_id, content_namespace])
   @@index([git_org_id])
   @@map("classrooms")
 }

--- a/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
@@ -1,0 +1,159 @@
+/**
+ * contentImport.service URL-rewrite helpers: isTextContentPath,
+ * rewriteContentUrls, rewriteStagedFiles. Pure functions only — no DB/GitHub.
+ * The runtime-heavy imports the service pulls in at module load are stubbed so
+ * importing it is cheap.
+ *
+ * What these guard: imported content must point at ITS OWN copied assets. If a
+ * rewrite is missed, the copy keeps referencing the SOURCE repo and every image
+ * 404s the moment the source classroom is deleted with GitHub cleanup.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+vi.mock('../../content/ContentService.ts', () => ({ ContentService: {} }));
+vi.mock('../../git/index.ts', () => ({ getGitProvider: vi.fn() }));
+vi.mock('../page.service.ts', () => ({ ensureContentRepo: vi.fn() }));
+vi.mock('../contentManifest.service.ts', () => ({ saveManifest: vi.fn() }));
+
+const { isTextContentPath, rewriteContentUrls, rewriteStagedFiles } =
+  await import('../contentImport.service.ts');
+
+/** Source and target deliberately live in DIFFERENT orgs — the org segment of
+ *  every URL must be swapped too, not just the repo name. */
+const ctx = {
+  sourceLogin: 'dartmouth-cs52',
+  sourceRepo: 'content-dartmouth-cs52-cs52-25s',
+  sourcePath: 'pages/lab-1',
+  targetLogin: 'brown-cs32',
+  targetRepo: 'content-brown-cs32-cs32-26f',
+  targetPath: 'pages/lab-1',
+};
+
+const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+const fromB64 = (s: string) => Buffer.from(s, 'base64').toString('utf8');
+
+describe('isTextContentPath', () => {
+  it('accepts the text formats content is authored in', () => {
+    expect(isTextContentPath('pages/lab-1/content.json')).toBe(true);
+    expect(isTextContentPath('slides/deck/index.html')).toBe(true);
+    expect(isTextContentPath('pages/lab-1/assets/diagram.svg')).toBe(true);
+  });
+
+  it('rejects binaries — decoding them as utf8 would corrupt the bytes', () => {
+    expect(isTextContentPath('pages/lab-1/assets/screenshot.png')).toBe(false);
+    expect(isTextContentPath('slides/deck/assets/demo.mp4')).toBe(false);
+  });
+});
+
+describe('rewriteContentUrls', () => {
+  it('rewrites this item’s own asset URLs onto its dedupe-suffixed target path', () => {
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text = `![d](https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/main/pages/lab-1/assets/d.png)`;
+    expect(rewriteContentUrls(text, suffixed)).toBe(
+      `![d](https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/main/pages/lab-1-2/assets/d.png)`
+    );
+  });
+
+  it('rewrites cross-item references repo-generally, keeping their own folder path', () => {
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text =
+      'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/main/pages/lab-9/assets/other.png';
+    // lab-9 is a DIFFERENT item: it keeps its folder, only org/repo change.
+    expect(rewriteContentUrls(text, suffixed)).toBe(
+      'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/main/pages/lab-9/assets/other.png'
+    );
+  });
+
+  it('rewrites the {login}.github.io Pages-CDN shape, item-specific and general', () => {
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const own =
+      'https://dartmouth-cs52.github.io/content-dartmouth-cs52-cs52-25s/pages/lab-1/a.svg';
+    const other =
+      'https://dartmouth-cs52.github.io/content-dartmouth-cs52-cs52-25s/pages/lab-9/b.svg';
+    expect(rewriteContentUrls(own, suffixed)).toBe(
+      'https://brown-cs32.github.io/content-brown-cs32-cs32-26f/pages/lab-1-2/a.svg'
+    );
+    expect(rewriteContentUrls(other, suffixed)).toBe(
+      'https://brown-cs32.github.io/content-brown-cs32-cs32-26f/pages/lab-9/b.svg'
+    );
+  });
+
+  it('rewrites every occurrence, not just the first', () => {
+    const url =
+      'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/main/pages/lab-1/a.png';
+    const out = rewriteContentUrls(`${url} and ${url}`, ctx);
+    expect(out).not.toContain('dartmouth-cs52');
+    expect(
+      out.match(
+        /https:\/\/raw\.githubusercontent\.com\/brown-cs32\/content-brown-cs32-cs32-26f\/main\/pages\/lab-1\/a\.png/g
+      )
+    ).toHaveLength(2);
+  });
+
+  it('returns text with no source URLs unchanged', () => {
+    const text = '{"type":"paragraph","text":"See https://example.com/logo.png for details"}';
+    expect(rewriteContentUrls(text, ctx)).toBe(text);
+  });
+
+  it('leaves an unrelated org’s GitHub URLs alone', () => {
+    const text = 'https://raw.githubusercontent.com/someone-else/other-repo/main/pages/lab-1/x.png';
+    expect(rewriteContentUrls(text, ctx)).toBe(text);
+  });
+});
+
+describe('rewriteStagedFiles', () => {
+  it('round-trips a text file through base64: decode, rewrite, re-encode', () => {
+    const original =
+      '{"src":"https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/main/pages/lab-1/hero.png"}';
+    const out = rewriteStagedFiles(
+      [{ path: 'pages/lab-1/content.json', content: b64(original), encoding: 'base64' as const }],
+      ctx
+    );
+    expect(fromB64(out[0]!.content)).toBe(
+      '{"src":"https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/main/pages/lab-1/hero.png"}'
+    );
+    expect(out[0]!.path).toBe('pages/lab-1/content.json');
+    expect(out[0]!.encoding).toBe('base64');
+  });
+
+  it('never touches a binary — its base64 survives byte-for-byte', () => {
+    // Bytes that are NOT valid utf8: a utf8 decode/encode round-trip would
+    // replace them with U+FFFD and silently corrupt the asset.
+    const raw = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00, 0x01]).toString('base64');
+    const out = rewriteStagedFiles(
+      [{ path: 'pages/lab-1/assets/hero.png', content: raw, encoding: 'base64' as const }],
+      ctx
+    );
+    expect(out[0]!.content).toBe(raw);
+  });
+
+  it('keeps the identical content string for text with no matches', () => {
+    const untouched = b64('{"type":"paragraph","text":"no urls here"}');
+    const out = rewriteStagedFiles(
+      [{ path: 'pages/lab-1/content.json', content: untouched, encoding: 'base64' as const }],
+      ctx
+    );
+    expect(out[0]!.content).toBe(untouched);
+  });
+
+  it('rewrites the text entries of a mixed batch and passes the rest through', () => {
+    const text = b64(
+      'https://dartmouth-cs52.github.io/content-dartmouth-cs52-cs52-25s/pages/lab-1/a.svg'
+    );
+    const binary = Buffer.from([0x00, 0xff, 0x10]).toString('base64');
+    const out = rewriteStagedFiles(
+      [
+        { path: 'pages/lab-1/content.json', content: text, encoding: 'base64' as const },
+        { path: 'pages/lab-1/assets/a.png', content: binary, encoding: 'base64' as const },
+      ],
+      ctx
+    );
+    expect(fromB64(out[0]!.content)).toBe(
+      'https://brown-cs32.github.io/content-brown-cs32-cs32-26f/pages/lab-1/a.svg'
+    );
+    expect(out[1]!.content).toBe(binary);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -309,6 +309,10 @@ export interface GitHubCleanupSummary {
  * (already gone), any other failure (incl. permission 403s) is recorded and
  * the rest proceed. The classroom rows are never touched here.
  *
+ * The content repo is held back (and recorded as a failure) when another
+ * classroom in the same org shares this classroom's content namespace — they
+ * resolve to the SAME repo, so deleting it would take out live content.
+ *
  * @param {string} classroomId - Classroom whose artifacts to delete
  * @param {string} userToken - The requesting user's GitHub token (required)
  */
@@ -348,7 +352,7 @@ export const deleteGitHubArtifacts = async (
     };
   }
 
-  const plan = classroomGitHubArtifactPlan({
+  let plan = classroomGitHubArtifactPlan({
     orgLogin: classroom.git_organization.login,
     slug: classroom.slug,
     contentNamespace: classroom.content_namespace,
@@ -364,6 +368,32 @@ export const deleteGitHubArtifacts = async (
     skipped: 0,
     failures: [],
   };
+
+  // The content repo name is derived from [org login, content namespace], so a
+  // sibling classroom sharing that pair OWNS THE SAME REPO — deleting it would
+  // destroy live content of a classroom nobody asked to remove. A DB unique
+  // constraint on [git_org_id, content_namespace] now prevents new collisions;
+  // this guard covers rows that predate it. Teams and assignment repos are
+  // per-classroom and never shared, so only the content repo is held back.
+  if (classroom.content_namespace) {
+    const sharer = await getPrisma().classroom.findFirst({
+      where: {
+        git_org_id: classroom.git_org_id,
+        content_namespace: classroom.content_namespace,
+        id: { not: classroom.id },
+      },
+      select: { slug: true },
+    });
+    if (sharer) {
+      const contentRepo = plan.find(a => a.label === 'content repo');
+      plan = plan.filter(a => a.label !== 'content repo');
+      if (contentRepo) {
+        summary.failures.push(
+          `content repo ${contentRepo.name}: shared with classroom '${sharer.slug}' — not deleted`
+        );
+      }
+    }
+  }
 
   for (const artifact of plan) {
     try {

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -115,6 +115,67 @@ export function formatWarning(scope: string, detail: string): string {
   return `${scope}: ${trimmed}`;
 }
 
+/** File extensions whose contents get source→target URL rewriting. */
+const TEXT_EXTENSIONS = /\.(json|html?|md|css|js|txt|svg)$/i;
+
+/** true when the path names a text file safe to URL-rewrite (never binaries). */
+export function isTextContentPath(path: string): boolean {
+  return TEXT_EXTENSIONS.test(path);
+}
+
+export interface UrlRewriteContext {
+  sourceLogin: string;
+  sourceRepo: string;
+  /** This item's folder in the source repo (e.g. `pages/lab-1`). */
+  sourcePath: string;
+  targetLogin: string;
+  targetRepo: string;
+  /** This item's folder in the target repo (may carry a dedupe suffix). */
+  targetPath: string;
+}
+
+/**
+ * Rewrite absolute source-repo URLs inside copied text content so imported
+ * pages/decks reference THEIR OWN copied assets instead of the source repo —
+ * without this, deleting the source classroom (with GitHub cleanup) 404s every
+ * image in the imported content. Handles both URL shapes the app emits:
+ * raw.githubusercontent.com and the {login}.github.io Pages CDN.
+ *
+ * Order matters: the item-specific folder rewrite runs first (it may carry a
+ * dedupe suffix), then the repo-general rewrite catches cross-item references
+ * (which keep their original folder path — correct whenever that item was
+ * imported un-renamed; a renamed cross-referenced item is a documented
+ * residual).
+ */
+export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string {
+  const rawSource = `https://raw.githubusercontent.com/${ctx.sourceLogin}/${ctx.sourceRepo}/main`;
+  const rawTarget = `https://raw.githubusercontent.com/${ctx.targetLogin}/${ctx.targetRepo}/main`;
+  const pagesSource = `https://${ctx.sourceLogin}.github.io/${ctx.sourceRepo}`;
+  const pagesTarget = `https://${ctx.targetLogin}.github.io/${ctx.targetRepo}`;
+  return text
+    .replaceAll(`${rawSource}/${ctx.sourcePath}/`, `${rawTarget}/${ctx.targetPath}/`)
+    .replaceAll(`${rawSource}/`, `${rawTarget}/`)
+    .replaceAll(`${pagesSource}/${ctx.sourcePath}/`, `${pagesTarget}/${ctx.targetPath}/`)
+    .replaceAll(`${pagesSource}/`, `${pagesTarget}/`);
+}
+
+/**
+ * Apply `rewriteContentUrls` to the text files in a staged item's writes
+ * (base64-decoded, rewritten, re-encoded); binaries pass through untouched.
+ */
+export function rewriteStagedFiles(
+  files: BatchFile[],
+  ctx: UrlRewriteContext
+): BatchFile[] {
+  return files.map(file => {
+    if (!isTextContentPath(file.path)) return file;
+    const decoded = Buffer.from(file.content, 'base64').toString('utf8');
+    const rewritten = rewriteContentUrls(decoded, ctx);
+    if (rewritten === decoded) return file;
+    return { ...file, content: Buffer.from(rewritten, 'utf8').toString('base64') };
+  });
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Impl helpers (touch DB/GitHub — not unit-tested)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -432,6 +493,16 @@ async function importPages({
       warn('pages', `skipped "${page.title}" — no files at ${page.content_path}`);
       continue;
     }
+    // Repoint absolute source-repo asset URLs at the copied files — otherwise
+    // deleting the source classroom (with GitHub cleanup) 404s every image.
+    files = rewriteStagedFiles(files, {
+      sourceLogin: source.login,
+      sourceRepo: source.repo,
+      sourcePath: page.content_path,
+      targetLogin: target.login,
+      targetRepo: target.repo,
+      targetPath: targetContentPath,
+    });
     staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath });
   }
 
@@ -467,7 +538,17 @@ async function importPages({
           width: item.source.width,
           show_in_student_menu: item.source.show_in_student_menu,
           menu_order: item.source.menu_order,
-          header_image_url: item.source.header_image_url,
+          // Same source→target URL repoint as the file contents get.
+          header_image_url: item.source.header_image_url
+            ? rewriteContentUrls(item.source.header_image_url, {
+                sourceLogin: source.login,
+                sourceRepo: source.repo,
+                sourcePath: item.source.content_path,
+                targetLogin: target.login,
+                targetRepo: target.repo,
+                targetPath: item.targetContentPath,
+              })
+            : item.source.header_image_url,
           header_image_position: item.source.header_image_position,
         } satisfies Prisma.PageUncheckedCreateInput,
       });
@@ -540,6 +621,16 @@ async function importSlides({
       warn('slides', `skipped "${slide.title}" — no files at ${slide.content_path}`);
       continue;
     }
+    // Repoint absolute source-repo asset URLs at the copied files (deck.json +
+    // index.html are rewritten in lockstep, keeping the pair consistent).
+    files = rewriteStagedFiles(files, {
+      sourceLogin: source.login,
+      sourceRepo: source.repo,
+      sourcePath: slide.content_path,
+      targetLogin: target.login,
+      targetRepo: target.repo,
+      targetPath: targetContentPath,
+    });
     staged.push({
       source: slide,
       files,


### PR DESCRIPTION
## Summary

A three-lens adversarial review of the pending staging→main promotion found one blocker and three real defects. All fixed:

- **Content-namespace uniqueness restored**: decoupling the namespace from the slug dropped a structural invariant — two classrooms in one org could resolve to the same content repo (adopt/overwrite/delete each other's content). Now enforced by `@@unique([git_org_id, content_namespace])` with a data-repair migration (existing duplicates repointed to their org-unique slug; verified zero-content), a create-time collision check, a P2002 race backstop, and a delete-side guard refusing to remove a still-shared content repo.
- **Create-classroom validation ordering**: all refusals (namespace length/collision, import source ownership) now run before the creation transaction — no more orphaned classrooms blocking same-slug retries.
- **Imported content URL rewriting**: copied pages/decks (and `header_image_url`) now repoint absolute source-repo asset URLs (raw + Pages CDN shapes) at the target repo, so deleting the source classroom no longer 404s imported images.
- **Failed GitHub cleanup aborts the delete**: the DB cascade destroys the rows naming the artifacts, so deleting anyway orphaned them permanently. Failures (or a thrown cleanup) now keep the classroom intact with a clear retry path; already-gone items are reported distinctly and never block. The modal also recovers from aborted/timed-out submissions.

## Testing
- 12 new unit tests (URL rewriting incl. cross-org and binary passthrough); services suite 714 passed / 12 skipped; webapp + services typecheck clean; utils 82 passed
- Migration applied on dev; prod duplicate rows pre-verified as zero-content via read-only census

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw