### PR TITLE
feat: Resend email templates + Support tab

### DIFF
--- a/apps/webapp/app/components/features/profile/ProviderBadge.tsx
+++ b/apps/webapp/app/components/features/profile/ProviderBadge.tsx
@@ -1,0 +1,42 @@
+import { GithubFilled, GitlabFilled } from '@ant-design/icons';
+
+type ProviderKey = 'GITHUB' | 'GITLAB';
+
+const PROVIDERS: Record<
+  ProviderKey,
+  { label: string; icon: React.ReactNode; classes: string }
+> = {
+  GITHUB: {
+    label: 'GitHub',
+    icon: <GithubFilled style={{ fontSize: 12 }} />,
+    classes:
+      'text-gray-700 bg-gray-100 border-gray-200 dark:text-gray-300 dark:bg-neutral-800 dark:border-neutral-700',
+  },
+  GITLAB: {
+    label: 'GitLab',
+    icon: <GitlabFilled style={{ fontSize: 12, color: '#FC6D26' }} />,
+    classes:
+      'text-[#C24A16] bg-[#FEEEE6] border-[#FBD3BE] dark:text-orange-300 dark:bg-orange-950/30 dark:border-orange-800/40',
+  },
+};
+
+/**
+ * Small pill showing which git provider the signed-in user authenticated with.
+ * Mirrors the RoleChip pattern. `provider` comes from `user.provider`
+ * (GitProvider enum). Legacy rows have `provider = null` — those pre-date GitLab
+ * support and are GitHub users, so unknown/null falls back to GitHub.
+ */
+export function ProviderBadge({ provider }: { provider?: string | null }) {
+  const key: ProviderKey = provider === 'GITLAB' ? 'GITLAB' : 'GITHUB';
+  const m = PROVIDERS[key];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 leading-none text-[11px] font-semibold px-1.5 py-0.5 rounded-full border shrink-0 ${m.classes}`}
+    >
+      {m.icon}
+      {m.label}
+    </span>
+  );
+}
+
+export default ProviderBadge;

--- a/apps/webapp/app/components/features/support/SupportModal.tsx
+++ b/apps/webapp/app/components/features/support/SupportModal.tsx
@@ -2,7 +2,9 @@ import { Modal } from 'antd';
 import { IconExternalLink, IconMail } from '@tabler/icons-react';
 
 const DISCUSSIONS_URL = 'https://github.com/classmoji/classmoji/discussions';
-const ISSUES_URL = 'https://github.com/classmoji/classmoji/issues/new';
+// Opens the guided bug form (.github/ISSUE_TEMPLATE/bug_report.yml) rather than
+// a blank issue, so reports arrive with repro steps and the `bug` label.
+const ISSUES_URL = 'https://github.com/classmoji/classmoji/issues/new?template=bug_report.yml';
 export const SUPPORT_EMAIL = 'hello@classmoji.io';
 
 interface SupportModalProps {
@@ -47,7 +49,7 @@ const SupportModal = ({ open, onClose }: SupportModalProps) => {
   return (
     <Modal open={open} onCancel={onClose} footer={null} width={520}>
       <div className="pr-6">
-        <h2 className="text-lg font-semibold text-ink-0 mb-1">Support</h2>
+        <h2 className="text-lg font-semibold text-ink-0 mb-1">Help &amp; Feedback</h2>
         <p className="text-sm text-ink-3 mb-5">
           Questions, bugs, or anything else. Pick whichever is easiest.
         </p>

--- a/apps/webapp/app/components/features/support/SupportModal.tsx
+++ b/apps/webapp/app/components/features/support/SupportModal.tsx
@@ -1,0 +1,81 @@
+import { Modal } from 'antd';
+import { IconExternalLink, IconMail } from '@tabler/icons-react';
+
+const DISCUSSIONS_URL = 'https://github.com/classmoji/classmoji/discussions';
+const ISSUES_URL = 'https://github.com/classmoji/classmoji/issues/new';
+export const SUPPORT_EMAIL = 'hello@classmoji.io';
+
+interface SupportModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface SupportOption {
+  title: string;
+  description: string;
+  href: string;
+  /** mailto links open the user's mail client, so they stay in the same tab. */
+  external: boolean;
+}
+
+const OPTIONS: SupportOption[] = [
+  {
+    title: 'Ask a question',
+    description: 'Get help from the community.',
+    href: DISCUSSIONS_URL,
+    external: true,
+  },
+  {
+    title: 'Report a bug',
+    description: 'Found a bug or have a feature request?',
+    href: ISSUES_URL,
+    external: true,
+  },
+  {
+    title: 'Email us',
+    description: SUPPORT_EMAIL,
+    href: `mailto:${SUPPORT_EMAIL}`,
+    external: false,
+  },
+];
+
+/**
+ * Support entry point from the sidebar. Three ways to reach us: community
+ * discussions, a Github issue, or plain email. Nothing is sent from here.
+ */
+const SupportModal = ({ open, onClose }: SupportModalProps) => {
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} width={520}>
+      <div className="pr-6">
+        <h2 className="text-lg font-semibold text-ink-0 mb-1">Support</h2>
+        <p className="text-sm text-ink-3 mb-5">
+          Questions, bugs, or anything else. Pick whichever is easiest.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        {OPTIONS.map(option => (
+          <a
+            key={option.title}
+            href={option.href}
+            {...(option.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            onClick={option.external ? undefined : onClose}
+            className="flex items-center justify-between gap-3 rounded-xl ring-1 ring-line px-4 py-3 no-underline hover:bg-nav-hover transition-colors"
+          >
+            <span className="min-w-0">
+              <span className="block font-semibold text-ink-0">{option.title}</span>
+              <span className="block text-sm text-ink-3 truncate">{option.description}</span>
+            </span>
+            {option.external ? (
+              <IconExternalLink size={18} strokeWidth={1.75} className="shrink-0 text-ink-3" />
+            ) : (
+              <IconMail size={18} strokeWidth={1.75} className="shrink-0 text-ink-3" />
+            )}
+          </a>
+        ))}
+      </div>
+    </Modal>
+  );
+};
+
+export default SupportModal;

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -12,6 +12,7 @@ import useStore from '~/store';
 import tokenImage from '~/assets/images/token.png';
 import githubLogo from '~/assets/images/github_logo.svg';
 import ProfileDropdown from '../../features/profile/ProfileDropdown';
+import SupportModal from '../../features/support/SupportModal';
 import { LockedBanner } from '~/components/features/classroom/LockedBanner';
 import type { AppUser, MembershipWithOrganization } from '~/types';
 
@@ -27,6 +28,7 @@ const OWNER_CORE_LINKS = new Set([
   '/assistants',
   '/grades',
   '/settings/general',
+  '/support',
 ]);
 
 interface MenuPage {
@@ -87,6 +89,7 @@ const CommonLayout = ({
     defaultValue: false,
   });
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [supportOpen, setSupportOpen] = useState(false);
   const { classroom } = useStore();
   const params = useParams();
 
@@ -182,6 +185,34 @@ const CommonLayout = ({
     // Lean owner nav: until "Show all features" is on, the OWNER sees only the
     // core set. Other roles keep their full nav.
     if (leanNav && !OWNER_CORE_LINKS.has(item.link)) return null;
+
+    // Support has no page of its own — it opens a modal with the ways to reach
+    // us (community, bug report, email), so it renders as a button, not a Link.
+    if (item.link === '/support') {
+      return (
+        <RequireRole roles={item.roles} key={key}>
+          <button
+            type="button"
+            onClick={() => setSupportOpen(true)}
+            className={`group flex items-center gap-2.5 rounded-md transition-colors duration-150 w-[calc(100%-12px)] ${
+              collapsed ? 'justify-center p-2 mx-1.5' : 'px-2 py-1.5 mx-1.5 text-left'
+            } hover:bg-nav-hover`}
+            style={{ color: 'var(--ink-1)' }}
+          >
+            {collapsed ? (
+              <Tooltip title={item.label} placement="right">
+                <item.icon size={20} strokeWidth={1.75} />
+              </Tooltip>
+            ) : (
+              <>
+                <item.icon size={20} strokeWidth={1.75} className="shrink-0" />
+                <span className="flex-1">{item.label}</span>
+              </>
+            )}
+          </button>
+        </RequireRole>
+      );
+    }
 
     if (item.isProTier && !isProTier && isDemoClassroom === false) return null;
     if (item.link === '/quizzes' && !isProTier && isDemoClassroom === false) return null;
@@ -651,6 +682,8 @@ const CommonLayout = ({
           </div>
         </div>
       </div>
+
+      <SupportModal open={supportOpen} onClose={() => setSupportOpen(false)} />
 
       {/* Mobile Overlay */}
       {mobileOpen && (

--- a/apps/webapp/app/components/utils/hocs/RequireGitProvider.tsx
+++ b/apps/webapp/app/components/utils/hocs/RequireGitProvider.tsx
@@ -1,0 +1,23 @@
+import type { GitProvider } from '@prisma/client';
+
+import { useGitProvider } from '~/hooks';
+
+interface RequireGitProviderProps {
+  /** Platform(s) that should see `children`. e.g. "GITHUB" or ["GITHUB", "GITLAB"]. */
+  provider: GitProvider | GitProvider[];
+  children: React.ReactNode;
+  /** Rendered when the current platform doesn't match. Defaults to nothing. */
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Show/hide UI based on the signed-in user's git platform (login provider).
+ * Mirrors the `RequireRole` wrapper. Reads `useGitProvider()`.
+ */
+const RequireGitProvider = ({ provider, children, fallback = null }: RequireGitProviderProps) => {
+  const current = useGitProvider();
+  const allowed = Array.isArray(provider) ? provider : [provider];
+  return allowed.includes(current) ? children : fallback;
+};
+
+export default RequireGitProvider;

--- a/apps/webapp/app/constants/routes.ts
+++ b/apps/webapp/app/constants/routes.ts
@@ -22,6 +22,7 @@ import {
   IconClipboardList,
   IconHeartRateMonitor,
   IconStack2,
+  IconLifebuoy,
 } from '@tabler/icons-react';
 
 /**
@@ -46,7 +47,7 @@ export const routeCategories = {
   },
   settings: {
     label: 'Settings',
-    items: ['settings', 'memberSettings'],
+    items: ['settings', 'memberSettings', 'support'],
   },
 };
 
@@ -207,6 +208,13 @@ export const routes = {
     label: 'Settings',
     icon: IconSettings,
     roles: ['STUDENT', 'ASSISTANT'],
+    category: 'settings',
+  },
+  support: {
+    link: '/support',
+    label: 'Support',
+    icon: IconLifebuoy,
+    roles: ['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT'],
     category: 'settings',
   },
 };

--- a/apps/webapp/app/constants/routes.ts
+++ b/apps/webapp/app/constants/routes.ts
@@ -212,7 +212,7 @@ export const routes = {
   },
   support: {
     link: '/support',
-    label: 'Support',
+    label: 'Help & Feedback',
     icon: IconLifebuoy,
     roles: ['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT'],
     category: 'settings',

--- a/apps/webapp/app/hooks/useGitProvider.ts
+++ b/apps/webapp/app/hooks/useGitProvider.ts
@@ -1,0 +1,15 @@
+import type { GitProvider } from '@prisma/client';
+
+import { useUser } from './useUser';
+
+/**
+ * The signed-in user's git platform (their login provider).
+ *
+ * Reads `user.provider`. Legacy rows pre-date GitLab support and are GitHub
+ * users, so null/unknown normalizes to `GITHUB` (same convention as
+ * `ProviderBadge`). Works on every page, including outside a classroom.
+ */
+export const useGitProvider = (): GitProvider => {
+  const { user } = useUser();
+  return (user?.provider ?? 'GITHUB') as GitProvider;
+};

--- a/apps/webapp/app/routes/registration/route.tsx
+++ b/apps/webapp/app/routes/registration/route.tsx
@@ -442,10 +442,11 @@ export const action = async ({ request }: Route.ActionArgs) => {
         expires_at: new Date(Date.now() + 10 * 60 * 1000),
       },
     });
+    // Subject and markup live in the Resend template `verify-email`; source of
+    // truth for the HTML is packages/services/src/emails/templates/verify-email.html
     await Tasks.sendEmailTask.trigger({
       to: formData.email,
-      subject: '[Classmoji] Verify your school email',
-      html: `<p>Your verification code is: <strong style="font-size:24px;letter-spacing:4px">${code}</strong></p><p>It expires in 10 minutes.</p>`,
+      template: { id: 'verify-email', variables: { CODE: code } },
     });
     return { codeSent: true };
   }

--- a/packages/services/src/classmoji/__tests__/gitlabUserToken.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/gitlabUserToken.service.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const findFirstMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    account: {
+      findFirst: (...a: unknown[]) => findFirstMock(...a),
+      update: (...a: unknown[]) => updateMock(...a),
+    },
+  }),
+}));
+
+const { getGitLabTokenForUser } = await import('../gitlabUserToken.service.ts');
+
+beforeEach(() => {
+  findFirstMock.mockReset();
+  updateMock.mockReset();
+  process.env.GITLAB_CLIENT_ID = 'cid';
+  process.env.GITLAB_CLIENT_SECRET = 'csecret';
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe('getGitLabTokenForUser', () => {
+  it('returns the stored token when it is still valid (no refresh)', async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    findFirstMock.mockResolvedValueOnce({
+      id: 'a1',
+      access_token: 'valid',
+      refresh_token: 'r',
+      access_token_expires_at: future,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getGitLabTokenForUser('u1');
+
+    expect(result).toEqual({ token: 'valid', expiresAt: future });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an expired token and persists the rotated tokens', async () => {
+    const past = new Date(Date.now() - 1000);
+    findFirstMock.mockResolvedValueOnce({
+      id: 'a1',
+      access_token: 'old',
+      refresh_token: 'oldR',
+      access_token_expires_at: past,
+    });
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({ access_token: 'new', refresh_token: 'newR', expires_in: 7200 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getGitLabTokenForUser('u1');
+
+    expect(result?.token).toBe('new');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://gitlab.com/oauth/token');
+    expect(String(init.body)).toContain('grant_type=refresh_token');
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const updateArg = updateMock.mock.calls[0][0];
+    expect(updateArg.data.access_token).toBe('new');
+    expect(updateArg.data.refresh_token).toBe('newR');
+  });
+
+  it('returns null when the user has no GitLab account', async () => {
+    findFirstMock.mockResolvedValueOnce(null);
+    expect(await getGitLabTokenForUser('u1')).toBeNull();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/roster.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/roster.service.test.ts
@@ -69,9 +69,40 @@ describe('roster.addStudents', () => {
       { school_email: 'new@x.edu', classroom_id: 'class-1', student_name: 'New' },
     ]);
 
+    // Subjects now live on the Resend templates, so the payload carries a
+    // template id plus variables rather than a rendered subject and body.
     expect(result.emails).toHaveLength(2);
-    expect(result.emails[0].payload.subject).toContain('added to CS1');
-    expect(result.emails[1].payload.subject).toContain('invited to join CS1');
+    expect(result.emails[0].payload.template.id).toBe('roster-added');
+    expect(result.emails[0].payload.template.variables.CLASSROOM_NAME).toBe('CS1');
+    expect(result.emails[1].payload.template.id).toBe('roster-invited');
+    expect(result.emails[1].payload.template.variables.CLASSROOM_NAME).toBe('CS1');
+  });
+
+  it('escapes user-authored names before they become template variables', async () => {
+    // Resend injects variables raw, so an unescaped teacher-typed name would
+    // put live markup in the invitee's inbox.
+    userFindMany.mockResolvedValue([]);
+
+    const result = await roster.addStudents({
+      classroomId: 'class-1',
+      students: [{ email: 'new@x.edu', name: '<b>Mallory</b>' }],
+    });
+
+    expect(result.emails[0].payload.template.variables.STUDENT_NAME).toBe(
+      '&lt;b&gt;Mallory&lt;/b&gt;'
+    );
+  });
+
+  it('falls back to a greeting when the teacher omits the student name', async () => {
+    // Previously rendered "Hi undefined!".
+    userFindMany.mockResolvedValue([]);
+
+    const result = await roster.addStudents({
+      classroomId: 'class-1',
+      students: [{ email: 'noname@x.edu' }],
+    });
+
+    expect(result.emails[0].payload.template.variables.STUDENT_NAME).toBe('there');
   });
 
   it('matches existing users case-insensitively', async () => {

--- a/packages/services/src/classmoji/gitlabUserToken.service.ts
+++ b/packages/services/src/classmoji/gitlabUserToken.service.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-user GitLab access token accessor — mirror of `githubUserToken.service.ts`.
+ *
+ * GitLab OAuth access tokens are short-lived (2h) and refreshed with a rotating
+ * refresh token (a new refresh token is returned on every refresh). Refreshes are
+ * guarded by a per-user, per-process mutex so two concurrent refreshes don't race
+ * and invalidate each other's rotated token.
+ *
+ * Unlike GitHub's OAuth endpoint (which returns HTTP 200 even for errors), GitLab
+ * returns proper status codes, so we can trust `res.ok`.
+ */
+
+import getPrisma from '@classmoji/database';
+import type { Account as PrismaAccount } from '@prisma/client';
+
+export interface GitLabTokenResult {
+  token: string;
+  expiresAt: Date | null;
+}
+
+interface RefreshedTokens {
+  accessToken: string;
+  refreshToken: string | undefined;
+  accessTokenExpiresAt: Date | null;
+}
+
+// Refresh this long before actual expiry so concurrent requests never serve a
+// token that dies mid-flight.
+const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes (GitLab tokens live 2h)
+
+// Per-user mutex — GitLab refresh tokens rotate (one-time-use), same hazard as
+// GitHub App refresh tokens.
+const refreshLocks = new Map<string, Promise<GitLabTokenResult | null>>();
+
+function gitlabIssuer(): string {
+  return (process.env.GITLAB_ISSUER || 'https://gitlab.com').replace(/\/+$/, '');
+}
+
+async function withRefreshLock(
+  userId: string,
+  fn: () => Promise<GitLabTokenResult | null>
+): Promise<GitLabTokenResult | null> {
+  const existing = refreshLocks.get(userId);
+  if (existing) return existing;
+
+  const promise = fn().finally(() => {
+    refreshLocks.delete(userId);
+  });
+  refreshLocks.set(userId, promise);
+  return promise;
+}
+
+async function refreshGitLabToken(
+  account: Pick<PrismaAccount, 'refresh_token'>
+): Promise<RefreshedTokens | null> {
+  if (!account.refresh_token) return null;
+
+  const clientId = process.env.GITLAB_CLIENT_ID;
+  const clientSecret = process.env.GITLAB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    console.error('[gitlabUserToken] Missing GITLAB_CLIENT_ID or GITLAB_CLIENT_SECRET');
+    return null;
+  }
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'refresh_token',
+    refresh_token: account.refresh_token,
+  });
+
+  const response = await fetch(`${gitlabIssuer()}/oauth/token`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      accept: 'application/json',
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    console.error(`[gitlabUserToken] GitLab token refresh failed (${response.status}): ${detail}`);
+    return null;
+  }
+
+  const data = await response.json();
+  if (!data.access_token) {
+    console.error('[gitlabUserToken] GitLab token refresh returned no access_token');
+    return null;
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token, // rotates on every refresh
+    accessTokenExpiresAt: data.expires_in
+      ? new Date(Date.now() + data.expires_in * 1000)
+      : null,
+  };
+}
+
+/**
+ * Get a valid GitLab access token for a user, refreshing if needed.
+ * Returns null when the user has no GitLab account or the refresh token is dead.
+ */
+export async function getGitLabTokenForUser(userId: string): Promise<GitLabTokenResult | null> {
+  return withRefreshLock(userId, async () => {
+    const account = await getPrisma().account.findFirst({
+      where: { user_id: userId, provider_id: 'gitlab' },
+      select: {
+        id: true,
+        access_token: true,
+        refresh_token: true,
+        access_token_expires_at: true,
+      },
+    });
+
+    if (!account) return null;
+
+    const isExpired =
+      !account.access_token ||
+      !account.access_token_expires_at ||
+      new Date(account.access_token_expires_at).getTime() - Date.now() < REFRESH_BUFFER_MS;
+
+    if (!isExpired) {
+      return { token: account.access_token as string, expiresAt: account.access_token_expires_at };
+    }
+
+    const newTokens = await refreshGitLabToken(account);
+    if (!newTokens) {
+      // Refresh failed — another machine may have already refreshed. Re-read.
+      const fresh = await getPrisma().account.findFirst({
+        where: { user_id: userId, provider_id: 'gitlab' },
+        select: { access_token: true, access_token_expires_at: true },
+      });
+      if (
+        fresh?.access_token &&
+        fresh.access_token_expires_at &&
+        new Date(fresh.access_token_expires_at) > new Date()
+      ) {
+        return { token: fresh.access_token as string, expiresAt: fresh.access_token_expires_at };
+      }
+      return null;
+    }
+
+    const updateData: Partial<
+      Pick<PrismaAccount, 'access_token' | 'access_token_expires_at' | 'refresh_token'>
+    > = {
+      access_token: newTokens.accessToken,
+      access_token_expires_at: newTokens.accessTokenExpiresAt,
+    };
+    if (newTokens.refreshToken) updateData.refresh_token = newTokens.refreshToken;
+
+    await getPrisma().account.update({ where: { id: account.id }, data: updateData });
+
+    return { token: newTokens.accessToken, expiresAt: newTokens.accessTokenExpiresAt };
+  });
+}

--- a/packages/services/src/classmoji/notification.service.ts
+++ b/packages/services/src/classmoji/notification.service.ts
@@ -157,7 +157,7 @@ const enqueueEmails = async ({
       const enabled = pref ? pref[prefField] : DEFAULT_PREFS[prefField];
       if (!enabled) continue;
 
-      const { subject, html } = renderEmail({
+      const { template } = renderEmail({
         type,
         title,
         classroomName: classroom?.name ?? null,
@@ -168,7 +168,7 @@ const enqueueEmails = async ({
       });
 
       try {
-        await tasks.trigger('send_email', { to: user.email, subject, html });
+        await tasks.trigger('send_email', { to: user.email, template });
       } catch (error) {
         console.error('[notifications] email enqueue failed', { userId: user.id, type, error });
       }

--- a/packages/services/src/classmoji/notificationEmails.ts
+++ b/packages/services/src/classmoji/notificationEmails.ts
@@ -1,6 +1,5 @@
 import type { NotificationType } from '@prisma/client';
-
-const WEBAPP_URL = process.env.WEBAPP_URL ?? 'https://classmoji.com';
+import { appUrl, escapeHtml } from '../emails/escape.ts';
 
 interface EmailContext {
   type: NotificationType;
@@ -12,18 +11,26 @@ interface EmailContext {
   metadata?: Record<string, unknown>;
 }
 
+/** Variables for the Resend template with alias `notification`. */
+export interface NotificationEmail {
+  template: {
+    id: 'notification';
+    variables: {
+      SUBJECT: string;
+      PREHEADER: string;
+      MESSAGE_HTML: string;
+      MESSAGE_TEXT: string;
+      ACTION_URL: string;
+      PREFS_URL: string;
+    };
+  };
+}
+
 const SUBJECT_PREFIX = '[Classmoji]';
 
 const subjectFor = (ctx: EmailContext): string => {
   const scope = ctx.classroomName ? ` ${ctx.classroomName}` : '';
   switch (ctx.type) {
-    case 'QUIZ_PUBLISHED':
-    case 'PAGE_PUBLISHED':
-    case 'REPOSITORY_PUBLISHED':
-      return `${SUBJECT_PREFIX}${scope} - ${ctx.title}`;
-    case 'PAGE_UNPUBLISHED':
-    case 'REPOSITORY_UNPUBLISHED':
-      return `${SUBJECT_PREFIX}${scope} - ${ctx.title}`;
     case 'ASSIGNMENT_DUE_DATE_CHANGED':
       return `${SUBJECT_PREFIX}${scope} - Due date changed`;
     case 'ASSIGNMENT_GRADED':
@@ -32,6 +39,11 @@ const subjectFor = (ctx: EmailContext): string => {
       return `${SUBJECT_PREFIX}${scope} - New grading assignment`;
     case 'TA_REGRADE_ASSIGNED':
       return `${SUBJECT_PREFIX}${scope} - New regrade request`;
+    default:
+      // QUIZ_PUBLISHED, PAGE_(UN)PUBLISHED, REPOSITORY_(UN)PUBLISHED — the verb
+      // is carried in `title` by the caller. A default also means a new enum
+      // member can no longer produce the literal subject "undefined".
+      return `${SUBJECT_PREFIX}${scope} - ${ctx.title}`;
   }
 };
 
@@ -49,54 +61,78 @@ const formatDate = (value: unknown): string | null => {
   });
 };
 
-const bodyFor = (ctx: EmailContext): string => {
+/**
+ * The message as one plain sentence, with nothing escaped. Used for the
+ * text/plain alternative, where entities would render literally as "&lt;".
+ */
+const sentenceFor = (ctx: EmailContext): string => {
   const cls = ctx.classroomName ?? 'your classroom';
+  switch (ctx.type) {
+    case 'ASSIGNMENT_DUE_DATE_CHANGED':
+      return `The due date for ${ctx.title} in ${cls} has changed.`;
+    case 'ASSIGNMENT_GRADED':
+      return `Your submission for ${ctx.title} in ${cls} has been graded.`;
+    case 'TA_GRADING_ASSIGNED':
+      return `You have been assigned to grade ${ctx.title} in ${cls}.`;
+    case 'TA_REGRADE_ASSIGNED':
+      return `A regrade request for ${ctx.title} in ${cls} has been assigned to you.`;
+    default:
+      return `${ctx.title} in ${cls}.`;
+  }
+};
+
+/**
+ * The message body, pre-rendered into a single already-escaped HTML fragment.
+ * Resend templates have no conditionals, so all nine notification types resolve
+ * here rather than branching in the template.
+ */
+const bodyFor = (ctx: EmailContext): string => {
+  const cls = escapeHtml(ctx.classroomName ?? 'your classroom');
+  const title = escapeHtml(ctx.title);
+
   switch (ctx.type) {
     case 'ASSIGNMENT_DUE_DATE_CHANGED': {
       const oldDate = formatDate(ctx.metadata?.previous_deadline);
       const newDate = formatDate(ctx.metadata?.new_deadline);
-      return `<p>The due date for <strong>${escapeHtml(ctx.title)}</strong> in <strong>${escapeHtml(cls)}</strong> has changed.</p>${
+      return `<p style="margin-top:0;">The due date for <strong>${title}</strong> in <strong>${cls}</strong> has changed.</p>${
         oldDate ? `<p>Previous: ${escapeHtml(oldDate)}</p>` : ''
-      }${newDate ? `<p>New: <strong>${escapeHtml(newDate)}</strong></p>` : ''}`;
+      }${newDate ? `<p style="margin-bottom:0;">New: <strong>${escapeHtml(newDate)}</strong></p>` : ''}`;
     }
     case 'ASSIGNMENT_GRADED':
-      return `<p>Your submission for <strong>${escapeHtml(ctx.title)}</strong> in <strong>${escapeHtml(cls)}</strong> has been graded.</p>`;
+      return `<p style="margin-top:0; margin-bottom:0;">Your submission for <strong>${title}</strong> in <strong>${cls}</strong> has been graded.</p>`;
     case 'TA_GRADING_ASSIGNED':
-      return `<p>You've been assigned to grade <strong>${escapeHtml(ctx.title)}</strong> in <strong>${escapeHtml(cls)}</strong>.</p>`;
+      return `<p style="margin-top:0; margin-bottom:0;">You've been assigned to grade <strong>${title}</strong> in <strong>${cls}</strong>.</p>`;
     case 'TA_REGRADE_ASSIGNED':
-      return `<p>A regrade request for <strong>${escapeHtml(ctx.title)}</strong> in <strong>${escapeHtml(cls)}</strong> has been assigned to you.</p>`;
+      return `<p style="margin-top:0; margin-bottom:0;">A regrade request for <strong>${title}</strong> in <strong>${cls}</strong> has been assigned to you.</p>`;
     default:
-      return `<p><strong>${escapeHtml(ctx.title)}</strong> in <strong>${escapeHtml(cls)}</strong>.</p>`;
+      return `<p style="margin-top:0; margin-bottom:0;"><strong>${title}</strong> in <strong>${cls}</strong>.</p>`;
   }
 };
 
-const shell = (recipientName: string | null, body: string): string => {
-  const greeting = recipientName ? `<p>Hi ${escapeHtml(recipientName)},</p>` : '';
-  return `<div style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:560px;margin:0 auto;padding:24px">
-    <div style="font-weight:600;font-size:18px;margin-bottom:16px">Classmoji</div>
-    ${greeting}
-    ${body}
-    <p style="margin-top:24px;font-size:13px;color:#666">
-      <a href="${WEBAPP_URL}/select-organization" style="color:#5b6cff">Open Classmoji</a>
-      &nbsp;|&nbsp;
-      <a href="${WEBAPP_URL}/settings/notifications" style="color:#666">Manage email preferences</a>
-    </p>
-  </div>`;
+export const renderEmail = (ctx: EmailContext): NotificationEmail => {
+  const greetingHtml = ctx.recipientName
+    ? `<p style="margin-top:0;">Hi ${escapeHtml(ctx.recipientName)},</p>`
+    : '';
+  const greetingText = ctx.recipientName ? `Hi ${ctx.recipientName},\n\n` : '';
+  const sentence = sentenceFor(ctx);
+
+  return {
+    template: {
+      id: 'notification',
+      variables: {
+        // Subject is a mail header, not HTML — escaping it would surface
+        // literal "&amp;" in the inbox.
+        SUBJECT: subjectFor(ctx),
+        // Lands in a hidden <div>, so it is escaped.
+        PREHEADER: escapeHtml(sentence),
+        MESSAGE_HTML: `${greetingHtml}${bodyFor(ctx)}`,
+        // The template supplies its own text/plain body from this. Without it
+        // Resend derives text from the HTML before substitution and leaks raw
+        // <p> tags into the plain part.
+        MESSAGE_TEXT: `${greetingText}${sentence}`,
+        ACTION_URL: `${appUrl()}/select-organization`,
+        PREFS_URL: `${appUrl()}/settings/notifications`,
+      },
+    },
+  };
 };
-
-const escapeHtml = (s: string): string =>
-  s.replace(/[&<>"']/g, c => {
-    const replacements: Record<string, string> = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;',
-    };
-    return replacements[c] ?? c;
-  });
-
-export const renderEmail = (ctx: EmailContext): { subject: string; html: string } => ({
-  subject: subjectFor(ctx),
-  html: shell(ctx.recipientName, bodyFor(ctx)),
-});

--- a/packages/services/src/classmoji/roster.service.ts
+++ b/packages/services/src/classmoji/roster.service.ts
@@ -1,4 +1,5 @@
 import getPrisma from '@classmoji/database';
+import { appUrl, escapeVars } from '../emails/escape.ts';
 import * as classroomService from './classroom.service.ts';
 import * as classroomMembershipService from './classroomMembership.service.ts';
 import * as classroomInviteService from './classroomInvite.service.ts';
@@ -9,7 +10,13 @@ export interface RosterStudentInput {
 }
 
 export interface RosterEmail {
-  payload: { to: string; subject: string; html: string };
+  payload: {
+    to: string;
+    template: {
+      id: 'roster-added' | 'roster-invited';
+      variables: Record<string, string | number>;
+    };
+  };
 }
 
 export interface AddStudentsResult {
@@ -80,10 +87,16 @@ export const addStudents = async ({
       emailsOut.push({
         payload: {
           to: student.email,
-          subject: `[Classmoji] You've been added to ${classroom.name}`,
-          html: `<p>Hi ${student.userName || student.name}!</p>
-          <p>You have been added to <b>${classroom.name}</b> on Classmoji.</p>
-          <p>Click the following link to access your classroom: <a href="${process.env.WEBAPP_URL}">${process.env.WEBAPP_URL}</a></p>`,
+          template: {
+            id: 'roster-added',
+            // Names and classroom titles are user-authored, and Resend injects
+            // variables raw, so escape before they reach the template.
+            variables: escapeVars({
+              STUDENT_NAME: student.userName || student.name || 'there',
+              CLASSROOM_NAME: classroom.name,
+              APP_URL: appUrl(),
+            }),
+          },
         },
       });
     }
@@ -102,10 +115,16 @@ export const addStudents = async ({
       emailsOut.push({
         payload: {
           to: student.email,
-          subject: `[Classmoji] You're invited to join ${classroom.name}`,
-          html: `<p>Hi ${student.name}!</p>
-          <p>You have been invited to join <b>${classroom.name}</b> on Classmoji.</p>
-          <p>Click the following link to login: <a href="${process.env.WEBAPP_URL}">${process.env.WEBAPP_URL}</a></p>`,
+          template: {
+            id: 'roster-invited',
+            // `student.name` is optional and teacher-typed: it previously
+            // rendered "Hi undefined!" when omitted, and was never escaped.
+            variables: escapeVars({
+              STUDENT_NAME: student.name || 'there',
+              CLASSROOM_NAME: classroom.name,
+              APP_URL: appUrl(),
+            }),
+          },
         },
       });
     }

--- a/packages/services/src/emails/escape.ts
+++ b/packages/services/src/emails/escape.ts
@@ -1,0 +1,38 @@
+/**
+ * Escape a value before it becomes a Resend template variable.
+ *
+ * Resend does NOT escape variable values — triple mustache is literal
+ * injection, verified against the live API by passing `<b>x</b>` and watching
+ * it render as markup. Every user-controlled string (student names, classroom
+ * names, assignment titles, regrade comments) must go through this first, or a
+ * student can inject HTML into a TA's inbox.
+ */
+export const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, c => {
+    const replacements: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    };
+    return replacements[c] ?? c;
+  });
+
+/** Escape every value in a variables bag. Numbers pass through untouched. */
+export const escapeVars = <T extends Record<string, string | number | null | undefined>>(
+  vars: T
+): Record<string, string | number> => {
+  const out: Record<string, string | number> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === null || value === undefined) continue;
+    out[key] = typeof value === 'number' ? value : escapeHtml(String(value));
+  }
+  return out;
+};
+
+/**
+ * The app URL used in email links. `notificationEmails.ts` historically
+ * defaulted to classmoji.com, which is wrong — the app is app.classmoji.io.
+ */
+export const appUrl = (): string => process.env.WEBAPP_URL ?? 'https://app.classmoji.io';

--- a/packages/services/src/emails/sync-templates.mjs
+++ b/packages/services/src/emails/sync-templates.mjs
@@ -1,0 +1,87 @@
+/**
+ * Pushes every template in ./templates.mjs to Resend and publishes it.
+ *
+ * Resend is the runtime source of truth, but this repo is the reviewable one.
+ * Run this after editing templates.mjs so the two cannot drift:
+ *
+ *   RESEND_API_KEY=re_... node packages/services/src/emails/sync-templates.mjs
+ *   RESEND_API_KEY=re_... node .../sync-templates.mjs --dry   # print, send nothing
+ *
+ * NOTE: this overwrites dashboard edits. If someone tweaks copy in the Resend
+ * UI, mirror it back into templates.mjs or the next sync discards it.
+ *
+ * The key here must be FULL ACCESS. The app's own RESEND_API_KEY is send-only
+ * (correct for runtime least-privilege) and returns 401 restricted_api_key on
+ * every /templates route. Mint a separate management key for this script.
+ */
+import { Resend } from 'resend';
+import { templates } from './templates.mjs';
+
+const dry = process.argv.includes('--dry');
+const apiKey = process.env.RESEND_API_KEY;
+
+if (!apiKey && !dry) {
+  console.error('RESEND_API_KEY is required (or pass --dry).');
+  process.exit(1);
+}
+
+// Constructed lazily: the Resend constructor throws on a missing key, which
+// would break --dry.
+const resend = dry ? null : new Resend(apiKey);
+
+// The SDK resolves with { data, error } instead of throwing, so every call is
+// checked explicitly.
+const check = (label, { data, error }) => {
+  if (error) throw new Error(`${label}: ${error.message}`);
+  return data;
+};
+
+let failed = 0;
+
+for (const t of templates) {
+  if (dry) {
+    console.log(`\n─── ${t.alias} ───`);
+    console.log(`subject: ${t.subject}`);
+    console.log(`vars   : ${t.variables.map(v => v.key).join(', ')}`);
+    console.log(t.html);
+    continue;
+  }
+
+  try {
+    const existing = await resend.templates.get(t.alias);
+
+    if (existing.error) {
+      check(
+        `create ${t.alias}`,
+        await resend.templates.create({
+          name: t.name,
+          alias: t.alias,
+          subject: t.subject,
+          html: t.html,
+          variables: t.variables,
+        })
+      );
+      console.log(`created  ${t.alias}`);
+    } else {
+      check(
+        `update ${t.alias}`,
+        await resend.templates.update(t.alias, {
+          name: t.name,
+          subject: t.subject,
+          html: t.html,
+          variables: t.variables,
+        })
+      );
+      console.log(`updated  ${t.alias}`);
+    }
+
+    // Drafts cannot send, and an update reverts a published template to draft.
+    check(`publish ${t.alias}`, await resend.templates.publish(t.alias));
+    console.log(`published ${t.alias}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`FAILED   ${t.alias}: ${err.message}`);
+  }
+}
+
+if (failed > 0) process.exit(1);

--- a/packages/services/src/emails/templates.mjs
+++ b/packages/services/src/emails/templates.mjs
@@ -144,9 +144,19 @@ export const templates = [
       { key: 'SUBJECT', type: 'string' },
       { key: 'PREHEADER', type: 'string', fallbackValue: 'You have a new Classmoji notification.' },
       { key: 'MESSAGE_HTML', type: 'string' },
+      { key: 'MESSAGE_TEXT', type: 'string' },
       { key: 'ACTION_URL', type: 'string' },
       { key: 'PREFS_URL', type: 'string' },
     ],
+    // Explicit text/plain. Resend derives text from the HTML *before* variable
+    // substitution, so an auto-derived body would ship raw <p> markup from
+    // MESSAGE_HTML into the plain part.
+    text: `{{{MESSAGE_TEXT}}}
+
+Open Classmoji: {{{ACTION_URL}}}
+
+Manage email preferences: {{{PREFS_URL}}}
+Need help, email us at hello@classmoji.io`,
     html: shell({
       title: 'Classmoji',
       preheader: '{{{PREHEADER}}}',

--- a/packages/services/src/emails/templates.mjs
+++ b/packages/services/src/emails/templates.mjs
@@ -1,0 +1,275 @@
+/**
+ * Source of truth for every Resend-hosted email template.
+ *
+ * Resend hosts the versions that actually send; this file is what gets code
+ * review. Run `node sync-templates.mjs` to push and publish.
+ *
+ * ── Escaping ────────────────────────────────────────────────────────────────
+ * Resend does NOT escape template variables. Triple mustache is literal
+ * injection: passing `<b>x</b>` as a variable renders live markup, verified
+ * against the live API. Every user-controlled value MUST be escaped by the
+ * caller before it becomes a variable. See escapeHtml in ./escape.ts.
+ *
+ * ── Client constraints ──────────────────────────────────────────────────────
+ * Table layout (Outlook ignores max-width + margin auto on a div), inline
+ * styles only (<style> gets stripped), longhand padding, bgcolor alongside
+ * background-color, and no images.
+ */
+
+const FONT = "'Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+const GREEN = '#1f883d';
+const INK = '#14151a';
+const BODY_INK = '#2b2d35';
+const MUTED = '#5b5f69';
+const FAINT = '#8a8d97';
+const HAIRLINE = '#e7e5e4';
+
+const text = (content, { size = 15, lh = 24, color = BODY_INK, weight = 400, pb = 24 } = {}) =>
+  `<tr>
+              <td style="padding-bottom:${pb}px; font-family:${FONT}; font-size:${size}px; line-height:${lh}px; font-weight:${weight}; color:${color};">
+                ${content}
+              </td>
+            </tr>`;
+
+const heading = content => text(content, { size: 20, lh: 28, color: INK, weight: 600, pb: 12 });
+
+const link = (href, label) =>
+  `<a href="${href}" style="color:${GREEN}; text-decoration:underline;">${label}</a>`;
+
+/** A primary action, rendered as a styled <a> in a <td> — never a <button>. */
+const button = (href, label) =>
+  `<tr>
+              <td style="padding-bottom:28px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td bgcolor="${GREEN}" style="background-color:${GREEN}; border-radius:8px;">
+                      <a href="${href}" style="display:inline-block; padding-top:11px; padding-right:20px; padding-bottom:11px; padding-left:20px; font-family:${FONT}; font-size:14px; line-height:20px; font-weight:600; color:#ffffff; text-decoration:none;">${label}</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>`;
+
+/** A quiet bordered box for codes, quotes, and grade strips. */
+const box = (content, { size = 15, lh = 24, weight = 400, align = 'left', extra = '' } = {}) =>
+  `<tr>
+              <td style="padding-bottom:24px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="${align}" bgcolor="#f6f8fa" style="background-color:#f6f8fa; border:1px solid ${HAIRLINE}; border-radius:8px; padding-top:16px; padding-right:16px; padding-bottom:16px; padding-left:16px; font-family:${FONT}; font-size:${size}px; line-height:${lh}px; font-weight:${weight}; color:${INK};${extra}">
+                      ${content}
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>`;
+
+const footer = extraLine =>
+  `<tr>
+              <td style="border-top:1px solid ${HAIRLINE}; padding-top:20px; font-family:${FONT}; font-size:12px; line-height:20px; color:${MUTED};">
+                ${extraLine ? `${extraLine}<br />` : ''}Need help, email us at ${link('mailto:hello@classmoji.io', 'hello@classmoji.io')}
+                <br />
+                <span style="font-size:12px; line-height:20px; color:${FAINT};">Made with ❤️ with support from ${link('https://dali.dartmouth.edu/', 'DALI')} and the ${link('https://web.cs.dartmouth.edu/', 'CS Department')} at Dartmouth College.</span>
+              </td>
+            </tr>`;
+
+/** Wraps rows in the shared chrome. `preheader` is the inbox preview line. */
+const shell = ({ title, preheader, rows, footerLine }) => `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta name="color-scheme" content="light" />
+    <title>${title}</title>
+  </head>
+  <body style="margin-top:0; margin-right:0; margin-bottom:0; margin-left:0; padding-top:0; padding-right:0; padding-bottom:0; padding-left:0; background-color:#ffffff;">
+    <div style="display:none; font-size:1px; line-height:1px; color:#ffffff; max-height:0; max-width:0; opacity:0; overflow:hidden;">
+      ${preheader}
+    </div>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff" style="background-color:#ffffff;">
+      <tr>
+        <td align="center" style="padding-top:40px; padding-right:20px; padding-bottom:40px; padding-left:20px;">
+          <table role="presentation" width="520" cellpadding="0" cellspacing="0" border="0" style="width:100%; max-width:520px;">
+            ${rows.join('\n\n            ')}
+
+            ${footer(footerLine)}
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+`;
+
+const PREFS_LINK = link('{{{PREFS_URL}}}', 'Manage email preferences');
+
+export const templates = [
+  {
+    name: 'Verify Email',
+    alias: 'verify-email',
+    subject: '[Classmoji] Verify your school email',
+    variables: [{ key: 'CODE', type: 'string' }],
+    html: shell({
+      title: 'Verify your email',
+      preheader: 'Your verification code is {{{CODE}}} and expires in 10 minutes.',
+      rows: [
+        heading('Verify your email'),
+        text('Enter this code to finish setting up your Classmoji account.'),
+        box('{{{CODE}}}', {
+          size: 30,
+          lh: 38,
+          weight: 700,
+          align: 'center',
+          extra: ' letter-spacing:8px; text-indent:8px;',
+        }),
+        text(
+          'This code expires in 10 minutes. If you did not request it, you can safely ignore this email.',
+          { size: 14, lh: 22, color: MUTED, pb: 28 }
+        ),
+      ],
+    }),
+  },
+
+  {
+    name: 'Notification',
+    alias: 'notification',
+    subject: '{{{SUBJECT}}}',
+    // MESSAGE_HTML is a pre-rendered, already-escaped fragment carrying the
+    // greeting too. Resend has no conditionals, so the 9 notification types all
+    // resolve to one fragment upstream rather than branching here.
+    variables: [
+      { key: 'SUBJECT', type: 'string' },
+      { key: 'PREHEADER', type: 'string', fallbackValue: 'You have a new Classmoji notification.' },
+      { key: 'MESSAGE_HTML', type: 'string' },
+      { key: 'ACTION_URL', type: 'string' },
+      { key: 'PREFS_URL', type: 'string' },
+    ],
+    html: shell({
+      title: 'Classmoji',
+      preheader: '{{{PREHEADER}}}',
+      rows: [text('{{{MESSAGE_HTML}}}', { pb: 28 }), button('{{{ACTION_URL}}}', 'Open Classmoji')],
+      footerLine: PREFS_LINK,
+    }),
+  },
+
+  {
+    name: 'Roster — Added',
+    alias: 'roster-added',
+    subject: "[Classmoji] You've been added to {{{CLASSROOM_NAME}}}",
+    variables: [
+      { key: 'STUDENT_NAME', type: 'string', fallbackValue: 'there' },
+      { key: 'CLASSROOM_NAME', type: 'string' },
+      { key: 'APP_URL', type: 'string' },
+    ],
+    html: shell({
+      title: 'You have been added to a classroom',
+      preheader: 'You have been added to {{{CLASSROOM_NAME}}} on Classmoji.',
+      rows: [
+        heading('You have been added to {{{CLASSROOM_NAME}}}'),
+        text('Hi {{{STUDENT_NAME}}}, you now have access to this classroom on Classmoji.'),
+        button('{{{APP_URL}}}', 'Open your classroom'),
+      ],
+    }),
+  },
+
+  {
+    name: 'Roster — Invited',
+    alias: 'roster-invited',
+    subject: "[Classmoji] You're invited to join {{{CLASSROOM_NAME}}}",
+    variables: [
+      { key: 'STUDENT_NAME', type: 'string', fallbackValue: 'there' },
+      { key: 'CLASSROOM_NAME', type: 'string' },
+      { key: 'APP_URL', type: 'string' },
+    ],
+    html: shell({
+      title: 'You are invited to join a classroom',
+      preheader: 'You have been invited to join {{{CLASSROOM_NAME}}} on Classmoji.',
+      rows: [
+        heading("You're invited to join {{{CLASSROOM_NAME}}}"),
+        text(
+          'Hi {{{STUDENT_NAME}}}, sign in to get started. Classmoji uses your Github account, so there is no new password to remember.'
+        ),
+        button('{{{APP_URL}}}', 'Join the classroom'),
+      ],
+    }),
+  },
+
+  {
+    name: 'Regrade — Requested',
+    alias: 'regrade-requested',
+    subject: '[Classmoji] Action required: Regrade requested',
+    variables: [
+      { key: 'STUDENT_NAME', type: 'string' },
+      { key: 'STUDENT_LOGIN', type: 'string' },
+      { key: 'ASSIGNMENT_TITLE', type: 'string' },
+      { key: 'ISSUE_URL', type: 'string' },
+      { key: 'PREVIOUS_GRADE', type: 'string', fallbackValue: '—' },
+      { key: 'STUDENT_COMMENT', type: 'string', fallbackValue: 'None' },
+    ],
+    html: shell({
+      title: 'Regrade requested',
+      preheader: '{{{STUDENT_NAME}}} requested a regrade for {{{ASSIGNMENT_TITLE}}}.',
+      rows: [
+        heading('Regrade requested'),
+        text(
+          '{{{STUDENT_NAME}}} (@{{{STUDENT_LOGIN}}}) has requested a regrade for {{{ASSIGNMENT_TITLE}}}.',
+          { pb: 16 }
+        ),
+        text('Previous grade: {{{PREVIOUS_GRADE}}}', { size: 14, lh: 22, color: MUTED, pb: 8 }),
+        box('{{{STUDENT_COMMENT}}}', { size: 14, lh: 22 }),
+        button('{{{ISSUE_URL}}}', 'Review the request'),
+      ],
+    }),
+  },
+
+  {
+    name: 'Regrade — Resolved',
+    alias: 'regrade-resolved',
+    subject: '[Classmoji] Regrade request resolved',
+    variables: [
+      { key: 'ASSIGNMENT_TITLE', type: 'string' },
+      { key: 'APP_URL', type: 'string' },
+    ],
+    html: shell({
+      title: 'Regrade request resolved',
+      preheader: 'Your regrade request for {{{ASSIGNMENT_TITLE}}} has been resolved.',
+      rows: [
+        heading('Regrade request resolved'),
+        text(
+          'Your regrade request for {{{ASSIGNMENT_TITLE}}} has been reviewed. Your updated grade is on your dashboard.',
+          { pb: 28 }
+        ),
+        button('{{{APP_URL}}}', 'View your grade'),
+      ],
+    }),
+  },
+
+  {
+    name: 'Extension — Status',
+    alias: 'extension-status',
+    // STATUS_LABEL is title-cased upstream; the raw enum is snake_case and
+    // leaked into the old copy as "in_review".
+    subject: '[Classmoji] Extension request {{{STATUS_LABEL}}}',
+    variables: [
+      { key: 'STUDENT_LOGIN', type: 'string' },
+      { key: 'ASSIGNMENT_TITLE', type: 'string', fallbackValue: 'your assignment' },
+      { key: 'STATUS_LABEL', type: 'string' },
+      { key: 'APP_URL', type: 'string' },
+    ],
+    html: shell({
+      title: 'Extension request update',
+      preheader: 'Your extension request for {{{ASSIGNMENT_TITLE}}} was {{{STATUS_LABEL}}}.',
+      rows: [
+        heading('Extension request {{{STATUS_LABEL}}}'),
+        text(
+          'Hi @{{{STUDENT_LOGIN}}}, your extension request for {{{ASSIGNMENT_TITLE}}} was {{{STATUS_LABEL}}}.',
+          { pb: 28 }
+        ),
+        button('{{{APP_URL}}}', 'Open Classmoji'),
+      ],
+    }),
+  },
+];

--- a/packages/services/src/emails/templates/verify-email.html
+++ b/packages/services/src/emails/templates/verify-email.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<!--
+  Source of truth for the Resend template with alias `verify-email`.
+
+  Resend hosts the version that actually sends; this file exists so the markup
+  gets code review and version history. After editing, push it to Resend and
+  publish — a draft cannot send.
+
+  Variables use TRIPLE mustache. Double braces render literally.
+    {{{CODE}}} — the 6-digit verification code (required, no fallback)
+
+  Email-client constraints this file deliberately follows:
+    - table-based layout; Outlook ignores max-width + margin:0 auto on a div
+    - all styles inline; <style> blocks get stripped
+    - longhand padding only; Outlook mis-parses the shorthand
+    - bgcolor attribute alongside background-color, again for Outlook
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta name="color-scheme" content="light" />
+    <title>Verify your email</title>
+  </head>
+  <body style="margin-top:0; margin-right:0; margin-bottom:0; margin-left:0; padding-top:0; padding-right:0; padding-bottom:0; padding-left:0; background-color:#ffffff;">
+    <!-- Preheader: shown in the inbox list preview, hidden in the body. -->
+    <div style="display:none; font-size:1px; line-height:1px; color:#ffffff; max-height:0; max-width:0; opacity:0; overflow:hidden;">
+      Your verification code is {{{CODE}}} and expires in 10 minutes.
+    </div>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff" style="background-color:#ffffff;">
+      <tr>
+        <td align="center" style="padding-top:40px; padding-right:20px; padding-bottom:40px; padding-left:20px;">
+          <table role="presentation" width="520" cellpadding="0" cellspacing="0" border="0" style="width:100%; max-width:520px;">
+            <tr>
+              <td style="padding-bottom:12px; font-family:'Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:20px; line-height:28px; font-weight:600; color:#14151a;">
+                Verify your email
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding-bottom:24px; font-family:'Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:15px; line-height:24px; color:#2b2d35;">
+                Enter this code to finish setting up your Classmoji account.
+              </td>
+            </tr>
+
+            <!-- Code -->
+            <tr>
+              <td style="padding-bottom:24px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" bgcolor="#f6f8fa" style="background-color:#f6f8fa; border:1px solid #e7e5e4; border-radius:8px; padding-top:20px; padding-right:16px; padding-bottom:20px; padding-left:16px; font-family:'Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:30px; line-height:38px; font-weight:700; letter-spacing:8px; text-indent:8px; color:#14151a;">
+                      {{{CODE}}}
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding-bottom:28px; font-family:'Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:14px; line-height:22px; color:#5b5f69;">
+                This code expires in 10 minutes. If you did not request it, you can safely ignore this email.
+              </td>
+            </tr>
+
+            <!-- Footer -->
+            <tr>
+              <td style="border-top:1px solid #e7e5e4; padding-top:20px; font-family:'Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:12px; line-height:20px; color:#5b5f69;">
+                Need help, email us at <a href="mailto:hello@classmoji.io" style="color:#1f883d; text-decoration:underline;">hello@classmoji.io</a>
+                <br />
+                <span style="font-size:12px; line-height:20px; color:#8a8d97;">Made with ❤️ with support from <a href="https://dali.dartmouth.edu/" style="color:#1f883d; text-decoration:underline;">DALI</a> and the <a href="https://web.cs.dartmouth.edu/" style="color:#1f883d; text-decoration:underline;">CS Department</a> at Dartmouth College.</span>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/packages/services/src/git/__tests__/GitLabProvider.addCollaborator.test.ts
+++ b/packages/services/src/git/__tests__/GitLabProvider.addCollaborator.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitLabProvider } from '../GitLabProvider.ts';
+
+function res(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    headers: new Headers(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('GitLabProvider.addCollaborator', () => {
+  it('adds a user to a project with the mapped access level (developer → 30)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, [{ id: 77 }])) // resolve user
+      .mockResolvedValueOnce(res(201, {}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    await provider.addCollaborator('grp', 'proj', 'ada', 'developer');
+
+    const [memUrl, memInit] = fetchMock.mock.calls[1];
+    expect(memUrl).toContain('/api/v4/projects/grp%2Fproj/members');
+    expect(JSON.parse(memInit.body)).toEqual({ user_id: 77, access_level: 30 });
+  });
+
+  it('maps GitHub-style permission names (push → 30, maintain → 40)', async () => {
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    for (const [perm, level] of [
+      ['push', 30],
+      ['maintain', 40],
+      ['pull', 20],
+    ] as const) {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(res(200, [{ id: 1 }]))
+        .mockResolvedValueOnce(res(201, {}));
+      vi.stubGlobal('fetch', fetchMock);
+      await provider.addCollaborator('grp', 'proj', 'ada', perm);
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body).access_level).toBe(level);
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/services/src/git/__tests__/GitLabProvider.createRepository.test.ts
+++ b/packages/services/src/git/__tests__/GitLabProvider.createRepository.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitLabProvider } from '../GitLabProvider.ts';
+
+function res(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    headers: new Headers(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('GitLabProvider.createRepository', () => {
+  it('resolves the group namespace and creates a private project', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { id: 42 })) // GET /groups/:path
+      .mockResolvedValueOnce(
+        res(201, { id: 100, path: 'hw1', web_url: 'https://gitlab.com/g/hw1' })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    const repo = await provider.createRepository('my-group', 'HW1', true);
+
+    expect(repo).toEqual({ id: '100', name: 'hw1', url: 'https://gitlab.com/g/hw1' });
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/v4/groups/my-group');
+    const [projUrl, projInit] = fetchMock.mock.calls[1];
+    expect(projUrl).toContain('/api/v4/projects');
+    expect(projInit.method).toBe('POST');
+    expect(JSON.parse(projInit.body)).toEqual({
+      name: 'HW1',
+      path: 'hw1',
+      namespace_id: 42,
+      visibility: 'private',
+    });
+  });
+
+  it('creates a public project when isPrivate is false', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { id: 7 }))
+      .mockResolvedValueOnce(res(201, { id: 9, path: 'p', web_url: 'u' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    await provider.createRepository('grp', 'P', false);
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).visibility).toBe('public');
+  });
+});

--- a/packages/services/src/git/__tests__/GitLabProvider.createTeam.test.ts
+++ b/packages/services/src/git/__tests__/GitLabProvider.createTeam.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitLabProvider } from '../GitLabProvider.ts';
+
+function res(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    headers: new Headers(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('GitLabProvider.createTeam (subgroup)', () => {
+  it('creates a subgroup under the parent group', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { id: 5 })) // resolve parent group
+      .mockResolvedValueOnce(res(201, { id: 88, path: 'cs101-fall', name: 'CS101 Fall' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    const team = await provider.createTeam('org', 'CS101 Fall');
+
+    expect(team).toEqual({ id: 88, slug: 'cs101-fall', name: 'CS101 Fall' });
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(url).toContain('/api/v4/groups');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      name: 'CS101 Fall',
+      path: 'cs101-fall',
+      parent_id: 5,
+      visibility: 'private',
+    });
+  });
+
+  it('is idempotent: fetches the existing subgroup when the path is taken', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { id: 5 })) // resolve parent group
+      .mockResolvedValueOnce(res(400, { message: 'has already been taken' })) // POST fails
+      .mockResolvedValueOnce(res(200, { id: 88, path: 'cs101-fall', name: 'CS101 Fall' })); // getTeam
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    const team = await provider.createTeam('org', 'CS101 Fall');
+
+    expect(team).toEqual({ id: 88, slug: 'cs101-fall', name: 'CS101 Fall' });
+    expect(fetchMock.mock.calls[2][0]).toContain('/api/v4/groups/org%2Fcs101-fall');
+  });
+});

--- a/packages/services/src/git/__tests__/GitLabProvider.getUserByLogin.test.ts
+++ b/packages/services/src/git/__tests__/GitLabProvider.getUserByLogin.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitLabProvider } from '../GitLabProvider.ts';
+
+function res(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    headers: new Headers(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('GitLabProvider.getUserByLogin', () => {
+  it('returns the first matching user', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(res(200, [{ id: 1, username: 'ada' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    const user = await provider.getUserByLogin('ada');
+
+    expect(user).toEqual({ id: 1, username: 'ada' });
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/v4/users?username=ada');
+  });
+
+  it('returns null when no user matches', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(res(200, []));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    expect(await provider.getUserByLogin('nobody')).toBeNull();
+  });
+});

--- a/packages/services/src/git/__tests__/GitLabProvider.inviteToOrganization.test.ts
+++ b/packages/services/src/git/__tests__/GitLabProvider.inviteToOrganization.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitLabProvider } from '../GitLabProvider.ts';
+
+function res(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    headers: new Headers(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('GitLabProvider.inviteToOrganization', () => {
+  it('invites by email via /invitations (default Reporter level)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { id: 5 })) // resolve group
+      .mockResolvedValueOnce(res(201, {}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    await provider.inviteToOrganization('org', 'ta@school.edu');
+
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(url).toContain('/api/v4/groups/5/invitations');
+    expect(JSON.parse(init.body)).toEqual({ email: 'ta@school.edu', access_level: 20 });
+  });
+
+  it('adds a username as a member (resolves user id) with the given level', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { id: 5 })) // resolve group
+      .mockResolvedValueOnce(res(200, [{ id: 77 }])) // resolve user
+      .mockResolvedValueOnce(res(201, {}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('g', 'g', 'tok');
+    await provider.inviteToOrganization('org', 'ada', undefined, 40);
+
+    expect(fetchMock.mock.calls[1][0]).toContain('/api/v4/users?username=ada');
+    const [memUrl, memInit] = fetchMock.mock.calls[2];
+    expect(memUrl).toContain('/api/v4/groups/5/members');
+    expect(JSON.parse(memInit.body)).toEqual({ user_id: 77, access_level: 40 });
+  });
+});

--- a/packages/services/src/git/__tests__/GitLabProvider.listGroups.test.ts
+++ b/packages/services/src/git/__tests__/GitLabProvider.listGroups.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GitLabProvider } from '../GitLabProvider.ts';
+
+function res(status: number, body?: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    headers: new Headers(),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('GitLabProvider.listGroups', () => {
+  it('lists Maintainer+ groups and maps to the option shape', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      res(200, [
+        { id: 1, full_path: 'uni', name: 'Uni', avatar_url: 'a' },
+        { id: 2, full_path: 'uni/cs', name: 'CS', avatar_url: null },
+      ])
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitLabProvider('', '', 'tok');
+    const groups = await provider.listGroups();
+
+    expect(groups).toEqual([
+      { id: 1, full_path: 'uni', name: 'Uni', avatar_url: 'a' },
+      { id: 2, full_path: 'uni/cs', name: 'CS', avatar_url: null },
+    ]);
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('/api/v4/groups');
+    expect(url).toContain('min_access_level=40');
+  });
+
+  it('returns [] on empty', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(res(200, [])));
+    const provider = new GitLabProvider('', '', 'tok');
+    expect(await provider.listGroups()).toEqual([]);
+  });
+});

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -87,6 +87,10 @@ export type {
 export { aggregateForTeam } from './classmoji/repoAnalytics.service.ts';
 export type { TeamAggregate, TeamRepoSnapshot } from './classmoji/repoAnalytics.service.ts';
 
+// Email helpers. Resend injects template variables raw, so every
+// user-controlled value must be escaped before it becomes one.
+export { appUrl, escapeHtml, escapeVars } from './emails/escape.ts';
+
 // Repo analytics flag heuristics (pure, client-safe)
 export {
   lateCommitRatio,

--- a/packages/tasks/src/workflows/__tests__/email.test.ts
+++ b/packages/tasks/src/workflows/__tests__/email.test.ts
@@ -109,6 +109,50 @@ describe('sendEmailTask', () => {
     expect(mocks.send).not.toHaveBeenCalled();
   });
 
+  it('sends via a hosted template and never alongside html', async () => {
+    mocks.send.mockResolvedValue({ data: { id: 'email-6' }, error: null });
+
+    await run({ to: 'student@school.edu', template: { id: 'verify-email', variables: { CODE: '123456' } } });
+
+    const [body] = mocks.send.mock.calls[0];
+    expect(body.template).toEqual({ id: 'verify-email', variables: { CODE: '123456' } });
+    // Mutually exclusive in the Resend API — sending both is a 422.
+    expect(body).not.toHaveProperty('html');
+    expect(body).not.toHaveProperty('subject');
+  });
+
+  it('lets a template send override the template subject when asked', async () => {
+    mocks.send.mockResolvedValue({ data: { id: 'email-7' }, error: null });
+
+    await run({ to: 'student@school.edu', subject: 'Override', template: { id: 'verify-email' } });
+
+    expect(mocks.send.mock.calls[0][0].subject).toBe('Override');
+  });
+
+  it('unwraps a batchTrigger-wrapped template payload', async () => {
+    mocks.send.mockResolvedValue({ data: { id: 'email-8' }, error: null });
+
+    await run({ payload: { to: 'student@school.edu', template: { id: 'verify-email' } } });
+
+    expect(mocks.send.mock.calls[0][0].template).toEqual({ id: 'verify-email' });
+  });
+
+  it('throws when a template send errors, same as the html path', async () => {
+    mocks.send.mockResolvedValue({ data: null, error: { message: 'template not found' } });
+
+    await expect(
+      run({ to: 'student@school.edu', template: { id: 'nope' } })
+    ).rejects.toThrow('template not found');
+  });
+
+  it('still sends html without a template field when given html', async () => {
+    mocks.send.mockResolvedValue({ data: { id: 'email-9' }, error: null });
+
+    await run(PAYLOAD);
+
+    expect(mocks.send.mock.calls[0][0]).not.toHaveProperty('template');
+  });
+
   it('retries enough times to survive Resend rate limiting', async () => {
     // trigger.config.js defaults to maxAttempts: 1, which would silently drop
     // 429s during a roster import. The per-task override is the guard.

--- a/packages/tasks/src/workflows/email.ts
+++ b/packages/tasks/src/workflows/email.ts
@@ -7,11 +7,34 @@ export interface SendEmailTaskPayload {
   html: string;
 }
 
-interface SendEmailTaskWrappedPayload {
-  payload: SendEmailTaskPayload;
+/**
+ * Send via a template hosted in Resend instead of inline HTML. `id` is the
+ * template alias (e.g. 'verify-email'), which is stable across edits — unlike
+ * the generated tmpl_ id, it needs no config entry.
+ *
+ * `subject` is optional because the template carries its own; pass it only to
+ * override per-send.
+ */
+export interface SendEmailTaskTemplatePayload {
+  to: string;
+  template: {
+    id: string;
+    variables?: Record<string, string | number>;
+  };
+  subject?: string;
 }
 
-type SendEmailTaskInput = SendEmailTaskPayload | SendEmailTaskWrappedPayload;
+type SendEmailTaskBody = SendEmailTaskPayload | SendEmailTaskTemplatePayload;
+
+interface SendEmailTaskWrappedPayload {
+  payload: SendEmailTaskBody;
+}
+
+type SendEmailTaskInput = SendEmailTaskBody | SendEmailTaskWrappedPayload;
+
+const isTemplatePayload = (
+  payload: SendEmailTaskBody
+): payload is SendEmailTaskTemplatePayload => 'template' in payload;
 
 interface SendEmailTaskContext {
   ctx: {
@@ -28,7 +51,7 @@ interface SendEmailTaskContext {
  * sites — one of which (notification.service.ts) triggers by string id and so
  * gets no type checking at all.
  */
-const extractPayload = (input: SendEmailTaskInput): SendEmailTaskPayload => {
+const extractPayload = (input: SendEmailTaskInput): SendEmailTaskBody => {
   return 'payload' in input ? input.payload : input;
 };
 
@@ -60,29 +83,45 @@ export const sendEmailTask = task({
       throw new Error('RESEND_API_KEY env var not set in Trigger.dev environment');
     }
 
-    const { to, subject, html } = extractPayload(input);
+    const payload = extractPayload(input);
     const resend = new Resend(apiKey);
+
+    const common = {
+      from: process.env.EMAIL_FROM || DEFAULT_FROM,
+      to: payload.to,
+      ...(process.env.EMAIL_REPLY_TO ? { replyTo: process.env.EMAIL_REPLY_TO } : {}),
+    };
+
+    // `template` is mutually exclusive with `html` in the Resend API, so the two
+    // branches must not merge their arguments.
+    const body = isTemplatePayload(payload)
+      ? {
+          ...common,
+          template: payload.template,
+          ...(payload.subject ? { subject: payload.subject } : {}),
+        }
+      : { ...common, subject: payload.subject, html: payload.html };
 
     // The Resend SDK does NOT throw on API errors — it resolves with
     // `{ data, error }`. Returning without inspecting `error` would mark every
     // failed send as a successful run.
-    const { data, error } = await resend.emails.send(
-      {
-        from: process.env.EMAIL_FROM || DEFAULT_FROM,
-        to,
-        subject,
-        html,
-        ...(process.env.EMAIL_REPLY_TO ? { replyTo: process.env.EMAIL_REPLY_TO } : {}),
-      },
-      { idempotencyKey: `send-email/${ctx.run.id}` }
-    );
+    const { data, error } = await resend.emails.send(body, {
+      idempotencyKey: `send-email/${ctx.run.id}`,
+    });
+
+    const logCtx = {
+      to: payload.to,
+      ...(isTemplatePayload(payload)
+        ? { template: payload.template.id }
+        : { subject: payload.subject }),
+    };
 
     if (error) {
-      logger.error('Resend send failed', { to, subject, error });
+      logger.error('Resend send failed', { ...logCtx, error });
       throw new Error(`Resend send failed: ${error.message}`);
     }
 
-    logger.info('Email sent', { to, subject, emailId: data?.id });
+    logger.info('Email sent', { ...logCtx, emailId: data?.id });
 
     return data;
   },

--- a/packages/tasks/src/workflows/extension.ts
+++ b/packages/tasks/src/workflows/extension.ts
@@ -1,5 +1,5 @@
 import { task } from '@trigger.dev/sdk';
-import { ClassmojiService } from '@classmoji/services';
+import { appUrl, ClassmojiService, escapeVars } from '@classmoji/services';
 import { sendEmailTask } from './email.ts';
 
 /**
@@ -64,14 +64,21 @@ export const updateExtensionTask = task({
 
     if (!student?.email) return;
 
-    const html = `<p>Hi @${student.login}.</p>
-      <p>Your extension request for "${gitRepoAssignment?.assignment?.title || 'assignment'}" has been <span style="font-weight:bold">${status.toLowerCase()}</span>.</p>
-    `;
+    // `status` is an allowlisted enum upstream (IN_REVIEW | APPROVED | DENIED),
+    // but it leaked into the copy as snake_case — "has been in_review".
+    const statusLabel = status.toLowerCase().replace(/_/g, ' ');
 
     await sendEmailTask.triggerAndWait({
       to: student.email,
-      subject: `[Classmoji] Extension Request Status`,
-      html: html,
+      template: {
+        id: 'extension-status',
+        variables: escapeVars({
+          STUDENT_LOGIN: student.login,
+          ASSIGNMENT_TITLE: gitRepoAssignment?.assignment?.title || 'your assignment',
+          STATUS_LABEL: statusLabel,
+          APP_URL: appUrl(),
+        }),
+      },
     });
   },
 });

--- a/packages/tasks/src/workflows/regrades.ts
+++ b/packages/tasks/src/workflows/regrades.ts
@@ -1,5 +1,5 @@
 import { task } from '@trigger.dev/sdk';
-import { ClassmojiService } from '@classmoji/services';
+import { appUrl, ClassmojiService, escapeVars } from '@classmoji/services';
 import { sendEmailTask } from './email.ts';
 import { emojiShortcodes } from '@classmoji/utils';
 
@@ -84,18 +84,20 @@ export const requestRegradeTask = task({
         gitRepoAssignment.graders.map(({ grader }) => ({
           payload: {
             to: grader.email,
-            subject: '[Classmoji] Action required: Regrade requested',
-            html: `<p>${student.name} (@${student.login}) has requested a regrade for
-                        <a href="${issueUrl}" style="text-decoration: underline;">${
-                          gitRepoAssignment.assignment.title
-                        }</a>
-                     .</p>
-                     <p>Previous grade: ${previous_grade
-                       .map(grade => emojiMap[grade] || grade)
-                       .join(' ')}</p>
-                     <p>Student comment: ${student_comment || 'None'}</p>
-                     <p>Please review the request and update the grade accordingly.</p>
-                     `,
+            template: {
+              id: 'regrade-requested',
+              // `student_comment` is free-form student input rendered into a
+              // TA's inbox, and Resend injects variables raw — escaping here is
+              // the only thing standing between the two.
+              variables: escapeVars({
+                STUDENT_NAME: student.name,
+                STUDENT_LOGIN: student.login,
+                ASSIGNMENT_TITLE: gitRepoAssignment.assignment.title,
+                ISSUE_URL: issueUrl,
+                PREVIOUS_GRADE: previous_grade.map(grade => emojiMap[grade] || grade).join(' '),
+                STUDENT_COMMENT: student_comment || 'None',
+              }),
+            },
           },
         }))
       );
@@ -114,10 +116,13 @@ export const updateRegradeRequestTask = task({
     const { request } = payload;
     sendEmailTask.trigger({
       to: request.student.email,
-      subject: '[Classmoji] Regrade request resolved',
-      html: `<p>Your regrade request for <u>${request.git_repo_assignment.assignment.title}</u> has been resolved.</p>
-             <p>Check your dashboard for the updated grade.</p>
-      `,
+      template: {
+        id: 'regrade-resolved',
+        variables: escapeVars({
+          ASSIGNMENT_TITLE: request.git_repo_assignment.assignment.title,
+          APP_URL: appUrl(),
+        }),
+      },
     });
   },
 });


### PR DESCRIPTION
## What changed?

**Email templates.** Follow-up to #197, which swapped the transport. This moves all 15 emails onto Resend-hosted templates so they render from one shared shell instead of ad-hoc inline HTML. 7 templates cover 15 emails, since the 9 notification types share one:

`verify-email` · `notification` (×9) · `roster-added` · `roster-invited` · `regrade-requested` · `regrade-resolved` · `extension-status`

They are generated from a shared shell in `templates.mjs` rather than copy-pasted, so the chrome cannot drift. `sync-templates.mjs` pushes and publishes them.

**Support tab.** A help modal in the sidebar with three routes to support: ask a question in Github Discussions, report a bug via the guided issue template, or email hello@classmoji.io.

### Worth a look in review

**Resend does not escape template variables.** Triple mustache is literal injection, verified against the live API. So moving to templates does not fix the pre-existing unescaped-input bug, it has to be done explicitly. New `escapeHtml` / `escapeVars` helpers are applied at every composition site, so a student name of `<b>Mallory</b>` or a regrade comment containing a `<script>` tag now renders as inert text rather than live markup in a TA's inbox.

Also fixed along the way: the `notification` template needed an explicit `text/plain` body (Resend derives text from HTML *before* substitution, leaking raw `<p>` tags), the `WEBAPP_URL` fallback pointed at `classmoji.com` instead of `app.classmoji.io`, `"Hi undefined!"` when a student name is omitted, the raw `in_review` enum leaking into copy, and two emails that had no link at all.

> [!NOTE]
> `sync-templates.mjs` needs a **full-access** Resend key. The app's `RESEND_API_KEY` is send-only (correct for runtime) and 401s on `/templates` routes. The seven templates are already created and published.

---

**Unrelated work on this branch:** commit `d5e2c2e` also carries in-progress GitLab provider work whose six `GitLabProvider.*.test.ts` files have 12 failing tests, so CI will be red for reasons unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)