### PR TITLE
feat(webapp): import can duplicate template repos as private copies

### DIFF
--- a/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
@@ -84,6 +84,12 @@ const StepImportModules = ({
     setSelectedModules(new Map());
   };
 
+  // Distinct non-empty template refs across the WHOLE source classroom — the
+  // duplication ceiling, independent of which repositories are selected.
+  const distinctTemplates = new Set(
+    repositories.map(m => (m.template ?? '').trim()).filter(Boolean)
+  ).size;
+
   // Calculate totals for summary
   let totalAssignments = 0;
   let totalQuizzes = 0;
@@ -277,6 +283,12 @@ const StepImportModules = ({
                           label: 'Modules',
                           count: sourceClassroom?._count?.modules ?? 0,
                           sublabel: 'items link only to content you import',
+                        },
+                        {
+                          key: 'duplicateTemplates',
+                          label: 'Duplicate template repos',
+                          count: distinctTemplates,
+                          sublabel: 'private copies in this org — keeps terms independent',
                         },
                         {
                           key: 'calendar',

--- a/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
@@ -24,10 +24,15 @@ interface StepReviewProps {
   importSelections?: ImportSelections;
 }
 
+/** Distinct non-empty template refs across a classroom's repositories. */
+const distinctTemplateCount = (classroom?: OwnedClassroom): number =>
+  new Set((classroom?.repositories ?? []).map(m => (m.template ?? '').trim()).filter(Boolean)).size;
+
 /** Human labels for the enabled "Also copy" groups, with counts where known. */
 const copySummaryParts = (
   selections: ImportSelections,
-  counts?: OwnedClassroom['_count']
+  counts?: OwnedClassroom['_count'],
+  templateCount = 0
 ): string[] => {
   const parts: string[] = [];
   if (selections.grading) parts.push('grading & late penalty');
@@ -42,6 +47,8 @@ const copySummaryParts = (
     parts.push(`slide decks (${counts?.slides})`);
   if (selections.modules && (counts?.modules ?? 0) > 0)
     parts.push(`modules (${counts?.modules})`);
+  if (selections.duplicateTemplates && templateCount > 0)
+    parts.push(`private template copies (${templateCount})`);
   if (selections.calendar && (counts?.calendar_events ?? 0) > 0)
     parts.push(`calendar events (${counts?.calendar_events})`);
   return parts;
@@ -127,7 +134,11 @@ const StepReview = ({
           size="small"
         >
           {(() => {
-            const parts = copySummaryParts(importSelections, sourceClassroom._count);
+            const parts = copySummaryParts(
+              importSelections,
+              sourceClassroom._count,
+              distinctTemplateCount(sourceClassroom)
+            );
             return parts.length > 0 ? (
               <div className="text-sm text-gray-700 dark:text-gray-300">
                 Copying from {sourceClassroom.name}: {parts.join(', ')}.

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -188,6 +188,12 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     warnings: string[];
   } | null = null;
   let modulesSummary: { modules: number; items: number; skipped_items: number } | null = null;
+  let templateSummary: {
+    duplicated: number;
+    relinked: number;
+    template_map: Record<string, string>;
+    warnings: string[];
+  } | null = null;
   const importWarnings: string[] = [];
 
   if (importRequested && sourceClassroomId) {
@@ -230,6 +236,23 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
           console.error('Error importing repositories:', error);
           importWarnings.push('repository copy failed');
         }
+      }
+    }
+
+    // Template duplication runs on the rows phase 2 just minted, so the copies
+    // exist before anything provisions student repos from them. Best-effort:
+    // a template that can't be duplicated keeps pointing at the original.
+    if (contentSelections.duplicateTemplates && (importResult?.repositories?.length ?? 0) > 0) {
+      try {
+        templateSummary = await ClassmojiService.templateImport.duplicateImportedTemplates(
+          sourceClassroomId,
+          classroom.id,
+          importResult!.repositories.map(repo => repo.id)
+        );
+        importWarnings.push(...(templateSummary?.warnings ?? []));
+      } catch (error: unknown) {
+        console.error('Error duplicating template repositories:', error);
+        importWarnings.push('template duplication failed');
       }
     }
 
@@ -313,6 +336,11 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     }
     if (modulesSummary && modulesSummary.modules > 0) {
       parts.push(plural(modulesSummary.modules, 'module'));
+    }
+    if (templateSummary && templateSummary.duplicated > 0) {
+      parts.push(
+        `${templateSummary.duplicated} duplicated template${templateSummary.duplicated === 1 ? '' : 's'}`
+      );
     }
     if (parts.length > 0) {
       successMessage = `Classroom created with ${parts.join(', ')} imported!`;

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -316,6 +316,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     pages: true,
     slides: true,
     modules: true,
+    duplicateTemplates: true,
   });
 
   // Navigate to new classroom on success
@@ -393,7 +394,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     const anySelection =
       selectedModules.size > 0 || Object.values(importSelections).some(Boolean);
     if (importEnabled && sourceClassroomId && anySelection) {
-      const { pages, slides, modules, ...config } = importSelections;
+      const { pages, slides, modules, duplicateTemplates, ...config } = importSelections;
       importConfig = {
         sourceClassroomId,
         repositories: Array.from(selectedModules.entries()).map(([id, cfg]) => ({
@@ -401,7 +402,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
           includeQuizzes: cfg.includeQuizzes || false,
         })),
         config,
-        content: { pages, slides, modules },
+        content: { pages, slides, modules, duplicateTemplates },
       };
     }
 

--- a/apps/webapp/app/routes/_user.create-classroom/types.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/types.ts
@@ -58,6 +58,8 @@ export interface ImportSelections {
   pages: boolean;
   slides: boolean;
   modules: boolean;
+  /** Copy each imported repo's template into this org as a private repo. */
+  duplicateTemplates: boolean;
 }
 
 export interface ModuleConfig {

--- a/packages/services/src/classmoji/__tests__/templateImport.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/templateImport.service.test.ts
@@ -1,0 +1,174 @@
+/**
+ * templateImport.service pure helpers: parseTemplateRef, formatTemplateRef,
+ * templateRefKey, groupTemplateRefs, templateNameCandidates, formatWarning.
+ * No DB/GitHub — the orchestrator's IO paths are out of scope here (repo
+ * pure-only test convention). The runtime-heavy imports the service pulls in at
+ * module load are stubbed so importing it is cheap.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+vi.mock('../../content/ContentService.ts', () => ({ ContentService: {} }));
+vi.mock('../../git/index.ts', () => ({ getGitProvider: vi.fn() }));
+
+const {
+  parseTemplateRef,
+  formatTemplateRef,
+  templateRefKey,
+  groupTemplateRefs,
+  templateNameCandidates,
+  formatWarning,
+} = await import('../templateImport.service.ts');
+
+describe('parseTemplateRef', () => {
+  it('splits the canonical owner-qualified form the repo form writes', () => {
+    expect(parseTemplateRef('cs101-org/lab1-template', 'fallback')).toEqual({
+      owner: 'cs101-org',
+      name: 'lab1-template',
+    });
+  });
+
+  it('resolves a bare name (repo_create over MCP allows it) against the fallback owner', () => {
+    expect(parseTemplateRef('lab1-template', 'src-org')).toEqual({
+      owner: 'src-org',
+      name: 'lab1-template',
+    });
+  });
+
+  it('trims surrounding whitespace and stray slashes', () => {
+    expect(parseTemplateRef('  org/lab1  ', 'x')).toEqual({ owner: 'org', name: 'lab1' });
+    expect(parseTemplateRef('/org/lab1/', 'x')).toEqual({ owner: 'org', name: 'lab1' });
+    expect(parseTemplateRef('org / lab1', 'x')).toEqual({ owner: 'org', name: 'lab1' });
+  });
+
+  it('recovers a half-written ref as a bare name — the read then 404s and keeps the link', () => {
+    expect(parseTemplateRef('org/', 'fallback')).toEqual({ owner: 'fallback', name: 'org' });
+  });
+
+  it('returns null for empty, whitespace-only, or absent refs', () => {
+    expect(parseTemplateRef('', 'org')).toBeNull();
+    expect(parseTemplateRef('   ', 'org')).toBeNull();
+    expect(parseTemplateRef(null, 'org')).toBeNull();
+    expect(parseTemplateRef(undefined, 'org')).toBeNull();
+  });
+
+  it('returns null for a bare name with no fallback owner to resolve against', () => {
+    expect(parseTemplateRef('lab1', '')).toBeNull();
+  });
+
+  it('returns null for refs carrying more path segments than a repo ref can hold', () => {
+    expect(parseTemplateRef('org/a/b', 'x')).toBeNull();
+    expect(parseTemplateRef('https://github.com/org/lab1', 'x')).toBeNull();
+  });
+});
+
+describe('formatTemplateRef', () => {
+  it("always produces owner/name — the format every template.split('/') consumer needs", () => {
+    expect(formatTemplateRef({ owner: 'org', name: 'lab1' })).toBe('org/lab1');
+  });
+});
+
+describe('templateRefKey', () => {
+  it('lowercases both halves (GitHub logins and repo names are case-insensitive)', () => {
+    expect(templateRefKey({ owner: 'CS101-Org', name: 'Lab1' })).toBe('cs101-org/lab1');
+    expect(templateRefKey({ owner: 'cs101-org', name: 'lab1' })).toBe(
+      templateRefKey({ owner: 'CS101-ORG', name: 'LAB1' })
+    );
+  });
+});
+
+describe('groupTemplateRefs', () => {
+  it('collapses rows sharing one template into a single group', () => {
+    const groups = groupTemplateRefs(
+      [{ template: 'src/lab1' }, { template: 'src/lab1' }, { template: 'src/lab2' }],
+      'src'
+    );
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toEqual({ ref: { owner: 'src', name: 'lab1' }, rawRefs: ['src/lab1'] });
+    expect(groups[1]!.ref.name).toBe('lab2');
+  });
+
+  it('groups bare and owner-qualified spellings of the same repo, keeping both raw refs', () => {
+    const groups = groupTemplateRefs([{ template: 'lab1' }, { template: 'src/lab1' }], 'src');
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.ref).toEqual({ owner: 'src', name: 'lab1' });
+    // Relinks match on the exact stored strings, so BOTH spellings are retained.
+    expect(groups[0]!.rawRefs).toEqual(['lab1', 'src/lab1']);
+  });
+
+  it('groups case-variant spellings but keeps each distinct raw ref', () => {
+    const groups = groupTemplateRefs([{ template: 'Src/Lab1' }, { template: 'src/lab1' }], 'src');
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.rawRefs).toEqual(['Src/Lab1', 'src/lab1']);
+  });
+
+  it('does not repeat an identical raw ref in rawRefs', () => {
+    const groups = groupTemplateRefs([{ template: 'src/lab1' }, { template: 'src/lab1' }], 'src');
+    expect(groups[0]!.rawRefs).toEqual(['src/lab1']);
+  });
+
+  it('skips null and empty templates', () => {
+    expect(
+      groupTemplateRefs([{ template: null }, { template: '' }, { template: '  ' }], 'src')
+    ).toEqual([]);
+  });
+
+  it('keeps templates owned by a third org as their own group (the caller warns)', () => {
+    const groups = groupTemplateRefs([{ template: 'other-org/lab1' }, { template: 'lab1' }], 'src');
+    expect(groups).toHaveLength(2);
+    expect(groups.map(g => g.ref.owner)).toEqual(['other-org', 'src']);
+  });
+});
+
+describe('templateNameCandidates', () => {
+  it('prefers the original name, then the namespace-qualified one, then numbers', () => {
+    expect(templateNameCandidates('lab1-template', 'cs101-w26', 4)).toEqual([
+      'lab1-template',
+      'lab1-template-cs101-w26',
+      'lab1-template-cs101-w26-2',
+      'lab1-template-cs101-w26-3',
+    ]);
+  });
+
+  it('skips the duplicate namespaced entry when there is no namespace', () => {
+    expect(templateNameCandidates('lab1', '', 3)).toEqual(['lab1', 'lab1-2', 'lab1-3']);
+  });
+
+  it('never emits a duplicate candidate', () => {
+    const candidates = templateNameCandidates('lab1', 'w26', 8);
+    expect(new Set(candidates).size).toBe(candidates.length);
+  });
+
+  it("clamps every candidate to GitHub's 100-character repo-name limit", () => {
+    const candidates = templateNameCandidates('a'.repeat(120), 'b'.repeat(40), 5);
+    for (const candidate of candidates) {
+      expect(candidate.length).toBeLessThanOrEqual(100);
+    }
+    expect(candidates[0]).toBe('a'.repeat(100));
+    // Name and namespaced form clamp to the same 100 chars — deduped, so the
+    // numbered variants start immediately rather than re-probing a dead name.
+    expect(candidates[1]!.endsWith('-2')).toBe(true);
+    expect(new Set(candidates).size).toBe(candidates.length);
+  });
+
+  it('honours the candidate limit', () => {
+    expect(templateNameCandidates('lab1', 'w26', 1)).toEqual(['lab1']);
+    expect(templateNameCandidates('lab1', 'w26')).toHaveLength(10);
+  });
+});
+
+describe('formatWarning', () => {
+  it('joins scope and detail', () => {
+    expect(formatWarning('template src/lab1', 'skipped')).toBe('template src/lab1: skipped');
+  });
+
+  it('truncates detail past 200 characters with an ellipsis', () => {
+    const warning = formatWarning('scope', 'x'.repeat(250));
+    expect(warning).toBe(`scope: ${'x'.repeat(200)}…`);
+  });
+
+  it('leaves detail at the limit untouched', () => {
+    expect(formatWarning('scope', 'x'.repeat(200))).toBe(`scope: ${'x'.repeat(200)}`);
+  });
+});

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -34,6 +34,7 @@ import * as quizService from './quiz.service.ts';
 import * as quizAttemptService from './quizAttempt.service.ts';
 import * as repositoryImportService from './repositoryImport.service.ts';
 import * as contentImportService from './contentImport.service.ts';
+import * as templateImportService from './templateImport.service.ts';
 import * as classroomConfigImportService from './classroomConfigImport.service.ts';
 import * as githubClassroomImportService from './githubClassroomImport.service.ts';
 import * as githubClassroomApiService from './githubClassroomApi.service.ts';
@@ -81,6 +82,7 @@ const ClassmojiService = {
   quizAttempt: quizAttemptService,
   repositoryImport: repositoryImportService,
   contentImport: contentImportService,
+  templateImport: templateImportService,
   classroomConfigImport: classroomConfigImportService,
   githubClassroomImport: githubClassroomImportService,
   githubClassroomApi: githubClassroomApiService,
@@ -134,6 +136,7 @@ export {
   quizAttemptService,
   repositoryImportService,
   contentImportService,
+  templateImportService,
   classroomConfigImportService,
   githubClassroomImportService,
   githubClassroomApiService,

--- a/packages/services/src/classmoji/templateImport.service.ts
+++ b/packages/services/src/classmoji/templateImport.service.ts
@@ -1,0 +1,459 @@
+/**
+ * templateImport.service.ts — duplicate the assignment TEMPLATE repositories an
+ * import just carried over, as PRIVATE repos in the TARGET classroom's org, and
+ * repoint the imported Repository rows at the copies.
+ *
+ * Why: `repositoryImport.cloneModule` copies `Repository.template` verbatim, so
+ * an imported term keeps pointing at the previous term's template. Editing or
+ * deleting that template then changes the new term, and a CROSS-ORG import
+ * leaves a ref the target org cannot even read (student provisioning clones the
+ * template with the TARGET org's installation token).
+ *
+ * Mirrors contentImport.service: ContentService reads (raw base64, 1MB per-file
+ * cap), ONE uploadBatch commit per template, warn() accumulation, and pure
+ * helpers kept separable for unit tests.
+ *
+ * Never touches the SOURCE classroom's rows or repos: every relink is scoped to
+ * the caller-supplied imported row ids, and the duplicate is always a NEW repo.
+ */
+
+import getPrisma from '@classmoji/database';
+import { ContentService } from '../content/ContentService.ts';
+import { getGitProvider } from '../git/index.ts';
+
+/** GitHub Contents API caps single-file reads at 1MB — larger files are skipped. */
+const ONE_MB = 1024 * 1024;
+
+/** Templates are starter code, not monorepos: past this a template is skipped whole. */
+const MAX_TEMPLATE_FILES = 200;
+
+/** Cap on retained warnings and on per-warning detail length (bounded output). */
+const MAX_WARNINGS = 50;
+const WARNING_DETAIL_MAX = 200;
+
+/** GitHub repository names are capped at 100 characters. */
+const MAX_REPO_NAME_LENGTH = 100;
+
+/** Candidate names tried before giving up on a free name in the target org. */
+const MAX_NAME_CANDIDATES = 10;
+
+export interface TemplateDuplicationSummary {
+  /** distinct templates duplicated */
+  duplicated: number;
+  /** imported Repository rows repointed */
+  relinked: number;
+  /** source template ref (`owner/name`) → new repo name in the target org */
+  template_map: Record<string, string>;
+  warnings: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers (unit-tested — no DB/GitHub)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface TemplateRef {
+  owner: string;
+  name: string;
+}
+
+/**
+ * Parse a stored `Repository.template`. The canonical form is owner-qualified
+ * (`owner/name` — the repo-form autocomplete writes GitHub's `full_name`, and
+ * three consumers do `template.split('/')`), but `repo_create` over MCP accepts
+ * a bare name, so bare rows exist: those resolve against `fallbackOwner`.
+ * Returns null for empty/unusable refs.
+ */
+export function parseTemplateRef(
+  ref: string | null | undefined,
+  fallbackOwner: string
+): TemplateRef | null {
+  const segments = (ref ?? '')
+    .split('/')
+    .map(segment => segment.trim())
+    .filter(Boolean);
+  if (segments.length === 1) {
+    return fallbackOwner ? { owner: fallbackOwner, name: segments[0]! } : null;
+  }
+  if (segments.length === 2) {
+    return { owner: segments[0]!, name: segments[1]! };
+  }
+  // Empty, or more path segments than a repo ref can carry — unusable.
+  return null;
+}
+
+/** Canonical `owner/name`, the format every `template.split('/')` consumer needs. */
+export function formatTemplateRef(ref: TemplateRef): string {
+  return `${ref.owner}/${ref.name}`;
+}
+
+/** Grouping key for a template ref — GitHub logins and repo names are case-insensitive. */
+export function templateRefKey(ref: TemplateRef): string {
+  return `${ref.owner.toLowerCase()}/${ref.name.toLowerCase()}`;
+}
+
+/** One distinct template plus every raw `template` string that resolved to it. */
+export interface TemplateRefGroup {
+  ref: TemplateRef;
+  /** the exact stored strings — relinks match on these, never on the canonical form */
+  rawRefs: string[];
+}
+
+/**
+ * Collapse the imported rows' `template` values into distinct templates. Bare
+ * and owner-qualified spellings of the same repo group together, so a template
+ * shared by several rows is duplicated ONCE and every spelling gets relinked.
+ */
+export function groupTemplateRefs(
+  rows: ReadonlyArray<{ template: string | null }>,
+  fallbackOwner: string
+): TemplateRefGroup[] {
+  const groups = new Map<string, TemplateRefGroup>();
+  for (const row of rows) {
+    const ref = parseTemplateRef(row.template, fallbackOwner);
+    if (!ref) continue;
+    const key = templateRefKey(ref);
+    const existing = groups.get(key);
+    const raw = row.template as string;
+    if (existing) {
+      if (!existing.rawRefs.includes(raw)) existing.rawRefs.push(raw);
+      continue;
+    }
+    groups.set(key, { ref, rawRefs: [raw] });
+  }
+  return [...groups.values()];
+}
+
+/**
+ * Names to try, in order, for the duplicate in the target org: the original
+ * name, then namespace-qualified, then numbered. Pure — the caller runs the
+ * `repositoryExists` probe over these. Each candidate is clamped to GitHub's
+ * 100-character repo-name limit.
+ */
+export function templateNameCandidates(
+  name: string,
+  targetNamespace: string,
+  limit: number = MAX_NAME_CANDIDATES
+): string[] {
+  const namespaced = targetNamespace ? `${name}-${targetNamespace}` : name;
+  const candidates: string[] = [];
+  // Clamping can make two candidates collide (a long name and its namespaced
+  // form truncate to the same 100 chars), so dedupe as we go — a repeated
+  // candidate would waste a repositoryExists probe on a name already rejected.
+  const push = (value: string) => {
+    if (value && !candidates.includes(value)) candidates.push(value);
+  };
+  push(name.slice(0, MAX_REPO_NAME_LENGTH));
+  push(namespaced.slice(0, MAX_REPO_NAME_LENGTH));
+  for (let n = 2; candidates.length < limit && n < limit + 2; n++) {
+    const suffix = `-${n}`;
+    push(namespaced.slice(0, MAX_REPO_NAME_LENGTH - suffix.length) + suffix);
+  }
+  return candidates.slice(0, limit);
+}
+
+/** Format one warning with truncated detail: `scope: detail…`. */
+export function formatWarning(scope: string, detail: string): string {
+  const trimmed =
+    detail.length > WARNING_DETAIL_MAX ? `${detail.slice(0, WARNING_DETAIL_MAX)}…` : detail;
+  return `${scope}: ${trimmed}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Impl helpers (touch DB/GitHub — not unit-tested)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Structural git-org shape ContentService + the git provider accept.
+interface GitOrgRecord {
+  id: string;
+  provider: string;
+  login: string;
+  github_installation_id?: string | null;
+  access_token?: string | null;
+  base_url?: string | null;
+  gitlab_group_id?: string | null;
+}
+
+type WarnFn = (scope: string, detail: string) => void;
+
+type BatchFile = { path: string; content: string; encoding: 'base64' };
+
+function errText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Every file path in a repo's DEFAULT branch. Reads omit `ref` on purpose —
+ * templates are not content repos and their default branch is often not `main`;
+ * the Contents API resolves the real default when no ref is given. Aborts as
+ * soon as the count exceeds `cap` so an oversized template costs a directory
+ * walk, not 200 content reads.
+ */
+async function listRepoFilePaths(
+  gitOrganization: GitOrgRecord,
+  repo: string,
+  cap: number
+): Promise<{ paths: string[]; exceededCap: boolean }> {
+  const paths: string[] = [];
+
+  const walk = async (dirPath: string): Promise<boolean> => {
+    const entries = await ContentService.listFolder({
+      gitOrganization,
+      repo,
+      path: dirPath,
+      skipCache: true,
+    });
+    for (const entry of entries) {
+      if (entry.type === 'dir') {
+        if (await walk(entry.path)) return true;
+        continue;
+      }
+      paths.push(entry.path);
+      if (paths.length > cap) return true;
+    }
+    return false;
+  };
+
+  const exceededCap = await walk('');
+  return { paths, exceededCap };
+}
+
+/**
+ * Read each path as raw base64 off the default branch. Files over 1MB are
+ * skipped with a warning (the Contents API returns no usable body for them).
+ */
+async function readRepoFiles({
+  gitOrganization,
+  repo,
+  paths,
+  scope,
+  warn,
+}: {
+  gitOrganization: GitOrgRecord;
+  repo: string;
+  paths: string[];
+  scope: string;
+  warn: WarnFn;
+}): Promise<BatchFile[]> {
+  const files: BatchFile[] = [];
+  for (const path of paths) {
+    const meta = await ContentService.getMeta({
+      gitOrganization,
+      repo,
+      path,
+      skipCache: true,
+    });
+    if (meta && meta.size > ONE_MB) {
+      warn(scope, `skipped ${path} (>1MB, ${meta.size} bytes)`);
+      continue;
+    }
+    const file = await ContentService.getContent({
+      gitOrganization,
+      repo,
+      path,
+      raw: true,
+      skipCache: true,
+    });
+    if (!file) {
+      warn(scope, `could not read ${path}`);
+      continue;
+    }
+    files.push({ path, content: file.content, encoding: 'base64' });
+  }
+  return files;
+}
+
+/** First candidate name free in the target org, or null when all are taken. */
+async function resolveFreeRepoName(
+  provider: ReturnType<typeof getGitProvider>,
+  orgLogin: string,
+  candidates: string[]
+): Promise<string | null> {
+  for (const candidate of candidates) {
+    if (!(await provider.repositoryExists(orgLogin, candidate))) return candidate;
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Duplicate the distinct template repos referenced by `importedRepositoryIds`
+ * into the target classroom's org as PRIVATE repos, then repoint those rows.
+ *
+ * Resilience: every failure mode is a warning that KEEPS the original ref —
+ * an unreadable template, an oversized one, a name-collision exhaustion, a
+ * failed create or commit. A template whose owner is neither the target org nor
+ * the source classroom's org is not readable with any installation this flow
+ * holds, so it is warned and left linked.
+ */
+export const duplicateImportedTemplates = async (
+  sourceClassroomId: string,
+  targetClassroomId: string,
+  importedRepositoryIds: string[],
+  _opts: Record<string, never> = {}
+): Promise<TemplateDuplicationSummary> => {
+  const warnings: string[] = [];
+  const warn: WarnFn = (scope, detail) => {
+    if (warnings.length >= MAX_WARNINGS) return;
+    warnings.push(formatWarning(scope, detail));
+  };
+
+  const summary: TemplateDuplicationSummary = {
+    duplicated: 0,
+    relinked: 0,
+    template_map: {},
+    warnings,
+  };
+
+  if (importedRepositoryIds.length === 0) return summary;
+
+  const [sourceClassroom, targetClassroom] = await Promise.all([
+    getPrisma().classroom.findUnique({
+      where: { id: sourceClassroomId },
+      include: { git_organization: true },
+    }),
+    getPrisma().classroom.findUnique({
+      where: { id: targetClassroomId },
+      include: { git_organization: true },
+    }),
+  ]);
+
+  const targetOrg = targetClassroom?.git_organization as GitOrgRecord | null | undefined;
+  if (!targetClassroom || !targetOrg?.login) {
+    warn('templates', 'target classroom has no git organization');
+    return summary;
+  }
+  if (targetOrg.provider !== 'GITHUB') {
+    warn(
+      'templates',
+      `template duplication supports GitHub only (target is ${targetOrg.provider})`
+    );
+    return summary;
+  }
+  const sourceOrg = sourceClassroom?.git_organization as GitOrgRecord | null | undefined;
+
+  // Scope to the target classroom as well as the id list — the relink queries
+  // below inherit this scope, which is what keeps SOURCE rows untouched.
+  const importedRows = await getPrisma().repository.findMany({
+    where: { id: { in: importedRepositoryIds }, classroom_id: targetClassroomId },
+    select: { id: true, template: true },
+  });
+  const scopedIds = importedRows.map(row => row.id);
+  if (scopedIds.length === 0) return summary;
+
+  const groups = groupTemplateRefs(importedRows, sourceOrg?.login ?? targetOrg.login);
+  if (groups.length === 0) return summary;
+
+  const targetProvider = getGitProvider(targetOrg);
+  const targetNamespace = targetClassroom.content_namespace ?? '';
+
+  for (const group of groups) {
+    const sourceRef = formatTemplateRef(group.ref);
+    const scope = `template ${sourceRef}`;
+
+    // Readable only through an installation this flow holds: the target org's,
+    // or the source classroom's. Anything else (a third org, a personal
+    // account) stays linked to the original.
+    const ownerLower = group.ref.owner.toLowerCase();
+    let readerOrg: GitOrgRecord | null = null;
+    if (ownerLower === targetOrg.login.toLowerCase()) {
+      readerOrg = targetOrg;
+    } else if (sourceOrg?.login && ownerLower === sourceOrg.login.toLowerCase()) {
+      readerOrg = sourceOrg.provider === 'GITHUB' ? sourceOrg : null;
+    }
+    if (!readerOrg) {
+      warn(scope, `not readable from ${targetOrg.login} — keeping the original link`);
+      continue;
+    }
+
+    try {
+      // Distinguish a DELETED template from an empty one — a dangling ref is
+      // the exact failure this feature exists to stop repeating, so say so.
+      const readerProvider = readerOrg === targetOrg ? targetProvider : getGitProvider(readerOrg);
+      if (!(await readerProvider.repositoryExists(group.ref.owner, group.ref.name))) {
+        warn(scope, 'skipped — template repository no longer exists');
+        continue;
+      }
+
+      const { paths, exceededCap } = await listRepoFilePaths(
+        readerOrg,
+        group.ref.name,
+        MAX_TEMPLATE_FILES
+      );
+      if (exceededCap) {
+        warn(scope, `skipped — more than ${MAX_TEMPLATE_FILES} files`);
+        continue;
+      }
+      if (paths.length === 0) {
+        warn(scope, 'skipped — no readable files on the default branch');
+        continue;
+      }
+
+      const files = await readRepoFiles({
+        gitOrganization: readerOrg,
+        repo: group.ref.name,
+        paths,
+        scope,
+        warn,
+      });
+      if (files.length === 0) {
+        warn(scope, 'skipped — every file was unreadable or oversized');
+        continue;
+      }
+
+      const newName = await resolveFreeRepoName(
+        targetProvider,
+        targetOrg.login,
+        templateNameCandidates(group.ref.name, targetNamespace)
+      );
+      if (!newName) {
+        warn(scope, `skipped — no free repository name in ${targetOrg.login}`);
+        continue;
+      }
+
+      await targetProvider.createRepository(targetOrg.login, newName, true);
+      try {
+        // The new repo has no commits: allowRootCommit seeds the initial commit
+        // (Contents API — the Git Data API 409s on an empty repo) and creates
+        // `main`, which becomes the default branch.
+        await ContentService.uploadBatch({
+          gitOrganization: targetOrg,
+          repo: newName,
+          files,
+          branch: 'main',
+          message: `Duplicated from ${sourceRef} for ${targetClassroom.slug}`,
+          allowRootCommit: true,
+        });
+      } catch (uploadError: unknown) {
+        // Drop the repo we just made rather than leave an empty shell behind —
+        // it has no commits, and the rows still point at the original template.
+        try {
+          await targetProvider.deleteRepository(targetOrg.login, newName);
+        } catch (cleanupError: unknown) {
+          warn(scope, `left an empty ${newName} behind: ${errText(cleanupError)}`);
+        }
+        throw uploadError;
+      }
+
+      const newRef = `${targetOrg.login}/${newName}`;
+      let relinked = 0;
+      for (const rawRef of group.rawRefs) {
+        const { count } = await getPrisma().repository.updateMany({
+          where: { id: { in: scopedIds }, template: rawRef },
+          data: { template: newRef },
+        });
+        relinked += count;
+      }
+
+      summary.duplicated++;
+      summary.relinked += relinked;
+      summary.template_map[sourceRef] = newName;
+    } catch (error: unknown) {
+      warn(scope, `duplication failed: ${errText(error)}`);
+    }
+  }
+
+  return summary;
+};

--- a/packages/services/src/content/ContentService.ts
+++ b/packages/services/src/content/ContentService.ts
@@ -1104,6 +1104,7 @@ export class ContentService {
     onProgress,
     verifyBaseTree,
     primeCache = false,
+    allowRootCommit = false,
   }: {
     gitOrganization?: GitOrganizationRecord;
     orgLogin?: string;
@@ -1134,6 +1135,17 @@ export class ContentService {
     verifyBaseTree?: (ctx: {
       getFileSha: (path: string) => Promise<string | null>;
     }) => Promise<void>;
+    /**
+     * Allow writing into a repository that has NO commits yet. Until an initial
+     * commit exists GitHub answers 409 "Git Repository is empty" to the whole
+     * Git Data API — `POST /git/blobs` included — so a root commit cannot be
+     * assembled at all. The only endpoint that works on an empty repo is the
+     * Contents API, so this seeds `files[0]` through it (creating `branch`,
+     * which becomes the repo's default) and then runs the normal batch path.
+     * Off by default — every existing caller writes to a branch that exists,
+     * where a missing ref is a real error worth surfacing.
+     */
+    allowRootCommit?: boolean;
   }): Promise<{
     commit: string;
     filesUploaded: number;
@@ -1145,6 +1157,43 @@ export class ContentService {
 
     const resolvedOrg = await resolveGitOrganization(gitOrganization, orgLogin);
     const octokit = await getOctokit(resolvedOrg);
+
+    // Step 0 (opt-in): give an EMPTY repository its initial commit, because
+    // every Git Data API call below — starting with blob creation — answers
+    // 409 "Git Repository is empty" until one exists. Passing `branch`
+    // explicitly makes the seed create that branch, so the result does not
+    // depend on the org's default-branch-name setting.
+    if (allowRootCommit) {
+      let repositoryIsEmpty = false;
+      try {
+        await octokit.request('GET /repos/{owner}/{repo}/git/ref/{ref}', {
+          owner: resolvedOrg.login,
+          repo,
+          ref: `heads/${branch}`,
+        });
+      } catch (error: unknown) {
+        // 409 is specifically "no commits yet". A 404 here means the REPO has
+        // commits but this branch is missing — a real error, left to surface.
+        if (!hasStatus(error, 409)) throw error;
+        repositoryIsEmpty = true;
+      }
+      if (repositoryIsEmpty) {
+        const seed = files[0]!;
+        await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+          owner: resolvedOrg.login,
+          repo,
+          path: seed.path,
+          message: message || `Upload ${files.length} files`,
+          content:
+            (seed.encoding ?? 'utf-8') === 'base64'
+              ? seed.content
+              : Buffer.from(seed.content).toString('base64'),
+          branch,
+        });
+        // The seed file is re-written identically by the batch below, so the
+        // final tree is exactly `files` either way.
+      }
+    }
 
     // Step 1: Create blobs for all files in parallel (done once, content-addressed and idempotent)
     // Track progress as each blob completes


### PR DESCRIPTION
## Summary

The import step gains a **Duplicate template repos** option (default ON): each distinct template referenced by the imported repositories is copied into the target org as a **private** repo, and the imported rows are repointed at the copy. Terms become self-contained — editing or deleting one term's templates can never affect another — templates no longer need to be public/shared, and cross-org imports stop producing dangling refs.

- Collision-safe naming (original → `-{namespace}` → numeric); per-template failures keep the original link with a warning and self-delete the partial repo; oversized templates (>200 files, >1MB files) fall back to linking
- Template refs are stored owner-qualified ('owner/name') — verified against the three `split('/')` consumers — and relinks always write that format
- `ContentService.uploadBatch` gains opt-in `allowRootCommit` for seeding empty repos. Live testing surfaced that GitHub returns **409, not 404**, for both ref lookups and blob creation on commitless repos — so the path pre-seeds the first file via the Contents API (deterministic branch) and then runs the unchanged normal path

## Testing
- 23 new unit tests; services 737 passed / 12 skipped; webapp + services typecheck clean
- **Live E2E on the dev org**: real import created `e2e-template-happy-tdup26z` private on `main` with byte-identical contents and relinked the imported row (first run caught the 409 bug; fix re-verified through the real service entry point). Separately, the student assignment-repo flow was proven to work from a **private** same-org template by executing the production `createRepository()` helper end-to-end with a real installation token — template commit SHAs propagated verbatim into the private student repo. All test artifacts cleaned from the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw