### PR TITLE
feat(webapp): delete-confirmation modal lists the exact GitHub artifacts

### DIFF
--- a/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
@@ -3,6 +3,7 @@ import { Button, Checkbox, Modal } from 'antd';
 
 import { namedAction } from 'remix-utils/named-action';
 import { useNavigate, useParams } from 'react-router';
+import type { ShouldRevalidateFunctionArgs } from 'react-router';
 
 import { useGlobalFetcher, useDisclosure } from '~/hooks';
 import { ClassmojiService } from '@classmoji/services';
@@ -11,7 +12,40 @@ import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
-const DangerZone = () => {
+// DB-only read: the exact cleanup plan the action would execute, so the modal
+// can show it before the user confirms. No GitHub calls — same plan, one source.
+export const loader = async ({ request, params }: Route.LoaderArgs) => {
+  const { classroom } = await requireClassroomAdmin(request, params.class!, {
+    resourceType: 'SETTINGS',
+    action: 'view_delete_plan',
+  });
+
+  const { artifacts, withheld } = await ClassmojiService.classroom.getClassroomGitHubArtifactPlan(
+    classroom.id
+  );
+  return { artifacts, withheld };
+};
+
+// The delete submission revalidates this loader by default. On SUCCESS the
+// classroom is gone, so the loader's own auth gate would throw 404 into the
+// error boundary before the confirm-then-navigate effect can run — skip it.
+// On failure the modal stays open for a retry, so the plan is refreshed.
+export const shouldRevalidate = ({ actionResult }: ShouldRevalidateFunctionArgs) =>
+  Boolean(actionResult?.error);
+
+const DangerZone = ({ loaderData }: Route.ComponentProps) => {
+  const { artifacts, withheld } = loaderData;
+  const repos = artifacts.filter(a => a.kind === 'repo');
+  const teams = artifacts.filter(a => a.kind === 'team');
+  // Content repo first, then assignment repos, then every team.
+  const artifactGroups = [
+    { heading: 'Content repository', items: artifacts.filter(a => a.label === 'content repo') },
+    {
+      heading: 'Assignment repositories',
+      items: artifacts.filter(a => a.label === 'assignment repo'),
+    },
+    { heading: 'Teams', items: teams },
+  ].filter(group => group.items.length > 0);
   const { fetcher, notify } = useGlobalFetcher();
   const { show, close, visible } = useDisclosure();
   const { class: classSlug } = useParams();
@@ -90,11 +124,51 @@ const DangerZone = () => {
             onChange={e => setDeleteGitHub(e.target.checked)}
           >
             Also delete this classroom&rsquo;s GitHub artifacts
-            <div className="text-xs text-gray-500">
+            <div className="text-xs text-gray-500 dark:text-gray-400">
               The content repository, the classroom teams, and all student assignment repositories
               in the GitHub organization. Leave unchecked to keep everything on GitHub.
             </div>
           </Checkbox>
+          {deleteGitHub && (
+            <div className="mt-2 rounded-md border border-gray-200 bg-gray-50 p-3 text-xs dark:border-neutral-700 dark:bg-neutral-800">
+              {artifacts.length === 0 ? (
+                <p className="text-gray-600 dark:text-gray-300">
+                  Nothing to delete on GitHub for this classroom.
+                </p>
+              ) : (
+                <>
+                  <p className="font-medium text-gray-700 dark:text-gray-200">
+                    Will delete {repos.length} repositor{repos.length === 1 ? 'y' : 'ies'} and{' '}
+                    {teams.length} team{teams.length === 1 ? '' : 's'}:
+                  </p>
+                  {/* Student assignment repos can run to hundreds — keep the list scrollable. */}
+                  <div className="mt-2 max-h-40 overflow-y-auto pr-1">
+                    {artifactGroups.map(group => (
+                      <div key={group.heading} className="mb-2 last:mb-0">
+                        <div className="uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                          {group.heading}
+                        </div>
+                        <ul className="font-mono text-gray-700 dark:text-gray-200">
+                          {group.items.map(artifact => (
+                            <li key={`${artifact.kind}:${artifact.name}`} className="truncate">
+                              {artifact.name}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+              {withheld && (
+                <p className="mt-2 text-amber-600 dark:text-amber-400">
+                  Content repo <span className="font-mono">{withheld.name}</span> is shared with
+                  classroom <span className="font-mono">{withheld.sharedWithSlug}</span>, so GitHub
+                  cleanup is blocked — uncheck this option to remove the classroom only.
+                </p>
+              )}
+            </div>
+          )}
         </div>
         <p className="pt-3">Are you sure you want to proceed?</p>
       </Modal>

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -282,6 +282,87 @@ export function classroomGitHubArtifactPlan({
   return plan;
 }
 
+/** A classroom's GitHub cleanup plan, loaded from the DB. */
+export interface ClassroomGitHubPlan {
+  /** Exactly the artifacts that would be deleted, in deletion order. */
+  artifacts: GitHubArtifact[];
+  /** Content repo held back because a sibling classroom resolves to the same repo. */
+  withheld: { name: string; sharedWithSlug: string } | null;
+  /** Reason no plan exists at all; reported verbatim as the executor's only failure. */
+  unavailable: string | null;
+}
+
+/**
+ * Load a classroom's GitHub cleanup plan from the DB. Single source of truth
+ * for BOTH the danger-zone preview and the executor below, so what the user is
+ * shown before confirming is exactly what gets deleted. DB reads only — never
+ * calls GitHub, so it is safe in a loader.
+ *
+ * The content repo is held back (`withheld`, and excluded from `artifacts`)
+ * when another classroom in the same org shares this classroom's content
+ * namespace — they resolve to the SAME repo, so deleting it would take out live
+ * content. A DB unique constraint on [git_org_id, content_namespace] now
+ * prevents new collisions; this guard covers rows that predate it. Teams and
+ * assignment repos are per-classroom and never shared.
+ *
+ * @param {string} classroomId - Classroom whose artifacts to enumerate
+ */
+export const getClassroomGitHubArtifactPlan = async (
+  classroomId: string
+): Promise<ClassroomGitHubPlan> => {
+  const classroom = await getPrisma().classroom.findUnique({
+    where: { id: classroomId },
+    include: {
+      git_organization: true,
+      git_repos: { select: { name: true } },
+      teams: {
+        where: { provider: 'GITHUB', provider_id: { not: null } },
+        select: { slug: true },
+      },
+    },
+  });
+  if (!classroom?.git_organization?.login) {
+    return { artifacts: [], withheld: null, unavailable: 'no git organization' };
+  }
+  if (classroom.git_organization.provider !== 'GITHUB') {
+    return {
+      artifacts: [],
+      withheld: null,
+      unavailable: 'provider not supported for cleanup — artifacts left in place',
+    };
+  }
+
+  const artifacts = classroomGitHubArtifactPlan({
+    orgLogin: classroom.git_organization.login,
+    slug: classroom.slug,
+    contentNamespace: classroom.content_namespace,
+    gitRepoNames: classroom.git_repos.map(r => r.name),
+    teamSlugs: classroom.teams.map(t => t.slug),
+  });
+
+  if (!classroom.content_namespace) {
+    return { artifacts, withheld: null, unavailable: null };
+  }
+  const sharer = await getPrisma().classroom.findFirst({
+    where: {
+      git_org_id: classroom.git_org_id,
+      content_namespace: classroom.content_namespace,
+      id: { not: classroom.id },
+    },
+    select: { slug: true },
+  });
+  if (!sharer) {
+    return { artifacts, withheld: null, unavailable: null };
+  }
+
+  const contentRepo = artifacts.find(a => a.label === 'content repo');
+  return {
+    artifacts: artifacts.filter(a => a.label !== 'content repo'),
+    withheld: contentRepo ? { name: contentRepo.name, sharedWithSlug: sharer.slug } : null,
+    unavailable: null,
+  };
+};
+
 /** Result of the optional GitHub cleanup that precedes a classroom delete. */
 export interface GitHubCleanupSummary {
   deleted_repos: number;
@@ -309,9 +390,9 @@ export interface GitHubCleanupSummary {
  * (already gone), any other failure (incl. permission 403s) is recorded and
  * the rest proceed. The classroom rows are never touched here.
  *
- * The content repo is held back (and recorded as a failure) when another
- * classroom in the same org shares this classroom's content namespace — they
- * resolve to the SAME repo, so deleting it would take out live content.
+ * What gets deleted comes from getClassroomGitHubArtifactPlan — the same plan
+ * the danger-zone modal previews. A withheld (shared-namespace) content repo is
+ * recorded as a failure: the cleanup did not fully complete.
  *
  * @param {string} classroomId - Classroom whose artifacts to delete
  * @param {string} userToken - The requesting user's GitHub token (required)
@@ -329,36 +410,10 @@ export const deleteGitHubArtifacts = async (
     };
   }
 
-  const classroom = await getPrisma().classroom.findUnique({
-    where: { id: classroomId },
-    include: {
-      git_organization: true,
-      git_repos: { select: { name: true } },
-      teams: {
-        where: { provider: 'GITHUB', provider_id: { not: null } },
-        select: { slug: true },
-      },
-    },
-  });
-  if (!classroom?.git_organization?.login) {
-    return { deleted_repos: 0, deleted_teams: 0, skipped: 0, failures: ['no git organization'] };
+  const { artifacts, withheld, unavailable } = await getClassroomGitHubArtifactPlan(classroomId);
+  if (unavailable) {
+    return { deleted_repos: 0, deleted_teams: 0, skipped: 0, failures: [unavailable] };
   }
-  if (classroom.git_organization.provider !== 'GITHUB') {
-    return {
-      deleted_repos: 0,
-      deleted_teams: 0,
-      skipped: 0,
-      failures: ['provider not supported for cleanup — artifacts left in place'],
-    };
-  }
-
-  let plan = classroomGitHubArtifactPlan({
-    orgLogin: classroom.git_organization.login,
-    slug: classroom.slug,
-    contentNamespace: classroom.content_namespace,
-    gitRepoNames: classroom.git_repos.map(r => r.name),
-    teamSlugs: classroom.teams.map(t => t.slug),
-  });
 
   // User-to-server octokit: GitHub checks the HUMAN's authority per call.
   const octokit = GitHubProvider.getUserOctokit(userToken);
@@ -369,33 +424,14 @@ export const deleteGitHubArtifacts = async (
     failures: [],
   };
 
-  // The content repo name is derived from [org login, content namespace], so a
-  // sibling classroom sharing that pair OWNS THE SAME REPO — deleting it would
-  // destroy live content of a classroom nobody asked to remove. A DB unique
-  // constraint on [git_org_id, content_namespace] now prevents new collisions;
-  // this guard covers rows that predate it. Teams and assignment repos are
-  // per-classroom and never shared, so only the content repo is held back.
-  if (classroom.content_namespace) {
-    const sharer = await getPrisma().classroom.findFirst({
-      where: {
-        git_org_id: classroom.git_org_id,
-        content_namespace: classroom.content_namespace,
-        id: { not: classroom.id },
-      },
-      select: { slug: true },
-    });
-    if (sharer) {
-      const contentRepo = plan.find(a => a.label === 'content repo');
-      plan = plan.filter(a => a.label !== 'content repo');
-      if (contentRepo) {
-        summary.failures.push(
-          `content repo ${contentRepo.name}: shared with classroom '${sharer.slug}' — not deleted`
-        );
-      }
-    }
+  // Recorded before the loop so it leads the failure list.
+  if (withheld) {
+    summary.failures.push(
+      `content repo ${withheld.name}: shared with classroom '${withheld.sharedWithSlug}' — not deleted`
+    );
   }
 
-  for (const artifact of plan) {
+  for (const artifact of artifacts) {
     try {
       if (artifact.kind === 'repo') {
         await octokit.request('DELETE /repos/{owner}/{repo}', {


### PR DESCRIPTION
## Summary

The danger-zone delete's GitHub-cleanup checkbox now shows the exact artifact list before confirming — content repo, assignment repos, and teams, with counts — computed through the same service seam the executor uses, so the displayed plan is the executed plan by construction. A shared content namespace renders an amber notice that cleanup is blocked (matching the executor's abort semantics). The new loader opts out of post-action revalidation so a successful delete still navigates instead of 404ing into the error boundary.

## Testing
- services 714 passed / 12 skipped; webapp + services typecheck clean; route types regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw