### PR TITLE
feat: content repo name is stored and fully user-editable

### DIFF
--- a/apps/mcp/src/tools/__tests__/deck.test.ts
+++ b/apps/mcp/src/tools/__tests__/deck.test.ts
@@ -113,7 +113,7 @@ const SLIDE = {
   updated_at: new Date('2026-08-01T00:00:00Z'),
   classroom: {
     id: 'class-1',
-    content_namespace: 'cs101',
+    content_repo: 'content-test-org-cs101',
     git_organization: { provider: 'GITHUB', login: 'test-org' },
   },
 };

--- a/apps/mcp/src/tools/__tests__/pageContent.test.ts
+++ b/apps/mcp/src/tools/__tests__/pageContent.test.ts
@@ -95,7 +95,7 @@ const PAGE = {
   is_draft: false,
   classroom: {
     id: 'class-1',
-    content_namespace: 'cs101',
+    content_repo: 'content-test-org-cs101',
     git_organization: { provider: 'GITHUB', login: 'test-org' },
   },
 };

--- a/apps/mcp/src/tools/__tests__/slides.test.ts
+++ b/apps/mcp/src/tools/__tests__/slides.test.ts
@@ -78,7 +78,7 @@ const SLIDE = {
   updated_at: new Date('2026-08-01T00:00:00Z'),
   classroom: {
     id: 'class-1',
-    content_namespace: 'cs101',
+    content_repo: 'content-test-org-cs101',
     git_organization: { provider: 'GITHUB', login: 'test-org' },
   },
 };

--- a/apps/mcp/src/tools/shared.ts
+++ b/apps/mcp/src/tools/shared.ts
@@ -183,7 +183,8 @@ export interface PageWithRepoRecord {
   is_draft: boolean;
   classroom: {
     id: string;
-    content_namespace: string;
+    /** Stored content repo name — never re-derived from org + namespace. */
+    content_repo: string;
     git_organization: {
       provider: string;
       login: string;
@@ -237,7 +238,8 @@ export interface SlideWithRepoRecord {
   updated_at: Date | string;
   classroom: {
     id: string;
-    content_namespace: string | null;
+    /** Stored content repo name — never re-derived from org + namespace. */
+    content_repo: string | null;
     git_organization: {
       provider: string;
       login: string;

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -150,9 +150,9 @@ export const loader = async ({
     login?: string;
     avatar_url?: string;
   } | null;
-  const contentNamespace = page.classroom.content_namespace;
-  const repoName =
-    contentNamespace && gitOrg?.login ? `content-${gitOrg.login}-${contentNamespace}` : null;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const contentRepo = page.classroom.content_repo;
+  const repoName = contentRepo && gitOrg?.login ? contentRepo : null;
 
   // GitHub's free diff UI for the pending preview (branch segment URL-encoded —
   // preview branch names contain slashes).

--- a/apps/pages/app/types/pages.ts
+++ b/apps/pages/app/types/pages.ts
@@ -41,7 +41,9 @@ export interface PageForContent {
     id: string;
     slug: string;
     name: string;
-    content_namespace: string;
+    // Repo holding this classroom's content: stored and user-editable, never
+    // re-derived. Required by the page content service (PageWithContentRepo).
+    content_repo: string;
     avatar_url?: string | null;
     git_organization?: {
       login: string;

--- a/apps/slides/app/routes/$classroomSlug.$slideId.delete/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.$slideId.delete/route.tsx
@@ -48,9 +48,9 @@ export const loader = async ({
 
   // Build the GitHub paths that will be deleted
   const gitOrgLogin = slideInfo.slide.classroom?.git_organization?.login;
-  const contentNamespace = slideInfo.slide.classroom?.content_namespace;
-  const repoName =
-    gitOrgLogin && contentNamespace ? `content-${gitOrgLogin}-${contentNamespace}` : null;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const contentRepo = slideInfo.slide.classroom?.content_repo;
+  const repoName = gitOrgLogin && contentRepo ? contentRepo : null;
   const contentPath = slideInfo.slide.content_path;
 
   return {

--- a/apps/slides/app/routes/$classroomSlug.new/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.new/route.tsx
@@ -43,14 +43,15 @@ export const loader = async ({
     throw new Response('Git organization not configured for this classroom', { status: 400 });
   }
 
-  const contentNamespace = classroom.content_namespace;
-  if (!contentNamespace) {
-    throw new Response('Classroom content namespace not configured', { status: 400 });
+  // Slides land in the classroom's STORED content repo (user-editable, never
+  // re-derived); creation is impossible without it.
+  if (!classroom.content_repo) {
+    throw new Response('Classroom content repo not configured', { status: 400 });
   }
 
   return {
     classroomSlug,
-    contentNamespace,
+    contentNamespace: classroom.content_namespace,
     gitOrgLogin,
     classroom,
     webappUrl: process.env.WEBAPP_URL || 'http://localhost:3000',
@@ -95,9 +96,10 @@ export const action = async ({
     return { error: 'Git organization not configured for this classroom' };
   }
 
-  const contentNamespace = classroom.content_namespace;
-  if (!contentNamespace) {
-    return { error: 'Classroom content namespace not configured' };
+  // Slides land in the classroom's STORED content repo (user-editable, never
+  // re-derived); creation is impossible without it.
+  if (!classroom.content_repo) {
+    return { error: 'Classroom content repo not configured' };
   }
 
   try {

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -138,8 +138,8 @@ export const loader = async ({
     throw new Response('Git organization not configured for this classroom', { status: 400 });
   }
 
-  // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
   // Build the content URL using content proxy (CDN-first + API fallback)
@@ -496,7 +496,8 @@ export const action = async ({
 
   // Used for content URLs and fallback orgLogin param
   const gitOrgLogin = gitOrganization.login;
-  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -60,8 +60,8 @@ export const loader = async ({
     throw new Response('Git organization not configured', { status: 400 });
   }
 
-  // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
   // Build the content URL using content proxy (CDN-first + API fallback)

--- a/apps/slides/app/routes/$slideId_.present/route.tsx
+++ b/apps/slides/app/routes/$slideId_.present/route.tsx
@@ -45,8 +45,8 @@ export const loader = async ({
     throw new Response('Git organization not configured', { status: 400 });
   }
 
-  // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
   // Build the content URL using content proxy (CDN-first + API fallback)

--- a/apps/slides/app/routes/$slideId_.speaker/route.tsx
+++ b/apps/slides/app/routes/$slideId_.speaker/route.tsx
@@ -52,8 +52,8 @@ export const loader = async ({
     throw new Response('Git organization not configured', { status: 400 });
   }
 
-  // Get content repo name and file path
-  const repo = `content-${gitOrgLogin}-${slide.classroom.content_namespace}`;
+  // Content repo is STORED and user-editable — never re-derived from the namespace.
+  const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
   // Fetch content using shared utility (CDN first, API fallback)

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -204,7 +204,8 @@ export const action = async ({ request }: { request: Request }) => {
         return { error: 'Git organization not configured for this classroom' };
       }
 
-      const repo = `content-${gitOrganization.login}-${slide.classroom?.content_namespace}`;
+      // Content repo is STORED and user-editable — never re-derived from the namespace.
+      const repo = slide.classroom.content_repo;
       const newSlug = `${slide.slug}-copy-${Date.now()}`;
       const newContentPath = `slides/${newSlug}`;
 

--- a/apps/slides/app/routes/content.$org.$repo.$/route.tsx
+++ b/apps/slides/app/routes/content.$org.$repo.$/route.tsx
@@ -5,7 +5,9 @@
  * Serves CSS, fonts, and other assets with correct MIME types.
  *
  * URL pattern: /content/:org/:repo/*path
- * Example: /content/myorg/content-myorg-25w/.slidesthemes/theme/lib/offline-v2.css
+ * The :repo segment is the classroom's stored content repo — user-editable, so
+ * it follows no derivable pattern.
+ * Example: /content/myorg/cs101-content/.slidesthemes/theme/lib/offline-v2.css
  *
  * SECURITY: This route validates access via one of:
  * 1. Authenticated user with classroom membership
@@ -32,7 +34,7 @@ import getPrisma from '@classmoji/database';
 
 interface ContentRouteMembership {
   classroom?: {
-    content_namespace?: string | null;
+    content_repo?: string | null;
     git_organization?: {
       login: string;
       settings?: Record<string, string> | null;
@@ -105,16 +107,17 @@ export const loader = async ({
   if (authData) {
     const memberships = await getCachedMemberships(authData.userId);
 
-    // STRICT validation: repo must EXACTLY match the content repo for a user's classroom
-    // Content repo pattern: content-{org}-{term} (e.g., content-csc-25w)
-    // Or explicitly set in organization.settings as any.content_repo_name
+    // STRICT validation: repo must EXACTLY match the content repo for a user's classroom.
+    // The classroom's content repo is STORED and user-editable — never re-derived.
+    // Legacy classrooms without one fall back to the ORG-level content repo
+    // (organization.settings.content_repo_name).
     hasAccess = memberships.some((m: ContentRouteMembership) => {
       const gitOrg = m.classroom?.git_organization;
       if (!gitOrg || gitOrg.login !== org) return false;
 
       // Get the expected content repo name for this classroom
-      const expectedRepo = m.classroom?.content_namespace
-        ? `content-${gitOrg.login}-${m.classroom.content_namespace}`
+      const expectedRepo = m.classroom?.content_repo
+        ? m.classroom.content_repo
         : getContentRepoName({
             login: gitOrg.login,
             settings: gitOrg.settings as { content_repo_name?: string } | undefined,
@@ -139,9 +142,10 @@ export const loader = async ({
     if (slide && slide.is_public && !slide.is_draft) {
       const gitOrg = slide.classroom?.git_organization;
       if (gitOrg && gitOrg.login === org) {
-        // Validate the requested repo matches the slide's content repo
-        const expectedRepo = slide.classroom.content_namespace
-          ? `content-${gitOrg.login}-${slide.classroom.content_namespace}`
+        // Validate the requested repo matches the slide's content repo (stored,
+        // user-editable — never re-derived)
+        const expectedRepo = slide.classroom.content_repo
+          ? slide.classroom.content_repo
           : getContentRepoName({ login: gitOrg.login });
 
         if (repo === expectedRepo) {

--- a/apps/slides/app/routes/import/route.tsx
+++ b/apps/slides/app/routes/import/route.tsx
@@ -60,8 +60,10 @@ export const loader = async ({ request }: { request: Request }) => {
   // Get repositories for dropdown
   const repositories = await ClassmojiService.repository.findByClassroomSlug(classroomSlug);
 
-  const repoName = classroom.content_namespace
-    ? `content-${gitOrgLogin}-${classroom.content_namespace}`
+  // Content repo is STORED and user-editable — never re-derived. Legacy
+  // classrooms without one fall back to the ORG-level content repo.
+  const repoName = classroom.content_repo
+    ? classroom.content_repo
     : getContentRepoName({ login: gitOrgLogin });
   const savedThemes = await listSavedThemes(gitOrgLogin, repoName);
 

--- a/apps/slides/app/utils/slidesComImporter.server.ts
+++ b/apps/slides/app/utils/slidesComImporter.server.ts
@@ -141,8 +141,10 @@ export async function processZipImport({
   // 5. Flat content path: slides/{slug}-{timestamp}
   const timestamp = Date.now();
   const contentPath = `slides/${slug}-${timestamp}`;
-  const repoName = classroom.content_namespace
-    ? `content-${classroom.git_organization.login}-${classroom.content_namespace}`
+  // Content repo is STORED and user-editable — never re-derived. Legacy
+  // classrooms without one fall back to the ORG-level content repo.
+  const repoName = classroom.content_repo
+    ? classroom.content_repo
     : getContentRepoName({ login: classroom.git_organization.login });
 
   // 6. Ensure content repo exists (org is git org login for GitHub API)

--- a/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepBasicInfo.tsx
@@ -3,6 +3,7 @@ import { useFormContext, Controller } from 'react-hook-form';
 import { Input, Select, Avatar, Button, Divider, Spin } from 'antd';
 import { PlusOutlined, LoadingOutlined, EditOutlined } from '@ant-design/icons';
 import { useGitHubAppInstallPopup } from '~/hooks';
+import { sanitizeRepoName } from '@classmoji/utils';
 import type { GitOrganizationOption } from './types';
 import { slugify } from './utils';
 
@@ -18,8 +19,8 @@ interface StepBasicInfoProps {
   availability?: AvailabilityResponse;
   availabilityLoading?: boolean;
   selectedOrgLogin: string;
-  namespaceSuggestion: string;
-  effectiveNamespace: string;
+  contentRepoSuggestion: string;
+  effectiveContentRepo: string;
 }
 
 const StepBasicInfo = ({
@@ -29,8 +30,8 @@ const StepBasicInfo = ({
   availability,
   availabilityLoading,
   selectedOrgLogin,
-  namespaceSuggestion,
-  effectiveNamespace,
+  contentRepoSuggestion,
+  effectiveContentRepo,
 }: StepBasicInfoProps) => {
   const {
     control,
@@ -44,7 +45,7 @@ const StepBasicInfo = ({
   const effectiveSlug = slugOverride && slugOverride.length > 0 ? slugOverride : slugPreview;
 
   const [editingSlug, setEditingSlug] = useState(false);
-  const [editingNamespace, setEditingNamespace] = useState(false);
+  const [editingContentRepo, setEditingContentRepo] = useState(false);
 
   const showResult = !!effectiveSlug && !availabilityLoading && !!availability;
   const slugTaken = showResult && availability!.slug_available === false;
@@ -145,10 +146,10 @@ const StepBasicInfo = ({
                   if (!editingSlug) {
                     setValue('slug', '', { shouldDirty: false });
                   }
-                  // Same for the content-namespace override: re-derive from the
+                  // Same for the content-repo override: re-derive from the
                   // fresh slug unless the user is editing it right now.
-                  if (!editingNamespace) {
-                    setValue('content_namespace', '', { shouldDirty: false });
+                  if (!editingContentRepo) {
+                    setValue('content_repo', '', { shouldDirty: false });
                   }
                 }}
               />
@@ -239,31 +240,41 @@ const StepBasicInfo = ({
           </div>
         )}
 
-        {/* Content repo name: content-{orgLogin}-{namespace}, namespace editable.
-            Shown once an org is selected and a slug exists to derive from. */}
+        {/* Content repo: the FULL repo name, fully editable (no fixed prefix).
+            Defaults to `content-{namespace}` and keeps re-deriving until the
+            user overrides it. Shown once an org is selected and a slug exists
+            to derive from. */}
         {(slugPreview || slugOverride) && selectedOrgLogin && (
           <div>
             <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 flex-wrap">
               <span>Content repo:</span>
-              {editingNamespace ? (
+              {editingContentRepo ? (
                 <Controller
-                  name="content_namespace"
+                  name="content_repo"
                   control={control}
                   render={({ field }) => (
                     <Input
                       {...field}
                       size="small"
                       style={{ width: 340 }}
-                      addonBefore={`content-${selectedOrgLogin}-`}
-                      value={(field.value as string) || namespaceSuggestion}
-                      onChange={e => field.onChange(slugify(e.target.value))}
+                      value={(field.value as string) || contentRepoSuggestion}
+                      // Per-keystroke: only lowercase + drop disallowed chars.
+                      // The FULL sanitize (edge-dash/dot trim) must wait for
+                      // blur — running it per keystroke eats every hyphen the
+                      // moment it is typed, because it is trailing right then.
+                      onChange={e =>
+                        field.onChange(e.target.value.toLowerCase().replace(/[^a-z0-9._-]+/g, '-'))
+                      }
                       onBlur={() => {
                         field.onBlur();
+                        const finalValue = sanitizeRepoName((field.value as string) ?? '');
                         // An override equal to the suggestion is not an override.
-                        if ((field.value as string) === namespaceSuggestion) {
-                          setValue('content_namespace', '', { shouldDirty: false });
-                        }
-                        setEditingNamespace(false);
+                        setValue(
+                          'content_repo',
+                          finalValue === contentRepoSuggestion ? '' : finalValue,
+                          { shouldDirty: false }
+                        );
+                        setEditingContentRepo(false);
                       }}
                       autoFocus
                     />
@@ -271,17 +282,17 @@ const StepBasicInfo = ({
                 />
               ) : (
                 <>
-                  <code className="bg-stone-100 dark:bg-neutral-800 text-gray-700 dark:text-gray-300 px-2 py-1 rounded">
-                    content-{selectedOrgLogin}-
+                  <code className="bg-stone-100 dark:bg-neutral-800 px-2 py-1 rounded">
+                    <span className="text-gray-500 dark:text-gray-400">{selectedOrgLogin}/</span>
                     <span className="font-semibold text-gray-900 dark:text-gray-100">
-                      {effectiveNamespace}
+                      {effectiveContentRepo}
                     </span>
                   </code>
                   <button
                     type="button"
-                    onClick={() => setEditingNamespace(true)}
+                    onClick={() => setEditingContentRepo(true)}
                     className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                    aria-label="Edit content namespace"
+                    aria-label="Edit content repo name"
                   >
                     <EditOutlined /> edit
                   </button>
@@ -290,7 +301,7 @@ const StepBasicInfo = ({
             </div>
             <div className="mt-1 text-xs text-gray-400 dark:text-gray-500">
               The GitHub repository that will store this classroom&rsquo;s pages &amp; slides
-              content.
+              content. It must not already exist.
             </div>
           </div>
         )}

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -8,8 +8,38 @@ import {
 } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import getPrisma from '@classmoji/database';
-import { maxContentNamespaceLength, suggestContentNamespace } from '@classmoji/utils';
+import {
+  defaultContentRepoName,
+  sanitizeRepoName,
+  suggestContentNamespace,
+} from '@classmoji/utils';
 import { slugify } from './utils';
+
+/**
+ * Pick a free internal content namespace for a new classroom in this org.
+ *
+ * content_namespace no longer names anything on GitHub (content_repo does), but
+ * it keeps a [git_org_id, content_namespace] unique constraint and is no longer
+ * user-editable — so a collision has to be resolved silently here instead of
+ * being handed back as an error the user has no field to fix. Candidates, in
+ * order: the org-prefix-stripped slug, the raw slug (unique per org), then
+ * numeric suffixes.
+ */
+async function pickContentNamespace(gitOrgId: string, orgLogin: string, slug: string) {
+  const suggested = suggestContentNamespace({ orgLogin, slug });
+  const candidates = [suggested, slug, ...Array.from({ length: 20 }, (_, i) => `${slug}-${i + 2}`)];
+
+  const taken = new Set(
+    (
+      await getPrisma().classroom.findMany({
+        where: { git_org_id: gitOrgId, content_namespace: { in: candidates } },
+        select: { content_namespace: true },
+      })
+    ).map(c => c.content_namespace)
+  );
+
+  return candidates.find(c => !taken.has(c)) ?? `${slug}-${Date.now()}`;
+}
 
 export const action = checkAuth(async ({ request }: { request: Request }) => {
   const authData = await getAuthSession(request);
@@ -27,7 +57,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     git_org_id,
     name,
     slug: slugInput,
-    content_namespace: namespaceInput,
+    content_repo: contentRepoInput,
     importConfig,
   } = await request.json();
 
@@ -75,32 +105,48 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   // Slug: prefer client-provided (user override / suggestion) when present, else derive from name.
   const slug = slugInput && typeof slugInput === 'string' ? slugify(slugInput) : slugify(name);
 
-  // Content namespace (names the classroom's content repo,
-  // `content-{orgLogin}-{namespace}`): client-provided override when present,
-  // else the org-prefix-stripped slug — never the raw slug, which doubles the
-  // org name in the repo whenever the slug starts with the course/org name.
-  const contentNamespace =
-    namespaceInput && typeof namespaceInput === 'string' && slugify(namespaceInput).length > 0
-      ? slugify(namespaceInput)
-      : suggestContentNamespace({ orgLogin: gitOrg.login, slug });
+  // Internal identifier only — names no repo, and no longer user-editable.
+  const contentNamespace = await pickContentNamespace(git_org_id, gitOrg.login, slug);
 
-  if (contentNamespace.length > maxContentNamespaceLength(gitOrg.login)) {
+  // Content repo: the user's name when supplied, else `content-{namespace}`.
+  // Sanitized to what GitHub accepts so the stored name and the real repo can
+  // never diverge; an input that sanitizes away entirely falls back to the
+  // default rather than storing an empty name.
+  const contentRepo =
+    (typeof contentRepoInput === 'string' ? sanitizeRepoName(contentRepoInput) : '') ||
+    defaultContentRepoName(contentNamespace);
+
+  // Two classrooms in one org sharing a content repo would share (and could
+  // overwrite or delete) each other's content. The DB unique constraint
+  // backstops the race; this check gives a friendly error.
+  const repoTaken = await getPrisma().classroom.findFirst({
+    where: { git_org_id, content_repo: contentRepo },
+    select: { slug: true },
+  });
+  if (repoTaken) {
     return {
-      error: `Content namespace is too long — keep it under ${maxContentNamespaceLength(gitOrg.login)} characters so the content repo name fits GitHub's limit`,
+      error: `Content repo '${contentRepo}' is already used by classroom '${repoTaken.slug}' in this organization — pick a different name`,
     };
   }
 
-  // The namespace names the content repo (content-{org}-{namespace}); a
-  // collision would make two classrooms share one repo. The DB unique
-  // constraint backstops the race; this check gives a friendly error.
-  const namespaceTaken = await getPrisma().classroom.findFirst({
-    where: { git_org_id, content_namespace: contentNamespace },
-    select: { slug: true },
-  });
-  if (namespaceTaken) {
+  // The content repo must be created FRESH. ensureContentRepo adopts a repo
+  // that already exists rather than failing, so an existing name here would
+  // silently make a student/template repo into this classroom's content repo
+  // (and a later classroom delete would offer to delete it). Refuse up front.
+  // Availability is best-effort: a failed check (network, rate limit) must not
+  // block creation — the DB constraint and ensure behavior are unchanged.
+  try {
+    await octokit.rest.repos.get({ owner: gitOrg.login, repo: contentRepo });
     return {
-      error: `Content namespace '${contentNamespace}' is already used by classroom '${namespaceTaken.slug}' in this organization — pick a different one`,
+      error: `Repository '${contentRepo}' already exists in ${gitOrg.login} — content repos must be created fresh; pick another name`,
     };
+  } catch (error: unknown) {
+    if ((error as { status?: number })?.status !== 404) {
+      console.warn(
+        `Could not verify content repo availability for ${gitOrg.login}/${contentRepo}:`,
+        error instanceof Error ? error.message : error
+      );
+    }
   }
 
   // ALL validation that can refuse creation must run BEFORE the transaction —
@@ -139,6 +185,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
           slug,
           name,
           content_namespace: contentNamespace,
+          content_repo: contentRepo,
         },
       });
 
@@ -158,12 +205,13 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
       return created;
     });
   } catch (error: unknown) {
-    // Unique-constraint race (slug or content namespace claimed between the
-    // pre-checks and the insert) — refuse cleanly instead of a 500.
+    // Unique-constraint race (slug, content repo, or the internal namespace
+    // claimed between the pre-checks and the insert) — refuse cleanly
+    // instead of a 500.
     if ((error as { code?: string })?.code === 'P2002') {
       return {
         error:
-          'That classroom slug or content namespace was just taken in this organization — adjust and try again',
+          'That classroom slug or content repo was just taken in this organization — adjust and try again',
       };
     }
     throw error;

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -8,7 +8,7 @@ import { useGlobalFetcher, useGitHubAppInstallPopup } from '~/hooks';
 import { ClassmojiService, GitHubProvider } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName, suggestContentNamespace } from '@classmoji/utils';
+import { defaultContentRepoName, suggestContentNamespace } from '@classmoji/utils';
 
 import StepBasicInfo from './StepBasicInfo';
 import StepImportModules from './StepImportModules';
@@ -286,7 +286,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
       git_org_id: '',
       name: '',
       slug: '',
-      content_namespace: '',
+      content_repo: '',
     },
   });
 
@@ -332,17 +332,22 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
   const slugOverride = (formValues as { slug?: string }).slug;
   const effectiveSlug = slugOverride && slugOverride.length > 0 ? slugOverride : slugPreview;
 
-  // Content namespace: manual override when set, else the org-prefix-stripped
-  // slug (mirrors the server's fallback so the preview always shows what an
-  // untouched submit would create).
+  // Content repo: manual override when set, else `content-{namespace}` where
+  // the namespace is the org-prefix-stripped slug (mirrors the server's
+  // fallback so the preview always shows what an untouched submit would create).
   const selectedOrgLogin = gitOrgs.find(o => o.id === formValues.git_org_id)?.login ?? '';
   const namespaceSuggestion =
     effectiveSlug && selectedOrgLogin
       ? suggestContentNamespace({ orgLogin: selectedOrgLogin, slug: effectiveSlug })
       : effectiveSlug;
-  const namespaceOverride = (formValues as { content_namespace?: string }).content_namespace;
-  const effectiveNamespace =
-    namespaceOverride && namespaceOverride.length > 0 ? namespaceOverride : namespaceSuggestion;
+  const contentRepoSuggestion = namespaceSuggestion
+    ? defaultContentRepoName(namespaceSuggestion)
+    : '';
+  const contentRepoOverride = (formValues as { content_repo?: string }).content_repo;
+  const effectiveContentRepo =
+    contentRepoOverride && contentRepoOverride.length > 0
+      ? contentRepoOverride
+      : contentRepoSuggestion;
 
   // Debounced availability check (shared with StepBasicInfo via props)
   const availabilityFetcher = useFetcher<{
@@ -409,7 +414,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     notify(ActionTypes.CREATE_CLASSROOM, 'Creating classroom...');
 
     fetcher!.submit(
-      { ...values, slug: effectiveSlug, content_namespace: effectiveNamespace, importConfig },
+      { ...values, slug: effectiveSlug, content_repo: effectiveContentRepo, importConfig },
       {
         method: 'post',
         action: '/create-classroom',
@@ -468,8 +473,8 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                 availability={availabilityFetcher.data}
                 availabilityLoading={availabilityFetcher.state !== 'idle'}
                 selectedOrgLogin={selectedOrgLogin}
-                namespaceSuggestion={namespaceSuggestion}
-                effectiveNamespace={effectiveNamespace}
+                contentRepoSuggestion={contentRepoSuggestion}
+                effectiveContentRepo={effectiveContentRepo}
               />
             )}
 
@@ -492,14 +497,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
                 formValues={formValues}
                 gitOrgs={gitOrgs}
                 slugPreview={effectiveSlug}
-                contentRepoName={
-                  selectedOrgLogin
-                    ? classroomContentRepoName({
-                        login: selectedOrgLogin,
-                        namespace: effectiveNamespace,
-                      })
-                    : null
-                }
+                contentRepoName={selectedOrgLogin ? effectiveContentRepo : null}
                 importEnabled={importEnabled}
                 sourceClassroom={sourceClassroom}
                 selectedModules={selectedModules}

--- a/apps/webapp/app/routes/_user.create-classroom/types.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/types.ts
@@ -70,6 +70,6 @@ export interface CreateClassroomFormValues {
   git_org_id: string;
   name: string;
   slug: string;
-  /** Manual content-namespace override; '' = derive from org login + slug. */
-  content_namespace: string;
+  /** Manual content-repo override; '' = default to `content-{namespace}`. */
+  content_repo: string;
 }

--- a/apps/webapp/app/routes/admin.$class.pages.$pageId/action.ts
+++ b/apps/webapp/app/routes/admin.$class.pages.$pageId/action.ts
@@ -10,7 +10,8 @@ interface PageWithClassroom {
   content_path: string;
   width: number;
   classroom: {
-    content_namespace: string;
+    // Stored, user-editable content repo name. Never re-derive it.
+    content_repo: string;
     git_organization: {
       login: string;
       provider: string;
@@ -90,7 +91,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
+      const repo = pageData.classroom.content_repo;
       const assetsFolder = `${page.content_path}/assets`;
 
       console.error('[upload-image action] Uploading to repo:', repo, 'folder:', assetsFolder);
@@ -162,7 +163,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
+      const repo = pageData.classroom.content_repo;
       const assetsFolder = `${page.content_path}/assets`;
 
       const buffer = Buffer.from(await file.arrayBuffer());
@@ -331,7 +332,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const pageData = page as unknown as PageWithClassroom;
       const gitOrg = pageData.classroom.git_organization;
-      const repo = `content-${gitOrg.login}-${pageData.classroom.content_namespace}`;
+      const repo = pageData.classroom.content_repo;
 
       // Upload header image to content repo (in page folder, not assets)
       const buffer = Buffer.from(await file.arrayBuffer());

--- a/apps/webapp/app/routes/admin.$class.pages.new/BatchImportTab.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages.new/BatchImportTab.tsx
@@ -18,14 +18,10 @@ interface ImportedPage {
 }
 
 interface BatchImportTabProps {
-  contentNamespace: string;
   onPagesChange: (pages: ImportedPage[]) => void;
 }
 
-export default function BatchImportTab({
-  contentNamespace,
-  onPagesChange,
-}: BatchImportTabProps) {
+export default function BatchImportTab({ onPagesChange }: BatchImportTabProps) {
   const [pages, setPages] = useState<ImportedPage[]>([]);
   const [isExtracting, setIsExtracting] = useState(false);
   const [extractError, setExtractError] = useState<string | null>(null);
@@ -194,7 +190,6 @@ export default function BatchImportTab({
 
       {/* Hidden inputs for form data */}
       <input type="hidden" name="intent" value="batch-import" />
-      <input type="hidden" name="contentNamespace" value={contentNamespace} />
     </div>
   );
 }

--- a/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.pages.new/route.tsx
@@ -24,11 +24,8 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     attemptedAction: 'create_page',
   });
 
-  const contentNamespace = classroom.content_namespace;
-
   // Include slug for navigation and gitOrgLogin for API calls
   return {
-    contentNamespace,
     classroom: {
       ...classroom,
       slug: classroom.slug, // For navigation URLs
@@ -57,16 +54,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     return { error: 'Git organization not configured' };
   }
 
-  const contentNamespace = classroom.content_namespace;
-  if (!contentNamespace) {
-    return { error: 'Classroom content namespace not configured' };
+  // Stored, user-editable content repo name. Never re-derive it.
+  const repoName = classroom.content_repo;
+  if (!repoName) {
+    return { error: 'Classroom content repo not configured' };
   }
 
   // Single page import/create
   const title = formData.get('title') as string;
-
-  // Content repo name: content-{gitOrgLogin}-{contentNamespace}
-  const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
 
   // Flat content path: pages/{slug}
   const contentPath = ClassmojiService.page.pageContentPath(title);
@@ -188,7 +183,7 @@ interface BatchPage {
 }
 
 export default function NewPage({ loaderData }: Route.ComponentProps) {
-  const { contentNamespace, classroom } = loaderData;
+  const { classroom } = loaderData;
   const fetcher = useFetcher();
   const navigate = useNavigate();
   const { opened, close } = useRouteDrawer({});
@@ -242,7 +237,6 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
       const initFormData = new FormData();
       initFormData.append('intent', 'batch-init');
       initFormData.append('classSlug', classroom.slug);
-      initFormData.append('contentNamespace', String(contentNamespace ?? ''));
 
       const initResponse = await fetch('/api/pages/batch', {
         method: 'POST',
@@ -265,7 +259,6 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
         const formData = new FormData();
         formData.append('intent', 'batch-import-single');
         formData.append('classSlug', classroom.slug);
-        formData.append('contentNamespace', String(contentNamespace ?? ''));
         formData.append('title', page.title);
         if (page.repository) formData.append('repository', page.repository);
         if (page.assignmentId) formData.append('assignmentId', page.assignmentId);
@@ -325,7 +318,6 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
 
   const handleSubmit = (values: Record<string, string>) => {
     const formData = new FormData();
-    formData.append('contentNamespace', String(contentNamespace ?? ''));
 
     if (activeTab === 'batch') {
       // Handle batch import with progress
@@ -369,9 +361,7 @@ export default function NewPage({ loaderData }: Route.ComponentProps) {
     {
       key: 'batch',
       label: 'Batch Import',
-      children: (
-        <BatchImportTab contentNamespace={contentNamespace ?? ''} onPagesChange={setBatchPages} />
-      ),
+      children: <BatchImportTab onPagesChange={setBatchPages} />,
     },
   ];
 

--- a/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
@@ -35,11 +35,10 @@ const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
 
   const { fetcher } = useGlobalFetcher();
 
-  // Generate repo name and URL for display
+  // content_repo is the stored, user-editable repo name; the org-level helper is
+  // only a fallback for legacy classrooms that predate it.
   const gitOrgLogin = organization.git_organization?.login || classSlug || '';
-  const repoName = organization.content_namespace
-    ? `content-${gitOrgLogin}-${organization.content_namespace}`
-    : getContentRepoName({ login: gitOrgLogin });
+  const repoName = organization.content_repo || getContentRepoName({ login: gitOrgLogin });
   const repoUrl = `https://github.com/${gitOrgLogin}/${repoName}`;
 
   // Handler for customizable repo name (currently disabled in UI)
@@ -119,10 +118,16 @@ const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
             />
           </Form.Item>
           <Form.Item label="Show Pages">
-            <Switch checked={settings.show_pages ?? true} onChange={handleNavToggle('show_pages')} />
+            <Switch
+              checked={settings.show_pages ?? true}
+              onChange={handleNavToggle('show_pages')}
+            />
           </Form.Item>
           <Form.Item label="Show Repositories">
-            <Switch checked={settings.show_repos ?? true} onChange={handleNavToggle('show_repos')} />
+            <Switch
+              checked={settings.show_repos ?? true}
+              onChange={handleNavToggle('show_repos')}
+            />
           </Form.Item>
         </Form>
       </SettingSection>
@@ -194,9 +199,7 @@ const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
             <div className="mt-4 p-4 bg-nav-hover rounded-lg border border-gray-200 dark:border-neutral-700">
               <div className="flex items-center gap-2 mb-3">
                 <IconInfoCircle size={16} className="text-ink-3" />
-                <span className="font-medium text-ink-0">
-                  About the Syllabus Bot
-                </span>
+                <span className="font-medium text-ink-0">About the Syllabus Bot</span>
               </div>
               <div className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
                 <p>

--- a/apps/webapp/app/routes/api.pages.batch/route.ts
+++ b/apps/webapp/app/routes/api.pages.batch/route.ts
@@ -26,9 +26,10 @@ export const action = async ({ request }: Route.ActionArgs) => {
     return Response.json({ error: 'Git organization not configured' });
   }
 
-  const contentNamespace = classroom.content_namespace;
-  if (!contentNamespace) {
-    return Response.json({ error: 'Classroom content namespace not configured' });
+  // Stored, user-editable content repo name. Never re-derive it.
+  const contentRepo = classroom.content_repo;
+  if (!contentRepo) {
+    return Response.json({ error: 'Classroom content repo not configured' });
   }
 
   // Initialize batch import - creates repo if needed
@@ -45,7 +46,6 @@ export const action = async ({ request }: Route.ActionArgs) => {
   if (intent === 'batch-import-single') {
     const title = formData.get('title') as string;
     const moduleId = (formData.get('assignmentId') as string) || null; // Optional - for linking
-    const repoName = `content-${gitOrgLogin}-${contentNamespace}`;
 
     try {
       // Flat content path: pages/{slug}
@@ -62,7 +62,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
       const { html, imageMap, unmatchedImages } = await processMarkdownImport(
         markdownText,
         imageFiles,
-        { org: gitOrgLogin, repo: repoName, contentPath, assetsFolder }
+        { org: gitOrgLogin, repo: contentRepo, contentPath, assetsFolder }
       );
 
       // Prepare files to upload

--- a/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
@@ -62,13 +62,11 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   const settings = await ClassmojiService.classroom.getClassroomSettingsForServer(classroom.id);
   const isInstructor = ['OWNER', 'TEACHER'].includes(membership!.role);
 
-  // Check if we have a content repo (either explicitly set or can be derived)
+  // content_repo is the stored, user-editable repo name; the org-level helper is
+  // only a fallback for legacy classrooms that predate it.
   const gitOrgLogin = classroom.git_organization?.login;
-  const contentRepoName = classroom.content_namespace
-    ? `content-${gitOrgLogin}-${classroom.content_namespace}`
-    : gitOrgLogin
-      ? getContentRepoName({ login: gitOrgLogin })
-      : '';
+  const contentRepoName =
+    classroom.content_repo || (gitOrgLogin ? getContentRepoName({ login: gitOrgLogin }) : '');
 
   return jsonResponse({
     enabled: settings?.syllabus_bot_enabled ?? false,
@@ -150,16 +148,14 @@ async function handleInitConversation(request: Request, classSlug: string, formD
     },
   };
 
-  // If content repo is configured, add clone info
-  // Use settings override or generate from classroom/git_org
+  // If content repo is configured, add clone info.
+  // Precedence: legacy settings override, then the classroom's stored
+  // content_repo, then the org-level fallback for legacy classrooms.
   const gitOrgLoginForClone = classroom.git_organization?.login;
   const contentRepoNameForClone =
     settings?.content_repo_name ||
-    (classroom.content_namespace
-      ? `content-${gitOrgLoginForClone}-${classroom.content_namespace}`
-      : gitOrgLoginForClone
-        ? getContentRepoName({ login: gitOrgLoginForClone })
-        : '');
+    classroom.content_repo ||
+    (gitOrgLoginForClone ? getContentRepoName({ login: gitOrgLoginForClone }) : '');
   if (contentRepoNameForClone && classroom.git_organization?.github_installation_id) {
     try {
       const accessToken = await getInstallationToken(classroom.git_organization);

--- a/apps/webapp/tests/owner/classroom/classroom-lifecycle.spec.ts
+++ b/apps/webapp/tests/owner/classroom/classroom-lifecycle.spec.ts
@@ -68,6 +68,7 @@ async function createDisposableClassroom(): Promise<{ id: string; slug: string }
       slug,
       name: 'E2E Disposable Classroom',
       content_namespace: slug,
+      content_repo: `content-${slug}`,
       git_org_id: gitOrgId,
       status: 'ACTIVE',
       settings: { create: {} },

--- a/packages/content/src/__tests__/index.test.ts
+++ b/packages/content/src/__tests__/index.test.ts
@@ -17,7 +17,6 @@ describe('@classmoji/content shim', () => {
 
     // URL builders
     expect(typeof shim.getContentUrl).toBe('function');
-    expect(typeof shim.getSlideContentUrl).toBe('function');
     expect(typeof shim.getRawContentUrl).toBe('function');
 
     // Validation utilities
@@ -35,7 +34,6 @@ describe('@classmoji/content shim', () => {
   it('re-exports the exact bindings from @classmoji/services', () => {
     expect(shim.ContentService).toBe(services.ContentService);
     expect(shim.getContentUrl).toBe(services.getContentUrl);
-    expect(shim.getSlideContentUrl).toBe(services.getSlideContentUrl);
     expect(shim.getRawContentUrl).toBe(services.getRawContentUrl);
     expect(shim.validateFile).toBe(services.validateFile);
     expect(shim.sanitizeFilename).toBe(services.sanitizeFilename);
@@ -50,9 +48,6 @@ describe('@classmoji/content shim', () => {
     expect(
       shim.getContentUrl({ org: 'dali', repo: 'content-dali-26w', path: '/pages/x.html' })
     ).toBe('https://dali.github.io/content-dali-26w/pages/x.html');
-    expect(
-      shim.getSlideContentUrl({ orgLogin: 'dali', term: '26w', contentPath: 'slides/intro' })
-    ).toBe('https://dali.github.io/content-dali-26w/slides/intro/index.html');
     expect(shim.getMimeType('photo.PNG')).toBe('image/png');
     expect(shim.isImageFile('photo.png')).toBe(true);
     expect(shim.isBinaryFile('doc.pdf')).toBe(true);

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -12,7 +12,6 @@ export {
   ContentService,
   // URL builders for reading content from GitHub Pages
   getContentUrl,
-  getSlideContentUrl,
   getRawContentUrl,
   // Validation utilities
   validateFile,

--- a/packages/database/migrations/20260813150000_classroom_content_repo/migration.sql
+++ b/packages/database/migrations/20260813150000_classroom_content_repo/migration.sql
@@ -1,0 +1,30 @@
+-- The classroom content repo name becomes a STORED, user-editable value
+-- instead of being re-derived as content-{orgLogin}-{content_namespace} at
+-- every call site. content_namespace stays as an internal identifier (and
+-- keeps its per-org unique constraint); it no longer names any repo.
+
+-- Add nullable so existing rows can be backfilled before the NOT NULL.
+ALTER TABLE "classrooms" ADD COLUMN "content_repo" TEXT;
+
+-- Backfill with the EXACT name the old derivation produced, so every existing
+-- classroom keeps pointing at the repo it already has on GitHub. This is the
+-- one place the legacy content-{orgLogin}-{content_namespace} pattern is still
+-- written down; nothing derives it at runtime any more.
+UPDATE "classrooms" c
+SET "content_repo" = 'content-' || g."login" || '-' || c."content_namespace"
+FROM "git_organizations" g
+WHERE c."git_org_id" = g."id";
+
+-- Defensive: a classroom whose org row is somehow missing (FK makes this
+-- unreachable) still needs a value for the NOT NULL below.
+UPDATE "classrooms"
+SET "content_repo" = 'content-' || "content_namespace"
+WHERE "content_repo" IS NULL;
+
+ALTER TABLE "classrooms" ALTER COLUMN "content_repo" SET NOT NULL;
+
+-- Two classrooms in one org sharing a content repo would share (and could
+-- adopt, overwrite, or delete) each other's content. The backfill cannot
+-- collide: it is a pure function of (login, content_namespace), and
+-- [git_org_id, content_namespace] is already unique.
+CREATE UNIQUE INDEX "classrooms_git_org_id_content_repo_key" ON "classrooms"("git_org_id", "content_repo");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -347,7 +347,15 @@ model Classroom {
   slug              String // URL slug: "cs101-fall-2025"
   git_org_id        String
   name              String
+  // Internal identifier only. Historically the content repo name was derived
+  // as content-{orgLogin}-{content_namespace}; it no longer names any repo.
   content_namespace String
+  // The GitHub repo (in git_organization) holding this classroom's pages &
+  // slides content. STORED and fully user-editable — never re-derived. Set at
+  // creation for every classroom; defaults to `content-{content_namespace}`.
+  // NOT the same as ClassroomSettings.content_repo_name, which is a legacy
+  // ORG-level content repo override (`content-{login}`) for a DIFFERENT repo.
+  content_repo      String
   status            ClassroomStatus @default(ACTIVE)
   is_archived       Boolean         @default(false)
   // True for the auto-provisioned per-user "Example Course" sandbox used by the
@@ -379,10 +387,13 @@ model Classroom {
   notifications         Notification[]
 
   @@unique([git_org_id, slug])
-  // The content repo name is content-{orgLogin}-{content_namespace}: two
-  // classrooms in one org sharing a namespace would share (and could adopt,
-  // overwrite, or delete) each other's content repo. Uniqueness is per-org.
+  // content_namespace no longer names the content repo, but stays unique
+  // per-org: it is the internal identifier legacy rows were named from.
   @@unique([git_org_id, content_namespace])
+  // Two classrooms in one org sharing a content repo would share (and could
+  // adopt, overwrite, or delete) each other's content. Uniqueness is per-org;
+  // repo names are org-scoped on GitHub too.
+  @@unique([git_org_id, content_repo])
   @@index([git_org_id])
   @@map("classrooms")
 }

--- a/packages/database/scripts/seed-fixtures.js
+++ b/packages/database/scripts/seed-fixtures.js
@@ -137,6 +137,7 @@ export async function seedForeignClassroom(prisma, { org }) {
       slug: 'classmoji-other-class',
       name: 'Other Class',
       content_namespace: 'classmoji-other-class',
+      content_repo: 'content-classmoji-other-class',
     },
   });
 

--- a/packages/database/scripts/seed.js
+++ b/packages/database/scripts/seed.js
@@ -37,6 +37,7 @@ async function main() {
         slug: 'classmoji-dev-winter-2025',
         name: 'Dev Classroom',
         content_namespace: 'classmoji-dev-winter-2025',
+        content_repo: 'content-classmoji-dev-winter-2025',
       },
     });
   }

--- a/packages/services/src/classmoji/__tests__/classroom.deleteArtifacts.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroom.deleteArtifacts.test.ts
@@ -4,19 +4,19 @@ import { classroomGitHubArtifactPlan } from '../classroom.service.ts';
 const base = {
   orgLogin: 'dartmouth-cs52',
   slug: 'dartmouth-cs52-26f',
-  contentNamespace: 'dartmouth-cs52-26f',
+  contentRepo: 'cs52-content',
   gitRepoNames: [] as string[],
   teamSlugs: [] as string[],
 };
 
 describe('classroomGitHubArtifactPlan', () => {
-  it('names the content repo from org login + namespace and the two conventional teams', () => {
+  it('names the content repo from the STORED name (never re-derived) and the two conventional teams', () => {
     const plan = classroomGitHubArtifactPlan(base);
     expect(plan).toEqual([
       {
         kind: 'repo',
         org: 'dartmouth-cs52',
-        name: 'content-dartmouth-cs52-dartmouth-cs52-26f',
+        name: 'cs52-content',
         label: 'content repo',
       },
       { kind: 'team', org: 'dartmouth-cs52', name: 'dartmouth-cs52-26f-students', label: 'classroom team' },
@@ -24,8 +24,15 @@ describe('classroomGitHubArtifactPlan', () => {
     ]);
   });
 
-  it('omits the content repo when the namespace is null', () => {
-    const plan = classroomGitHubArtifactPlan({ ...base, contentNamespace: null });
+  it('uses the stored name verbatim even when it looks nothing like the legacy pattern', () => {
+    const plan = classroomGitHubArtifactPlan({ ...base, contentRepo: 'My.Course_Notes-26F' });
+    expect(plan.filter(a => a.label === 'content repo').map(a => a.name)).toEqual([
+      'My.Course_Notes-26F',
+    ]);
+  });
+
+  it('omits the content repo when the stored name is null', () => {
+    const plan = classroomGitHubArtifactPlan({ ...base, contentRepo: null });
     expect(plan.filter(a => a.label === 'content repo')).toHaveLength(0);
     expect(plan.filter(a => a.kind === 'team')).toHaveLength(2);
   });
@@ -43,7 +50,7 @@ describe('classroomGitHubArtifactPlan', () => {
     expect(plan.filter(a => a.label === 'project team').map(a => a.name)).toEqual(['team-rocket']);
   });
 
-  it('never invents artifacts: empty inputs yield only the derived content repo + conventional teams', () => {
+  it('never invents artifacts: empty inputs yield only the stored content repo + conventional teams', () => {
     const plan = classroomGitHubArtifactPlan(base);
     expect(plan).toHaveLength(3);
   });

--- a/packages/services/src/classmoji/__tests__/page.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/page.service.test.ts
@@ -70,7 +70,7 @@ const gitOrganization = { id: 'org-1', login: 'test-org', provider: 'GITHUB' };
 const classroom = {
   id: 'class-1',
   name: 'Test Class',
-  content_namespace: 'cs101',
+  content_repo: 'content-test-org-cs101',
   git_organization: gitOrganization,
 };
 
@@ -216,7 +216,7 @@ describe('page.createPage', () => {
     expect(createPublicRepositoryMock).toHaveBeenCalledWith(
       'test-org',
       'content-test-org-cs101',
-      'Course content for Test Class - cs101'
+      'Course content for Test Class'
     );
     expect(enableGitHubPagesMock).toHaveBeenCalledWith('test-org', 'content-test-org-cs101');
   });
@@ -227,10 +227,10 @@ describe('page.createPage', () => {
       createPage({ classroomId: 'class-1', title: 'X', createdBy: 'user-1' })
     ).rejects.toThrow('Git organization not configured');
 
-    classroomFindUniqueMock.mockResolvedValue({ ...classroom, content_namespace: null });
+    classroomFindUniqueMock.mockResolvedValue({ ...classroom, content_repo: null });
     await expect(
       createPage({ classroomId: 'class-1', title: 'X', createdBy: 'user-1' })
-    ).rejects.toThrow('Classroom content namespace not configured');
+    ).rejects.toThrow('Classroom content repo not configured');
   });
 
   it('refuses a content-path collision BEFORE any GitHub write (U3)', async () => {

--- a/packages/services/src/classmoji/__tests__/pageContent.saveMerge.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.saveMerge.test.ts
@@ -32,7 +32,7 @@ const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
 const page = {
   title: 'Syllabus',
   content_path: 'pages/syllabus',
-  classroom: { content_namespace: 'cs101', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-cs101', git_organization: gitOrganization },
 };
 
 const PATH = 'pages/syllabus/content.json';

--- a/packages/services/src/classmoji/__tests__/pageContent.saveOps.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.saveOps.test.ts
@@ -40,7 +40,7 @@ const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
 const page = {
   title: 'Syllabus',
   content_path: 'pages/syllabus',
-  classroom: { content_namespace: 'cs101', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-cs101', git_organization: gitOrganization },
 };
 
 const PATH = 'pages/syllabus/content.json';

--- a/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.semantic.test.ts
@@ -38,7 +38,7 @@ const gitOrganization = { provider: 'GITHUB', login: 'test-org' };
 const page = {
   title: 'Syllabus',
   content_path: 'pages/syllabus',
-  classroom: { content_namespace: 'cs101', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-cs101', git_organization: gitOrganization },
 };
 const PREVIEW_BRANCH = 'preview/pages/syllabus';
 

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -48,7 +48,7 @@ const page = {
   title: 'Syllabus',
   content_path: 'pages/syllabus',
   classroom: {
-    content_namespace: 'cs101',
+    content_repo: 'content-test-org-cs101',
     git_organization: gitOrganization,
   },
 };

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -1,5 +1,4 @@
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName } from '@classmoji/utils';
 import { GitHubProvider } from '../git/index.ts';
 import type { Prisma, Role } from '@prisma/client';
 
@@ -132,7 +131,8 @@ export const findAll = async (query: Prisma.ClassroomWhereInput = {}) => {
  * @param {string} data.git_org_id - UUID of the GitOrganization
  * @param {string} data.slug - URL-friendly slug
  * @param {string} data.name - Display name
- * @param {string} data.content_namespace - Identifier embedded in content repo name
+ * @param {string} data.content_namespace - Internal identifier (names no repo)
+ * @param {string} data.content_repo - GitHub repo holding this classroom's content
  * @param {string} [data.emoji] - Emoji (default: "dart")
  * @returns {Promise<Object>}
  */
@@ -242,7 +242,7 @@ export interface GitHubArtifact {
 
 /**
  * Pure helper: enumerate the GitHub artifacts a classroom owns, from DB-known
- * facts ONLY — the content repo (derived from org login + content namespace),
+ * facts ONLY — the content repo (the classroom's STORED content_repo name),
  * the two conventional classroom teams ({slug}-students / {slug}-assistants),
  * any provider-backed project-team slugs, and the classroom's git repos by
  * exact recorded name. Nothing is pattern-matched or discovered live: if the
@@ -251,22 +251,22 @@ export interface GitHubArtifact {
 export function classroomGitHubArtifactPlan({
   orgLogin,
   slug,
-  contentNamespace,
+  contentRepo,
   gitRepoNames,
   teamSlugs,
 }: {
   orgLogin: string;
   slug: string;
-  contentNamespace: string | null;
+  contentRepo: string | null;
   gitRepoNames: string[];
   teamSlugs: string[];
 }): GitHubArtifact[] {
   const plan: GitHubArtifact[] = [];
-  if (contentNamespace) {
+  if (contentRepo) {
     plan.push({
       kind: 'repo',
       org: orgLogin,
-      name: classroomContentRepoName({ login: orgLogin, namespace: contentNamespace }),
+      name: contentRepo,
       label: 'content repo',
     });
   }
@@ -299,11 +299,11 @@ export interface ClassroomGitHubPlan {
  * calls GitHub, so it is safe in a loader.
  *
  * The content repo is held back (`withheld`, and excluded from `artifacts`)
- * when another classroom in the same org shares this classroom's content
- * namespace — they resolve to the SAME repo, so deleting it would take out live
- * content. A DB unique constraint on [git_org_id, content_namespace] now
- * prevents new collisions; this guard covers rows that predate it. Teams and
- * assignment repos are per-classroom and never shared.
+ * when another classroom in the same org names the SAME content repo — deleting
+ * it would take out live content. A DB unique constraint on
+ * [git_org_id, content_repo] now prevents new collisions; this guard covers
+ * rows that predate it. Teams and assignment repos are per-classroom and never
+ * shared.
  *
  * @param {string} classroomId - Classroom whose artifacts to enumerate
  */
@@ -335,18 +335,18 @@ export const getClassroomGitHubArtifactPlan = async (
   const artifacts = classroomGitHubArtifactPlan({
     orgLogin: classroom.git_organization.login,
     slug: classroom.slug,
-    contentNamespace: classroom.content_namespace,
+    contentRepo: classroom.content_repo,
     gitRepoNames: classroom.git_repos.map(r => r.name),
     teamSlugs: classroom.teams.map(t => t.slug),
   });
 
-  if (!classroom.content_namespace) {
+  if (!classroom.content_repo) {
     return { artifacts, withheld: null, unavailable: null };
   }
   const sharer = await getPrisma().classroom.findFirst({
     where: {
       git_org_id: classroom.git_org_id,
-      content_namespace: classroom.content_namespace,
+      content_repo: classroom.content_repo,
       id: { not: classroom.id },
     },
     select: { slug: true },

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -20,7 +20,7 @@
  */
 
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName, titleToIdentifier } from '@classmoji/utils';
+import { titleToIdentifier } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import { getGitProvider } from '../git/index.ts';
 import * as contentManifestService from './contentManifest.service.ts';
@@ -207,8 +207,8 @@ function errText(error: unknown): string {
 
 /**
  * Load a classroom's content-repo coordinates. Returns null when the classroom
- * (or its git org / content namespace) is not configured — the caller turns
- * that into a zeros+warning result for the SOURCE side, or a throw for TARGET.
+ * (or its git org / content repo) is not configured — the caller turns that
+ * into a zeros+warning result for the SOURCE side, or a throw for TARGET.
  */
 async function loadRepoContext(classroomId: string): Promise<RepoContext | null> {
   const classroom = await getPrisma().classroom.findUnique({
@@ -216,17 +216,14 @@ async function loadRepoContext(classroomId: string): Promise<RepoContext | null>
     include: { git_organization: true },
   });
   const gitOrganization = classroom?.git_organization as GitOrgRecord | null | undefined;
-  if (!classroom || !gitOrganization?.login || !classroom.content_namespace) {
+  if (!classroom || !gitOrganization?.login || !classroom.content_repo) {
     return null;
   }
   return {
     classroomId,
     gitOrganization,
     login: gitOrganization.login,
-    repo: classroomContentRepoName({
-      login: gitOrganization.login,
-      namespace: classroom.content_namespace,
-    }),
+    repo: classroom.content_repo,
     slug: classroom.slug,
   };
 }

--- a/packages/services/src/classmoji/contentManifest.service.ts
+++ b/packages/services/src/classmoji/contentManifest.service.ts
@@ -1,5 +1,4 @@
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 
 interface ManifestAssignmentEntry {
@@ -92,10 +91,7 @@ export async function saveManifest(classroomId: string): Promise<void> {
     .map(s => s.slug ?? String(s.id));
 
   // Write to repo
-  const repoName = classroomContentRepoName({
-    login: classroom.git_organization.login,
-    namespace: classroom.content_namespace,
-  });
+  const repoName = classroom.content_repo;
 
   try {
     await ContentService.put({

--- a/packages/services/src/classmoji/exampleClassroom.service.ts
+++ b/packages/services/src/classmoji/exampleClassroom.service.ts
@@ -23,6 +23,7 @@
  */
 
 import getPrisma from '@classmoji/database';
+import { defaultContentRepoName } from '@classmoji/utils';
 
 const EXAMPLE_ORG = {
   provider: 'GITHUB' as const,
@@ -91,6 +92,7 @@ export async function provisionExampleClassroom(params: {
           slug,
           name: 'Example Course',
           content_namespace: slug,
+          content_repo: defaultContentRepoName(slug),
           is_example: true,
           settings: { create: { show_grades_to_students: true, quizzes_enabled: true } },
         },

--- a/packages/services/src/classmoji/githubClassroomImport.service.ts
+++ b/packages/services/src/classmoji/githubClassroomImport.service.ts
@@ -23,7 +23,7 @@
  */
 
 import getPrisma from '@classmoji/database';
-import { titleToIdentifier } from '@classmoji/utils';
+import { defaultContentRepoName, titleToIdentifier } from '@classmoji/utils';
 
 // ---------------------------------------------------------------------------
 // Input shape (structural subset of the webapp parser's ParsedClassroom).
@@ -252,6 +252,7 @@ export async function importGithubClassroom(
           slug,
           name: gh.name,
           content_namespace: slug,
+          content_repo: defaultContentRepoName(slug),
           settings: { create: { show_grades_to_students: true, quizzes_enabled: true } },
         },
         update: { name: gh.name },

--- a/packages/services/src/classmoji/page.service.ts
+++ b/packages/services/src/classmoji/page.service.ts
@@ -1,5 +1,5 @@
 import getPrisma from '@classmoji/database';
-import { titleToIdentifier, classroomContentRepoName } from '@classmoji/utils';
+import { titleToIdentifier } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import { getGitProvider } from '../git/index.ts';
 import * as contentManifestService from './contentManifest.service.ts';
@@ -91,7 +91,7 @@ export interface PageFileUpload {
 /** Error `code` set when a new page's derived content path is already taken. */
 export const PAGE_CONTENT_PATH_CONFLICT = 'PAGE_CONTENT_PATH_CONFLICT';
 
-/** Load the classroom and derive its content-repo coordinates, or throw. */
+/** Load the classroom and its content-repo coordinates, or throw. */
 async function resolveContentRepo(classroomId: string) {
   const classroom = await getPrisma().classroom.findUnique({
     where: { id: classroomId },
@@ -104,17 +104,14 @@ async function resolveContentRepo(classroomId: string) {
   if (!gitOrgLogin) {
     throw new Error('Git organization not configured');
   }
-  if (!classroom.content_namespace) {
-    throw new Error('Classroom content namespace not configured');
+  if (!classroom.content_repo) {
+    throw new Error('Classroom content repo not configured');
   }
-  // Content repo name: content-{gitOrgLogin}-{contentNamespace}
+  // Stored, user-editable repo name — never re-derived from org + namespace.
   return {
     classroom,
     gitOrgLogin,
-    repoName: classroomContentRepoName({
-      login: gitOrgLogin,
-      namespace: classroom.content_namespace,
-    }),
+    repoName: classroom.content_repo,
   };
 }
 
@@ -155,7 +152,7 @@ async function ensureContentRepoExists({ classroom, gitOrgLogin, repoName }: Con
       await gitProvider.createPublicRepository(
         gitOrgLogin,
         repoName,
-        `Course content for ${classroom.name || gitOrgLogin} - ${classroom.content_namespace}`
+        `Course content for ${classroom.name || gitOrgLogin}`
       );
 
       // Give GitHub a moment to initialize the repo
@@ -588,10 +585,7 @@ export async function deletePage(pageId: string) {
 
   // Delete from GitHub if configured
   if (gitOrgLogin && page.content_path) {
-    const repoName = classroomContentRepoName({
-      login: gitOrgLogin,
-      namespace: page.classroom.content_namespace,
-    });
+    const repoName = page.classroom.content_repo;
 
     try {
       await ContentService.deleteFolder({

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
-import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import {
   dedupeMergedTreeIds,
@@ -40,7 +39,8 @@ export interface PageWithContentRepo {
   title: string;
   content_path: string;
   classroom: {
-    content_namespace: string;
+    /** Stored content repo name — never re-derived from org + namespace. */
+    content_repo: string;
     git_organization?: {
       provider: string;
       login: string;
@@ -74,13 +74,10 @@ function contentRepoFor(page: PageWithContentRepo) {
   if (!gitOrganization?.login) {
     throw new Error('Git organization not configured');
   }
-  return {
-    gitOrganization,
-    repo: classroomContentRepoName({
-      login: gitOrganization.login,
-      namespace: page.classroom.content_namespace,
-    }),
-  };
+  if (!page.classroom.content_repo) {
+    throw new Error('Classroom content repo not configured');
+  }
+  return { gitOrganization, repo: page.classroom.content_repo };
 }
 
 // ─── Load / save ─────────────────────────────────────────────────────────────

--- a/packages/services/src/content/__tests__/ContentService.integration.test.ts
+++ b/packages/services/src/content/__tests__/ContentService.integration.test.ts
@@ -186,7 +186,6 @@ describe.skipIf(!RUN)('ContentService live-GitHub integration', () => {
 
   beforeAll(async () => {
     ({ ContentService } = await import('../ContentService.ts'));
-    const { classroomContentRepoName } = await import('@classmoji/utils');
     const getPrisma = (await import('@classmoji/database')).default;
     const db = getPrisma();
     prisma = db as unknown as { $disconnect: () => Promise<void> };
@@ -213,10 +212,8 @@ describe.skipIf(!RUN)('ContentService live-GitHub integration', () => {
       );
     }
     gitOrganization = classroom.git_organization;
-    repo = classroomContentRepoName({
-      login: gitOrganization.login,
-      namespace: classroom.content_namespace,
-    });
+    // Stored on the classroom row and user-editable — never re-derived.
+    repo = classroom.content_repo;
 
     // Verify the content repo actually exists before writing anything.
     const probe = await ContentService.compareBranches({

--- a/packages/services/src/content/urls.ts
+++ b/packages/services/src/content/urls.ts
@@ -5,7 +5,6 @@
  * No authentication required - URLs are public but unlisted
  */
 
-import { classroomContentRepoName } from '@classmoji/utils';
 
 /**
  * Build a GitHub Pages URL for content
@@ -29,30 +28,6 @@ export function getContentUrl({
   return `https://${org}.github.io/${repo}/${cleanPath}`;
 }
 
-/**
- * Build a GitHub Pages URL for slide content
- * @param {Object} options
- * @param {string} options.orgLogin - Organization login
- * @param {string} options.term - Term identifier (e.g., "26w")
- * @param {string} options.contentPath - Path within content repo
- * @param {string} [options.filename] - Specific file (default: index.html)
- * @returns {string} GitHub Pages URL for the slide
- */
-export function getSlideContentUrl({
-  orgLogin,
-  term,
-  contentPath,
-  filename = 'index.html',
-}: {
-  orgLogin: string;
-  term: string;
-  contentPath: string;
-  filename?: string;
-}): string {
-  const repo = classroomContentRepoName({ login: orgLogin, namespace: term });
-  const path = filename ? `${contentPath}/${filename}` : contentPath;
-  return getContentUrl({ org: orgLogin, repo, path });
-}
 
 /**
  * Build a GitHub raw content URL (alternative to Pages)

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -13,7 +13,7 @@ export {
 // Content management for GitHub-backed storage (moved from @classmoji/content;
 // that package is now a thin re-export shim over these)
 export { ContentService } from './content/ContentService.ts';
-export { getContentUrl, getSlideContentUrl, getRawContentUrl } from './content/urls.ts';
+export { getContentUrl, getRawContentUrl } from './content/urls.ts';
 export {
   validateFile,
   sanitizeFilename,

--- a/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.semantic.test.ts
@@ -52,7 +52,7 @@ const slide = {
   id: 'slide-1',
   title: 'My Deck',
   content_path: 'slides/my-deck',
-  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-26w', git_organization: gitOrganization },
 };
 
 const BRANCH = 'preview/slides/my-deck';

--- a/packages/services/src/slides/__tests__/deckPreview.service.test.ts
+++ b/packages/services/src/slides/__tests__/deckPreview.service.test.ts
@@ -56,7 +56,7 @@ const slide = {
   id: 'slide-1',
   title: 'My Deck',
   content_path: 'slides/my-deck',
-  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-26w', git_organization: gitOrganization },
 };
 
 const BRANCH = 'preview/slides/my-deck';

--- a/packages/services/src/slides/__tests__/deckSaveFromOps.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveFromOps.test.ts
@@ -47,7 +47,7 @@ const slide = {
   id: 'slide-1',
   title: 'My Deck',
   content_path: 'slides/my-deck',
-  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-26w', git_organization: gitOrganization },
 };
 
 const DECK_PATH = 'slides/my-deck/deck.json';

--- a/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
+++ b/packages/services/src/slides/__tests__/deckSaveMerge.test.ts
@@ -46,7 +46,7 @@ const slide = {
   id: 'slide-1',
   title: 'My Deck',
   content_path: 'slides/my-deck',
-  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-26w', git_organization: gitOrganization },
 };
 
 const DECK_PATH = 'slides/my-deck/deck.json';

--- a/packages/services/src/slides/__tests__/slide.service.test.ts
+++ b/packages/services/src/slides/__tests__/slide.service.test.ts
@@ -81,7 +81,7 @@ const gitOrganization = {
 const classroom = {
   id: 'class-1',
   name: 'Test Class',
-  content_namespace: '26w',
+  content_repo: 'content-test-org-26w',
   git_organization: gitOrganization,
 };
 
@@ -269,10 +269,10 @@ describe('createSlide', () => {
       createSlide({ classroomId: 'class-1', title: 'T', createdBy: 'u' })
     ).rejects.toThrow('Git organization not configured');
 
-    classroomFindUniqueMock.mockResolvedValue({ ...classroom, content_namespace: null });
+    classroomFindUniqueMock.mockResolvedValue({ ...classroom, content_repo: null });
     await expect(
       createSlide({ classroomId: 'class-1', title: 'T', createdBy: 'u' })
-    ).rejects.toThrow('content namespace');
+    ).rejects.toThrow('Classroom content repo not configured');
   });
 });
 
@@ -347,14 +347,14 @@ describe('theme detection (deck.json first, index.html regex fallback)', () => {
   });
 
   it('countSlidesUsingTheme reads deck.json.theme first with html fallback', async () => {
-    const result = await countSlidesUsingTheme('test-org', '26w', 'foo');
+    const result = await countSlidesUsingTheme('test-org', 'content-test-org-26w', 'foo');
     expect(result.count).toBe(2);
     expect(result.slides.map(s => s.id)).toEqual(['slide-a', 'slide-c']);
   });
 
   it('returns zero when the git organization has no installation', async () => {
     gitOrgFindFirstMock.mockResolvedValue(null);
-    const result = await countSlidesUsingTheme('test-org', '26w', 'foo');
+    const result = await countSlidesUsingTheme('test-org', 'content-test-org-26w', 'foo');
     expect(result).toEqual({ count: 0, slides: [] });
     expect(slideFindManyMock).not.toHaveBeenCalled();
   });

--- a/packages/services/src/slides/__tests__/slideContent.integration.test.ts
+++ b/packages/services/src/slides/__tests__/slideContent.integration.test.ts
@@ -58,7 +58,6 @@ describe.skipIf(!RUN)('saveDeck live-GitHub integration', () => {
   let prisma: { $disconnect: () => Promise<void> } | null = null;
 
   let gitOrganization: GitOrgRecord;
-  let contentNamespace: string;
   let repo: string;
 
   type DeckJson = import('../deckTypes.ts').DeckJson;
@@ -101,7 +100,7 @@ describe.skipIf(!RUN)('saveDeck live-GitHub integration', () => {
       title,
       content_path: contentPath,
       classroom: {
-        content_namespace: contentNamespace,
+        content_repo: repo,
         git_organization: gitOrganization,
       },
     };
@@ -132,7 +131,6 @@ describe.skipIf(!RUN)('saveDeck live-GitHub integration', () => {
     slideContent = await import('../slideContent.service.ts');
     deckHtml = await import('../deckHtml.ts');
     ({ getGitProvider } = await import('../../git/index.ts'));
-    const { classroomContentRepoName } = await import('@classmoji/utils');
     const getPrisma = (await import('@classmoji/database')).default;
     const db = getPrisma();
     prisma = db as unknown as { $disconnect: () => Promise<void> };
@@ -157,11 +155,8 @@ describe.skipIf(!RUN)('saveDeck live-GitHub integration', () => {
       );
     }
     gitOrganization = classroom.git_organization;
-    contentNamespace = classroom.content_namespace;
-    repo = classroomContentRepoName({
-      login: gitOrganization.login,
-      namespace: contentNamespace,
-    });
+    // Stored on the classroom row and user-editable — never re-derived.
+    repo = classroom.content_repo;
 
     const probe = await ContentService.compareBranches({
       gitOrganization,

--- a/packages/services/src/slides/__tests__/slideContent.service.test.ts
+++ b/packages/services/src/slides/__tests__/slideContent.service.test.ts
@@ -35,7 +35,7 @@ const slide = {
   id: 'slide-1',
   title: 'My Deck',
   content_path: 'slides/my-deck',
-  classroom: { content_namespace: '26w', git_organization: gitOrganization },
+  classroom: { content_repo: 'content-test-org-26w', git_organization: gitOrganization },
 };
 
 const deck: DeckJson = {
@@ -257,18 +257,18 @@ describe('saveDeck — misc', () => {
     ).rejects.toThrow('Git organization not configured');
   });
 
-  it('throws when the classroom content namespace is missing', async () => {
+  it('throws when the classroom content repo is missing', async () => {
     await expect(
       saveDeck({
         slide: {
           title: 'X',
           content_path: 'slides/x',
-          classroom: { content_namespace: null, git_organization: gitOrganization },
+          classroom: { content_repo: null, git_organization: gitOrganization },
         },
         deck,
         message: 'm',
       })
-    ).rejects.toThrow('content namespace');
+    ).rejects.toThrow('Classroom content repo not configured');
   });
 });
 

--- a/packages/services/src/slides/slide.service.ts
+++ b/packages/services/src/slides/slide.service.ts
@@ -11,7 +11,6 @@
  */
 
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import * as contentManifestService from '../classmoji/contentManifest.service.ts';
 import { ensureContentRepo } from '../classmoji/page.service.ts';
@@ -279,8 +278,8 @@ export async function createSlide({
   if (!classroom.git_organization?.login) {
     throw new Error('Git organization not configured');
   }
-  if (!classroom.content_namespace) {
-    throw new Error('Classroom content namespace not configured');
+  if (!classroom.content_repo) {
+    throw new Error('Classroom content repo not configured');
   }
 
   const slug = slideSlug(title);
@@ -315,10 +314,7 @@ export async function createSlide({
   // have pending (stale) edits — clear it before the first write.
   await deletePreviewBranchBestEffort({
     orgLogin: classroom.git_organization.login,
-    repo: classroomContentRepoName({
-      login: classroom.git_organization.login,
-      namespace: classroom.content_namespace,
-    }),
+    repo: classroom.content_repo,
     contentPath,
     context: 'stale preview from a reused slug, cleared before create',
   });
@@ -404,10 +400,15 @@ async function readSharedThemeName({
 /**
  * Count how many slides are using a specific shared theme.
  * Ported from apps/slides slideService.server.ts with deck.json-first reads.
+ *
+ * A shared theme lives in the content REPO, so the slides that could be using
+ * it are exactly the slides of the classroom(s) pointing at that repo — keyed
+ * on the stored `content_repo`. The org is part of the DB filter (repo names
+ * are only unique within an org), not a post-filter in JS.
  */
 export async function countSlidesUsingTheme(
   gitOrgLogin: string,
-  contentNamespace: string,
+  contentRepo: string,
   themeName: string
 ): Promise<{ count: number; slides: Array<{ id: string; title: string }> }> {
   const gitOrg = await getPrisma().gitOrganization.findFirst({
@@ -417,26 +418,26 @@ export async function countSlidesUsingTheme(
     return { count: 0, slides: [] };
   }
 
-  const slides = await getPrisma().slide.findMany({
-    where: { classroom: { content_namespace: contentNamespace } },
+  const orgSlides = await getPrisma().slide.findMany({
+    where: {
+      classroom: {
+        content_repo: contentRepo,
+        git_organization: { provider: 'GITHUB', login: gitOrgLogin },
+      },
+    },
     include: {
       classroom: {
         include: { git_organization: true },
       },
     },
   });
-  const orgSlides = slides.filter(
-    (s: { classroom?: { git_organization?: { login?: string } | null } | null }) =>
-      s.classroom?.git_organization?.login === gitOrgLogin
-  );
 
-  const repoName = classroomContentRepoName({ login: gitOrgLogin, namespace: contentNamespace });
   const slidesUsingTheme: Array<{ id: string; title: string }> = [];
 
   for (const slide of orgSlides) {
     const slideTheme = await readSharedThemeName({
       orgLogin: gitOrgLogin,
-      repo: repoName,
+      repo: contentRepo,
       contentPath: slide.content_path,
     });
     if (slideTheme === themeName) {
@@ -452,7 +453,7 @@ export async function countSlidesUsingTheme(
  */
 export async function deleteSharedTheme(
   gitOrgLogin: string,
-  contentNamespace: string,
+  contentRepo: string,
   themeName: string
 ): Promise<void> {
   const gitOrg = await getPrisma().gitOrganization.findFirst({
@@ -462,10 +463,9 @@ export async function deleteSharedTheme(
     throw new Error('Git organization not found');
   }
 
-  const repoName = classroomContentRepoName({ login: gitOrgLogin, namespace: contentNamespace });
   await ContentService.deleteFolder({
     orgLogin: gitOrgLogin,
-    repo: repoName,
+    repo: contentRepo,
     path: `${THEMES_FOLDER}/${themeName}`,
     message: `Delete shared theme: ${themeName}`,
   });
@@ -523,10 +523,7 @@ export async function deleteSlide({
     throw new Error('GitHub installation not configured');
   }
 
-  const repoName = classroomContentRepoName({
-    login: gitOrgLogin,
-    namespace: slide.classroom.content_namespace,
-  });
+  const repoName = slide.classroom.content_repo;
 
   // Check if this slide uses a shared theme (deck.json-first).
   const themeName = await readSharedThemeName({
@@ -570,16 +567,12 @@ export async function deleteSlide({
 
   // Handle shared theme deletion if requested.
   if (themeName && deleteTheme) {
-    const themeUsage = await countSlidesUsingTheme(
-      gitOrgLogin,
-      slide.classroom.content_namespace,
-      themeName
-    );
+    const themeUsage = await countSlidesUsingTheme(gitOrgLogin, repoName, themeName);
     otherSlidesUsingTheme = themeUsage.slides.filter(s => s.id !== slideId).length;
 
     if (otherSlidesUsingTheme === 0) {
       try {
-        await deleteSharedTheme(gitOrgLogin, slide.classroom.content_namespace, themeName);
+        await deleteSharedTheme(gitOrgLogin, repoName, themeName);
         themeDeleted = true;
       } catch (error: unknown) {
         console.error('Failed to delete shared theme:', error);
@@ -621,10 +614,7 @@ export async function getSlideDeleteInfo(slideId: string) {
     return { slide, themeName: null };
   }
 
-  const repoName = classroomContentRepoName({
-    login: gitOrgLogin,
-    namespace: slide.classroom.content_namespace,
-  });
+  const repoName = slide.classroom.content_repo;
 
   const themeName = await readSharedThemeName({
     orgLogin: gitOrgLogin,
@@ -635,11 +625,7 @@ export async function getSlideDeleteInfo(slideId: string) {
     return { slide, themeName: null };
   }
 
-  const themeUsage = await countSlidesUsingTheme(
-    gitOrgLogin,
-    slide.classroom.content_namespace,
-    themeName
-  );
+  const themeUsage = await countSlidesUsingTheme(gitOrgLogin, repoName, themeName);
   const otherSlides = themeUsage.slides.filter(s => s.id !== slideId);
 
   return {

--- a/packages/services/src/slides/slideContent.service.ts
+++ b/packages/services/src/slides/slideContent.service.ts
@@ -8,7 +8,6 @@
  */
 
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import {
   DeckParseError,
@@ -39,7 +38,8 @@ export interface SlideContentTarget {
   title: string;
   content_path: string;
   classroom?: {
-    content_namespace: string | null;
+    /** Stored content repo name — never re-derived from org + namespace. */
+    content_repo: string | null;
     git_organization: GitOrgRecord | null;
   } | null;
 }
@@ -77,14 +77,11 @@ export function resolveSlideRepoContext(slide: SlideContentTarget): {
   if (!gitOrganization?.login) {
     throw new Error('Git organization not configured');
   }
-  const namespace = slide.classroom?.content_namespace;
-  if (!namespace) {
-    throw new Error('Classroom content namespace not configured');
+  const repo = slide.classroom?.content_repo;
+  if (!repo) {
+    throw new Error('Classroom content repo not configured');
   }
-  return {
-    gitOrganization,
-    repo: classroomContentRepoName({ login: gitOrganization.login, namespace }),
-  };
+  return { gitOrganization, repo };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/tasks/src/scripts/migrate-pages-to-blocknote.ts
+++ b/packages/tasks/src/scripts/migrate-pages-to-blocknote.ts
@@ -117,14 +117,15 @@ async function migratePagesToBlockNote(): Promise<void> {
           ? { ...gitOrg, login: OVERRIDE_GIT_ORG_LOGIN }
           : gitOrg;
 
-        const contentNamespace = page.classroom.content_namespace as string;
-        const repo = `content-${effectiveGitOrg.login}-${contentNamespace}`;
+        // Stored repo name — user-editable, so it is never re-derived. The git
+        // org override still redirects which ORG is read; it cannot rename the
+        // repo.
+        const repo = page.classroom.content_repo as string;
 
         console.log(`\n🔍 Processing: ${page.slug}`);
         console.log(
           `   Git Org: ${gitOrg.login} ${OVERRIDE_GIT_ORG_LOGIN ? `→ ${effectiveGitOrg.login} (overridden)` : ''}`
         );
-        console.log(`   Content namespace: ${contentNamespace}`);
         console.log(`   Repo: ${repo}`);
         console.log(`   Path: ${page.content_path}`);
 

--- a/packages/tasks/src/scripts/migrate-slides-to-deck.ts
+++ b/packages/tasks/src/scripts/migrate-slides-to-deck.ts
@@ -33,7 +33,6 @@
  */
 
 import getPrisma from '@classmoji/database';
-import { classroomContentRepoName } from '@classmoji/utils';
 import { ContentService } from '@classmoji/services';
 import { DeckParseError, parseDeckHtml } from '@classmoji/services/slides';
 
@@ -194,16 +193,13 @@ async function migrateSlidesToDeck(options: CliOptions): Promise<void> {
 
     try {
       const gitOrganization = classroom?.git_organization;
-      const namespace = classroom?.content_namespace;
-      if (!classroom || !gitOrganization?.login || !namespace) {
-        console.log(
-          `⚠️  Skipping ${label} — classroom missing git organization or content namespace`
-        );
+      const repo = classroom?.content_repo;
+      if (!classroom || !gitOrganization?.login || !repo) {
+        console.log(`⚠️  Skipping ${label} — classroom missing git organization or content repo`);
         counts.noRepo++;
         continue;
       }
 
-      const repo = classroomContentRepoName({ login: gitOrganization.login, namespace });
       const deckPath = `${slide.content_path}/deck.json`;
       const htmlPath = `${slide.content_path}/index.html`;
 

--- a/packages/utils/src/__tests__/repoNames.test.ts
+++ b/packages/utils/src/__tests__/repoNames.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import {
   classroomContentRepoName,
+  defaultContentRepoName,
   maxContentNamespaceLength,
+  sanitizeRepoName,
   suggestContentNamespace,
   GITHUB_REPO_NAME_MAX,
 } from '../repoNames.ts';
 import { getContentRepoName } from '../content.ts';
 
-describe('classroomContentRepoName', () => {
+// LEGACY pattern. classroomContentRepoName no longer names any live repo —
+// Classroom.content_repo is stored and user-editable. These cases pin the
+// string the migration backfilled existing rows with.
+describe('classroomContentRepoName (legacy backfill pattern)', () => {
   it('builds the per-classroom content repo name', () => {
     expect(classroomContentRepoName({ login: 'dali', namespace: '26w' })).toBe('content-dali-26w');
   });
@@ -60,6 +65,65 @@ describe('suggestContentNamespace', () => {
     expect(suggestContentNamespace({ orgLogin: 'dartmouth-cs5', slug: 'dartmouth-cs52-26f' })).toBe(
       'dartmouth-cs52-26f'
     );
+  });
+});
+
+describe('sanitizeRepoName', () => {
+  it('leaves an already-valid name untouched', () => {
+    expect(sanitizeRepoName('content-cs52-26f')).toBe('content-cs52-26f');
+  });
+
+  it('keeps the full GitHub-legal character set (dots and underscores included)', () => {
+    expect(sanitizeRepoName('my.course_notes-26f')).toBe('my.course_notes-26f');
+  });
+
+  it('lowercases', () => {
+    expect(sanitizeRepoName('CS52-Fall')).toBe('cs52-fall');
+  });
+
+  it('collapses each run of illegal characters to a single dash', () => {
+    expect(sanitizeRepoName('cs52   fall  2026')).toBe('cs52-fall-2026');
+    expect(sanitizeRepoName('cs52/@#$fall')).toBe('cs52-fall');
+  });
+
+  it('trims leading and trailing dashes and dots', () => {
+    expect(sanitizeRepoName('--cs52--')).toBe('cs52');
+    expect(sanitizeRepoName('..cs52..')).toBe('cs52');
+    expect(sanitizeRepoName('  cs52  ')).toBe('cs52');
+  });
+
+  it('truncates to GitHub’s cap and never leaves a trailing dash behind', () => {
+    expect(sanitizeRepoName('x'.repeat(150))).toHaveLength(GITHUB_REPO_NAME_MAX);
+    // Truncation lands mid-separator: the cut must not leave an edge dash.
+    const cut = sanitizeRepoName(`${'x'.repeat(GITHUB_REPO_NAME_MAX - 1)} tail`);
+    expect(cut).toHaveLength(GITHUB_REPO_NAME_MAX - 1);
+    expect(cut.endsWith('-')).toBe(false);
+  });
+
+  it('returns empty when nothing usable survives — callers MUST fall back', () => {
+    expect(sanitizeRepoName('///')).toBe('');
+    expect(sanitizeRepoName('   ')).toBe('');
+    expect(sanitizeRepoName('')).toBe('');
+  });
+
+  it('is idempotent', () => {
+    const once = sanitizeRepoName('CS 52 // Fall!! 2026--');
+    expect(sanitizeRepoName(once)).toBe(once);
+  });
+});
+
+describe('defaultContentRepoName', () => {
+  it('prefixes the namespace WITHOUT repeating the org login', () => {
+    expect(defaultContentRepoName('26f')).toBe('content-26f');
+    expect(defaultContentRepoName('dartmouth-cs52-26f')).toBe('content-dartmouth-cs52-26f');
+  });
+
+  it('sanitizes the namespace it is given', () => {
+    expect(defaultContentRepoName('Fall 2026')).toBe('content-fall-2026');
+  });
+
+  it('stays within the GitHub repo-name cap', () => {
+    expect(defaultContentRepoName('x'.repeat(200)).length).toBe(GITHUB_REPO_NAME_MAX);
   });
 });
 

--- a/packages/utils/src/content.ts
+++ b/packages/utils/src/content.ts
@@ -13,9 +13,9 @@ interface Organization {
  * Generate the content repository name for an organization.
  * Uses settings.content_repo_name if set, otherwise falls back to `content-{login}`.
  *
- * Per-classroom repo names (`content-{org}-{namespace}`) are built inline at
- * call sites with `classroom.content_namespace`. This helper is for org-level
- * fallback only.
+ * Per-classroom content repos are a DIFFERENT repo: their name is stored on
+ * `Classroom.content_repo` (user-editable, never derived). This helper is for
+ * the org-level fallback only — do not unify the two.
  */
 export const getContentRepoName = (organization: Organization): string => {
   if (organization.settings?.content_repo_name) {

--- a/packages/utils/src/repoNames.ts
+++ b/packages/utils/src/repoNames.ts
@@ -3,8 +3,13 @@
  */
 
 /**
- * Generate the per-classroom content repository name.
- * Pattern: `content-{orgLogin}-{contentNamespace}` (e.g. `content-dali-26w`).
+ * @deprecated LEGACY PATTERN — the content repo name is now STORED on
+ * `Classroom.content_repo` and fully user-editable. Nothing derives it at
+ * runtime any more; read `classroom.content_repo` instead. Kept only to
+ * document the historical name (`content-{orgLogin}-{contentNamespace}`, e.g.
+ * `content-dali-26w`) that the 20260813150000_classroom_content_repo migration
+ * backfilled existing rows with, and for one-off migration scripts that must
+ * reconstruct pre-backfill names.
  *
  * Distinct from the legacy org-level helper `getContentRepoName` in
  * `content.ts` (`content-{login}`, with a settings override) — that names a
@@ -22,6 +27,45 @@ export function classroomContentRepoName({
 
 /** GitHub caps repository names at 100 characters. */
 export const GITHUB_REPO_NAME_MAX = 100;
+
+/**
+ * Default content repo name for a NEW classroom: `content-{namespace}`.
+ *
+ * Deliberately does NOT embed the org login — the repo already lives inside the
+ * org, so `content-dartmouth-cs52-26f` under org `dartmouth-cs52` just repeated
+ * it. Only a default: `Classroom.content_repo` is stored and fully editable, so
+ * this is never used to re-derive an existing classroom's repo name.
+ *
+ * Every classroom-creation path MUST set content_repo (the column is NOT NULL);
+ * use this when the caller has no user-supplied name.
+ */
+export function defaultContentRepoName(namespace: string): string {
+  return sanitizeRepoName(`content-${namespace}`);
+}
+
+/**
+ * Normalize user input into a name GitHub will accept for a repository.
+ *
+ * GitHub allows only [A-Za-z0-9._-] in repo names; anything else it silently
+ * rewrites, so a name that round-trips differently would leave the DB pointing
+ * at a repo that doesn't exist. Normalizing up front keeps the stored name and
+ * the real repo identical.
+ *
+ * Rules: lowercase; every run of disallowed characters collapses to a single
+ * '-'; leading/trailing dashes and dots are trimmed (GitHub rejects '.' and
+ * '..' and dislikes edge punctuation); truncated to GitHub's 100-char cap,
+ * then re-trimmed so truncation can't leave a trailing dash.
+ *
+ * Returns '' when nothing usable survives — callers MUST fall back to a
+ * default rather than storing an empty name.
+ */
+export function sanitizeRepoName(input: string): string {
+  const collapsed = String(input ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-');
+  const trimmed = collapsed.replace(/^[-.]+/, '').replace(/[-.]+$/, '');
+  return trimmed.slice(0, GITHUB_REPO_NAME_MAX).replace(/[-.]+$/, '');
+}
 
 /**
  * Longest content namespace that keeps `content-{login}-{namespace}` within


### PR DESCRIPTION
## Summary

The content repo name becomes a stored value (`Classroom.content_repo`) instead of being re-derived as `content-{orgLogin}-{namespace}` at ~30 call sites. The create form's namespace row becomes a single fully-editable **Content repo** field — name it anything (default `content-{namespace}`, no more org login embedded in every name).

- Migration backfills existing rows with their exact current derived names (zero behavior change) + per-org uniqueness constraint
- Guards: friendly uniqueness error naming the colliding classroom, P2002 race backstop, and a create-time GitHub existence check on the requester's token — prevents a content repo from ever adopting an existing student/template repo
- All consumers repointed (pages, slides, imports, delete plan, settings, syllabus bot, mcp, tasks); fixes a latent cross-org collision in shared-theme counting; deletes dead `getSlideContentUrl` (derived the now-wrong name)
- UI keystroke bug found in testing and fixed: full sanitization ran per keystroke and ate hyphens as they were typed (edge-dash trim); now lenient while typing, full sanitize on blur

## Testing
- Gates: services 738, utils 93, content 3, mcp 306, all workspace typechecks clean; dev backfill verified 0 diverged
- Live E2E on dev: guard rejected an existing repo name; classroom created with free-form name `my-cool-site-26r`; page creation provisioned that exact repo (Pages enabled, manifest, content); delete-with-cleanup listed and removed it by its stored name — confirmed gone on GitHub

## Deploy note
Ships a migration (additive column + backfill + unique index). Prod rows all satisfy uniqueness by construction (backfill is a pure function of the already-unique namespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw