### PR TITLE
perf(tasks): batch email fan-out into one request per 100 recipients

### DIFF
--- a/apps/mcp/src/tools/__tests__/roster.test.ts
+++ b/apps/mcp/src/tools/__tests__/roster.test.ts
@@ -34,7 +34,7 @@ vi.mock('@classmoji/services', () => ({
 }));
 
 vi.mock('@classmoji/tasks', () => ({
-  default: { sendEmailTask: { batchTrigger: (...a: unknown[]) => mocks.batchTrigger(...a) } },
+  default: { sendBatchEmailTask: { trigger: (...a: unknown[]) => mocks.batchTrigger(...a) } },
 }));
 
 vi.mock('@trigger.dev/sdk', () => ({
@@ -75,7 +75,7 @@ describe('roster_add_student', () => {
     mocks.addStudents.mockResolvedValue({
       addedExistingUsers: 1,
       invitedNewUsers: 1,
-      emails: [{ payload: { to: 'a@x.edu', subject: 's', html: 'h' } }],
+      emails: [{ payload: { to: 'a@x.edu', template: { id: 'roster-added', variables: {} } } }],
     });
 
     const payload = parse(await rosterAddStudentTool.handler(ARGS, CTX));
@@ -86,7 +86,11 @@ describe('roster_add_student', () => {
       classroomId: 'class-1',
       students: ARGS.students,
     });
+    // One batched request for the whole roster, not one per recipient.
     expect(mocks.batchTrigger).toHaveBeenCalledTimes(1);
+    expect(mocks.batchTrigger).toHaveBeenCalledWith({
+      emails: [{ to: 'a@x.edu', template: { id: 'roster-added', variables: {} } }],
+    });
     expect((mocks.auditCreate.mock.calls[0][0] as { action: string }).action).toBe('CREATE');
   });
 
@@ -100,7 +104,7 @@ describe('roster_add_student', () => {
     mocks.addStudents.mockResolvedValue({
       addedExistingUsers: 1,
       invitedNewUsers: 0,
-      emails: [{ payload: { to: 'a@x.edu', subject: 's', html: 'h' } }],
+      emails: [{ payload: { to: 'a@x.edu', template: { id: 'roster-added', variables: {} } } }],
     });
     mocks.batchTrigger.mockRejectedValue(new Error('trigger down'));
 

--- a/apps/mcp/src/tools/roster.ts
+++ b/apps/mcp/src/tools/roster.ts
@@ -84,7 +84,7 @@ export const rosterAddStudentTool: ToolDefinition<RosterAddStudentArgs> = {
     });
 
     if (result.emails.length > 0) {
-      await Tasks.sendEmailTask.batchTrigger(result.emails);
+      await Tasks.sendBatchEmailTask.trigger({ emails: result.emails.map(e => e.payload) });
     }
 
     return ok({

--- a/apps/webapp/app/routes/admin.$class.students.add/action.ts
+++ b/apps/webapp/app/routes/admin.$class.students.add/action.ts
@@ -26,7 +26,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   });
 
   if (result.emails.length > 0) {
-    await Tasks.sendEmailTask.batchTrigger(result.emails);
+    await Tasks.sendBatchEmailTask.trigger({ emails: result.emails.map(e => e.payload) });
   }
 
   return {

--- a/packages/services/src/classmoji/notification.service.ts
+++ b/packages/services/src/classmoji/notification.service.ts
@@ -151,6 +151,12 @@ const enqueueEmails = async ({
         })
       : null;
 
+    // Collect first, then enqueue once. A classroom-wide notification used to
+    // fire one trigger (and one Resend request) per recipient, which burns the
+    // team-wide 10 req/s budget; the batch task collapses it into one request
+    // per 100 recipients.
+    const emails = [];
+
     for (const user of recipients) {
       if (!user.email) continue;
       const pref = user.notification_preference;
@@ -167,11 +173,16 @@ const enqueueEmails = async ({
         metadata: asRecord(metadata),
       });
 
-      try {
-        await tasks.trigger('send_email', { to: user.email, template });
-      } catch (error) {
-        console.error('[notifications] email enqueue failed', { userId: user.id, type, error });
-      }
+      emails.push({ to: user.email, template });
+    }
+
+    if (emails.length === 0) return;
+
+    try {
+      await tasks.trigger('send_batch_email', { emails });
+    } catch (error) {
+      // Notifications must never break the primary action.
+      console.error('[notifications] email enqueue failed', { type, count: emails.length, error });
     }
   } catch (error) {
     console.error('[notifications] enqueueEmails failed', { type, error });

--- a/packages/tasks/src/workflows/__tests__/email.test.ts
+++ b/packages/tasks/src/workflows/__tests__/email.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   send: vi.fn(),
+  batchSend: vi.fn(),
 }));
 
 // `task()` normally returns a wrapped trigger handle; return the config itself
@@ -25,10 +26,11 @@ vi.mock('@trigger.dev/sdk', () => ({
 vi.mock('resend', () => ({
   Resend: class {
     emails = { send: (...a: unknown[]) => mocks.send(...a) };
+    batch = { send: (...a: unknown[]) => mocks.batchSend(...a) };
   },
 }));
 
-const { sendEmailTask } = await import('../email.ts');
+const { sendEmailTask, sendBatchEmailTask } = await import('../email.ts');
 
 const CTX = { ctx: { run: { id: 'run_abc123' } } };
 const PAYLOAD = { to: 'student@school.edu', subject: 'Hi', html: '<p>Hi</p>' };
@@ -158,5 +160,83 @@ describe('sendEmailTask', () => {
     // 429s during a roster import. The per-task override is the guard.
     const { retry } = sendEmailTask as unknown as { retry: { maxAttempts: number } };
     expect(retry.maxAttempts).toBeGreaterThan(1);
+  });
+});
+
+describe('sendBatchEmailTask', () => {
+  const runBatch = (input: unknown) =>
+    (sendBatchEmailTask as unknown as { run: (i: unknown, c: unknown) => Promise<unknown> }).run(
+      input,
+      CTX
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.RESEND_API_KEY = 're_test_key';
+    delete process.env.EMAIL_FROM;
+    delete process.env.EMAIL_REPLY_TO;
+  });
+
+  it('collapses many recipients into a single request', async () => {
+    mocks.batchSend.mockResolvedValue({ data: [{ id: 'a' }, { id: 'b' }], error: null });
+
+    await runBatch({
+      emails: [
+        { to: 'a@x.edu', template: { id: 'roster-added' } },
+        { to: 'b@x.edu', template: { id: 'roster-added' } },
+      ],
+    });
+
+    expect(mocks.batchSend).toHaveBeenCalledTimes(1);
+    expect(mocks.batchSend.mock.calls[0][0]).toHaveLength(2);
+    // Single-send endpoint must not be touched — that was the whole point.
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+
+  it('chunks at 100, since Resend rejects larger batches', async () => {
+    mocks.batchSend.mockResolvedValue({ data: [], error: null });
+
+    const emails = Array.from({ length: 250 }, (_, i) => ({
+      to: `s${i}@x.edu`,
+      template: { id: 'notification' },
+    }));
+    await runBatch({ emails });
+
+    expect(mocks.batchSend).toHaveBeenCalledTimes(3);
+    expect(mocks.batchSend.mock.calls[0][0]).toHaveLength(100);
+    expect(mocks.batchSend.mock.calls[2][0]).toHaveLength(50);
+  });
+
+  it('gives each chunk its own idempotency key', async () => {
+    // One key across chunks would 409, since the payloads differ.
+    mocks.batchSend.mockResolvedValue({ data: [], error: null });
+
+    await runBatch({
+      emails: Array.from({ length: 150 }, (_, i) => ({ to: `s${i}@x.edu`, html: 'h', subject: 's' })),
+    });
+
+    const keys = mocks.batchSend.mock.calls.map(c => c[1].idempotencyKey);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it('throws when a batch errors rather than reporting success', async () => {
+    mocks.batchSend.mockResolvedValue({ data: null, error: { message: 'rate_limit_exceeded' } });
+
+    await expect(
+      runBatch({ emails: [{ to: 'a@x.edu', template: { id: 'roster-added' } }] })
+    ).rejects.toThrow('rate_limit_exceeded');
+  });
+
+  it('is a no-op on an empty list', async () => {
+    await expect(runBatch({ emails: [] })).resolves.toEqual([]);
+    expect(mocks.batchSend).not.toHaveBeenCalled();
+  });
+
+  it('unwraps the wrapped payload form', async () => {
+    mocks.batchSend.mockResolvedValue({ data: [], error: null });
+
+    await runBatch({ payload: { emails: [{ to: 'a@x.edu', html: 'h', subject: 's' }] } });
+
+    expect(mocks.batchSend).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tasks/src/workflows/email.ts
+++ b/packages/tasks/src/workflows/email.ts
@@ -57,14 +57,44 @@ const extractPayload = (input: SendEmailTaskInput): SendEmailTaskBody => {
 
 const DEFAULT_FROM = 'Classmoji <hello@classmoji.io>';
 
+/**
+ * Build the Resend request body. `template` is mutually exclusive with `html`,
+ * so the two branches must never merge their arguments.
+ */
+const buildBody = (payload: SendEmailTaskBody) => {
+  const common = {
+    from: process.env.EMAIL_FROM || DEFAULT_FROM,
+    to: payload.to,
+    ...(process.env.EMAIL_REPLY_TO ? { replyTo: process.env.EMAIL_REPLY_TO } : {}),
+  };
+
+  return isTemplatePayload(payload)
+    ? {
+        ...common,
+        template: payload.template,
+        ...(payload.subject ? { subject: payload.subject } : {}),
+      }
+    : { ...common, subject: payload.subject, html: payload.html };
+};
+
+/** Log context that never includes the message body. */
+const describe = (payload: SendEmailTaskBody) => ({
+  to: payload.to,
+  ...(isTemplatePayload(payload)
+    ? { template: payload.template.id }
+    : { subject: payload.subject }),
+});
+
 export const sendEmailTask = task({
   id: 'send_email',
   /**
-   * Resend's default rate limit is 2 requests/second, and three call sites use
-   * `batchTrigger` (one run per recipient). A roster import will burst well past
-   * that. The global default in trigger.config.js is `maxAttempts: 1`, so without
-   * this override a 429 silently drops an invitation email — silently because
-   * notification.service.ts deliberately swallows enqueue failures.
+   * Resend allows 10 requests/second per team, shared across every API key, so
+   * concurrent fan-out can still hit 429. The global default in
+   * trigger.config.js is `maxAttempts: 1`, so without this override a 429
+   * silently drops an email — silently because notification.service.ts
+   * deliberately swallows enqueue failures.
+   *
+   * Prefer sendBatchEmailTask for any fan-out; this task is for single sends.
    */
   retry: {
     maxAttempts: 5,
@@ -86,35 +116,14 @@ export const sendEmailTask = task({
     const payload = extractPayload(input);
     const resend = new Resend(apiKey);
 
-    const common = {
-      from: process.env.EMAIL_FROM || DEFAULT_FROM,
-      to: payload.to,
-      ...(process.env.EMAIL_REPLY_TO ? { replyTo: process.env.EMAIL_REPLY_TO } : {}),
-    };
-
-    // `template` is mutually exclusive with `html` in the Resend API, so the two
-    // branches must not merge their arguments.
-    const body = isTemplatePayload(payload)
-      ? {
-          ...common,
-          template: payload.template,
-          ...(payload.subject ? { subject: payload.subject } : {}),
-        }
-      : { ...common, subject: payload.subject, html: payload.html };
-
     // The Resend SDK does NOT throw on API errors — it resolves with
     // `{ data, error }`. Returning without inspecting `error` would mark every
     // failed send as a successful run.
-    const { data, error } = await resend.emails.send(body, {
+    const { data, error } = await resend.emails.send(buildBody(payload), {
       idempotencyKey: `send-email/${ctx.run.id}`,
     });
 
-    const logCtx = {
-      to: payload.to,
-      ...(isTemplatePayload(payload)
-        ? { template: payload.template.id }
-        : { subject: payload.subject }),
-    };
+    const logCtx = describe(payload);
 
     if (error) {
       logger.error('Resend send failed', { ...logCtx, error });
@@ -124,5 +133,86 @@ export const sendEmailTask = task({
     logger.info('Email sent', { ...logCtx, emailId: data?.id });
 
     return data;
+  },
+});
+
+/** Resend caps a batch at 100 messages per request. */
+const RESEND_BATCH_LIMIT = 100;
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+};
+
+export interface SendBatchEmailTaskPayload {
+  emails: SendEmailTaskBody[];
+}
+
+type SendBatchEmailTaskInput = SendBatchEmailTaskPayload | { payload: SendBatchEmailTaskPayload };
+
+/**
+ * Send many messages in as few API requests as possible.
+ *
+ * Resend allows 10 requests/second per team, shared across every API key, so
+ * fanning out one request per recipient burns the whole budget on a roster
+ * import and starves anything else running. The batch endpoint collapses up to
+ * 100 messages into a single request: a 250-student import goes from 250
+ * requests to 3.
+ *
+ * Batch supports `template`, so every email type can use this path. It does not
+ * support attachments, which nothing here sends.
+ */
+export const sendBatchEmailTask = task({
+  id: 'send_batch_email',
+  retry: {
+    maxAttempts: 5,
+    minTimeoutInMs: 1000,
+    maxTimeoutInMs: 30000,
+    factor: 2,
+    randomize: true,
+  },
+  run: async (input: SendBatchEmailTaskInput, { ctx }: SendEmailTaskContext) => {
+    if (typeof window !== 'undefined') {
+      throw new Error('sendBatchEmailTask must run on the server');
+    }
+
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error('RESEND_API_KEY env var not set in Trigger.dev environment');
+    }
+
+    const { emails } = 'payload' in input ? input.payload : input;
+    if (!emails?.length) {
+      logger.info('No emails to send, skipping batch');
+      return [];
+    }
+
+    const resend = new Resend(apiKey);
+    const sent: unknown[] = [];
+    const batches = chunk(emails, RESEND_BATCH_LIMIT);
+
+    for (const [index, batch] of batches.entries()) {
+      const { data, error } = await resend.batch.send(batch.map(buildBody), {
+        // Scoped per chunk: a retry of the same run must reuse the same key, but
+        // two chunks in one run are different payloads and would 409 if they
+        // shared one.
+        idempotencyKey: `send-batch-email/${ctx.run.id}/${index}`,
+      });
+
+      if (error) {
+        logger.error('Resend batch send failed', {
+          batch: index,
+          size: batch.length,
+          error,
+        });
+        throw new Error(`Resend batch send failed: ${error.message}`);
+      }
+
+      logger.info('Batch sent', { batch: index, size: batch.length });
+      sent.push(data);
+    }
+
+    return sent;
   },
 });

--- a/packages/tasks/src/workflows/regrades.ts
+++ b/packages/tasks/src/workflows/regrades.ts
@@ -1,6 +1,6 @@
 import { task } from '@trigger.dev/sdk';
 import { appUrl, ClassmojiService, escapeVars } from '@classmoji/services';
-import { sendEmailTask } from './email.ts';
+import { sendBatchEmailTask, sendEmailTask } from './email.ts';
 import { emojiShortcodes } from '@classmoji/utils';
 
 const emojiMap: Record<string, string> = emojiShortcodes;
@@ -80,27 +80,27 @@ export const requestRegradeTask = task({
     const issueUrl = `https://github.com/${classroom.git_organization.login}/${gitRepoAssignment.git_repo.name}/issues/${gitRepoAssignment.provider_issue_number}`;
 
     if (gitRepoAssignment.graders && gitRepoAssignment.graders.length > 0) {
-      sendEmailTask.batchTrigger(
-        gitRepoAssignment.graders.map(({ grader }) => ({
-          payload: {
-            to: grader.email,
-            template: {
-              id: 'regrade-requested',
-              // `student_comment` is free-form student input rendered into a
-              // TA's inbox, and Resend injects variables raw — escaping here is
-              // the only thing standing between the two.
-              variables: escapeVars({
-                STUDENT_NAME: student.name,
-                STUDENT_LOGIN: student.login,
-                ASSIGNMENT_TITLE: gitRepoAssignment.assignment.title,
-                ISSUE_URL: issueUrl,
-                PREVIOUS_GRADE: previous_grade.map(grade => emojiMap[grade] || grade).join(' '),
-                STUDENT_COMMENT: student_comment || 'None',
-              }),
-            },
+      // One batched request rather than one run (and one API request) per
+      // grader — Resend's 10 req/s ceiling is shared team-wide.
+      sendBatchEmailTask.trigger({
+        emails: gitRepoAssignment.graders.map(({ grader }) => ({
+          to: grader.email,
+          template: {
+            id: 'regrade-requested',
+            // `student_comment` is free-form student input rendered into a TA's
+            // inbox, and Resend injects variables raw — escaping here is the
+            // only thing standing between the two.
+            variables: escapeVars({
+              STUDENT_NAME: student.name,
+              STUDENT_LOGIN: student.login,
+              ASSIGNMENT_TITLE: gitRepoAssignment.assignment.title,
+              ISSUE_URL: issueUrl,
+              PREVIOUS_GRADE: previous_grade.map(grade => emojiMap[grade] || grade).join(' '),
+              STUDENT_COMMENT: student_comment || 'None',
+            }),
           },
-        }))
-      );
+        })),
+      });
     }
   },
 });


### PR DESCRIPTION
## What changed?

Resend allows **10 requests/second per team, shared across every API key**. Fanning out one request per recipient burned that whole budget on a roster import and starved every other Resend call in the system, not just its own sends.

Adds `sendBatchEmailTask`, which chunks at Resend's 100-message cap. The [batch endpoint supports `template`](https://resend.com/docs/api-reference/emails/send-batch-emails), so every email type can use it.

| Site | Before | After |
|---|---|---|
| Roster add (webapp + MCP) | N requests | `ceil(N/100)` |
| Notification fan-out | N requests | `ceil(N/100)` |
| Regrade → graders | N requests | 1 |

A 250-student import now costs 3 requests instead of 250.

Two details worth a look: body building is shared between the single and batch paths so the `template`/`html` exclusivity can't drift, and each chunk gets its own idempotency key, since one key across chunks would 409 on differing payloads.

Also corrects the rate limit in the retry comment. It said 2 req/s; the documented default is 10.

> [!NOTE]
> Based on `PT/email-service` (#198), not staging, so the diff stays scoped to the batching change. Merge #198 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)