### PR TITLE
feat: background classroom import — trigger task set, git-clone content copy, live progress banner

### DIFF
--- a/apps/webapp/app/components/features/import/ImportProgressBanner.tsx
+++ b/apps/webapp/app/components/features/import/ImportProgressBanner.tsx
@@ -1,0 +1,292 @@
+/**
+ * ImportProgressBanner — live status for a background classroom import.
+ *
+ * Classroom creation now returns as soon as the `ImportJob` row exists, so the
+ * GitHub-bound phases (template duplication, the content-repo copy, modules)
+ * finish minutes AFTER the user lands in their new classroom. This banner is
+ * the only thing that tells them that work is still happening, how far along it
+ * is, and — the case it was built for — that a long pause is a GitHub rate-limit
+ * wait rather than a hang.
+ *
+ * Polls the admin-gated read endpoint every 2s while the job is live and stops
+ * dead on a terminal status; a completed run tidies itself away, and a failed
+ * one stays put with a retry that RESUMES rather than restarts.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher } from 'react-router';
+import {
+  overallPercent,
+  IMPORT_PHASE_LABELS,
+  IMPORT_PHASE_ORDER,
+  COUNTED_PHASE_KEYS,
+  type CountedPhaseProgress,
+  type ImportPhaseKey,
+  type ImportPhaseStatus,
+  type ImportProgress,
+} from '@classmoji/services/import-progress';
+import type { ImportJobView } from '~/routes/api.import-jobs.$jobId/route';
+
+/** Poll cadence while the job is live. Matches the task's ~1s progress writes. */
+const POLL_INTERVAL_MS = 2000;
+
+/** How long a finished banner stays up before tidying itself away. */
+const COMPLETED_AUTOHIDE_MS = 8000;
+
+/** A completed run stays REOPENABLE this long, so the summary isn't lost on a stray click. */
+const COMPLETED_REOPEN_WINDOW_MS = 10 * 60 * 1000;
+
+/** Human names for the coarse `phase` column, for the retry button's label. */
+const COARSE_PHASE_LABELS: Record<string, string> = {
+  config: 'settings',
+  repositories: 'repositories',
+  templates: 'template repositories',
+  content: 'content',
+  modules: 'modules',
+};
+
+const isCounted = (key: ImportPhaseKey): boolean =>
+  (COUNTED_PHASE_KEYS as readonly string[]).includes(key);
+
+/** Per-status chip colours, in both themes. */
+const CHIP_STYLES: Record<ImportPhaseStatus, string> = {
+  done: 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
+  running:
+    'border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  failed:
+    'border-red-300 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-300',
+  pending:
+    'border-gray-200 bg-gray-50 text-gray-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-gray-400',
+  skipped:
+    'border-gray-200 bg-gray-50 text-gray-400 dark:border-neutral-700 dark:bg-neutral-800 dark:text-gray-500',
+};
+
+const Spinner = () => (
+  <svg
+    className="h-4 w-4 shrink-0 animate-spin text-blue-600 dark:text-blue-400"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+  </svg>
+);
+
+/** One phase, with its count when it has one. */
+const PhaseChip = ({
+  phaseKey,
+  progress,
+}: {
+  phaseKey: ImportPhaseKey;
+  progress: ImportProgress;
+}) => {
+  const phase = progress.phases?.[phaseKey];
+  if (!phase || phase.status === 'skipped') return null;
+
+  const counted = isCounted(phaseKey) ? (phase as CountedPhaseProgress) : null;
+  const showCount = counted && counted.total > 0 && phase.status !== 'pending';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${CHIP_STYLES[phase.status]}`}
+    >
+      {phase.status === 'done' && <span aria-hidden="true">✓</span>}
+      {phase.status === 'failed' && <span aria-hidden="true">✕</span>}
+      {IMPORT_PHASE_LABELS[phaseKey]}
+      {showCount && (
+        <span className="tabular-nums opacity-80">
+          {counted.done}/{counted.total}
+        </span>
+      )}
+    </span>
+  );
+};
+
+export interface ImportProgressBannerProps {
+  /** The job as the layout loader saw it; polling takes over from here. */
+  job: ImportJobView;
+  /** Source classroom name, for the title. Falls back to a generic phrase. */
+  sourceName?: string | null;
+}
+
+const ImportProgressBanner = ({ job: initialJob, sourceName }: ImportProgressBannerProps) => {
+  const poll = useFetcher<ImportJobView>();
+  const retry = useFetcher<ImportJobView | { error: string }>();
+
+  // Session-only dismissal: deliberately NOT persisted. The banner describes one
+  // run in flight; a remembered dismissal would silently hide a later failure.
+  const [dismissed, setDismissed] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
+  const autoHideRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Freshest of: the loader's row, the poll's response, the retry's response.
+  //
+  // Compared by `updated_at` rather than by precedence, because a fetcher keeps
+  // its data after the submission settles: a retry response would otherwise
+  // outrank every later poll FOREVER, freezing the banner on the PENDING
+  // snapshot it returned — a hung progress bar, which is the exact failure this
+  // component exists to prevent.
+  const retried = retry.data && 'id' in retry.data ? retry.data : null;
+  const job = [initialJob, poll.data, retried]
+    .filter((candidate): candidate is ImportJobView => Boolean(candidate))
+    .reduce((newest, candidate) =>
+      new Date(newest.updated_at) >= new Date(candidate.updated_at) ? newest : candidate
+    );
+  const isLive = job.status === 'PENDING' || job.status === 'RUNNING';
+
+  const jobId = job.id;
+  const pollRef = useRef(poll);
+  pollRef.current = poll;
+
+  useEffect(() => {
+    if (!isLive || dismissed) return;
+    const timer = setInterval(() => {
+      // `load` is a no-op while one is already in flight, so a slow response
+      // cannot stack up requests.
+      if (pollRef.current.state === 'idle') {
+        pollRef.current.load(`/api/import-jobs/${jobId}`);
+      }
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [isLive, dismissed, jobId]);
+
+  // A finished import tidies itself away, but stays reopenable for a while —
+  // the summary line is the only place the final counts are shown.
+  useEffect(() => {
+    if (job.status !== 'COMPLETED') return;
+    autoHideRef.current = setTimeout(() => setCollapsed(true), COMPLETED_AUTOHIDE_MS);
+    return () => {
+      if (autoHideRef.current) clearTimeout(autoHideRef.current);
+    };
+  }, [job.status]);
+
+  if (dismissed) return null;
+
+  const progress = (job.progress ?? { phases: {} }) as ImportProgress;
+  const percent = progress.phases ? overallPercent(progress) : 0;
+  const age = Date.now() - new Date(job.updated_at).getTime();
+
+  if (job.status === 'COMPLETED' && collapsed) {
+    // Past the reopen window the banner is simply done.
+    if (age > COMPLETED_REOPEN_WINDOW_MS) return null;
+    return (
+      <div className="mb-3 flex justify-end">
+        <button
+          type="button"
+          onClick={() => setCollapsed(false)}
+          className="rounded-full border border-emerald-300 bg-emerald-50 px-3 py-1 text-xs text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300 dark:hover:bg-emerald-900"
+        >
+          ✓ Import complete — view summary
+        </button>
+      </div>
+    );
+  }
+
+  // The first phase still reporting a transient note (a GitHub rate-limit wait,
+  // repo pacing). Surfacing it is the whole reason `note` exists: without it a
+  // 60s backoff is indistinguishable from a dead job.
+  const waitingNote = IMPORT_PHASE_ORDER.map(key => progress.phases?.[key]?.note).find(Boolean);
+
+  const failed = job.status === 'FAILED';
+  const completed = job.status === 'COMPLETED';
+  const retryLabel = job.phase
+    ? `Retry ${COARSE_PHASE_LABELS[job.phase] ?? job.phase}`
+    : 'Retry import';
+  const retryError = retry.data && 'error' in retry.data ? retry.data.error : null;
+
+  const tone = failed
+    ? 'border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/40'
+    : completed
+      ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/40'
+      : 'border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/40';
+
+  return (
+    <div className={`mb-4 rounded-xl border p-4 ${tone}`} role="status" aria-live="polite">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          {isLive && <Spinner />}
+          <h2 className="truncate text-sm font-semibold text-gray-800 dark:text-gray-100">
+            {failed
+              ? 'Import stopped'
+              : completed
+                ? 'Import complete'
+                : `Importing from ${sourceName || 'the source classroom'}…`}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="Hide import progress"
+          className="shrink-0 rounded p-1 text-gray-400 hover:bg-black/5 hover:text-gray-600 dark:hover:bg-white/10 dark:hover:text-gray-200"
+        >
+          ✕
+        </button>
+      </div>
+
+      {!failed && !completed && (
+        <div className="mt-3">
+          <div className="h-2 w-full overflow-hidden rounded-full bg-blue-100 dark:bg-blue-900/50">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all duration-500 dark:bg-blue-400"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <div className="mt-1 text-xs tabular-nums text-gray-500 dark:text-gray-400">
+            {percent}%
+          </div>
+        </div>
+      )}
+
+      {completed && (
+        <p className="mt-2 text-sm text-emerald-800 dark:text-emerald-300">
+          {progress.parts && progress.parts.length > 0
+            ? `Imported ${progress.parts.join(', ')}.`
+            : 'Everything selected has been imported.'}
+        </p>
+      )}
+
+      {waitingNote && !failed && !completed && (
+        <p className="mt-2 rounded-md bg-amber-100 px-2 py-1 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+          {waitingNote}
+        </p>
+      )}
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {IMPORT_PHASE_ORDER.map(key => (
+          <PhaseChip key={key} phaseKey={key} progress={progress} />
+        ))}
+      </div>
+
+      {failed && (
+        <div className="mt-3 space-y-2">
+          <p className="text-sm text-red-800 dark:text-red-300">
+            {job.error || 'The import could not finish.'}
+          </p>
+          <p className="text-xs text-gray-600 dark:text-gray-400">
+            Everything imported so far is saved. Retrying picks up where it stopped — nothing is
+            copied twice.
+          </p>
+          <retry.Form method="post" action={`/api/import-jobs/${jobId}`}>
+            <button
+              type="submit"
+              disabled={retry.state !== 'idle'}
+              className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-60 dark:bg-red-700 dark:hover:bg-red-600"
+            >
+              {retry.state === 'idle' ? retryLabel : 'Restarting…'}
+            </button>
+          </retry.Form>
+          {retryError && <p className="text-xs text-red-700 dark:text-red-400">{retryError}</p>}
+        </div>
+      )}
+
+      {job.warnings?.length > 0 && (
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          {job.warnings.length} item{job.warnings.length === 1 ? '' : 's'} skipped.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ImportProgressBanner;

--- a/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
+++ b/apps/webapp/app/components/layout/navigation/CommonLayout.tsx
@@ -14,6 +14,9 @@ import githubLogo from '~/assets/images/github_logo.svg';
 import ProfileDropdown from '../../features/profile/ProfileDropdown';
 import SupportModal from '../../features/support/SupportModal';
 import { LockedBanner } from '~/components/features/classroom/LockedBanner';
+import ImportProgressBanner, {
+  type ImportProgressBannerProps,
+} from '../../features/import/ImportProgressBanner';
 import type { AppUser, MembershipWithOrganization } from '~/types';
 
 // Lean owner navigation. New/imported instructors land in a small core that
@@ -70,6 +73,13 @@ interface CommonLayoutProps {
    * navigation/revalidation rather than depending on the root-loader→store sync.
    */
   navVisibility?: NavVisibility;
+  /**
+   * A background classroom import worth showing progress for, from the layout
+   * loader. Only the ADMIN layout passes this: the progress endpoint the banner
+   * polls is admin-gated, so rendering it for an assistant would just 403 every
+   * two seconds.
+   */
+  importBanner?: ImportProgressBannerProps | null;
 }
 
 const CommonLayout = ({
@@ -79,6 +89,7 @@ const CommonLayout = ({
   groupViewersByRole = false,
   pagesUrl: _pagesUrl = 'http://localhost:7100',
   navVisibility,
+  importBanner = null,
 }: CommonLayoutProps) => {
   const [collapsed, setCollapsed] = useLocalStorageState('classmoji-collapsed', {
     defaultValue: false,
@@ -670,6 +681,15 @@ const CommonLayout = ({
             }
           >
             {classroom?.status === 'LOCKED' && role !== 'OWNER' && <LockedBanner />}
+            {/* Pinned above the page content on every teaching route, because
+                the import outlives the page the user started it from. */}
+            {importBanner && (
+              <ImportProgressBanner
+                key={importBanner.job.id}
+                job={importBanner.job}
+                sourceName={importBanner.sourceName}
+              />
+            )}
             {/* Recently-viewed: route-specific, so it lives with the content
                 (not the left nav). Rendered in-flow at the top-right above the
                 page so it never overlaps a page's header action buttons. */}

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -6,6 +6,18 @@ import {
   getGitProvider,
   ensureClassroomTeam,
 } from '@classmoji/services';
+import {
+  applyPhaseUpdates,
+  buildInitialProgress,
+  buildSummaryParts,
+  withCounts,
+  withIdMaps,
+  type ImportPhaseCounts,
+  type ImportPhaseSelections,
+  type ImportProgress,
+  type ImportSummaryCounts,
+} from '@classmoji/services/import-progress';
+import Tasks from '@classmoji/tasks';
 import { ActionTypes } from '~/constants';
 import getPrisma from '@classmoji/database';
 import {
@@ -14,6 +26,10 @@ import {
   suggestContentNamespace,
 } from '@classmoji/utils';
 import { slugify } from './utils';
+
+/** Background work needs Trigger.dev; without it the async phases can't run. */
+const isTriggerConfigured = () =>
+  Boolean(process.env.TRIGGER_SECRET_KEY || process.env.TRIGGER_ACCESS_TOKEN);
 
 /**
  * Pick a free internal content namespace for a new classroom in this org.
@@ -217,10 +233,15 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     throw error;
   }
 
-  // Import from a source classroom if configured. Phases (each best-effort,
-  // logged, never fails classroom creation): 1 settings/scales/calendar,
-  // 2 repositories(+assignments/quizzes), 3 pages/slides content,
-  // 4 module containers last (they remap onto the ids minted in 2 and 3).
+  // Import from a source classroom if configured.
+  //
+  // SPLIT BY COST, not by phase order. Everything that is pure DB and finishes
+  // in seconds runs here, inside the request: the settings/scales/calendar copy
+  // and the repository(+assignment/quiz) clone. Everything that talks to GitHub
+  // — template duplication, the content-repo copy, and the modules phase that
+  // depends on the ids those mint — is handed to the `classroom-import`
+  // Trigger.dev task, and this action returns as soon as the job row exists.
+  // Before that split a real course pinned this request for 40+ minutes.
   let importResult = null;
   let configSummary: {
     settings_fields: string[];
@@ -228,21 +249,9 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     letter_grade_mappings: number;
     calendar_events: number;
   } | null = null;
-  let contentSummary: {
-    pages: number;
-    slides: number;
-    page_id_map: Record<string, string>;
-    slide_id_map: Record<string, string>;
-    warnings: string[];
-  } | null = null;
-  let modulesSummary: { modules: number; items: number; skipped_items: number } | null = null;
-  let templateSummary: {
-    duplicated: number;
-    relinked: number;
-    template_map: Record<string, string>;
-    warnings: string[];
-  } | null = null;
   const importWarnings: string[] = [];
+  /** Source repositories that survived the ownership filter (drives templates). */
+  let repoConfigs: Array<{ id: string; includeQuizzes?: boolean }> = [];
 
   if (importRequested && sourceClassroomId) {
     if (anyConfigSelected) {
@@ -269,7 +278,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
           })
         ).map(r => r.id)
       );
-      const repoConfigs = requestedRepos.filter(r => sourceRepoIds.has(r.id));
+      repoConfigs = requestedRepos.filter(r => sourceRepoIds.has(r.id));
       if (repoConfigs.length !== requestedRepos.length) {
         importWarnings.push('repositories outside the source classroom were skipped');
       }
@@ -284,56 +293,6 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
           console.error('Error importing repositories:', error);
           importWarnings.push('repository copy failed');
         }
-      }
-    }
-
-    // Template duplication runs on the rows phase 2 just minted, so the copies
-    // exist before anything provisions student repos from them. Best-effort:
-    // a template that can't be duplicated keeps pointing at the original.
-    if (contentSelections.duplicateTemplates && (importResult?.repositories?.length ?? 0) > 0) {
-      try {
-        templateSummary = await ClassmojiService.templateImport.duplicateImportedTemplates(
-          sourceClassroomId,
-          classroom.id,
-          importResult!.repositories.map(repo => repo.id)
-        );
-        importWarnings.push(...(templateSummary?.warnings ?? []));
-      } catch (error: unknown) {
-        console.error('Error duplicating template repositories:', error);
-        importWarnings.push('template duplication failed');
-      }
-    }
-
-    if (contentSelections.pages || contentSelections.slides) {
-      try {
-        contentSummary = await ClassmojiService.contentImport.importClassroomContent(
-          sourceClassroomId,
-          classroom.id,
-          user.id,
-          { pages: !!contentSelections.pages, slides: !!contentSelections.slides }
-        );
-        importWarnings.push(...(contentSummary?.warnings ?? []));
-      } catch (error: unknown) {
-        console.error('Error importing pages/slides content:', error);
-        importWarnings.push('page/slide content copy failed');
-      }
-    }
-
-    if (contentSelections.modules) {
-      try {
-        modulesSummary = await ClassmojiService.classroomConfigImport.importModules(
-          sourceClassroomId,
-          classroom.id,
-          {
-            repositories: importResult?.idMaps?.repositories ?? {},
-            quizzes: importResult?.idMaps?.quizzes ?? {},
-            pages: contentSummary?.page_id_map ?? {},
-            slides: contentSummary?.slide_id_map ?? {},
-          }
-        );
-      } catch (error: unknown) {
-        console.error('Error importing modules:', error);
-        importWarnings.push('module copy failed');
       }
     }
   }
@@ -357,51 +316,175 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     );
   }
 
-  // Build success message
-  let successMessage = 'Classroom created successfully!';
-  {
-    const plural = (n: number, singular: string, pluralForm = `${singular}s`) =>
-      `${n} ${n === 1 ? singular : pluralForm}`;
-    const parts: string[] = [];
-    if (importResult) {
-      if (importResult.repositories.length > 0)
-        parts.push(plural(importResult.repositories.length, 'repository', 'repositories'));
-      if (importResult.assignments.length > 0)
-        parts.push(plural(importResult.assignments.length, 'assignment'));
-      if (importResult.quizzes.length > 0)
-        parts.push(plural(importResult.quizzes.length, 'quiz', 'quizzes'));
+  // ── Hand the GitHub-bound phases to the background task ────────────────────
+  // Templates only matter if repositories were actually cloned — there is
+  // nothing to duplicate or relink otherwise.
+  const wantsTemplates =
+    !!contentSelections.duplicateTemplates && (importResult?.repositories.length ?? 0) > 0;
+  const wantsPages = !!contentSelections.pages;
+  const wantsSlides = !!contentSelections.slides;
+  const wantsModules = !!contentSelections.modules;
+  const hasBackgroundWork =
+    importRequested &&
+    !!sourceClassroomId &&
+    (wantsTemplates || wantsPages || wantsSlides || wantsModules);
+
+  /** What THIS request imported — seeded onto the job so the final line is whole. */
+  const syncCounts: ImportSummaryCounts = {
+    repositories: importResult?.repositories.length ?? 0,
+    assignments: importResult?.assignments.length ?? 0,
+    quizzes: importResult?.quizzes.length ?? 0,
+    settings: (configSummary?.settings_fields.length ?? 0) > 0,
+    grade_mappings:
+      (configSummary?.emoji_mappings ?? 0) + (configSummary?.letter_grade_mappings ?? 0),
+    calendar_events: configSummary?.calendar_events ?? 0,
+  };
+
+  let importJobId: string | null = null;
+  if (hasBackgroundWork) {
+    // Cheap totals so the bars are sized before the task even starts — an
+    // unsized bar is the thing that makes a slow import look broken. The task
+    // re-reports the real total when each phase begins.
+    const [sourcePages, sourceSlides, templateRows] = await Promise.all([
+      wantsPages
+        ? getPrisma().page.count({ where: { classroom_id: sourceClassroomId } })
+        : Promise.resolve(0),
+      wantsSlides
+        ? getPrisma().slide.count({ where: { classroom_id: sourceClassroomId } })
+        : Promise.resolve(0),
+      wantsTemplates
+        ? getPrisma().repository.findMany({
+            where: { id: { in: repoConfigs.map(r => r.id) } },
+            select: { template: true },
+          })
+        : Promise.resolve([] as Array<{ template: string | null }>),
+    ]);
+
+    const phaseSelections: ImportPhaseSelections = {
+      config: anyConfigSelected,
+      repositories: repoConfigs.length > 0,
+      templates: wantsTemplates,
+      pages: wantsPages,
+      slides: wantsSlides,
+      modules: wantsModules,
+    };
+    const phaseCounts: ImportPhaseCounts = {
+      repositories: importResult?.repositories.length ?? 0,
+      // Distinct templates, not rows: several assignments commonly share one.
+      templates: ClassmojiService.templateImport.groupTemplateRefs(templateRows, gitOrg.login)
+        .length,
+      pages: sourcePages,
+      slides: sourceSlides,
+    };
+
+    let progress: ImportProgress = buildInitialProgress(phaseSelections, phaseCounts);
+    // The two phases this request already finished are recorded as done up
+    // front, so the banner opens showing real completed work rather than an
+    // empty bar that has to catch up.
+    progress = applyPhaseUpdates(progress, [
+      ...(anyConfigSelected
+        ? [
+            {
+              phase: 'config' as const,
+              status: 'done' as const,
+              summary:
+                buildSummaryParts({
+                  settings: syncCounts.settings,
+                  grade_mappings: syncCounts.grade_mappings,
+                  calendar_events: syncCounts.calendar_events,
+                }).join(', ') || 'nothing to copy',
+            },
+          ]
+        : []),
+      ...(repoConfigs.length > 0
+        ? [
+            {
+              phase: 'repositories' as const,
+              status: 'done' as const,
+              done: importResult?.repositories.length ?? 0,
+              total: importResult?.repositories.length ?? 0,
+            },
+          ]
+        : []),
+    ]);
+    // The ids the modules phase will remap onto. They exist only in this
+    // request's memory, so the row is the only way they reach the task.
+    progress = withIdMaps(progress, {
+      repositories: importResult?.idMaps.repositories ?? {},
+      quizzes: importResult?.idMaps.quizzes ?? {},
+    });
+    progress = withCounts(progress, syncCounts);
+
+    try {
+      const job = await getPrisma().importJob.create({
+        data: {
+          classroom_id: classroom.id,
+          source_classroom_id: sourceClassroomId,
+          requested_by: user.id,
+          status: 'PENDING',
+          selections: {
+            config: configSelections,
+            repositories: repoConfigs,
+            content: contentSelections,
+          },
+          progress: progress as unknown as object,
+          warnings: importWarnings as unknown as object,
+        },
+      });
+      importJobId = job.id;
+
+      if (!isTriggerConfigured()) {
+        // No worker to pick this up. Fail the job immediately rather than leave
+        // a PENDING row the banner would poll forever.
+        await getPrisma().importJob.update({
+          where: { id: job.id },
+          data: {
+            status: 'FAILED',
+            error: 'The background job service (Trigger.dev) is not configured here.',
+          },
+        });
+        importWarnings.push('background import service unavailable — import not started');
+      } else {
+        await Tasks.classroomImportTask.trigger({ importJobId: job.id });
+      }
+    } catch (error: unknown) {
+      // The classroom itself is fine and everything synchronous already landed,
+      // so this is a warning on a successful create — never an error response.
+      console.error('Error starting the background import:', error);
+      if (importJobId) {
+        await getPrisma()
+          .importJob.update({
+            where: { id: importJobId },
+            data: {
+              status: 'FAILED',
+              error: error instanceof Error ? error.message : String(error),
+            },
+          })
+          .catch(() => {});
+      }
+      importWarnings.push('could not start the background import');
     }
-    if (configSummary) {
-      if (configSummary.settings_fields.length > 0) parts.push('settings');
-      const scales = configSummary.emoji_mappings + configSummary.letter_grade_mappings;
-      if (scales > 0) parts.push(plural(scales, 'grade mapping'));
-      if (configSummary.calendar_events > 0)
-        parts.push(plural(configSummary.calendar_events, 'calendar event'));
-    }
-    if (contentSummary) {
-      if (contentSummary.pages > 0) parts.push(plural(contentSummary.pages, 'page'));
-      if (contentSummary.slides > 0) parts.push(plural(contentSummary.slides, 'slide deck'));
-    }
-    if (modulesSummary && modulesSummary.modules > 0) {
-      parts.push(plural(modulesSummary.modules, 'module'));
-    }
-    if (templateSummary && templateSummary.duplicated > 0) {
-      parts.push(
-        `${templateSummary.duplicated} duplicated template${templateSummary.duplicated === 1 ? '' : 's'}`
-      );
-    }
-    if (parts.length > 0) {
-      successMessage = `Classroom created with ${parts.join(', ')} imported!`;
-    }
-    if (importWarnings.length > 0) {
-      successMessage += ` (${importWarnings.length} item${importWarnings.length === 1 ? '' : 's'} skipped — see server logs)`;
-    }
+  }
+
+  // Build success message — only what this request actually imported. The
+  // background phases report themselves through the progress banner.
+  const syncParts = buildSummaryParts(syncCounts);
+  let successMessage =
+    syncParts.length > 0
+      ? `Classroom created with ${syncParts.join(', ')} imported!`
+      : 'Classroom created successfully!';
+  if (importJobId) {
+    successMessage += ' Import continuing in the background.';
+  }
+  if (importWarnings.length > 0) {
+    successMessage += ` (${importWarnings.length} item${importWarnings.length === 1 ? '' : 's'} skipped — see server logs)`;
   }
 
   return {
     success: successMessage,
     action: ActionTypes.CREATE_CLASSROOM,
     classroomSlug: classroom.slug,
+    import_job_id: importJobId,
     import_warnings: importWarnings,
   };
 });

--- a/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.danger-zone/route.tsx
@@ -39,12 +39,17 @@ const DangerZone = ({ loaderData }: Route.ComponentProps) => {
   const { artifacts, withheld } = loaderData;
   const repos = artifacts.filter(a => a.kind === 'repo');
   const teams = artifacts.filter(a => a.kind === 'team');
-  // Content repo first, then assignment repos, then every team.
+  // Content repo first, then assignment repos, then the template duplicates this
+  // classroom's own import created, then every team.
   const artifactGroups = [
     { heading: 'Content repository', items: artifacts.filter(a => a.label === 'content repo') },
     {
       heading: 'Assignment repositories',
       items: artifacts.filter(a => a.label === 'assignment repo'),
+    },
+    {
+      heading: 'Imported template repositories',
+      items: artifacts.filter(a => a.label === 'template repo'),
     },
     { heading: 'Teams', items: teams },
   ].filter(group => group.items.length > 0);
@@ -138,8 +143,9 @@ const DangerZone = ({ loaderData }: Route.ComponentProps) => {
           >
             Also delete this classroom&rsquo;s GitHub artifacts
             <div className="text-xs text-gray-500 dark:text-gray-400">
-              The content repository, the classroom teams, and all student assignment repositories
-              in the GitHub organization. Leave unchecked to keep everything on GitHub.
+              The content repository, the classroom teams, all student assignment repositories, and
+              any template repositories this classroom&rsquo;s import created. Leave unchecked to
+              keep everything on GitHub.
             </div>
           </Checkbox>
           {deleteGitHub && (

--- a/apps/webapp/app/routes/admin/route.tsx
+++ b/apps/webapp/app/routes/admin/route.tsx
@@ -1,9 +1,53 @@
 import { Outlet } from 'react-router';
 import { CommonLayout, RequireRole } from '~/components';
 import { ClassmojiService } from '@classmoji/services';
+import getPrisma from '@classmoji/database';
 import { requireClassroomAdmin } from '~/utils/routeAuth.server';
 import { DEFAULT_NAV_VISIBILITY, navVisibilityFromSettings } from '~/utils/navVisibility';
+import type { ImportProgressBannerProps } from '~/components/features/import/ImportProgressBanner';
 import type { Route } from './+types/route';
+
+/** A finished import stays visible this long, then stops being loaded at all. */
+const COMPLETED_BANNER_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * The classroom's background import, when it is worth showing.
+ *
+ * PENDING/RUNNING is obvious, and FAILED is deliberately included even though it
+ * is terminal — a failed import is exactly the state the user must see, and it
+ * carries the retry. Only COMPLETED ages out, so a classroom imported last term
+ * doesn't greet its owner with a stale success banner.
+ */
+async function loadImportBanner(classroomId: string): Promise<ImportProgressBannerProps | null> {
+  const job = await getPrisma().importJob.findUnique({ where: { classroom_id: classroomId } });
+  if (!job) return null;
+  if (
+    job.status === 'COMPLETED' &&
+    Date.now() - job.updated_at.getTime() > COMPLETED_BANNER_WINDOW_MS
+  ) {
+    return null;
+  }
+
+  const source = await getPrisma().classroom.findUnique({
+    where: { id: job.source_classroom_id },
+    select: { name: true },
+  });
+
+  // Field by field, matching the API route's ImportJobView — the banner polls
+  // that endpoint, so the initial payload has to be the same narrow shape.
+  return {
+    job: {
+      id: job.id,
+      status: job.status as ImportProgressBannerProps['job']['status'],
+      phase: job.phase,
+      progress: job.progress as unknown as ImportProgressBannerProps['job']['progress'],
+      warnings: (job.warnings ?? []) as string[],
+      error: job.error,
+      updated_at: job.updated_at.toISOString(),
+    },
+    sourceName: source?.name ?? null,
+  };
+}
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const { class: classSlug } = params;
@@ -20,11 +64,13 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     // Fetch pages that should appear in menu (same as student view)
     const menuPages = await ClassmojiService.page.findForStudentMenu(classroom.id);
 
+    const importBanner = await loadImportBanner(classroom.id);
+
     // Check if recent viewers feature is enabled (settings included from findBySlug)
     const recentViewersEnabled = classroom.settings?.recent_viewers_enabled ?? true;
 
     if (!recentViewersEnabled) {
-      return { menuPages, recentViewers: [] };
+      return { menuPages, recentViewers: [], importBanner };
     }
 
     // Normalize the current path
@@ -53,6 +99,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
       menuPages,
       recentViewers,
       isAdmin: true,
+      importBanner,
       pagesUrl: process.env.PAGES_URL || 'http://localhost:7100',
       navVisibility: navVisibilityFromSettings(classroom.settings),
     };
@@ -69,6 +116,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 
 const Admin = ({ loaderData }: Route.ComponentProps) => {
   const { menuPages, recentViewers, isAdmin, pagesUrl, navVisibility } = loaderData;
+  const importBanner = 'importBanner' in loaderData ? loaderData.importBanner : null;
 
   return (
     <CommonLayout
@@ -77,6 +125,7 @@ const Admin = ({ loaderData }: Route.ComponentProps) => {
       groupViewersByRole={isAdmin}
       pagesUrl={pagesUrl}
       navVisibility={navVisibility}
+      importBanner={importBanner}
     >
       <RequireRole roles={['OWNER']}>
         <Outlet />

--- a/apps/webapp/app/routes/api.import-jobs.$jobId/route.ts
+++ b/apps/webapp/app/routes/api.import-jobs.$jobId/route.ts
@@ -1,5 +1,10 @@
 import getPrisma from '@classmoji/database';
-import type { ImportProgress } from '@classmoji/services/import-progress';
+import {
+  applyPhaseUpdates,
+  IMPORT_PHASE_ORDER,
+  type ImportProgress,
+} from '@classmoji/services/import-progress';
+import Tasks from '@classmoji/tasks';
 import { requireClassroomAdmin } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
@@ -33,6 +38,29 @@ export interface ImportJobView {
  * what authorizes the read — a job id alone says nothing about who may see it.
  * An unknown id 404s without touching the auth path.
  */
+/**
+ * Row → wire shape. `progress` and `warnings` are Json columns; the writers
+ * (the create-classroom action and the import task) are the single source of
+ * these shapes.
+ */
+const toView = (job: {
+  id: string;
+  status: string;
+  phase: string | null;
+  progress: unknown;
+  warnings: unknown;
+  error: string | null;
+  updated_at: Date;
+}): ImportJobView => ({
+  id: job.id,
+  status: job.status as ImportJobStatusValue,
+  phase: job.phase,
+  progress: job.progress as ImportProgress,
+  warnings: (job.warnings ?? []) as string[],
+  error: job.error,
+  updated_at: job.updated_at.toISOString(),
+});
+
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const jobId = params.jobId!;
 
@@ -50,17 +78,84 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     action: 'view_import_job',
   });
 
-  // `progress` and `warnings` are Json columns; the writers (the create-classroom
-  // action and the import task) are the single source of these shapes.
-  const view: ImportJobView = {
-    id: job.id,
-    status: job.status as ImportJobStatusValue,
-    phase: job.phase,
-    progress: job.progress as unknown as ImportProgress,
-    warnings: (job.warnings ?? []) as unknown as string[],
-    error: job.error,
-    updated_at: job.updated_at.toISOString(),
-  };
+  return Response.json(toView(job));
+};
 
-  return Response.json(view);
+/**
+ * POST /api/import-jobs/:jobId — retry a FAILED import.
+ *
+ * Resumes; it does not restart. Only the phases that actually FAILED go back to
+ * `pending`; every phase already `done` keeps its status, and the orchestrator
+ * skips those on the next run. That is what makes retrying safe when the
+ * per-item creates are not idempotent — nothing already imported is touched.
+ *
+ * Refused for any status but FAILED: retrying a PENDING or RUNNING job would
+ * put two workers on the same row, and a COMPLETED one has nothing to redo.
+ *
+ * Same admin gate as the read — a retry re-runs a copy out of the source
+ * classroom, so it is at least as privileged as viewing the progress.
+ */
+export const action = async ({ params, request }: Route.ActionArgs) => {
+  const jobId = params.jobId!;
+
+  if (request.method !== 'POST') {
+    throw new Response('Method not allowed', { status: 405 });
+  }
+
+  const job = await getPrisma().importJob.findUnique({
+    where: { id: jobId },
+    include: { classroom: { select: { slug: true } } },
+  });
+
+  if (!job) {
+    throw new Response('Not found', { status: 404 });
+  }
+
+  await requireClassroomAdmin(request, job.classroom.slug, {
+    resourceType: 'IMPORT_JOB',
+    action: 'retry_import_job',
+  });
+
+  if (job.status !== 'FAILED') {
+    return Response.json(
+      { error: `Only a failed import can be retried (this one is ${job.status}).` },
+      { status: 409 }
+    );
+  }
+
+  const progress = job.progress as unknown as ImportProgress;
+  const reset = applyPhaseUpdates(
+    progress,
+    IMPORT_PHASE_ORDER.filter(key => progress.phases?.[key]?.status === 'failed').map(phase => ({
+      phase,
+      status: 'pending' as const,
+      note: null,
+    }))
+  );
+
+  // PENDING before the trigger: if the trigger throws, the row is left claiming
+  // a run that never started, which the caller sees and can retry again.
+  const updated = await getPrisma().importJob.update({
+    where: { id: job.id },
+    data: {
+      status: 'PENDING',
+      error: null,
+      progress: reset as unknown as object,
+    },
+    include: { classroom: { select: { slug: true } } },
+  });
+
+  try {
+    await Tasks.classroomImportTask.trigger({ importJobId: job.id });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to re-trigger classroom import:', error);
+    const failed = await getPrisma().importJob.update({
+      where: { id: job.id },
+      data: { status: 'FAILED', error: `Could not restart the import: ${message}` },
+    });
+    return Response.json(toView(failed), { status: 502 });
+  }
+
+  return Response.json(toView(updated));
 };

--- a/apps/webapp/app/routes/api.import-jobs.$jobId/route.ts
+++ b/apps/webapp/app/routes/api.import-jobs.$jobId/route.ts
@@ -1,0 +1,66 @@
+import getPrisma from '@classmoji/database';
+import type { ImportProgress } from '@classmoji/services/import-progress';
+import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import type { Route } from './+types/route';
+
+/** Lifecycle of an `ImportJob` row (mirrors the `ImportJobStatus` enum). */
+export type ImportJobStatusValue = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+
+/**
+ * The ONLY fields this endpoint exposes. Deliberately narrower than the row:
+ * `selections`, `requested_by` and `source_classroom_id` describe the request
+ * and the source classroom, and nothing polling this needs them — so the
+ * response is built field by field rather than spread, which is what stops a
+ * later column being leaked by accident.
+ */
+export interface ImportJobView {
+  id: string;
+  status: ImportJobStatusValue;
+  phase: string | null;
+  progress: ImportProgress;
+  warnings: string[];
+  error: string | null;
+  /** ISO 8601 — serialized here so the wire type is a string, not a Date. */
+  updated_at: string;
+}
+
+/**
+ * GET /api/import-jobs/:jobId
+ *
+ * Read-only poll target for a background classroom import.
+ *
+ * The job is loaded BEFORE any auth work because the classroom it belongs to is
+ * what authorizes the read — a job id alone says nothing about who may see it.
+ * An unknown id 404s without touching the auth path.
+ */
+export const loader = async ({ params, request }: Route.LoaderArgs) => {
+  const jobId = params.jobId!;
+
+  const job = await getPrisma().importJob.findUnique({
+    where: { id: jobId },
+    include: { classroom: { select: { slug: true } } },
+  });
+
+  if (!job) {
+    throw new Response('Not found', { status: 404 });
+  }
+
+  await requireClassroomAdmin(request, job.classroom.slug, {
+    resourceType: 'IMPORT_JOB',
+    action: 'view_import_job',
+  });
+
+  // `progress` and `warnings` are Json columns; the writers (the create-classroom
+  // action and the import task) are the single source of these shapes.
+  const view: ImportJobView = {
+    id: job.id,
+    status: job.status as ImportJobStatusValue,
+    phase: job.phase,
+    progress: job.progress as unknown as ImportProgress,
+    warnings: (job.warnings ?? []) as unknown as string[],
+    error: job.error,
+    updated_at: job.updated_at.toISOString(),
+  };
+
+  return Response.json(view);
+};

--- a/packages/database/migrations/20260814120000_import_jobs/migration.sql
+++ b/packages/database/migrations/20260814120000_import_jobs/migration.sql
@@ -1,0 +1,52 @@
+-- Classroom IMPORT becomes a background job with a tracked progress bar.
+--
+-- Copying a source classroom (settings, repositories, template duplication,
+-- pages/slides content, modules) used to run inside the create-classroom
+-- action. On a real classroom that is a multi-minute request — a live import
+-- ran past 10 minutes — which risks a proxy timeout and shows the user nothing
+-- but a spinner. The work now runs in the `classroom-import` Trigger.dev task,
+-- and this table is the durable handoff: the action creates the row and
+-- triggers the task, the task advances phase/progress/warnings, and the admin
+-- dashboard polls the row to draw the bar.
+
+-- CreateEnum
+CREATE TYPE "ImportJobStatus" AS ENUM ('PENDING', 'RUNNING', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+-- `selections` carries the whole import request (settings groups, repository
+-- ids with their includeQuizzes flags, content/module toggles) so the trigger
+-- payload stays a bare { importJobId } and the run is replayable from the row.
+-- `progress` holds the per-phase shape documented in schema.prisma and built by
+-- @classmoji/services `importProgress.ts`.
+CREATE TABLE "import_jobs" (
+    "id" TEXT NOT NULL,
+    "classroom_id" TEXT NOT NULL,
+    "source_classroom_id" TEXT NOT NULL,
+    "requested_by" TEXT NOT NULL,
+    "status" "ImportJobStatus" NOT NULL DEFAULT 'PENDING',
+    "phase" TEXT,
+    "selections" JSONB NOT NULL DEFAULT '{}',
+    "progress" JSONB NOT NULL DEFAULT '{}',
+    "warnings" JSONB NOT NULL DEFAULT '[]',
+    "error" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "import_jobs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+-- ONE import per classroom. The per-item creates (pages, decks, repositories)
+-- are not idempotent, so a second job for the same classroom would silently
+-- duplicate content — the constraint makes that unrepresentable rather than
+-- relying on callers to check first.
+CREATE UNIQUE INDEX "import_jobs_classroom_id_key" ON "import_jobs"("classroom_id");
+
+-- CreateIndex
+-- Supports sweeping for non-terminal jobs (PENDING/RUNNING) without scanning.
+CREATE INDEX "import_jobs_status_idx" ON "import_jobs"("status");
+
+-- AddForeignKey
+-- Cascade: an import job describes work on exactly one classroom and has no
+-- meaning once that classroom is deleted.
+ALTER TABLE "import_jobs" ADD CONSTRAINT "import_jobs_classroom_id_fkey" FOREIGN KEY ("classroom_id") REFERENCES "classrooms"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -385,6 +385,7 @@ model Classroom {
   classroom_invites     ClassroomInvite[]
   resource_views        ResourceView[]
   notifications         Notification[]
+  import_job            ImportJob?
 
   @@unique([git_org_id, slug])
   // content_namespace no longer names the content repo, but stays unique
@@ -452,6 +453,66 @@ model ClassroomMembership {
   @@index([classroom_id, user_id])
   @@index([user_id])
   @@map("classroom_memberships")
+}
+
+enum ImportJobStatus {
+  PENDING
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
+// Tracks the BACKGROUND copy of a source classroom into a newly created one.
+// Classroom creation returns as soon as this row exists and the
+// `classroom-import` Trigger.dev task is triggered; the task then owns every
+// phase (config → repositories → templates → content → modules), and the admin
+// dashboard polls this row to draw a progress bar. Before this existed the copy
+// ran inside the create action and could pin a request for 10+ minutes.
+//
+// One import per classroom (`classroom_id` is unique): the per-item creates are
+// NOT idempotent, so a second run would duplicate pages, decks and repos. That
+// same non-idempotency is why the task sets `retry: { maxAttempts: 1 }`.
+model ImportJob {
+  id                  String          @id @default(uuid())
+  classroom_id        String          @unique
+  source_classroom_id String
+  // The user whose ownership of the source classroom was verified. The task
+  // re-verifies it before copying anything (defense in depth), and imported
+  // content is attributed to them.
+  requested_by        String
+  status              ImportJobStatus @default(PENDING)
+  // Coarse phase name: config | repositories | templates | content | modules.
+  // Null before the task starts and after it finishes.
+  phase               String?
+  // What the user asked to import — settings groups, per-repository ids and
+  // their includeQuizzes flags, and the content/module toggles. The task reads
+  // its whole input from this row, which is what keeps the trigger payload a
+  // bare { importJobId } and the run replayable.
+  selections          Json            @default("{}")
+  // Per-phase progress; see @classmoji/services `importProgress.ts` for the
+  // shape and the pure builders/reducer that produce it:
+  // { phases: { config: { status, summary?, note? },
+  //             repositories | templates | pages | slides:
+  //               { status, done, total, note? },
+  //             modules: { status, summary?, note? } },
+  //   parts?: string[] }
+  // status is pending | running | done | skipped | failed. `note` carries
+  // transient state such as a GitHub rate-limit backoff, so a wait is visible
+  // rather than looking like a hang. `parts` holds the final success-message
+  // fragments, written once at COMPLETED.
+  progress            Json            @default("{}")
+  // Best-effort per-item failures, same strings the synchronous import
+  // collected. A warning never fails the job.
+  warnings            Json            @default("[]")
+  // Set only when status is FAILED — the whole import died, not one item.
+  error               String?
+  created_at          DateTime        @default(now())
+  updated_at          DateTime        @default(now()) @updatedAt
+
+  classroom Classroom @relation(fields: [classroom_id], references: [id], onDelete: Cascade)
+
+  @@index([status])
+  @@map("import_jobs")
 }
 
 // ============================================================================

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./flags": "./src/classmoji/repoAnalytics.flags.ts",
+    "./import-progress": "./src/classmoji/importProgress.ts",
     "./slides": "./src/slides/index.ts",
     "./slides/ops": "./src/slides/deckOps.ts"
   },

--- a/packages/services/src/classmoji/__tests__/classroom.deleteArtifacts.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroom.deleteArtifacts.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { classroomGitHubArtifactPlan } from '../classroom.service.ts';
+import {
+  classroomGitHubArtifactPlan,
+  exclusiveImportedTemplateNames,
+  importedTemplateRepoNames,
+  ownedTemplateRepoNames,
+} from '../classroom.service.ts';
 
 const base = {
   orgLogin: 'dartmouth-cs52',
@@ -19,8 +24,18 @@ describe('classroomGitHubArtifactPlan', () => {
         name: 'cs52-content',
         label: 'content repo',
       },
-      { kind: 'team', org: 'dartmouth-cs52', name: 'dartmouth-cs52-26f-students', label: 'classroom team' },
-      { kind: 'team', org: 'dartmouth-cs52', name: 'dartmouth-cs52-26f-assistants', label: 'classroom team' },
+      {
+        kind: 'team',
+        org: 'dartmouth-cs52',
+        name: 'dartmouth-cs52-26f-students',
+        label: 'classroom team',
+      },
+      {
+        kind: 'team',
+        org: 'dartmouth-cs52',
+        name: 'dartmouth-cs52-26f-assistants',
+        label: 'classroom team',
+      },
     ]);
   });
 
@@ -53,5 +68,141 @@ describe('classroomGitHubArtifactPlan', () => {
   it('never invents artifacts: empty inputs yield only the stored content repo + conventional teams', () => {
     const plan = classroomGitHubArtifactPlan(base);
     expect(plan).toHaveLength(3);
+  });
+
+  it('lists import-created template repos after the assignment repos', () => {
+    const plan = classroomGitHubArtifactPlan({
+      ...base,
+      gitRepoNames: ['hw1-alice'],
+      templateRepoNames: ['lab1-template-26w', 'lab2-template-26w'],
+    });
+    expect(plan.filter(a => a.label === 'template repo')).toEqual([
+      {
+        kind: 'repo',
+        org: 'dartmouth-cs52',
+        name: 'lab1-template-26w',
+        label: 'template repo',
+      },
+      {
+        kind: 'repo',
+        org: 'dartmouth-cs52',
+        name: 'lab2-template-26w',
+        label: 'template repo',
+      },
+    ]);
+    expect(plan.filter(a => a.kind === 'repo').map(a => a.name)).toEqual([
+      'cs52-content',
+      'hw1-alice',
+      'lab1-template-26w',
+      'lab2-template-26w',
+    ]);
+  });
+
+  it('yields no template artifacts when the classroom never imported any', () => {
+    expect(classroomGitHubArtifactPlan(base).filter(a => a.label === 'template repo')).toEqual([]);
+  });
+
+  it('lists a repo once: a template name already claimed as content or assignment repo is dropped', () => {
+    const plan = classroomGitHubArtifactPlan({
+      ...base,
+      gitRepoNames: ['hw1-alice'],
+      // Case-variant spellings of names already in the plan — GitHub treats
+      // these as the same repo, so a second DELETE would be pointless.
+      templateRepoNames: ['CS52-Content', 'HW1-Alice', 'lab1-template-26w'],
+    });
+    expect(plan.filter(a => a.kind === 'repo').map(a => a.name)).toEqual([
+      'cs52-content',
+      'hw1-alice',
+      'lab1-template-26w',
+    ]);
+  });
+});
+
+describe('importedTemplateRepoNames', () => {
+  it('reads the created duplicate names out of id_maps.templates', () => {
+    expect(
+      importedTemplateRepoNames({
+        id_maps: { templates: { 'old-org/lab1': 'lab1-26w', 'old-org/lab2': 'lab2-26w' } },
+      })
+    ).toEqual(['lab1-26w', 'lab2-26w']);
+  });
+
+  it('also accepts the flat template_map alias and de-duplicates across both', () => {
+    expect(
+      importedTemplateRepoNames({
+        id_maps: { templates: { 'old-org/lab1': 'lab1-26w' } },
+        template_map: { 'old-org/lab1': 'LAB1-26W', 'old-org/lab2': 'lab2-26w' },
+      })
+    ).toEqual(['lab1-26w', 'lab2-26w']);
+  });
+
+  it('yields nothing for a classroom with no import job, or an import that duplicated none', () => {
+    expect(importedTemplateRepoNames(null)).toEqual([]);
+    expect(importedTemplateRepoNames(undefined)).toEqual([]);
+    expect(importedTemplateRepoNames({})).toEqual([]);
+    expect(importedTemplateRepoNames({ id_maps: { templates: {} } })).toEqual([]);
+  });
+
+  it('degrades to nothing rather than throwing on a progress column of any other shape', () => {
+    // A row written before this feature (or by a future shape) must never make
+    // the danger-zone loader 500 — the delete path has to stay reachable.
+    expect(importedTemplateRepoNames('not json')).toEqual([]);
+    expect(importedTemplateRepoNames(42)).toEqual([]);
+    expect(importedTemplateRepoNames({ id_maps: 'nope' })).toEqual([]);
+    expect(importedTemplateRepoNames({ id_maps: { templates: { a: 5, b: '', c: '  ' } } })).toEqual(
+      []
+    );
+  });
+});
+
+describe('ownedTemplateRepoNames', () => {
+  it('keeps owner-qualified refs owned by the org, and bare refs (which resolve to it)', () => {
+    expect(ownedTemplateRepoNames(['cs52-org/lab1', 'lab2'], 'cs52-org')).toEqual(['lab1', 'lab2']);
+  });
+
+  it('drops refs owned by a different account — cleanup never reaches outside the org', () => {
+    expect(ownedTemplateRepoNames(['other-org/lab1', 'someuser/lab2'], 'cs52-org')).toEqual([]);
+  });
+
+  it('matches the owner case-insensitively and de-duplicates names the same way', () => {
+    expect(ownedTemplateRepoNames(['CS52-Org/Lab1', 'cs52-org/lab1'], 'cs52-org')).toEqual([
+      'Lab1',
+    ]);
+  });
+
+  it('skips empty, null and over-segmented refs', () => {
+    expect(ownedTemplateRepoNames([null, undefined, '', '   ', 'a/b/c'], 'cs52-org')).toEqual([]);
+  });
+});
+
+describe('exclusiveImportedTemplateNames', () => {
+  it('keeps duplicates no other classroom points at', () => {
+    expect(
+      exclusiveImportedTemplateNames({
+        createdNames: ['lab1-26w', 'lab2-26w'],
+        otherClassroomTemplateRefs: ['cs52-org/something-else'],
+        orgLogin: 'cs52-org',
+      })
+    ).toEqual(['lab1-26w', 'lab2-26w']);
+  });
+
+  it('withholds one a DIFFERENT classroom was relinked to, in either ref spelling', () => {
+    expect(
+      exclusiveImportedTemplateNames({
+        createdNames: ['lab1-26w', 'lab2-26w', 'lab3-26w'],
+        otherClassroomTemplateRefs: ['cs52-org/LAB1-26W', 'lab2-26w'],
+        orgLogin: 'cs52-org',
+      })
+    ).toEqual(['lab3-26w']);
+  });
+
+  it('ignores a same-named repo owned by another org — that is not this duplicate', () => {
+    expect(
+      exclusiveImportedTemplateNames({
+        createdNames: ['lab1-26w'],
+        otherClassroomTemplateRefs: ['other-org/lab1-26w'],
+        orgLogin: 'cs52-org',
+      })
+    ).toEqual(['lab1-26w']);
   });
 });

--- a/packages/services/src/classmoji/__tests__/importProgress.test.ts
+++ b/packages/services/src/classmoji/__tests__/importProgress.test.ts
@@ -12,6 +12,9 @@ import {
   applyPhaseUpdate,
   applyPhaseUpdates,
   withSummaryParts,
+  withIdMaps,
+  importedSourceIds,
+  buildSummaryParts,
   overallPercent,
   IMPORT_PHASE_ORDER,
   IMPORT_PHASE_LABELS,
@@ -342,5 +345,129 @@ describe('overallPercent', () => {
       { phase: 'pages', status: 'running', done: 1, total: 3 },
     ]);
     expect(Number.isInteger(overallPercent(progress))).toBe(true);
+  });
+});
+
+describe('withIdMaps', () => {
+  const base = buildInitialProgress({ pages: true, slides: true });
+
+  it('attaches maps to a progress object that had none', () => {
+    const next = withIdMaps(base, { pages: { 'src-1': 'new-1' } });
+    expect(next.id_maps).toEqual({ pages: { 'src-1': 'new-1' } });
+  });
+
+  it('MERGES rather than replaces — one phase must not erase another phase hand-off', () => {
+    const withRepos = withIdMaps(base, { repositories: { 'r-1': 'R1' }, quizzes: { 'q-1': 'Q1' } });
+    const withPages = withIdMaps(withRepos, { pages: { 'p-1': 'P1' } });
+    expect(withPages.id_maps).toEqual({
+      repositories: { 'r-1': 'R1' },
+      quizzes: { 'q-1': 'Q1' },
+      pages: { 'p-1': 'P1' },
+    });
+  });
+
+  it('merges INTO an existing kind, later entries winning per key', () => {
+    const first = withIdMaps(base, { pages: { 'p-1': 'P1', 'p-2': 'P2' } });
+    const second = withIdMaps(first, { pages: { 'p-2': 'P2-again', 'p-3': 'P3' } });
+    expect(second.id_maps?.pages).toEqual({ 'p-1': 'P1', 'p-2': 'P2-again', 'p-3': 'P3' });
+  });
+
+  it('is pure: neither the progress nor the incoming maps are mutated', () => {
+    const incoming = { pages: { 'p-1': 'P1' } };
+    const first = withIdMaps(base, incoming);
+    withIdMaps(first, { pages: { 'p-2': 'P2' } });
+    expect(base.id_maps).toBeUndefined();
+    expect(first.id_maps?.pages).toEqual({ 'p-1': 'P1' });
+    expect(incoming).toEqual({ pages: { 'p-1': 'P1' } });
+  });
+
+  it('leaves the phases untouched', () => {
+    expect(withIdMaps(base, { slides: { 's-1': 'S1' } }).phases).toEqual(base.phases);
+  });
+});
+
+describe('importedSourceIds', () => {
+  it('returns the SOURCE ids already imported for a kind — the resume skip-set', () => {
+    const progress = withIdMaps(buildInitialProgress({ pages: true }), {
+      pages: { 'src-a': 'new-a', 'src-b': 'new-b' },
+    });
+    const skip = importedSourceIds(progress, 'pages');
+    expect(skip.has('src-a')).toBe(true);
+    expect(skip.has('src-b')).toBe(true);
+    expect(skip.has('new-a')).toBe(false);
+    expect(skip.size).toBe(2);
+  });
+
+  it('is empty for a kind never written, and for a job with no maps at all', () => {
+    const progress = withIdMaps(buildInitialProgress({ pages: true }), { pages: { a: 'A' } });
+    expect(importedSourceIds(progress, 'slides').size).toBe(0);
+    expect(importedSourceIds(buildInitialProgress({}), 'pages').size).toBe(0);
+  });
+});
+
+describe('buildSummaryParts', () => {
+  it('emits the fragments in the order the synchronous action used', () => {
+    expect(
+      buildSummaryParts({
+        repositories: 2,
+        assignments: 3,
+        quizzes: 1,
+        settings: true,
+        grade_mappings: 4,
+        calendar_events: 5,
+        pages: 24,
+        slides: 19,
+        modules: 6,
+        duplicated_templates: 2,
+      })
+    ).toEqual([
+      '2 repositories',
+      '3 assignments',
+      '1 quiz',
+      'settings',
+      '4 grade mappings',
+      '5 calendar events',
+      '24 pages',
+      '19 slide decks',
+      '6 modules',
+      '2 duplicated templates',
+    ]);
+  });
+
+  it('singularizes each count, including the irregular plurals', () => {
+    expect(
+      buildSummaryParts({
+        repositories: 1,
+        assignments: 1,
+        quizzes: 1,
+        grade_mappings: 1,
+        calendar_events: 1,
+        pages: 1,
+        slides: 1,
+        modules: 1,
+        duplicated_templates: 1,
+      })
+    ).toEqual([
+      '1 repository',
+      '1 assignment',
+      '1 quiz',
+      '1 grade mapping',
+      '1 calendar event',
+      '1 page',
+      '1 slide deck',
+      '1 module',
+      '1 duplicated template',
+    ]);
+  });
+
+  it('omits zero and absent counts — a run must never claim "0 quizzes"', () => {
+    expect(buildSummaryParts({ pages: 3, slides: 0, quizzes: 0, settings: false })).toEqual([
+      '3 pages',
+    ]);
+    expect(buildSummaryParts({})).toEqual([]);
+  });
+
+  it('reports settings as a bare word, with no count', () => {
+    expect(buildSummaryParts({ settings: true })).toEqual(['settings']);
   });
 });

--- a/packages/services/src/classmoji/__tests__/importProgress.test.ts
+++ b/packages/services/src/classmoji/__tests__/importProgress.test.ts
@@ -1,0 +1,346 @@
+/**
+ * importProgress pure helpers: buildInitialProgress, applyPhaseUpdate,
+ * applyPhaseUpdates, withSummaryParts, overallPercent.
+ *
+ * The module has no imports at all (that is a load-bearing property — it ships
+ * into the browser bundle), so nothing needs stubbing here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildInitialProgress,
+  applyPhaseUpdate,
+  applyPhaseUpdates,
+  withSummaryParts,
+  overallPercent,
+  IMPORT_PHASE_ORDER,
+  IMPORT_PHASE_LABELS,
+  COUNTED_PHASE_KEYS,
+  SUMMARY_PHASE_KEYS,
+  CONTENT_PHASE_KEYS,
+  type ImportProgress,
+} from '../importProgress.ts';
+
+const allSelected = {
+  config: true,
+  repositories: true,
+  templates: true,
+  pages: true,
+  slides: true,
+  modules: true,
+};
+
+describe('buildInitialProgress', () => {
+  it('marks selected phases pending and unselected phases skipped', () => {
+    const progress = buildInitialProgress({ config: true, pages: true });
+
+    expect(progress.phases.config.status).toBe('pending');
+    expect(progress.phases.pages.status).toBe('pending');
+    expect(progress.phases.repositories.status).toBe('skipped');
+    expect(progress.phases.templates.status).toBe('skipped');
+    expect(progress.phases.slides.status).toBe('skipped');
+    expect(progress.phases.modules.status).toBe('skipped');
+  });
+
+  it('skips everything when no selections are passed at all', () => {
+    const progress = buildInitialProgress();
+    for (const key of IMPORT_PHASE_ORDER) {
+      expect(progress.phases[key].status).toBe('skipped');
+    }
+  });
+
+  it('seeds counted phases with the totals the caller could count cheaply', () => {
+    const progress = buildInitialProgress(allSelected, {
+      repositories: 3,
+      templates: 2,
+      pages: 12,
+      slides: 5,
+    });
+
+    expect(progress.phases.repositories).toEqual({ status: 'pending', done: 0, total: 3 });
+    expect(progress.phases.pages).toEqual({ status: 'pending', done: 0, total: 12 });
+    expect(progress.phases.slides).toEqual({ status: 'pending', done: 0, total: 5 });
+    expect(progress.phases.templates).toEqual({ status: 'pending', done: 0, total: 2 });
+  });
+
+  it('defaults an uncounted total to 0 so the writer can fill it in later', () => {
+    const progress = buildInitialProgress({ pages: true });
+    expect(progress.phases.pages).toEqual({ status: 'pending', done: 0, total: 0 });
+  });
+
+  it('never carries a total on a skipped phase', () => {
+    const progress = buildInitialProgress({ pages: false }, { pages: 40 });
+    expect(progress.phases.pages).toEqual({ status: 'skipped', done: 0, total: 0 });
+  });
+
+  it('coerces a negative or fractional total to a sane whole number', () => {
+    const progress = buildInitialProgress(allSelected, { pages: -4, slides: 2.7 });
+    expect(progress.phases.pages.total).toBe(0);
+    expect(progress.phases.slides.total).toBe(2);
+  });
+});
+
+describe('phase key constants', () => {
+  it('labels every phase in the render order', () => {
+    for (const key of IMPORT_PHASE_ORDER) {
+      expect(IMPORT_PHASE_LABELS[key]).toBeTruthy();
+    }
+  });
+
+  it('partitions the phases into exactly counted + summary', () => {
+    expect([...COUNTED_PHASE_KEYS, ...SUMMARY_PHASE_KEYS].sort()).toEqual(
+      [...IMPORT_PHASE_ORDER].sort()
+    );
+  });
+
+  it('expands the coarse content phase into its two counted phases', () => {
+    // The ImportJob.phase column says `content`; progress tracks pages and
+    // slides separately. Guard the mapping so the two cannot drift.
+    expect(CONTENT_PHASE_KEYS).toEqual(['pages', 'slides']);
+    for (const key of CONTENT_PHASE_KEYS) {
+      expect(COUNTED_PHASE_KEYS).toContain(key);
+    }
+  });
+});
+
+describe('applyPhaseUpdate', () => {
+  it('does not mutate the input progress object', () => {
+    const before = buildInitialProgress(allSelected, { pages: 4 });
+    const snapshot = JSON.parse(JSON.stringify(before)) as ImportProgress;
+
+    const after = applyPhaseUpdate(before, { phase: 'pages', status: 'running', done: 2 });
+
+    expect(before).toEqual(snapshot);
+    expect(after).not.toBe(before);
+    expect(after.phases).not.toBe(before.phases);
+    expect(after.phases.pages.done).toBe(2);
+  });
+
+  it('leaves the other phases untouched', () => {
+    const before = buildInitialProgress(allSelected, { pages: 4, slides: 9 });
+    const after = applyPhaseUpdate(before, { phase: 'pages', done: 1 });
+
+    expect(after.phases.slides).toEqual(before.phases.slides);
+    expect(after.phases.config).toEqual(before.phases.config);
+  });
+
+  it('patches only the fields supplied', () => {
+    const start = buildInitialProgress(allSelected, { repositories: 5 });
+    const running = applyPhaseUpdate(start, { phase: 'repositories', status: 'running' });
+    const advanced = applyPhaseUpdate(running, { phase: 'repositories', done: 3 });
+
+    expect(advanced.phases.repositories).toEqual({ status: 'running', done: 3, total: 5 });
+  });
+
+  it('raises total and done together in one patch', () => {
+    const start = buildInitialProgress(allSelected);
+    const after = applyPhaseUpdate(start, {
+      phase: 'templates',
+      status: 'running',
+      done: 2,
+      total: 7,
+    });
+
+    expect(after.phases.templates).toEqual({ status: 'running', done: 2, total: 7 });
+  });
+
+  it('clamps done to the known total so the bar never reads 13/12', () => {
+    const start = buildInitialProgress(allSelected, { pages: 12 });
+    const after = applyPhaseUpdate(start, { phase: 'pages', done: 13 });
+    expect(after.phases.pages.done).toBe(12);
+  });
+
+  it('clamps a negative done to zero', () => {
+    const start = buildInitialProgress(allSelected, { pages: 12 });
+    const after = applyPhaseUpdate(start, { phase: 'pages', done: -3 });
+    expect(after.phases.pages.done).toBe(0);
+  });
+
+  it('allows done to run ahead while the total is still unknown', () => {
+    // total 0 means "not counted yet" — clamping to it would freeze the bar.
+    const start = buildInitialProgress({ pages: true });
+    const after = applyPhaseUpdate(start, { phase: 'pages', done: 4 });
+    expect(after.phases.pages).toEqual({ status: 'pending', done: 4, total: 0 });
+  });
+
+  it('sets a summary on a summary phase', () => {
+    const start = buildInitialProgress(allSelected);
+    const after = applyPhaseUpdate(start, {
+      phase: 'config',
+      status: 'done',
+      summary: 'settings, 4 grade mappings',
+    });
+
+    expect(after.phases.config).toEqual({
+      status: 'done',
+      summary: 'settings, 4 grade mappings',
+    });
+  });
+
+  it('ignores done/total on a summary phase', () => {
+    const start = buildInitialProgress(allSelected);
+    const after = applyPhaseUpdate(start, {
+      phase: 'modules',
+      status: 'running',
+      done: 9,
+      total: 9,
+    });
+
+    expect(after.phases.modules).toEqual({ status: 'running' });
+    expect(after.phases.modules).not.toHaveProperty('done');
+  });
+
+  it('ignores summary on a counted phase', () => {
+    const start = buildInitialProgress(allSelected, { pages: 3 });
+    const after = applyPhaseUpdate(start, { phase: 'pages', summary: 'nope' });
+
+    expect(after.phases.pages).not.toHaveProperty('summary');
+  });
+
+  describe('note (transient status, e.g. a GitHub rate-limit wait)', () => {
+    it('sets a note on a counted phase without disturbing its counts', () => {
+      const start = applyPhaseUpdate(buildInitialProgress(allSelected, { templates: 14 }), {
+        phase: 'templates',
+        status: 'running',
+        done: 14,
+      });
+      const waiting = applyPhaseUpdate(start, {
+        phase: 'templates',
+        note: 'waiting out GitHub rate limit (~45s)',
+      });
+
+      expect(waiting.phases.templates).toEqual({
+        status: 'running',
+        done: 14,
+        total: 14,
+        note: 'waiting out GitHub rate limit (~45s)',
+      });
+    });
+
+    it('clears the note with null once the wait ends', () => {
+      const waiting = applyPhaseUpdate(buildInitialProgress(allSelected, { templates: 2 }), {
+        phase: 'templates',
+        note: 'waiting out GitHub rate limit (~45s)',
+      });
+      const resumed = applyPhaseUpdate(waiting, { phase: 'templates', note: null });
+
+      expect(resumed.phases.templates).not.toHaveProperty('note');
+    });
+
+    it('leaves an existing note alone when note is omitted', () => {
+      const waiting = applyPhaseUpdate(buildInitialProgress(allSelected, { templates: 2 }), {
+        phase: 'templates',
+        note: 'pacing repository creation',
+      });
+      const advanced = applyPhaseUpdate(waiting, { phase: 'templates', done: 1 });
+
+      expect(advanced.phases.templates.note).toBe('pacing repository creation');
+    });
+
+    it('supports notes on summary phases too', () => {
+      const after = applyPhaseUpdate(buildInitialProgress(allSelected), {
+        phase: 'config',
+        note: 'retrying',
+      });
+      expect(after.phases.config.note).toBe('retrying');
+    });
+  });
+});
+
+describe('applyPhaseUpdates', () => {
+  it('applies a batch in order, last write winning per field', () => {
+    const after = applyPhaseUpdates(buildInitialProgress(allSelected, { pages: 3 }), [
+      { phase: 'pages', status: 'running' },
+      { phase: 'pages', done: 1 },
+      { phase: 'pages', done: 3 },
+      { phase: 'pages', status: 'done' },
+      { phase: 'config', status: 'done', summary: 'settings' },
+    ]);
+
+    expect(after.phases.pages).toEqual({ status: 'done', done: 3, total: 3 });
+    expect(after.phases.config).toEqual({ status: 'done', summary: 'settings' });
+  });
+
+  it('returns the input unchanged for an empty batch', () => {
+    const start = buildInitialProgress(allSelected);
+    expect(applyPhaseUpdates(start, [])).toBe(start);
+  });
+});
+
+describe('withSummaryParts', () => {
+  it('attaches parts without mutating or disturbing the phases', () => {
+    const start = buildInitialProgress(allSelected, { pages: 2 });
+    const after = withSummaryParts(start, ['3 repositories', '2 pages']);
+
+    expect(after.parts).toEqual(['3 repositories', '2 pages']);
+    expect(after.phases).toEqual(start.phases);
+    expect(start).not.toHaveProperty('parts');
+  });
+});
+
+describe('overallPercent', () => {
+  it('is 0 for a freshly seeded job', () => {
+    expect(overallPercent(buildInitialProgress(allSelected, { pages: 10 }))).toBe(0);
+  });
+
+  it('is 100 when every selected phase is done', () => {
+    const progress = applyPhaseUpdates(buildInitialProgress({ config: true, modules: true }), [
+      { phase: 'config', status: 'done' },
+      { phase: 'modules', status: 'done' },
+    ]);
+    expect(overallPercent(progress)).toBe(100);
+  });
+
+  it('excludes skipped phases from the denominator', () => {
+    // Importing settings alone must be able to reach 100%.
+    const progress = applyPhaseUpdate(buildInitialProgress({ config: true }), {
+      phase: 'config',
+      status: 'done',
+    });
+    expect(overallPercent(progress)).toBe(100);
+  });
+
+  it('is 100 when nothing at all was selected', () => {
+    expect(overallPercent(buildInitialProgress())).toBe(100);
+  });
+
+  it('counts a running counted phase by its real done/total ratio', () => {
+    // Two phases selected; one done, one half way => 75%.
+    const progress = applyPhaseUpdates(buildInitialProgress({ config: true, pages: true }), [
+      { phase: 'config', status: 'done' },
+      { phase: 'pages', status: 'running', done: 5, total: 10 },
+    ]);
+    expect(overallPercent(progress)).toBe(75);
+  });
+
+  it('treats a failed phase as finished so the bar cannot stall forever', () => {
+    const progress = applyPhaseUpdates(buildInitialProgress({ config: true, pages: true }), [
+      { phase: 'config', status: 'failed' },
+      { phase: 'pages', status: 'done' },
+    ]);
+    expect(overallPercent(progress)).toBe(100);
+  });
+
+  it('contributes nothing for a running phase whose total is unknown', () => {
+    const progress = applyPhaseUpdates(buildInitialProgress({ config: true, pages: true }), [
+      { phase: 'config', status: 'done' },
+      { phase: 'pages', status: 'running', done: 3 },
+    ]);
+    expect(overallPercent(progress)).toBe(50);
+  });
+
+  it('does not credit a pending counted phase that already reports a total', () => {
+    const progress = applyPhaseUpdates(buildInitialProgress(allSelected, { pages: 4 }), [
+      { phase: 'pages', done: 4 },
+    ]);
+    // Still pending, so it contributes 0 of the 6 selected phases.
+    expect(overallPercent(progress)).toBe(0);
+  });
+
+  it('returns a whole number', () => {
+    const progress = applyPhaseUpdates(buildInitialProgress(allSelected, { pages: 3 }), [
+      { phase: 'pages', status: 'running', done: 1, total: 3 },
+    ]);
+    expect(Number.isInteger(overallPercent(progress))).toBe(true);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/templateImport.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/templateImport.service.test.ts
@@ -1,6 +1,7 @@
 /**
  * templateImport.service pure helpers: parseTemplateRef, formatTemplateRef,
- * templateRefKey, groupTemplateRefs, templateNameCandidates, formatWarning.
+ * templateRefKey, groupTemplateRefs, templateNameCandidates, formatWarning,
+ * parseSecondaryRateLimit.
  * No DB/GitHub — the orchestrator's IO paths are out of scope here (repo
  * pure-only test convention). The runtime-heavy imports the service pulls in at
  * module load are stubbed so importing it is cheap.
@@ -19,6 +20,7 @@ const {
   groupTemplateRefs,
   templateNameCandidates,
   formatWarning,
+  parseSecondaryRateLimit,
 } = await import('../templateImport.service.ts');
 
 describe('parseTemplateRef', () => {
@@ -170,5 +172,117 @@ describe('formatWarning', () => {
 
   it('leaves detail at the limit untouched', () => {
     expect(formatWarning('scope', 'x'.repeat(200))).toBe(`scope: ${'x'.repeat(200)}`);
+  });
+});
+
+/**
+ * parseSecondaryRateLimit encodes the fix for a real production stall: creating
+ * ~14 template duplicates back-to-back tripped GitHub's secondary content-
+ * creation limit, and the next create sat in octokit's backoff for 30+ minutes.
+ * The clock is injected so reset-header arithmetic is deterministic.
+ */
+describe('parseSecondaryRateLimit', () => {
+  const err = (status: number, message: string, headers?: Record<string, unknown>): unknown => ({
+    status,
+    message,
+    response: headers ? { headers } : undefined,
+  });
+
+  it('detects a named secondary-limit trip with no headers and uses the 60s default', () => {
+    expect(parseSecondaryRateLimit(err(403, 'You have exceeded a secondary rate limit'))).toEqual({
+      retryAfterMs: 60_000,
+    });
+  });
+
+  it('detects the abuse-detection wording GitHub also uses', () => {
+    expect(parseSecondaryRateLimit(err(403, 'triggered an abuse detection mechanism'))).toEqual({
+      retryAfterMs: 60_000,
+    });
+  });
+
+  it('honors retry-after on a 429', () => {
+    expect(parseSecondaryRateLimit(err(429, 'Too Many Requests', { 'retry-after': '30' }))).toEqual(
+      { retryAfterMs: 30_000 }
+    );
+  });
+
+  it('treats a retry-after header alone as a trip even without the named message', () => {
+    // GitHub does not always name the limit; an explicit retry-after is an
+    // unambiguous "wait this long" and is enough on its own.
+    expect(parseSecondaryRateLimit(err(403, 'Forbidden', { 'retry-after': '12' }))).toEqual({
+      retryAfterMs: 12_000,
+    });
+  });
+
+  it('does NOT treat x-ratelimit-reset alone as a trip', () => {
+    // The anti-false-positive case: x-ratelimit-reset rides on nearly every
+    // GitHub response, an ordinary permissions 403 included. If it could
+    // DETECT, every 403 would be retried as though it were a rate limit.
+    expect(
+      parseSecondaryRateLimit(
+        err(403, 'Resource not accessible by integration', { 'x-ratelimit-reset': '2000' })
+      )
+    ).toBeNull();
+  });
+
+  it('sizes the wait from x-ratelimit-reset once the message names the limit', () => {
+    const nowMs = 1_900_000;
+    expect(
+      parseSecondaryRateLimit(
+        err(403, 'secondary rate limit', { 'x-ratelimit-reset': '2000' }),
+        nowMs
+      )
+    ).toEqual({ retryAfterMs: 100_000 });
+  });
+
+  it('prefers retry-after over x-ratelimit-reset when both are present', () => {
+    expect(
+      parseSecondaryRateLimit(
+        err(403, 'secondary rate limit', { 'retry-after': '5', 'x-ratelimit-reset': '999999' }),
+        0
+      )
+    ).toEqual({ retryAfterMs: 5_000 });
+  });
+
+  it('floors an already-past reset at 1s rather than retrying instantly', () => {
+    expect(
+      parseSecondaryRateLimit(
+        err(403, 'secondary rate limit', { 'x-ratelimit-reset': '1000' }),
+        5_000_000
+      )
+    ).toEqual({ retryAfterMs: 1000 });
+  });
+
+  it('caps an absurd retry-after so one bad header cannot park the job', () => {
+    expect(
+      parseSecondaryRateLimit(err(403, 'secondary rate limit', { 'retry-after': '9999' }))
+    ).toEqual({ retryAfterMs: 120_000 });
+  });
+
+  it('reads headers case-insensitively', () => {
+    expect(parseSecondaryRateLimit(err(429, 'slow down', { 'Retry-After': '7' }))).toEqual({
+      retryAfterMs: 7_000,
+    });
+  });
+
+  it('ignores a non-numeric retry-after and falls back to the default', () => {
+    expect(
+      parseSecondaryRateLimit(err(403, 'secondary rate limit', { 'retry-after': 'soon' }))
+    ).toEqual({ retryAfterMs: 60_000 });
+  });
+
+  it('returns null for statuses that are not 403/429', () => {
+    expect(parseSecondaryRateLimit(err(500, 'secondary rate limit'))).toBeNull();
+    expect(parseSecondaryRateLimit(err(404, 'Not Found'))).toBeNull();
+  });
+
+  it('returns null for an ordinary 403 with no limit signal at all', () => {
+    expect(parseSecondaryRateLimit(err(403, 'Must have admin rights to Repository'))).toBeNull();
+  });
+
+  it('returns null for non-object errors', () => {
+    expect(parseSecondaryRateLimit(null)).toBeNull();
+    expect(parseSecondaryRateLimit(undefined)).toBeNull();
+    expect(parseSecondaryRateLimit('secondary rate limit')).toBeNull();
   });
 });

--- a/packages/services/src/classmoji/__tests__/templateImport.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/templateImport.service.test.ts
@@ -18,6 +18,7 @@ const {
   formatTemplateRef,
   templateRefKey,
   groupTemplateRefs,
+  lookupKnownTemplate,
   templateNameCandidates,
   formatWarning,
   parseSecondaryRateLimit,
@@ -284,5 +285,38 @@ describe('parseSecondaryRateLimit', () => {
     expect(parseSecondaryRateLimit(null)).toBeNull();
     expect(parseSecondaryRateLimit(undefined)).toBeNull();
     expect(parseSecondaryRateLimit('secondary rate limit')).toBeNull();
+  });
+});
+
+describe('lookupKnownTemplate', () => {
+  const ref = { owner: 'src-org', name: 'lab1-template' };
+
+  it('returns the duplicate a previous run already made', () => {
+    expect(
+      lookupKnownTemplate({ 'src-org/lab1-template': 'lab1-template-26w' }, ref, 'tgt-org')
+    ).toBe('lab1-template-26w');
+  });
+
+  it('matches case-insensitively — a missed match would duplicate the template twice', () => {
+    expect(lookupKnownTemplate({ 'SRC-ORG/Lab1-Template': 'lab1-26w' }, ref, 'tgt-org')).toBe(
+      'lab1-26w'
+    );
+  });
+
+  it('resolves a bare key against the fallback owner', () => {
+    expect(lookupKnownTemplate({ 'lab1-template': 'lab1-26w' }, ref, 'src-org')).toBe('lab1-26w');
+    // Same bare key, but the fallback now names a different org — not a match.
+    expect(lookupKnownTemplate({ 'lab1-template': 'lab1-26w' }, ref, 'tgt-org')).toBeNull();
+  });
+
+  it('returns null for an unknown template, an absent map, or an empty name', () => {
+    expect(lookupKnownTemplate({ 'src-org/other': 'other-26w' }, ref, 'tgt-org')).toBeNull();
+    expect(lookupKnownTemplate(undefined, ref, 'tgt-org')).toBeNull();
+    expect(lookupKnownTemplate({}, ref, 'tgt-org')).toBeNull();
+    expect(lookupKnownTemplate({ 'src-org/lab1-template': '' }, ref, 'tgt-org')).toBeNull();
+  });
+
+  it('ignores unusable keys instead of throwing', () => {
+    expect(lookupKnownTemplate({ '': 'x', 'a/b/c': 'y' }, ref, 'tgt-org')).toBeNull();
   });
 });

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -241,12 +241,131 @@ export interface GitHubArtifact {
 }
 
 /**
+ * Pure helper: the duplicate-template repo names an import actually CREATED for
+ * this classroom, read out of its `ImportJob.progress`.
+ *
+ * PROVENANCE, never inference. A template repo is only ever deletable because
+ * THIS classroom's import made it — never because it merely looks unused or
+ * carries a familiar name. Reference-counting was considered and rejected: in a
+ * small org the only classroom referencing a hand-authored original would make
+ * that original look exclusive, and cleanup would destroy the instructor's real
+ * template. Naming heuristics are equally unsafe — a same-org duplicate is
+ * effectively always term-suffixed (the original name is taken), while a
+ * CROSS-ORG duplicate usually keeps the bare original name, so the two are
+ * indistinguishable by name alone.
+ *
+ * Reads `id_maps.templates` (canonical: source ref → created name) and the
+ * `template_map` alias, tolerating anything in the Json column — a row written
+ * by an older shape must degrade to "no template artifacts", never throw.
+ * A classroom with no ImportJob (every pre-feature classroom) yields none.
+ */
+export function importedTemplateRepoNames(progress: unknown): string[] {
+  if (!progress || typeof progress !== 'object') return [];
+  const record = progress as Record<string, unknown>;
+  const idMaps = record.id_maps;
+  const sources = [
+    idMaps && typeof idMaps === 'object'
+      ? (idMaps as Record<string, unknown>).templates
+      : undefined,
+    record.template_map,
+  ];
+
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const source of sources) {
+    if (!source || typeof source !== 'object') continue;
+    for (const value of Object.values(source as Record<string, unknown>)) {
+      if (typeof value !== 'string') continue;
+      const name = value.trim();
+      if (!name) continue;
+      const key = name.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Pure helper: the repo NAMES a set of stored `Repository.template` refs point
+ * at WITHIN `orgLogin`, de-duplicated case-insensitively (GitHub repo names and
+ * logins are case-insensitive; the first spelling seen wins).
+ *
+ * Two accepted ref shapes, matching what the app writes: the canonical
+ * owner-qualified `owner/name` (the repo-form autocomplete stores GitHub's
+ * `full_name`), and a bare `name` (accepted by `repo_create` over MCP), which
+ * resolves against the classroom's OWN org exactly as templateImport resolves
+ * it. A ref owned by any other account is somebody else's repo and is dropped.
+ *
+ * Used to work out which OTHER classrooms still point at a duplicate this
+ * classroom created — not to discover deletable repos on its own.
+ */
+export function ownedTemplateRepoNames(
+  templateRefs: ReadonlyArray<string | null | undefined>,
+  orgLogin: string
+): string[] {
+  const wantedOwner = orgLogin.toLowerCase();
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const ref of templateRefs) {
+    const segments = (ref ?? '')
+      .split('/')
+      .map(segment => segment.trim())
+      .filter(Boolean);
+    let name: string | null = null;
+    if (segments.length === 1) {
+      name = segments[0]!;
+    } else if (segments.length === 2 && segments[0]!.toLowerCase() === wantedOwner) {
+      name = segments[1]!;
+    }
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Pure helper: of the duplicate templates this classroom's import created, the
+ * ones no OTHER classroom in the org still points at.
+ *
+ * The safety guard on top of provenance: an instructor can relink a later
+ * term's assignment to a duplicate this classroom made, and deleting it would
+ * break that live classroom. Comparison is by resolved repo NAME within the
+ * org, so `org/lab1-26w` and a bare `lab1-26w` both count as a reference.
+ */
+export function exclusiveImportedTemplateNames({
+  createdNames,
+  otherClassroomTemplateRefs,
+  orgLogin,
+}: {
+  createdNames: string[];
+  otherClassroomTemplateRefs: ReadonlyArray<string | null | undefined>;
+  orgLogin: string;
+}): string[] {
+  const stillReferenced = new Set(
+    ownedTemplateRepoNames(otherClassroomTemplateRefs, orgLogin).map(name => name.toLowerCase())
+  );
+  return createdNames.filter(name => !stillReferenced.has(name.toLowerCase()));
+}
+
+/**
  * Pure helper: enumerate the GitHub artifacts a classroom owns, from DB-known
  * facts ONLY — the content repo (the classroom's STORED content_repo name),
  * the two conventional classroom teams ({slug}-students / {slug}-assistants),
- * any provider-backed project-team slugs, and the classroom's git repos by
- * exact recorded name. Nothing is pattern-matched or discovered live: if the
- * DB doesn't name it, it is not in the plan.
+ * any provider-backed project-team slugs, the classroom's git repos by exact
+ * recorded name, and the duplicate TEMPLATE repos its own import created (the
+ * caller supplies only those no other classroom in the org still references).
+ * Nothing is pattern-matched or discovered live: if the DB doesn't name it, it
+ * is not in the plan.
+ *
+ * Template repos are listed LAST among repos, and any name already claimed by
+ * the content repo or an assignment repo is dropped rather than listed twice —
+ * one repo must appear once, or the modal double-counts and the executor issues
+ * a pointless second DELETE.
  */
 export function classroomGitHubArtifactPlan({
   orgLogin,
@@ -254,24 +373,33 @@ export function classroomGitHubArtifactPlan({
   contentRepo,
   gitRepoNames,
   teamSlugs,
+  templateRepoNames = [],
 }: {
   orgLogin: string;
   slug: string;
   contentRepo: string | null;
   gitRepoNames: string[];
   teamSlugs: string[];
+  /** Import-created duplicate templates nothing else references (see exclusiveImportedTemplateNames). */
+  templateRepoNames?: string[];
 }): GitHubArtifact[] {
   const plan: GitHubArtifact[] = [];
+  const claimed = new Set<string>();
+  const pushRepo = (name: string, label: string) => {
+    const key = name.toLowerCase();
+    if (claimed.has(key)) return;
+    claimed.add(key);
+    plan.push({ kind: 'repo', org: orgLogin, name, label });
+  };
+
   if (contentRepo) {
-    plan.push({
-      kind: 'repo',
-      org: orgLogin,
-      name: contentRepo,
-      label: 'content repo',
-    });
+    pushRepo(contentRepo, 'content repo');
   }
-  for (const name of [...new Set(gitRepoNames)]) {
-    plan.push({ kind: 'repo', org: orgLogin, name, label: 'assignment repo' });
+  for (const name of gitRepoNames) {
+    pushRepo(name, 'assignment repo');
+  }
+  for (const name of templateRepoNames) {
+    pushRepo(name, 'template repo');
   }
   for (const suffix of ['students', 'assistants']) {
     plan.push({ kind: 'team', org: orgLogin, name: `${slug}-${suffix}`, label: 'classroom team' });
@@ -315,6 +443,10 @@ export const getClassroomGitHubArtifactPlan = async (
     include: {
       git_organization: true,
       git_repos: { select: { name: true } },
+      // Provenance for the template-repo artifacts: the duplicates THIS
+      // classroom's import created. The row survives until the delete cascade,
+      // and this plan always runs before it.
+      import_job: { select: { progress: true } },
       teams: {
         where: { provider: 'GITHUB', provider_id: { not: null } },
         select: { slug: true },
@@ -332,12 +464,34 @@ export const getClassroomGitHubArtifactPlan = async (
     };
   }
 
+  // Template duplicates this classroom's import created, minus any a DIFFERENT
+  // classroom in the org has since been relinked to. The `otherRefs` query is
+  // skipped entirely when the import created no templates — the common case.
+  const orgLogin = classroom.git_organization.login;
+  const createdTemplateNames = importedTemplateRepoNames(classroom.import_job?.progress);
+  const templateRepoNames = createdTemplateNames.length
+    ? exclusiveImportedTemplateNames({
+        createdNames: createdTemplateNames,
+        otherClassroomTemplateRefs: (
+          await getPrisma().repository.findMany({
+            where: {
+              classroom_id: { not: classroom.id },
+              classroom: { git_org_id: classroom.git_org_id },
+            },
+            select: { template: true },
+          })
+        ).map(row => row.template),
+        orgLogin,
+      })
+    : [];
+
   const artifacts = classroomGitHubArtifactPlan({
-    orgLogin: classroom.git_organization.login,
+    orgLogin,
     slug: classroom.slug,
     contentRepo: classroom.content_repo,
     gitRepoNames: classroom.git_repos.map(r => r.name),
     teamSlugs: classroom.teams.map(t => t.slug),
+    templateRepoNames,
   });
 
   if (!classroom.content_repo) {

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -38,7 +38,21 @@ const WARNING_DETAIL_MAX = 200;
 export interface ContentImportOptions {
   pages?: boolean;
   slides?: boolean;
+  /**
+   * Optional per-item progress. Invoked as each page/deck folder finishes
+   * READING (the slow, network-bound part) and once more after the DB rows
+   * land. Never awaited for correctness: the caller fires-and-forgets, so a
+   * progress failure can never fail an import.
+   */
+  onProgress?: (update: {
+    kind: 'pages' | 'slides';
+    done: number;
+    total: number;
+  }) => void | Promise<void>;
 }
+
+/** Named once so both per-type passes can take the same callback. */
+type ContentProgressFn = NonNullable<ContentImportOptions['onProgress']>;
 
 export interface ContentImportSummary {
   pages: number;
@@ -163,10 +177,7 @@ export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string
  * Apply `rewriteContentUrls` to the text files in a staged item's writes
  * (base64-decoded, rewritten, re-encoded); binaries pass through untouched.
  */
-export function rewriteStagedFiles(
-  files: BatchFile[],
-  ctx: UrlRewriteContext
-): BatchFile[] {
+export function rewriteStagedFiles(files: BatchFile[], ctx: UrlRewriteContext): BatchFile[] {
   return files.map(file => {
     if (!isTextContentPath(file.path)) return file;
     const decoded = Buffer.from(file.content, 'base64').toString('utf8');
@@ -203,6 +214,23 @@ type WarnFn = (scope: string, detail: string) => void;
 
 function errText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Fire-and-forget progress. Progress reporting must never fail (or slow) an
+ * import, so the result is deliberately not awaited and every error is
+ * swallowed — including a synchronous throw from a bad callback.
+ */
+function emitProgress<T>(
+  onProgress: ((update: T) => void | Promise<void>) | undefined,
+  update: T
+): void {
+  if (!onProgress) return;
+  try {
+    void Promise.resolve(onProgress(update)).catch(() => {});
+  } catch {
+    // ignore
+  }
 }
 
 /**
@@ -386,6 +414,7 @@ export const importClassroomContent = async (
         commitMessage,
         warn,
         idMap: summary.page_id_map,
+        onProgress: opts.onProgress,
       });
       summary.pages = created;
       if (created > 0) createdAny = true;
@@ -404,6 +433,7 @@ export const importClassroomContent = async (
         commitMessage,
         warn,
         idMap: summary.slide_id_map,
+        onProgress: opts.onProgress,
       });
       summary.slides = created;
       if (created > 0) createdAny = true;
@@ -437,6 +467,7 @@ async function importPages({
   commitMessage,
   warn,
   idMap,
+  onProgress,
 }: {
   source: RepoContext;
   target: RepoContext;
@@ -444,11 +475,16 @@ async function importPages({
   commitMessage: string;
   warn: WarnFn;
   idMap: Record<string, string>;
+  onProgress?: ContentProgressFn;
 }): Promise<number> {
   const sourcePages = await getPrisma().page.findMany({
     where: { classroom_id: source.classroomId },
     orderBy: { created_at: 'asc' },
   });
+  // The real total lands before the empty-set return, so the bar sizes itself
+  // the moment the phase starts even when there is nothing to copy.
+  const total = sourcePages.length;
+  emitProgress(onProgress, { kind: 'pages', done: 0, total });
   if (sourcePages.length === 0) return 0;
 
   // Seed collision sets from existing TARGET rows.
@@ -460,47 +496,55 @@ async function importPages({
   const takenSlugs = new Set(targetPages.map(p => p.content_path.replace(/^pages\//, '')));
 
   const staged: StagedItem<SourcePage>[] = [];
+  let consumed = 0;
 
   for (const page of sourcePages) {
-    const base = routeSlug(page.title);
-    if (!base) {
-      warn('pages', `skipped "${page.title}" — title has no slug-able characters`);
-      continue;
-    }
-    const targetSlug = dedupe(base, takenSlugs, slugSuffix);
-    takenSlugs.add(targetSlug);
-    const targetTitle = dedupe(page.title, takenTitles, titleSuffix);
-    takenTitles.add(targetTitle);
-    const targetContentPath = `pages/${targetSlug}`;
-
-    let files: BatchFile[];
+    // `finally` owns the count, not the end of the body: every skip below is a
+    // `continue`, and `done` tracks source pages CONSUMED, not pages staged.
     try {
-      files = await collectFolderFiles({
-        source,
+      const base = routeSlug(page.title);
+      if (!base) {
+        warn('pages', `skipped "${page.title}" — title has no slug-able characters`);
+        continue;
+      }
+      const targetSlug = dedupe(base, takenSlugs, slugSuffix);
+      takenSlugs.add(targetSlug);
+      const targetTitle = dedupe(page.title, takenTitles, titleSuffix);
+      takenTitles.add(targetTitle);
+      const targetContentPath = `pages/${targetSlug}`;
+
+      let files: BatchFile[];
+      try {
+        files = await collectFolderFiles({
+          source,
+          sourcePath: page.content_path,
+          targetPath: targetContentPath,
+          scope: 'pages',
+          warn,
+        });
+      } catch (error: unknown) {
+        warn('pages', `skipped "${page.title}" — read failed: ${errText(error)}`);
+        continue;
+      }
+      if (files.length === 0) {
+        warn('pages', `skipped "${page.title}" — no files at ${page.content_path}`);
+        continue;
+      }
+      // Repoint absolute source-repo asset URLs at the copied files — otherwise
+      // deleting the source classroom (with GitHub cleanup) 404s every image.
+      files = rewriteStagedFiles(files, {
+        sourceLogin: source.login,
+        sourceRepo: source.repo,
         sourcePath: page.content_path,
+        targetLogin: target.login,
+        targetRepo: target.repo,
         targetPath: targetContentPath,
-        scope: 'pages',
-        warn,
       });
-    } catch (error: unknown) {
-      warn('pages', `skipped "${page.title}" — read failed: ${errText(error)}`);
-      continue;
+      staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath });
+    } finally {
+      consumed++;
+      emitProgress(onProgress, { kind: 'pages', done: consumed, total });
     }
-    if (files.length === 0) {
-      warn('pages', `skipped "${page.title}" — no files at ${page.content_path}`);
-      continue;
-    }
-    // Repoint absolute source-repo asset URLs at the copied files — otherwise
-    // deleting the source classroom (with GitHub cleanup) 404s every image.
-    files = rewriteStagedFiles(files, {
-      sourceLogin: source.login,
-      sourceRepo: source.repo,
-      sourcePath: page.content_path,
-      targetLogin: target.login,
-      targetRepo: target.repo,
-      targetPath: targetContentPath,
-    });
-    staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath });
   }
 
   if (staged.length === 0) return 0;
@@ -555,6 +599,9 @@ async function importPages({
       warn('pages', `DB row failed for "${item.targetTitle}": ${errText(error)}`);
     }
   }
+  // The phase is finished once the rows land — say so explicitly rather than
+  // leaving the bar on whatever the last staging tick reported.
+  emitProgress(onProgress, { kind: 'pages', done: total, total });
   return created;
 }
 
@@ -567,6 +614,7 @@ async function importSlides({
   commitMessage,
   warn,
   idMap,
+  onProgress,
 }: {
   source: RepoContext;
   target: RepoContext;
@@ -574,11 +622,15 @@ async function importSlides({
   commitMessage: string;
   warn: WarnFn;
   idMap: Record<string, string>;
+  onProgress?: ContentProgressFn;
 }): Promise<number> {
   const sourceSlides = await getPrisma().slide.findMany({
     where: { classroom_id: source.classroomId },
     orderBy: { created_at: 'asc' },
   });
+  // Same as pages: the real total before the empty-set return.
+  const total = sourceSlides.length;
+  emitProgress(onProgress, { kind: 'slides', done: 0, total });
   if (sourceSlides.length === 0) return 0;
 
   // Slides carry a [classroom_id, slug] unique constraint — slug drives both the
@@ -590,51 +642,59 @@ async function importSlides({
   const takenSlugs = new Set(targetSlides.map(s => s.slug));
 
   const staged: StagedItem<SourceSlide>[] = [];
+  let consumed = 0;
 
   for (const slide of sourceSlides) {
-    const base = routeSlug(slide.title);
-    if (!base) {
-      warn('slides', `skipped "${slide.title}" — title has no slug-able characters`);
-      continue;
-    }
-    const targetSlug = dedupe(base, takenSlugs, slugSuffix);
-    takenSlugs.add(targetSlug);
-    const targetContentPath = `slides/${targetSlug}`;
-
-    let files: BatchFile[];
+    // `finally` owns the count, not the end of the body: every skip below is a
+    // `continue`, and `done` tracks source decks CONSUMED, not decks staged.
     try {
-      files = await collectFolderFiles({
-        source,
+      const base = routeSlug(slide.title);
+      if (!base) {
+        warn('slides', `skipped "${slide.title}" — title has no slug-able characters`);
+        continue;
+      }
+      const targetSlug = dedupe(base, takenSlugs, slugSuffix);
+      takenSlugs.add(targetSlug);
+      const targetContentPath = `slides/${targetSlug}`;
+
+      let files: BatchFile[];
+      try {
+        files = await collectFolderFiles({
+          source,
+          sourcePath: slide.content_path,
+          targetPath: targetContentPath,
+          scope: 'slides',
+          warn,
+        });
+      } catch (error: unknown) {
+        warn('slides', `skipped "${slide.title}" — read failed: ${errText(error)}`);
+        continue;
+      }
+      if (files.length === 0) {
+        warn('slides', `skipped "${slide.title}" — no files at ${slide.content_path}`);
+        continue;
+      }
+      // Repoint absolute source-repo asset URLs at the copied files (deck.json +
+      // index.html are rewritten in lockstep, keeping the pair consistent).
+      files = rewriteStagedFiles(files, {
+        sourceLogin: source.login,
+        sourceRepo: source.repo,
         sourcePath: slide.content_path,
+        targetLogin: target.login,
+        targetRepo: target.repo,
         targetPath: targetContentPath,
-        scope: 'slides',
-        warn,
       });
-    } catch (error: unknown) {
-      warn('slides', `skipped "${slide.title}" — read failed: ${errText(error)}`);
-      continue;
+      staged.push({
+        source: slide,
+        files,
+        targetTitle: slide.title,
+        targetSlug,
+        targetContentPath,
+      });
+    } finally {
+      consumed++;
+      emitProgress(onProgress, { kind: 'slides', done: consumed, total });
     }
-    if (files.length === 0) {
-      warn('slides', `skipped "${slide.title}" — no files at ${slide.content_path}`);
-      continue;
-    }
-    // Repoint absolute source-repo asset URLs at the copied files (deck.json +
-    // index.html are rewritten in lockstep, keeping the pair consistent).
-    files = rewriteStagedFiles(files, {
-      sourceLogin: source.login,
-      sourceRepo: source.repo,
-      sourcePath: slide.content_path,
-      targetLogin: target.login,
-      targetRepo: target.repo,
-      targetPath: targetContentPath,
-    });
-    staged.push({
-      source: slide,
-      files,
-      targetTitle: slide.title,
-      targetSlug,
-      targetContentPath,
-    });
   }
 
   if (staged.length === 0) return 0;
@@ -676,5 +736,7 @@ async function importSlides({
       warn('slides', `DB row failed for "${item.targetTitle}": ${errText(error)}`);
     }
   }
+  // The phase is finished once the rows land — same closing tick as pages.
+  emitProgress(onProgress, { kind: 'slides', done: total, total });
   return created;
 }

--- a/packages/services/src/classmoji/importProgress.ts
+++ b/packages/services/src/classmoji/importProgress.ts
@@ -89,6 +89,28 @@ export interface CountedPhaseProgress {
   note?: string;
 }
 
+/**
+ * Source id → new id, per entity kind, accumulated ACROSS phases.
+ *
+ * Two jobs, both load-bearing:
+ *  - HAND-OFF: the modules phase remaps module items onto ids minted by earlier
+ *    phases (repositories/quizzes in the synchronous action, pages/slides in the
+ *    content task). Carrying them on the row is what lets those phases run in
+ *    separate task runs with no shared memory.
+ *  - RESUME: a retried run skips source items already present here, so a phase
+ *    that died halfway does not duplicate what it already created.
+ *
+ * `templates` is keyed by source template ref (`owner/name`) rather than an id,
+ * matching `TemplateDuplicationSummary.template_map`.
+ */
+export interface ImportIdMaps {
+  repositories?: Record<string, string>;
+  quizzes?: Record<string, string>;
+  pages?: Record<string, string>;
+  slides?: Record<string, string>;
+  templates?: Record<string, string>;
+}
+
 export interface ImportProgress {
   phases: {
     config: SummaryPhaseProgress;
@@ -104,6 +126,37 @@ export interface ImportProgress {
    * one place — the same parts the old synchronous action returned inline.
    */
   parts?: string[];
+  /** See ImportIdMaps — cross-phase hand-off plus resume skip-sets. */
+  id_maps?: ImportIdMaps;
+  /**
+   * What each finished phase actually imported, accumulated as the run goes.
+   * The action seeds the phases it ran synchronously; the task adds its own.
+   * `buildSummaryParts` turns this into the final success line — which is why
+   * it has to survive on the row rather than living in one phase's memory.
+   */
+  counts?: ImportSummaryCounts;
+}
+
+/**
+ * A verbatim snapshot of the `importConfig` the create-classroom request
+ * carried, stored on `ImportJob.selections`.
+ *
+ * The task reads its WHOLE input from this row, which is what keeps the trigger
+ * payload a bare `{ importJobId }` and the run replayable. `config` and
+ * `repositories` describe phases the action already ran synchronously — they
+ * are kept for the record (and for a future resume of those phases), not re-run.
+ */
+export interface ImportJobSelections {
+  /** ClassroomSettings groups, as the create-classroom form posts them. */
+  config?: Record<string, boolean>;
+  /** Source repository ids the user picked, with their per-repo quiz flag. */
+  repositories?: Array<{ id: string; includeQuizzes?: boolean }>;
+  content?: {
+    pages?: boolean;
+    slides?: boolean;
+    modules?: boolean;
+    duplicateTemplates?: boolean;
+  };
 }
 
 /** Which phases the user actually asked for. Unselected phases start `skipped`. */
@@ -236,6 +289,102 @@ export function applyPhaseUpdates(
 /** Attach the final success-message parts (returns a new object). */
 export function withSummaryParts(progress: ImportProgress, parts: string[]): ImportProgress {
   return { ...progress, parts };
+}
+
+/** Every kind an ImportIdMaps can carry, so merges iterate one list. */
+const ID_MAP_KINDS: readonly (keyof ImportIdMaps)[] = [
+  'repositories',
+  'quizzes',
+  'pages',
+  'slides',
+  'templates',
+];
+
+/**
+ * Merge id-map entries into `progress.id_maps` (returns a new object; neither
+ * input is mutated).
+ *
+ * Merge, never replace: a phase only ever knows about the ids IT minted, and
+ * blowing away another phase's entries would break both the modules hand-off
+ * and the resume skip-sets. Later entries win per key, which makes a re-run of
+ * the same item idempotent rather than duplicative.
+ */
+export function withIdMaps(progress: ImportProgress, maps: ImportIdMaps): ImportProgress {
+  const merged: ImportIdMaps = { ...progress.id_maps };
+  for (const kind of ID_MAP_KINDS) {
+    const incoming = maps[kind];
+    if (!incoming) continue;
+    merged[kind] = { ...merged[kind], ...incoming };
+  }
+  return { ...progress, id_maps: merged };
+}
+
+/** The ids of one kind already imported — the resume skip-set for that phase. */
+export function importedSourceIds(
+  progress: ImportProgress,
+  kind: keyof ImportIdMaps
+): ReadonlySet<string> {
+  return new Set(Object.keys(progress.id_maps?.[kind] ?? {}));
+}
+
+/**
+ * Merge counted results into `progress.counts` (returns a new object).
+ *
+ * Patch, not replace: each phase only reports what IT imported, and the final
+ * success line is the union. A repeated key overwrites rather than adds, so a
+ * resumed phase that re-reports its own total stays accurate instead of
+ * doubling.
+ */
+export function withCounts(progress: ImportProgress, patch: ImportSummaryCounts): ImportProgress {
+  return { ...progress, counts: { ...progress.counts, ...patch } };
+}
+
+/** Everything the final success line can mention. Every field optional/zeroed. */
+export interface ImportSummaryCounts {
+  repositories?: number;
+  assignments?: number;
+  quizzes?: number;
+  /** true when any ClassroomSettings field was actually copied. */
+  settings?: boolean;
+  /** emoji + letter-grade mappings, already summed. */
+  grade_mappings?: number;
+  calendar_events?: number;
+  pages?: number;
+  slides?: number;
+  modules?: number;
+  duplicated_templates?: number;
+}
+
+/** `1 page` / `3 pages` — irregular plurals passed explicitly. */
+function plural(n: number, singular: string, pluralForm = `${singular}s`): string {
+  return `${n} ${n === 1 ? singular : pluralForm}`;
+}
+
+/**
+ * The final success-message fragments, in the order the synchronous action used
+ * to emit them ("Classroom created with <parts joined by ', '> imported!").
+ *
+ * Pure and unit-tested here rather than in the banner, because the phases that
+ * produce these counts now finish in a background task long after the action
+ * returned — the wording has to be built somewhere both sides agree on.
+ * A zero/absent count contributes NOTHING: a run that imported no quizzes must
+ * not claim "0 quizzes".
+ */
+export function buildSummaryParts(counts: ImportSummaryCounts): string[] {
+  const parts: string[] = [];
+  if (counts.repositories) parts.push(plural(counts.repositories, 'repository', 'repositories'));
+  if (counts.assignments) parts.push(plural(counts.assignments, 'assignment'));
+  if (counts.quizzes) parts.push(plural(counts.quizzes, 'quiz', 'quizzes'));
+  if (counts.settings) parts.push('settings');
+  if (counts.grade_mappings) parts.push(plural(counts.grade_mappings, 'grade mapping'));
+  if (counts.calendar_events) parts.push(plural(counts.calendar_events, 'calendar event'));
+  if (counts.pages) parts.push(plural(counts.pages, 'page'));
+  if (counts.slides) parts.push(plural(counts.slides, 'slide deck'));
+  if (counts.modules) parts.push(plural(counts.modules, 'module'));
+  if (counts.duplicated_templates) {
+    parts.push(plural(counts.duplicated_templates, 'duplicated template'));
+  }
+  return parts;
 }
 
 /**

--- a/packages/services/src/classmoji/importProgress.ts
+++ b/packages/services/src/classmoji/importProgress.ts
@@ -1,0 +1,267 @@
+/**
+ * importProgress.ts — the shape of `ImportJob.progress` plus the pure builders
+ * and reducer that produce it.
+ *
+ * Lives in @classmoji/services (not beside any one consumer) because the
+ * producers and the readers are in different packages: whatever seeds the row
+ * and whatever advances it run server-side, while the progress UI renders the
+ * same JSON in the browser. One definition is what stops them drifting.
+ *
+ * Everything here is PURE — no DB, no GitHub, no clock, and no imports at all,
+ * so it is safe to pull into a client bundle (exported as
+ * `@classmoji/services/import-progress`; the package root barrel drags octokit
+ * and cheerio in and must not be imported from a component).
+ *
+ * The intended write pattern: the writer owns the canonical progress object in
+ * memory and persists it WHOLESALE. These helpers only ever compute a NEW
+ * object from an old one, so a persist can never read-modify-write (and lose) a
+ * concurrent phase update.
+ *
+ * Phase keys vs the `ImportJob.phase` column: the column is coarse
+ * (config|repositories|templates|content|modules — what the user is told is
+ * happening), while progress carries `pages` and `slides` as SEPARATE counted
+ * phases. One column value, `content`, covers both — see CONTENT_PHASE_KEYS.
+ */
+
+/** Per-phase lifecycle. `skipped` means the user never selected that phase. */
+export type ImportPhaseStatus = 'pending' | 'running' | 'done' | 'skipped' | 'failed';
+
+/** The coarse phase names stored on `ImportJob.phase`. */
+export type ImportPhaseName = 'config' | 'repositories' | 'templates' | 'content' | 'modules';
+
+/** Every phase tracked inside `progress.phases`. */
+export type ImportPhaseKey =
+  | 'config'
+  | 'repositories'
+  | 'templates'
+  | 'pages'
+  | 'slides'
+  | 'modules';
+
+/** The progress phases the coarse `content` phase expands into. */
+export const CONTENT_PHASE_KEYS = ['pages', 'slides'] as const;
+
+/** Phases reported as one line — no per-item count is meaningful for them. */
+export const SUMMARY_PHASE_KEYS = ['config', 'modules'] as const;
+
+/** Phases long enough to deserve a done/total bar. */
+export const COUNTED_PHASE_KEYS = ['repositories', 'templates', 'pages', 'slides'] as const;
+
+/** Stable render order for the per-phase breakdown. */
+export const IMPORT_PHASE_ORDER: readonly ImportPhaseKey[] = [
+  'config',
+  'repositories',
+  'templates',
+  'pages',
+  'slides',
+  'modules',
+];
+
+/** Human labels for the progress UI (kept beside the order so they can't diverge). */
+export const IMPORT_PHASE_LABELS: Record<ImportPhaseKey, string> = {
+  config: 'Settings, scales & calendar',
+  repositories: 'Repositories',
+  templates: 'Template repositories',
+  pages: 'Pages',
+  slides: 'Slide decks',
+  modules: 'Modules',
+};
+
+/**
+ * A phase reported as a single line.
+ *
+ * `note` is TRANSIENT operator-facing status for a phase that is still running
+ * — most importantly "waiting out GitHub rate limit (~Ns)". Without it a
+ * rate-limit backoff looks identical to a hang, which is the exact failure this
+ * feature exists to make visible.
+ */
+export interface SummaryPhaseProgress {
+  status: ImportPhaseStatus;
+  summary?: string;
+  note?: string;
+}
+
+/** A phase with fine-grained per-item counts. */
+export interface CountedPhaseProgress {
+  status: ImportPhaseStatus;
+  done: number;
+  total: number;
+  note?: string;
+}
+
+export interface ImportProgress {
+  phases: {
+    config: SummaryPhaseProgress;
+    repositories: CountedPhaseProgress;
+    templates: CountedPhaseProgress;
+    pages: CountedPhaseProgress;
+    slides: CountedPhaseProgress;
+    modules: SummaryPhaseProgress;
+  };
+  /**
+   * Final success-message parts, filled once at COMPLETED. Stored (rather than
+   * recomputed in the card) so the wording is built and unit-tested in exactly
+   * one place — the same parts the old synchronous action returned inline.
+   */
+  parts?: string[];
+}
+
+/** Which phases the user actually asked for. Unselected phases start `skipped`. */
+export interface ImportPhaseSelections {
+  config?: boolean;
+  repositories?: boolean;
+  templates?: boolean;
+  pages?: boolean;
+  slides?: boolean;
+  modules?: boolean;
+}
+
+/**
+ * Totals known cheaply at seed time (the action counts source rows). Anything
+ * omitted starts at 0 and is filled in by the task when the phase begins.
+ */
+export interface ImportPhaseCounts {
+  repositories?: number;
+  templates?: number;
+  pages?: number;
+  slides?: number;
+}
+
+const countedPhase = (selected: boolean, total: number): CountedPhaseProgress => ({
+  status: selected ? 'pending' : 'skipped',
+  done: 0,
+  total: selected ? Math.max(0, Math.trunc(total)) : 0,
+});
+
+const summaryPhase = (selected: boolean): SummaryPhaseProgress => ({
+  status: selected ? 'pending' : 'skipped',
+});
+
+/**
+ * The progress skeleton for a freshly created ImportJob: every selected phase
+ * `pending`, every unselected phase `skipped`, counted phases seeded with
+ * whatever totals the caller could count cheaply.
+ */
+export function buildInitialProgress(
+  selections: ImportPhaseSelections = {},
+  counts: ImportPhaseCounts = {}
+): ImportProgress {
+  return {
+    phases: {
+      config: summaryPhase(!!selections.config),
+      repositories: countedPhase(!!selections.repositories, counts.repositories ?? 0),
+      templates: countedPhase(!!selections.templates, counts.templates ?? 0),
+      pages: countedPhase(!!selections.pages, counts.pages ?? 0),
+      slides: countedPhase(!!selections.slides, counts.slides ?? 0),
+      modules: summaryPhase(!!selections.modules),
+    },
+  };
+}
+
+/**
+ * One phase mutation. Every field is optional so callers patch only what they
+ * know: a per-item callback sends `{ done }`, a phase start sends
+ * `{ status: 'running', total }`, a backoff sends `{ note }`.
+ *
+ * `note: null` CLEARS the note (a plain `undefined` leaves it alone) — that is
+ * how a phase drops its "waiting out GitHub rate limit" line once it resumes.
+ * `done`/`summary` are ignored for phases that have no such field, so a caller
+ * can hand the same patch shape to any phase.
+ */
+export interface ImportPhaseUpdate {
+  phase: ImportPhaseKey;
+  status?: ImportPhaseStatus;
+  done?: number;
+  total?: number;
+  summary?: string;
+  note?: string | null;
+}
+
+const isCountedKey = (key: ImportPhaseKey): key is (typeof COUNTED_PHASE_KEYS)[number] =>
+  (COUNTED_PHASE_KEYS as readonly string[]).includes(key);
+
+/** Apply `note` (undefined = leave, null = clear) to a phase patch. */
+function applyNote<T extends { note?: string }>(next: T, note: string | null | undefined): T {
+  if (note === undefined) return next;
+  if (note === null) {
+    delete next.note;
+    return next;
+  }
+  next.note = note;
+  return next;
+}
+
+/**
+ * Return a NEW progress object with one phase patched. Pure: the input is never
+ * mutated, so the task can keep the canonical object and swap it atomically.
+ *
+ * `done` is clamped to >= 0 and, once a total is known, never exceeds it — a
+ * bar that reads 13/12 reads as a bug to the person watching it.
+ */
+export function applyPhaseUpdate(
+  progress: ImportProgress,
+  update: ImportPhaseUpdate
+): ImportProgress {
+  const { phase } = update;
+  const phases = { ...progress.phases };
+
+  if (isCountedKey(phase)) {
+    const current = progress.phases[phase];
+    const next: CountedPhaseProgress = { ...current };
+    if (update.status !== undefined) next.status = update.status;
+    if (update.total !== undefined) next.total = Math.max(0, Math.trunc(update.total));
+    if (update.done !== undefined) next.done = Math.max(0, Math.trunc(update.done));
+    // Clamp AFTER both, so a patch that raises total and done together works.
+    if (next.total > 0) next.done = Math.min(next.done, next.total);
+    phases[phase] = applyNote(next, update.note);
+  } else {
+    const current = progress.phases[phase];
+    const next: SummaryPhaseProgress = { ...current };
+    if (update.status !== undefined) next.status = update.status;
+    if (update.summary !== undefined) next.summary = update.summary;
+    phases[phase] = applyNote(next, update.note);
+  }
+
+  return { ...progress, phases };
+}
+
+/** Apply several phase patches in order (same purity guarantee). */
+export function applyPhaseUpdates(
+  progress: ImportProgress,
+  updates: readonly ImportPhaseUpdate[]
+): ImportProgress {
+  return updates.reduce(applyPhaseUpdate, progress);
+}
+
+/** Attach the final success-message parts (returns a new object). */
+export function withSummaryParts(progress: ImportProgress, parts: string[]): ImportProgress {
+  return { ...progress, parts };
+}
+
+/**
+ * Overall completion as a 0-100 integer, for the single top-level bar.
+ *
+ * Counted phases contribute their real done/total ratio; summary phases are
+ * all-or-nothing. `skipped` phases are excluded from the denominator entirely,
+ * so an import of settings alone reaches 100%. A `failed` phase counts as
+ * finished — the run is over for it, and the bar must not stall at 80% forever.
+ */
+export function overallPercent(progress: ImportProgress): number {
+  let done = 0;
+  let total = 0;
+  for (const key of IMPORT_PHASE_ORDER) {
+    const phase = progress.phases[key];
+    if (phase.status === 'skipped') continue;
+    total += 1;
+    if (phase.status === 'done' || phase.status === 'failed') {
+      done += 1;
+      continue;
+    }
+    if (phase.status === 'running' && isCountedKey(key)) {
+      const counted = phase as CountedPhaseProgress;
+      if (counted.total > 0) done += Math.min(1, counted.done / counted.total);
+    }
+  }
+  if (total === 0) return 100;
+  return Math.round((done / total) * 100);
+}

--- a/packages/services/src/classmoji/repositoryImport.service.ts
+++ b/packages/services/src/classmoji/repositoryImport.service.ts
@@ -10,6 +10,23 @@ type SourceAssignmentWithLegacyFields = Prisma.AssignmentGetPayload<Record<strin
 };
 
 /**
+ * Fire-and-forget progress. Progress reporting must never fail (or slow) an
+ * import, so the result is deliberately not awaited and every error is
+ * swallowed — including a synchronous throw from a bad callback.
+ */
+function emitProgress<T>(
+  onProgress: ((update: T) => void | Promise<void>) | undefined,
+  update: T
+): void {
+  if (!onProgress) return;
+  try {
+    void Promise.resolve(onProgress(update)).catch(() => {});
+  } catch {
+    // ignore
+  }
+}
+
+/**
  * Clone or find an existing tag in the target classroom
  * @param {string} sourceTagId - Source tag ID
  * @param {string} targetClassroomId - Target classroom ID
@@ -270,14 +287,18 @@ export const cloneModule = async (
  * @param {boolean} [moduleConfigs[].includeQuizzes=false] - Include quizzes
  * @param {Object} [options] - Global options
  * @param {boolean} [options.stripDeadlines=true] - Remove deadline fields
+ * @param {Function} [options.onProgress] - Per-repository progress callback
  * @returns {Promise<Object>} - Summary of cloned items
  */
 export const cloneModulesWithRelations = async (
   targetClassroomId: string,
   moduleConfigs: Array<{ id: string; includeQuizzes?: boolean }>,
-  options: { stripDeadlines?: boolean } = {}
+  options: {
+    stripDeadlines?: boolean;
+    onProgress?: (update: { done: number; total: number }) => void | Promise<void>;
+  } = {}
 ) => {
-  const { stripDeadlines = true } = options;
+  const { stripDeadlines = true, onProgress } = options;
 
   return getPrisma().$transaction(async tx => {
     const results: {
@@ -300,7 +321,16 @@ export const cloneModulesWithRelations = async (
       },
     };
 
-    for (const config of moduleConfigs) {
+    // CONSTRAINT: this loop runs INSIDE an interactive transaction. The callback
+    // must never touch `tx` and is never awaited — awaiting a DB write here
+    // would stretch the transaction window and risk a transaction timeout, so
+    // progress is fire-and-forget (see emitProgress). Progress reported for
+    // repositories that later ROLL BACK is acceptable: the caller marks the
+    // whole phase failed on error, which supersedes any count it had shown.
+    const total = moduleConfigs.length;
+    emitProgress(onProgress, { done: 0, total });
+
+    for (const [index, config] of moduleConfigs.entries()) {
       const cloneResult = await cloneModule(
         config.id,
         targetClassroomId,
@@ -317,6 +347,7 @@ export const cloneModulesWithRelations = async (
       results.quizzes.push(...cloneResult.quizzes);
       Object.assign(results.idMaps.repositories, cloneResult.idMaps.repositories);
       Object.assign(results.idMaps.quizzes, cloneResult.idMaps.quizzes);
+      emitProgress(onProgress, { done: index + 1, total });
     }
 
     return results;

--- a/packages/services/src/classmoji/templateImport.service.ts
+++ b/packages/services/src/classmoji/templateImport.service.ts
@@ -37,6 +37,27 @@ const MAX_REPO_NAME_LENGTH = 100;
 /** Candidate names tried before giving up on a free name in the target org. */
 const MAX_NAME_CANDIDATES = 10;
 
+/**
+ * Minimum spacing between repository CREATE calls.
+ *
+ * GitHub enforces a secondary rate limit on content-creation requests
+ * (repo/issue/comment creates) that is far tighter than the 5000/hr primary
+ * limit and is not advertised in the rate-limit headers. Creating ~14 template
+ * duplicates back-to-back tripped it in production and wedged the next create
+ * in octokit's retry/backoff for over half an hour. In a background job with a
+ * progress bar, spacing the creates out is free; tripping the limit is not.
+ */
+const REPO_CREATE_SPACING_MS = 15_000;
+
+/** Retries for a create that trips the secondary limit before the item is given up on. */
+const MAX_SECONDARY_LIMIT_RETRIES = 3;
+
+/** Upper bound on an honored Retry-After, so one bad header cannot stall the job. */
+const MAX_RETRY_AFTER_MS = 120_000;
+
+/** Wait for a named secondary-limit trip that carries no header — GitHub's own advice. */
+const SECONDARY_LIMIT_DEFAULT_WAIT_MS = 60_000;
+
 export interface TemplateDuplicationSummary {
   /** distinct templates duplicated */
   duplicated: number;
@@ -45,6 +66,15 @@ export interface TemplateDuplicationSummary {
   /** source template ref (`owner/name`) → new repo name in the target org */
   template_map: Record<string, string>;
   warnings: string[];
+}
+
+export interface TemplateImportOptions {
+  onProgress?: (update: {
+    done: number;
+    total: number;
+    /** Transient status (e.g. a rate-limit wait). `null` clears it. */
+    note?: string | null;
+  }) => void | Promise<void>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -158,6 +188,68 @@ export function formatWarning(scope: string, detail: string): string {
   return `${scope}: ${trimmed}`;
 }
 
+/** Case-insensitive header read — octokit lowercases, other error shapes may not. */
+function readHeader(headers: Record<string, unknown>, name: string): unknown {
+  if (name in headers) return headers[name];
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === name) return value;
+  }
+  return undefined;
+}
+
+/** A numeric header value (octokit hands them back as strings), or null. */
+function headerNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Detect GitHub's secondary rate limit and the wait it asks for. Matches the
+ * documented shapes: a 403/429 whose message names the secondary limit or the
+ * abuse-detection mechanism, and/or a `retry-after` (seconds) or
+ * `x-ratelimit-reset` (epoch seconds) header. Returns null when the error is
+ * something else, so ordinary failures keep their existing per-item handling.
+ */
+export function parseSecondaryRateLimit(
+  error: unknown,
+  nowMs: number = Date.now()
+): { retryAfterMs: number } | null {
+  if (!error || typeof error !== 'object') return null;
+  const { status, message, response } = error as {
+    status?: unknown;
+    message?: unknown;
+    response?: { headers?: Record<string, unknown> | null } | null;
+  };
+  if (status !== 403 && status !== 429) return null;
+
+  const headers = response?.headers ?? {};
+  const retryAfterSeconds = headerNumber(readHeader(headers, 'retry-after'));
+  const text = typeof message === 'string' ? message.toLowerCase() : '';
+  const named = text.includes('secondary rate limit') || text.includes('abuse detection');
+
+  // `x-ratelimit-reset` rides on nearly every GitHub response, an ordinary
+  // permissions 403 included — it may SIZE the wait but must never be what
+  // detects one, or every 403 would be retried as if it were a rate limit.
+  if (!named && retryAfterSeconds === null) return null;
+
+  let waitMs: number | null = null;
+  if (retryAfterSeconds !== null) {
+    waitMs = retryAfterSeconds * 1000;
+  } else {
+    const resetSeconds = headerNumber(readHeader(headers, 'x-ratelimit-reset'));
+    if (resetSeconds !== null) waitMs = resetSeconds * 1000 - nowMs;
+  }
+  // The common shape is a named trip with no header at all: GitHub just says to
+  // wait a while, so fall back to the interval its own docs suggest.
+  if (waitMs === null) waitMs = SECONDARY_LIMIT_DEFAULT_WAIT_MS;
+
+  // Clamped both ways: a stale reset (already past) must still cost a real
+  // pause, and one absurd header must not park the job for an hour.
+  return { retryAfterMs: Math.min(Math.max(Math.round(waitMs), 1000), MAX_RETRY_AFTER_MS) };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Impl helpers (touch DB/GitHub — not unit-tested)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -179,6 +271,62 @@ type BatchFile = { path: string; content: string; encoding: 'base64' };
 
 function errText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** The only timers in this file: create pacing and secondary-limit backoff. */
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Fire-and-forget progress. Progress reporting must never fail (or slow) an
+ * import, so the result is deliberately not awaited and every error is
+ * swallowed — including a synchronous throw from a bad callback.
+ */
+function emitProgress<T>(
+  onProgress: ((update: T) => void | Promise<void>) | undefined,
+  update: T
+): void {
+  if (!onProgress) return;
+  try {
+    void Promise.resolve(onProgress(update)).catch(() => {});
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Create the duplicate repo, riding out GitHub's secondary rate limit instead
+ * of letting octokit's internal backoff swallow the run: a detected trip is
+ * reported as a NOTE on the still-running phase — a visible wait rather than a
+ * hang — then slept off and retried, up to MAX_SECONDARY_LIMIT_RETRIES times.
+ *
+ * Only the create is wrapped. The file reads and the uploadBatch keep their
+ * existing single-attempt handling, and once the retries are spent the ORIGINAL
+ * error is rethrown untouched so the per-template catch warns and skips exactly
+ * as it always has.
+ */
+async function createRepositoryWithBackoff({
+  provider,
+  orgLogin,
+  name,
+  onWait,
+}: {
+  provider: ReturnType<typeof getGitProvider>;
+  orgLogin: string;
+  name: string;
+  onWait: (note: string | null) => void;
+}): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await provider.createRepository(orgLogin, name, true);
+      return;
+    } catch (error: unknown) {
+      const limit = parseSecondaryRateLimit(error);
+      if (!limit || attempt >= MAX_SECONDARY_LIMIT_RETRIES) throw error;
+      onWait(`waiting out GitHub rate limit (~${Math.round(limit.retryAfterMs / 1000)}s)`);
+      await sleep(limit.retryAfterMs);
+      onWait(null);
+    }
+  }
 }
 
 /**
@@ -292,7 +440,7 @@ export const duplicateImportedTemplates = async (
   sourceClassroomId: string,
   targetClassroomId: string,
   importedRepositoryIds: string[],
-  _opts: Record<string, never> = {}
+  opts: TemplateImportOptions = {}
 ): Promise<TemplateDuplicationSummary> => {
   const warnings: string[] = [];
   const warn: WarnFn = (scope, detail) => {
@@ -344,114 +492,153 @@ export const duplicateImportedTemplates = async (
   if (scopedIds.length === 0) return summary;
 
   const groups = groupTemplateRefs(importedRows, sourceOrg?.login ?? targetOrg.login);
+
+  // The real total lands before the empty-set return, so the bar sizes itself
+  // the moment the phase starts even when there is nothing to duplicate.
+  const total = groups.length;
+  let consumed = 0;
+  /**
+   * Count/note emit for this phase. An omitted `note` LEAVES the current one
+   * alone (the progress reducer's convention); `null` clears it.
+   */
+  const emit = (note?: string | null) =>
+    emitProgress(opts.onProgress, { done: consumed, total, note });
+  emit();
+
   if (groups.length === 0) return summary;
 
   const targetProvider = getGitProvider(targetOrg);
   const targetNamespace = targetClassroom.content_namespace ?? '';
 
+  // Pacing is per RUN, not per template: the first create pays nothing, every
+  // later one waits out REPO_CREATE_SPACING_MS first.
+  let attemptedAnyCreate = false;
+
   for (const group of groups) {
-    const sourceRef = formatTemplateRef(group.ref);
-    const scope = `template ${sourceRef}`;
-
-    // Readable only through an installation this flow holds: the target org's,
-    // or the source classroom's. Anything else (a third org, a personal
-    // account) stays linked to the original.
-    const ownerLower = group.ref.owner.toLowerCase();
-    let readerOrg: GitOrgRecord | null = null;
-    if (ownerLower === targetOrg.login.toLowerCase()) {
-      readerOrg = targetOrg;
-    } else if (sourceOrg?.login && ownerLower === sourceOrg.login.toLowerCase()) {
-      readerOrg = sourceOrg.provider === 'GITHUB' ? sourceOrg : null;
-    }
-    if (!readerOrg) {
-      warn(scope, `not readable from ${targetOrg.login} — keeping the original link`);
-      continue;
-    }
-
+    // `finally` owns the count, not the end of the body: every skip below is a
+    // `continue`, and `done` tracks source templates CONSUMED, not duplicated.
     try {
-      // Distinguish a DELETED template from an empty one — a dangling ref is
-      // the exact failure this feature exists to stop repeating, so say so.
-      const readerProvider = readerOrg === targetOrg ? targetProvider : getGitProvider(readerOrg);
-      if (!(await readerProvider.repositoryExists(group.ref.owner, group.ref.name))) {
-        warn(scope, 'skipped — template repository no longer exists');
+      const sourceRef = formatTemplateRef(group.ref);
+      const scope = `template ${sourceRef}`;
+
+      // Readable only through an installation this flow holds: the target org's,
+      // or the source classroom's. Anything else (a third org, a personal
+      // account) stays linked to the original.
+      const ownerLower = group.ref.owner.toLowerCase();
+      let readerOrg: GitOrgRecord | null = null;
+      if (ownerLower === targetOrg.login.toLowerCase()) {
+        readerOrg = targetOrg;
+      } else if (sourceOrg?.login && ownerLower === sourceOrg.login.toLowerCase()) {
+        readerOrg = sourceOrg.provider === 'GITHUB' ? sourceOrg : null;
+      }
+      if (!readerOrg) {
+        warn(scope, `not readable from ${targetOrg.login} — keeping the original link`);
         continue;
       }
 
-      const { paths, exceededCap } = await listRepoFilePaths(
-        readerOrg,
-        group.ref.name,
-        MAX_TEMPLATE_FILES
-      );
-      if (exceededCap) {
-        warn(scope, `skipped — more than ${MAX_TEMPLATE_FILES} files`);
-        continue;
-      }
-      if (paths.length === 0) {
-        warn(scope, 'skipped — no readable files on the default branch');
-        continue;
-      }
-
-      const files = await readRepoFiles({
-        gitOrganization: readerOrg,
-        repo: group.ref.name,
-        paths,
-        scope,
-        warn,
-      });
-      if (files.length === 0) {
-        warn(scope, 'skipped — every file was unreadable or oversized');
-        continue;
-      }
-
-      const newName = await resolveFreeRepoName(
-        targetProvider,
-        targetOrg.login,
-        templateNameCandidates(group.ref.name, targetNamespace)
-      );
-      if (!newName) {
-        warn(scope, `skipped — no free repository name in ${targetOrg.login}`);
-        continue;
-      }
-
-      await targetProvider.createRepository(targetOrg.login, newName, true);
       try {
-        // The new repo has no commits: allowRootCommit seeds the initial commit
-        // (Contents API — the Git Data API 409s on an empty repo) and creates
-        // `main`, which becomes the default branch.
-        await ContentService.uploadBatch({
-          gitOrganization: targetOrg,
-          repo: newName,
-          files,
-          branch: 'main',
-          message: `Duplicated from ${sourceRef} for ${targetClassroom.slug}`,
-          allowRootCommit: true,
-        });
-      } catch (uploadError: unknown) {
-        // Drop the repo we just made rather than leave an empty shell behind —
-        // it has no commits, and the rows still point at the original template.
-        try {
-          await targetProvider.deleteRepository(targetOrg.login, newName);
-        } catch (cleanupError: unknown) {
-          warn(scope, `left an empty ${newName} behind: ${errText(cleanupError)}`);
+        // Distinguish a DELETED template from an empty one — a dangling ref is
+        // the exact failure this feature exists to stop repeating, so say so.
+        const readerProvider = readerOrg === targetOrg ? targetProvider : getGitProvider(readerOrg);
+        if (!(await readerProvider.repositoryExists(group.ref.owner, group.ref.name))) {
+          warn(scope, 'skipped — template repository no longer exists');
+          continue;
         }
-        throw uploadError;
-      }
 
-      const newRef = `${targetOrg.login}/${newName}`;
-      let relinked = 0;
-      for (const rawRef of group.rawRefs) {
-        const { count } = await getPrisma().repository.updateMany({
-          where: { id: { in: scopedIds }, template: rawRef },
-          data: { template: newRef },
+        const { paths, exceededCap } = await listRepoFilePaths(
+          readerOrg,
+          group.ref.name,
+          MAX_TEMPLATE_FILES
+        );
+        if (exceededCap) {
+          warn(scope, `skipped — more than ${MAX_TEMPLATE_FILES} files`);
+          continue;
+        }
+        if (paths.length === 0) {
+          warn(scope, 'skipped — no readable files on the default branch');
+          continue;
+        }
+
+        const files = await readRepoFiles({
+          gitOrganization: readerOrg,
+          repo: group.ref.name,
+          paths,
+          scope,
+          warn,
         });
-        relinked += count;
-      }
+        if (files.length === 0) {
+          warn(scope, 'skipped — every file was unreadable or oversized');
+          continue;
+        }
 
-      summary.duplicated++;
-      summary.relinked += relinked;
-      summary.template_map[sourceRef] = newName;
-    } catch (error: unknown) {
-      warn(scope, `duplication failed: ${errText(error)}`);
+        const newName = await resolveFreeRepoName(
+          targetProvider,
+          targetOrg.login,
+          templateNameCandidates(group.ref.name, targetNamespace)
+        );
+        if (!newName) {
+          warn(scope, `skipped — no free repository name in ${targetOrg.login}`);
+          continue;
+        }
+
+        // Pace BEFORE the retry loop, so a create that just slept off a
+        // rate-limit backoff is not made to wait all over again.
+        if (attemptedAnyCreate) {
+          emit('pacing repository creation to stay under GitHub limits');
+          await sleep(REPO_CREATE_SPACING_MS);
+          emit(null);
+        }
+        // Marked on ATTEMPT, not on success: a failed create still spends
+        // GitHub's content-creation budget, so the next one still gets paced.
+        attemptedAnyCreate = true;
+        await createRepositoryWithBackoff({
+          provider: targetProvider,
+          orgLogin: targetOrg.login,
+          name: newName,
+          onWait: emit,
+        });
+        try {
+          // The new repo has no commits: allowRootCommit seeds the initial commit
+          // (Contents API — the Git Data API 409s on an empty repo) and creates
+          // `main`, which becomes the default branch.
+          await ContentService.uploadBatch({
+            gitOrganization: targetOrg,
+            repo: newName,
+            files,
+            branch: 'main',
+            message: `Duplicated from ${sourceRef} for ${targetClassroom.slug}`,
+            allowRootCommit: true,
+          });
+        } catch (uploadError: unknown) {
+          // Drop the repo we just made rather than leave an empty shell behind —
+          // it has no commits, and the rows still point at the original template.
+          try {
+            await targetProvider.deleteRepository(targetOrg.login, newName);
+          } catch (cleanupError: unknown) {
+            warn(scope, `left an empty ${newName} behind: ${errText(cleanupError)}`);
+          }
+          throw uploadError;
+        }
+
+        const newRef = `${targetOrg.login}/${newName}`;
+        let relinked = 0;
+        for (const rawRef of group.rawRefs) {
+          const { count } = await getPrisma().repository.updateMany({
+            where: { id: { in: scopedIds }, template: rawRef },
+            data: { template: newRef },
+          });
+          relinked += count;
+        }
+
+        summary.duplicated++;
+        summary.relinked += relinked;
+        summary.template_map[sourceRef] = newName;
+      } catch (error: unknown) {
+        warn(scope, `duplication failed: ${errText(error)}`);
+      }
+    } finally {
+      consumed++;
+      emit();
     }
   }
 

--- a/packages/services/src/classmoji/templateImport.service.ts
+++ b/packages/services/src/classmoji/templateImport.service.ts
@@ -75,6 +75,18 @@ export interface TemplateImportOptions {
     /** Transient status (e.g. a rate-limit wait). `null` clears it. */
     note?: string | null;
   }) => void | Promise<void>;
+  /**
+   * Templates a PREVIOUS run of this same import already duplicated: source ref
+   * (`owner/name`) → the duplicate's name in the target org.
+   *
+   * Resume support. Duplicating a repo is not idempotent — a second run would
+   * mint `lab1-template-2` beside the perfectly good `lab1-template` the first
+   * run made, and burn a paced 15s create doing it. A ref listed here is
+   * RELINKED ONLY: the rows are repointed if they aren't already (a run that
+   * died between the create and the relink left them stale), and no GitHub call
+   * is made at all.
+   */
+  knownTemplateMap?: Readonly<Record<string, string>>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -151,6 +163,29 @@ export function groupTemplateRefs(
     groups.set(key, { ref, rawRefs: [raw] });
   }
   return [...groups.values()];
+}
+
+/**
+ * The already-made duplicate's name for `ref`, or null when this template has
+ * not been duplicated yet.
+ *
+ * Matched on `templateRefKey`, not on raw string equality: the map is written
+ * from `formatTemplateRef` output, but the rows it will be compared against can
+ * spell the same template with different casing (GitHub is case-insensitive),
+ * and a missed match would duplicate the template a second time.
+ */
+export function lookupKnownTemplate(
+  knownTemplateMap: Readonly<Record<string, string>> | undefined,
+  ref: TemplateRef,
+  fallbackOwner: string
+): string | null {
+  if (!knownTemplateMap) return null;
+  const wanted = templateRefKey(ref);
+  for (const [knownRef, newName] of Object.entries(knownTemplateMap)) {
+    const parsed = parseTemplateRef(knownRef, fallbackOwner);
+    if (parsed && templateRefKey(parsed) === wanted) return newName || null;
+  }
+  return null;
 }
 
 /**
@@ -493,6 +528,26 @@ export const duplicateImportedTemplates = async (
 
   const groups = groupTemplateRefs(importedRows, sourceOrg?.login ?? targetOrg.login);
 
+  /**
+   * Repoint every imported row that spells this template one of `rawRefs` at the
+   * duplicate `newName`, returning how many rows actually changed. Scoped to
+   * `scopedIds` (target-classroom rows only) — that scope is what keeps SOURCE
+   * rows untouched. A row already pointing at the new ref reports 0, which is
+   * what makes a resumed relink a no-op rather than a double count.
+   */
+  const relinkRows = async (rawRefs: string[], newName: string): Promise<number> => {
+    const newRef = `${targetOrg.login}/${newName}`;
+    let relinked = 0;
+    for (const rawRef of rawRefs) {
+      const { count } = await getPrisma().repository.updateMany({
+        where: { id: { in: scopedIds }, template: rawRef },
+        data: { template: newRef },
+      });
+      relinked += count;
+    }
+    return relinked;
+  };
+
   // The real total lands before the empty-set return, so the bar sizes itself
   // the moment the phase starts even when there is nothing to duplicate.
   const total = groups.length;
@@ -520,6 +575,23 @@ export const duplicateImportedTemplates = async (
     try {
       const sourceRef = formatTemplateRef(group.ref);
       const scope = `template ${sourceRef}`;
+
+      // Resume: a previous attempt of THIS import already duplicated this
+      // template. Repoint anything still stale (a run can die between the create
+      // and the relink) and move on — no GitHub call, no second copy, and none
+      // of the 15s create pacing. Counted as consumed by the `finally`, and
+      // reported in `template_map` so the caller's total stays right, but NOT
+      // as `duplicated`: this run did not duplicate it.
+      const knownName = lookupKnownTemplate(opts.knownTemplateMap, group.ref, targetOrg.login);
+      if (knownName) {
+        try {
+          summary.relinked += await relinkRows(group.rawRefs, knownName);
+          summary.template_map[sourceRef] = knownName;
+        } catch (error: unknown) {
+          warn(scope, `relink of the existing duplicate failed: ${errText(error)}`);
+        }
+        continue;
+      }
 
       // Readable only through an installation this flow holds: the target org's,
       // or the source classroom's. Anything else (a third org, a personal
@@ -620,18 +692,8 @@ export const duplicateImportedTemplates = async (
           throw uploadError;
         }
 
-        const newRef = `${targetOrg.login}/${newName}`;
-        let relinked = 0;
-        for (const rawRef of group.rawRefs) {
-          const { count } = await getPrisma().repository.updateMany({
-            where: { id: { in: scopedIds }, template: rawRef },
-            data: { template: newRef },
-          });
-          relinked += count;
-        }
-
         summary.duplicated++;
-        summary.relinked += relinked;
+        summary.relinked += await relinkRows(group.rawRefs, newName);
         summary.template_map[sourceRef] = newName;
       } catch (error: unknown) {
         warn(scope, `duplication failed: ${errText(error)}`);

--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -1,0 +1,251 @@
+/**
+ * cloneContentRepo.ts — copy a classroom's WHOLE content repository into a
+ * freshly created target content repo with one git clone and one force-push.
+ *
+ * Why not the Contents API: the per-file importer
+ * (`contentImport.importClassroomContent`) reads every page/deck folder file by
+ * file and writes them back through blob commits. On a real course that is
+ * hundreds of sequential round-trips against a ~1/sec limiter — a production
+ * import spent 40+ minutes in that phase. Git moves the same bytes in one
+ * transfer, so the copy takes a minute or two, and files over the Contents
+ * API's 1MB single-file read cap (previously skipped with a warning) come
+ * across intact.
+ *
+ * The clone is SHALLOW and its `.git` is discarded: the target gets a single
+ * fresh "Import content from <source>" commit, never the source repo's history.
+ * That is deliberate — a term rollover must not ship the previous term's
+ * deleted files, which a full-history copy would keep recoverable forever.
+ *
+ * Force-push is intended and safe here: the target content repo was created by
+ * this same import moments earlier (`ensureContentRepo`, which seeds an
+ * auto-init commit), so the only thing overwritten is that empty scaffold. This
+ * helper must never be pointed at a content repo with real content in it.
+ *
+ * Mirrors packages/tasks/src/helpers/createRepository.ts: simple-git with
+ * `x-access-token:<installation token>` clone URLs, and a `finally` that always
+ * removes the working directory.
+ */
+
+import { simpleGit } from 'simple-git';
+import { logger } from '@trigger.dev/sdk';
+import path from 'path';
+import fs from 'fs';
+
+import { ClassmojiService } from '@classmoji/services';
+
+/** Top-level folders the content repo organizes managed content under. */
+const PAGES_DIR = 'pages';
+const SLIDES_DIR = 'slides';
+
+/**
+ * The manifest is rebuilt wholesale from the TARGET's DB rows after the import
+ * (contentManifest.saveManifest), so copying the source's would publish the
+ * source classroom's ids until that ran — and leave them if it failed.
+ */
+const MANIFEST_PATH = path.join('.classmoji', 'manifest.json');
+
+/** Cap on a single file's in-memory URL rewrite. Content files are text, not datasets. */
+const MAX_REWRITE_BYTES = 5 * 1024 * 1024;
+
+export interface ContentRepoCoordinates {
+  orgLogin: string;
+  repo: string;
+  /** Installation access token for that org (gitProvider.getAccessToken()). */
+  token: string;
+}
+
+export interface CloneContentRepoPayload {
+  source: ContentRepoCoordinates;
+  target: ContentRepoCoordinates;
+  /** Drop the `pages/` tree when false (the user imported slides only). */
+  keepPages: boolean;
+  /** Drop the `slides/` tree when false. */
+  keepSlides: boolean;
+  commitMessage: string;
+  /** Coarse step reporting for the progress banner. Never awaited by callers. */
+  onStep?: (note: string) => void;
+}
+
+export interface CloneContentRepoResult {
+  /** false when the source repo had no commits — nothing to copy, not an error. */
+  pushed: boolean;
+  /** Files whose absolute source-repo URLs were repointed at the target repo. */
+  rewritten: number;
+  /** Files in the pushed tree (excluding .git). */
+  files: number;
+}
+
+const cloneUrl = ({ orgLogin, repo, token }: ContentRepoCoordinates): string =>
+  `https://x-access-token:${token}@github.com/${orgLogin}/${repo}.git`;
+
+/** Every file under `dir`, recursively, as absolute paths. Skips `.git`. */
+function listFilesRecursive(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '.git') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...listFilesRecursive(full));
+      continue;
+    }
+    if (entry.isFile()) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Repoint absolute source-repo asset URLs at the target repo, in place.
+ *
+ * Reuses the SAME pure helpers the per-file importer uses
+ * (`isTextContentPath` to keep binaries untouched, `rewriteContentUrls` to do
+ * the substitution), so both import paths rewrite identically.
+ *
+ * On a whole-repo copy the item folder path is IDENTICAL on both sides — this
+ * is a fresh repo, so nothing is renamed or dedupe-suffixed — which means only
+ * the org/repo segments of a URL actually change. The per-item path arguments
+ * are therefore passed as the same value; the helper's item-specific pass
+ * becomes a no-op and its repo-general pass does all the work.
+ */
+function rewriteAssetUrls({
+  root,
+  source,
+  target,
+}: {
+  root: string;
+  source: ContentRepoCoordinates;
+  target: ContentRepoCoordinates;
+}): { rewritten: number; files: number } {
+  const { rewriteContentUrls, isTextContentPath } = ClassmojiService.contentImport;
+  const files = listFilesRecursive(root);
+  let rewritten = 0;
+
+  for (const file of files) {
+    const relative = path.relative(root, file);
+    if (!isTextContentPath(relative)) continue;
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(file);
+    } catch {
+      continue;
+    }
+    if (stat.size > MAX_REWRITE_BYTES) {
+      logger.warn('content import: skipped URL rewrite for an oversized text file', {
+        file: relative,
+        size: stat.size,
+      });
+      continue;
+    }
+
+    const original = fs.readFileSync(file, 'utf8');
+    const updated = rewriteContentUrls(original, {
+      sourceLogin: source.orgLogin,
+      sourceRepo: source.repo,
+      sourcePath: '',
+      targetLogin: target.orgLogin,
+      targetRepo: target.repo,
+      targetPath: '',
+    });
+    if (updated === original) continue;
+    fs.writeFileSync(file, updated, 'utf8');
+    rewritten++;
+  }
+
+  return { rewritten, files: files.length };
+}
+
+/**
+ * Clone the source content repo, prune it to the selected content types, drop
+ * the stale manifest, repoint asset URLs, and force-push the result as a single
+ * commit onto the target repo's `main`.
+ *
+ * Idempotent by construction: re-running pushes the same tree to the same
+ * branch, so a retried import converges instead of duplicating anything.
+ */
+export const cloneContentRepo = async (
+  payload: CloneContentRepoPayload
+): Promise<CloneContentRepoResult> => {
+  const { source, target, keepPages, keepSlides, commitMessage, onStep } = payload;
+
+  // Unique per run: two imports in the same org must never share a directory.
+  const localPath = path.join(
+    process.cwd(),
+    'repos',
+    `content-import-${target.repo}-${Date.now()}`
+  );
+
+  try {
+    if (fs.existsSync(localPath)) {
+      fs.rmSync(localPath, { recursive: true, force: true });
+    }
+
+    onStep?.(`cloning ${source.orgLogin}/${source.repo}`);
+    // --depth 1: only the current tree is wanted, and the history is dropped
+    // below anyway. On a content repo with years of commits this is the
+    // difference between seconds and minutes.
+    await simpleGit().clone(cloneUrl(source), localPath, ['--depth', '1']);
+
+    const repoGit = simpleGit(localPath);
+    let sourceHasCommits = true;
+    try {
+      await repoGit.raw(['rev-parse', '--verify', 'HEAD']);
+    } catch {
+      sourceHasCommits = false;
+    }
+    if (!sourceHasCommits) {
+      logger.warn('content import: source content repo has no commits — nothing to copy', {
+        repo: `${source.orgLogin}/${source.repo}`,
+      });
+      return { pushed: false, rewritten: 0, files: 0 };
+    }
+
+    // Discard the source's history: the target gets one fresh commit.
+    fs.rmSync(path.join(localPath, '.git'), { recursive: true, force: true });
+
+    onStep?.('preparing content');
+    if (!keepPages) {
+      fs.rmSync(path.join(localPath, PAGES_DIR), { recursive: true, force: true });
+    }
+    if (!keepSlides) {
+      fs.rmSync(path.join(localPath, SLIDES_DIR), { recursive: true, force: true });
+    }
+    fs.rmSync(path.join(localPath, MANIFEST_PATH), { force: true });
+
+    const { rewritten, files } = rewriteAssetUrls({ root: localPath, source, target });
+    if (files === 0) {
+      logger.warn('content import: nothing left to push after pruning', {
+        repo: `${source.orgLogin}/${source.repo}`,
+        keepPages,
+        keepSlides,
+      });
+      return { pushed: false, rewritten: 0, files: 0 };
+    }
+
+    onStep?.(`pushing ${files} files to ${target.orgLogin}/${target.repo}`);
+    const freshGit = simpleGit(localPath);
+    await freshGit.init();
+    await freshGit.addConfig('user.name', 'Classmoji Bot');
+    await freshGit.addConfig('user.email', 'hello@classmoji.com');
+    // `git init` picks up the machine's init.defaultBranch, which is not
+    // guaranteed to be `main` — every consumer (Pages, the content readers)
+    // assumes `main`, so name it explicitly.
+    await freshGit.checkoutLocalBranch('main');
+    await freshGit.add('.');
+    await freshGit.commit(commitMessage);
+    await freshGit.addRemote('origin', cloneUrl(target));
+    // Overwrites ONLY the auto-init scaffold ensureContentRepo just created.
+    await freshGit.push('origin', 'main', ['--force']);
+
+    logger.info('content import: pushed content repo copy', {
+      from: `${source.orgLogin}/${source.repo}`,
+      to: `${target.orgLogin}/${target.repo}`,
+      files,
+      rewritten,
+    });
+
+    return { pushed: true, rewritten, files };
+  } finally {
+    if (fs.existsSync(localPath)) {
+      fs.rmSync(localPath, { recursive: true, force: true });
+    }
+  }
+};

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -10,6 +10,7 @@ import * as contributionTasks from './workflows/contribution.ts';
 import * as repoAnalyticsTasks from './workflows/repoAnalytics.ts';
 import * as notificationTasks from './workflows/notifications.ts';
 import * as importGithubClassroomTasks from './workflows/importGithubClassroom.ts';
+import * as classroomImportTasks from './workflows/classroomImport.ts';
 
 // comment to trigger a build
 
@@ -26,6 +27,7 @@ const Tasks = {
   ...repoAnalyticsTasks,
   ...notificationTasks,
   ...importGithubClassroomTasks,
+  ...classroomImportTasks,
 };
 
 export default Tasks;

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -1,0 +1,814 @@
+/**
+ * classroomImport.ts — the background half of "create a classroom from an
+ * existing one".
+ *
+ * The create-classroom action keeps only what finishes in seconds (the
+ * classroom/settings/membership transaction, the settings+scales+calendar copy,
+ * and the repository/assignment/quiz clone — all pure DB), then hands every
+ * GitHub-bound phase to this orchestrator and returns immediately. Before this
+ * existed the whole copy ran inside the request: a real course spent 40+
+ * minutes in it, with the browser watching a spinner and no way to tell a slow
+ * import from a dead one.
+ *
+ * Topology — one orchestrator, four children, each awaited in order:
+ *
+ *   classroom-import (orchestrator, maxAttempts 1, maxDuration 3600)
+ *     ├─ import-content-repo   provision the target content repo   (before templates)
+ *     ├─ import-templates      duplicate + relink template repos
+ *     ├─ import-content        clone/push the content repo, then Page/Slide rows
+ *     └─ import-modules        module containers, remapped onto every earlier id
+ *
+ * Children rather than inline steps because each is a separately retryable unit
+ * of work with its own failure surface, and because a child's output is visible
+ * per-phase in the Trigger.dev run tree. Every task is `maxAttempts: 1`: none of
+ * these phases is idempotent enough to replay blindly, so recovery is the
+ * explicit user-driven retry (which resumes, skipping phases already `done`).
+ *
+ * ALL task input comes from the `ImportJob` row, never the payload — the
+ * payload is a bare `{ importJobId }`. That is what makes a run replayable and
+ * what lets the retry endpoint resume a half-finished import by editing the row.
+ */
+
+import { task, logger } from '@trigger.dev/sdk';
+import getPrisma from '@classmoji/database';
+import { ClassmojiService, getGitProvider } from '@classmoji/services';
+/*
+ * The zero-import progress module, via its package subpath export. The eslint
+ * resolver here does not follow "exports" subpaths (the same reason
+ * trigger.config.js disables this rule); tsc and the bundler both resolve it.
+ */
+import {
+  applyPhaseUpdates,
+  buildSummaryParts,
+  importedSourceIds,
+  overallPercent,
+  withCounts,
+  withIdMaps,
+  withSummaryParts,
+  CONTENT_PHASE_KEYS,
+  type ImportIdMaps,
+  type ImportJobSelections,
+  type ImportPhaseUpdate,
+  type ImportProgress,
+  type ImportSummaryCounts,
+} from '@classmoji/services/import-progress'; // eslint-disable-line import/no-unresolved
+import { titleToIdentifier } from '@classmoji/utils';
+import { cloneContentRepo } from '../helpers/cloneContentRepo.ts';
+
+/**
+ * Minimum spacing between `progress` writes.
+ *
+ * The per-item callbacks fire far faster than anything needs to be persisted (a
+ * page-row loop can tick dozens of times a second), and every write is a row
+ * update the banner polls at 2s anyway. Debouncing to 1s keeps the bar live
+ * without turning progress reporting into the job's dominant DB load.
+ */
+const PROGRESS_WRITE_INTERVAL_MS = 1000;
+
+/** Cap on retained warnings, mirroring the services' own bound. */
+const MAX_WARNINGS = 50;
+
+type PrismaClient = ReturnType<typeof getPrisma>;
+
+/** The ImportJob row as every task here reads it, with the Json columns typed. */
+interface LoadedImportJob {
+  id: string;
+  classroom_id: string;
+  source_classroom_id: string;
+  requested_by: string;
+  status: string;
+  phase: string | null;
+  selections: ImportJobSelections;
+  progress: ImportProgress;
+  warnings: string[];
+}
+
+/**
+ * Load the job row and give its Json columns their real shapes. Throws when the
+ * row is gone — a run whose job was deleted (the classroom was removed
+ * mid-import) has nothing to do and nowhere to report.
+ */
+async function loadJob(prisma: PrismaClient, importJobId: string): Promise<LoadedImportJob> {
+  const job = await prisma.importJob.findUnique({ where: { id: importJobId } });
+  if (!job) {
+    throw new Error(`ImportJob ${importJobId} no longer exists`);
+  }
+  return {
+    id: job.id,
+    classroom_id: job.classroom_id,
+    source_classroom_id: job.source_classroom_id,
+    requested_by: job.requested_by,
+    status: job.status,
+    phase: job.phase,
+    selections: (job.selections ?? {}) as unknown as ImportJobSelections,
+    progress: (job.progress ?? {}) as unknown as ImportProgress,
+    warnings: (job.warnings ?? []) as unknown as string[],
+  };
+}
+
+/**
+ * Debounced, WHOLESALE writer for one job's `progress`.
+ *
+ * Owns the canonical progress object in memory and persists it entire, never
+ * read-modify-write: the pure reducer already guarantees a new object per
+ * patch, and a wholesale write cannot lose a field to a racing read. That is
+ * safe here because exactly one task writes a given job at a time —
+ * `triggerAndWait` serializes the children, and the orchestrator re-reads the
+ * row after each child returns rather than keeping a stale copy.
+ *
+ * Writes are spaced by PROGRESS_WRITE_INTERVAL_MS on a TRAILING timer, so a
+ * single late patch (a rate-limit note posted just after a write) still lands
+ * about a second later instead of waiting for the next patch — which for a 15s
+ * pacing sleep would be the whole point of the note, lost.
+ */
+class ProgressWriter {
+  readonly #prisma: PrismaClient;
+  readonly #jobId: string;
+  #progress: ImportProgress;
+  #warnings: string[];
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #lastWriteAt = 0;
+  #dirty = false;
+  #chain: Promise<void> = Promise.resolve();
+
+  constructor(prisma: PrismaClient, job: LoadedImportJob) {
+    this.#prisma = prisma;
+    this.#jobId = job.id;
+    this.#progress = job.progress;
+    this.#warnings = job.warnings;
+  }
+
+  get progress(): ImportProgress {
+    return this.#progress;
+  }
+
+  /** Patch one or more phases (counts, status, note). */
+  patch(...updates: ImportPhaseUpdate[]): void {
+    this.#progress = applyPhaseUpdates(this.#progress, updates);
+    this.#schedule();
+  }
+
+  /** Record ids this phase minted, for the modules hand-off and for resume. */
+  mergeIdMaps(maps: ImportIdMaps): void {
+    this.#progress = withIdMaps(this.#progress, maps);
+    this.#schedule();
+  }
+
+  /** Record what this phase imported, for the final success line. */
+  mergeCounts(counts: ImportSummaryCounts): void {
+    this.#progress = withCounts(this.#progress, counts);
+    this.#schedule();
+  }
+
+  /** Append best-effort per-item failures (bounded, same cap as the services). */
+  addWarnings(warnings: readonly string[]): void {
+    if (warnings.length === 0) return;
+    this.#warnings = [...this.#warnings, ...warnings].slice(0, MAX_WARNINGS);
+    this.#schedule();
+  }
+
+  #schedule(): void {
+    this.#dirty = true;
+    if (this.#timer) return;
+    const wait = Math.max(0, PROGRESS_WRITE_INTERVAL_MS - (Date.now() - this.#lastWriteAt));
+    this.#timer = setTimeout(() => {
+      this.#timer = null;
+      void this.#write();
+    }, wait);
+  }
+
+  /** Serialized so a timer write and a flush can never interleave. */
+  #write(): Promise<void> {
+    this.#chain = this.#chain.then(() => this.#persist());
+    return this.#chain;
+  }
+
+  async #persist(): Promise<void> {
+    if (!this.#dirty) return;
+    this.#dirty = false;
+    this.#lastWriteAt = Date.now();
+    const progress = this.#progress;
+    const warnings = this.#warnings;
+    try {
+      await this.#prisma.importJob.update({
+        where: { id: this.#jobId },
+        data: {
+          progress: progress as unknown as object,
+          warnings: warnings as unknown as object,
+        },
+      });
+    } catch (error: unknown) {
+      // Progress must never fail the import it is describing. Stay dirty so the
+      // next tick (or the awaited final flush) retries the same snapshot.
+      this.#dirty = true;
+      logger.warn('import progress write failed', { jobId: this.#jobId, error });
+    }
+  }
+
+  /**
+   * Persist immediately and await it. Every child calls this before returning,
+   * so the row is never left describing a phase that already finished.
+   */
+  async flush(): Promise<void> {
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+    this.#dirty = true;
+    await this.#write();
+  }
+}
+
+/**
+ * Fire-and-forget progress callback plumbing for the services, which invoke
+ * `onProgress` without awaiting it. Patching is synchronous (the writer batches
+ * the DB work itself), so nothing here can slow or fail an import.
+ */
+function phaseProgress(
+  writer: ProgressWriter,
+  phase: ImportPhaseUpdate['phase']
+): (update: { done: number; total: number; note?: string | null }) => void {
+  return ({ done, total, note }) => {
+    writer.patch({ phase, status: 'running', done, total, note });
+  };
+}
+
+/**
+ * Re-verify that the requester still OWNS the source classroom, at the moment
+ * the copy actually happens.
+ *
+ * Defense in depth: the create-classroom action already checked this before
+ * creating the row, but the copy now runs later, in a different process, from
+ * data on a row. Ownership can be revoked in between, and settings can carry
+ * API keys — so the task refuses rather than trusting its own input.
+ */
+async function assertSourceOwnership(prisma: PrismaClient, job: LoadedImportJob): Promise<void> {
+  const membership = await prisma.classroomMembership.findFirst({
+    where: {
+      classroom_id: job.source_classroom_id,
+      user_id: job.requested_by,
+      role: 'OWNER',
+    },
+    select: { id: true },
+  });
+  if (!membership) {
+    throw new Error('Requester no longer owns the source classroom — import refused');
+  }
+}
+
+/** A classroom's org login + content repo, or null when either is unconfigured. */
+async function contentRepoCoordinates(
+  prisma: PrismaClient,
+  classroomId: string
+): Promise<{ orgLogin: string; repo: string; token: string } | null> {
+  const classroom = await prisma.classroom.findUnique({
+    where: { id: classroomId },
+    include: { git_organization: true },
+  });
+  const org = classroom?.git_organization;
+  if (!classroom || !org?.login || !classroom.content_repo) return null;
+  const token = await getGitProvider(org).getAccessToken();
+  return { orgLogin: org.login, repo: classroom.content_repo, token };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Children
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Provision the TARGET content repo, before anything wants to write to it.
+ *
+ * Runs ahead of templates deliberately: repo creation is the operation GitHub's
+ * secondary rate limit punishes, and the content repo is the one the rest of
+ * the import cannot proceed without. Idempotent (ensureContentRepo adopts an
+ * existing repo), so a resumed run simply re-confirms it.
+ */
+export const importContentRepoTask = task({
+  id: 'import-content-repo',
+  retry: { maxAttempts: 1 },
+  maxDuration: 600,
+  run: async ({ importJobId }: { importJobId: string }) => {
+    const prisma = getPrisma();
+    const job = await loadJob(prisma, importJobId);
+    const writer = new ProgressWriter(prisma, job);
+
+    // The content phases own this step: it has no chip of its own, and a
+    // failure here is a content failure as far as the user is concerned.
+    const running = CONTENT_PHASE_KEYS.filter(
+      key => job.progress.phases[key]?.status !== 'skipped'
+    );
+    writer.patch(
+      ...running.map(phase => ({
+        phase,
+        status: 'running' as const,
+        note: 'preparing the content repository',
+      }))
+    );
+    await writer.flush();
+
+    try {
+      const { repoName } = await ClassmojiService.page.ensureContentRepo(job.classroom_id);
+      logger.info('import: content repo ready', { repo: repoName });
+      return { repo: repoName };
+    } finally {
+      writer.patch(...running.map(phase => ({ phase, note: null })));
+      await writer.flush();
+    }
+  },
+});
+
+/**
+ * Duplicate the template repos the imported assignments point at, into the
+ * target org, and repoint the imported rows at the copies.
+ *
+ * The slowest phase by design: creates are paced 15s apart to stay under
+ * GitHub's secondary content-creation limit (see templateImport.service), and
+ * that pacing surfaces as a phase note so the wait reads as a wait.
+ */
+export const importTemplatesTask = task({
+  id: 'import-templates',
+  retry: { maxAttempts: 1 },
+  // Pacing alone costs 15s per template, and a tripped secondary limit adds up
+  // to 3 backoffs of up to 2 minutes each — well past the 900s config default.
+  maxDuration: 3600,
+  run: async ({ importJobId }: { importJobId: string }) => {
+    const prisma = getPrisma();
+    const job = await loadJob(prisma, importJobId);
+    const writer = new ProgressWriter(prisma, job);
+
+    const importedRepositoryIds = Object.values(job.progress.id_maps?.repositories ?? {});
+    writer.patch({ phase: 'templates', status: 'running' });
+
+    const summary = await ClassmojiService.templateImport.duplicateImportedTemplates(
+      job.source_classroom_id,
+      job.classroom_id,
+      importedRepositoryIds,
+      {
+        onProgress: phaseProgress(writer, 'templates'),
+        // Resume: templates a previous attempt already duplicated are relinked,
+        // not made a second time.
+        knownTemplateMap: job.progress.id_maps?.templates ?? {},
+      }
+    );
+
+    writer.mergeIdMaps({ templates: summary.template_map });
+    writer.mergeCounts({
+      duplicated_templates: Object.keys({
+        ...job.progress.id_maps?.templates,
+        ...summary.template_map,
+      }).length,
+    });
+    writer.addWarnings(summary.warnings);
+    writer.patch({ phase: 'templates', status: 'done', note: null });
+    await writer.flush();
+
+    return { duplicated: summary.duplicated, relinked: summary.relinked };
+  },
+});
+
+/**
+ * Copy the source classroom's page + slide-deck content.
+ *
+ * Two halves: one git clone+force-push of the whole content repo (see
+ * helpers/cloneContentRepo — minutes rather than the 40+ the file-by-file
+ * Contents API path cost), then the Page/Slide rows that point into it.
+ *
+ * Because the target repo is FRESH, every item keeps its source `content_path`
+ * verbatim — no dedupe, no suffixing, no path rewriting. That is what lets the
+ * bulk copy be a single tree push instead of a per-item staged commit.
+ */
+export const importContentTask = task({
+  id: 'import-content',
+  retry: { maxAttempts: 1 },
+  maxDuration: 3600,
+  run: async ({ importJobId }: { importJobId: string }) => {
+    const prisma = getPrisma();
+    const job = await loadJob(prisma, importJobId);
+    const writer = new ProgressWriter(prisma, job);
+
+    const wantPages = job.progress.phases.pages?.status !== 'skipped';
+    const wantSlides = job.progress.phases.slides?.status !== 'skipped';
+    const activePhases = CONTENT_PHASE_KEYS.filter(key =>
+      key === 'pages' ? wantPages : wantSlides
+    );
+
+    const [source, target] = await Promise.all([
+      contentRepoCoordinates(prisma, job.source_classroom_id),
+      contentRepoCoordinates(prisma, job.classroom_id),
+    ]);
+    if (!source) {
+      // A source with no content repo has no content — zeros and a warning,
+      // exactly as the per-file importer behaved.
+      writer.addWarnings(['source: source classroom has no configured content repository']);
+      writer.patch(...activePhases.map(phase => ({ phase, status: 'done' as const, note: null })));
+      await writer.flush();
+      return { pages: 0, slides: 0, pushed: false };
+    }
+    if (!target) {
+      throw new Error('Target classroom content repository is not configured');
+    }
+
+    writer.patch(
+      ...activePhases.map(phase => ({
+        phase,
+        status: 'running' as const,
+        note: 'copying the content repository',
+      }))
+    );
+    await writer.flush();
+
+    const clone = await cloneContentRepo({
+      source,
+      target,
+      keepPages: wantPages,
+      keepSlides: wantSlides,
+      commitMessage: `Import content from ${source.repo}`,
+      onStep: note => writer.patch(...activePhases.map(phase => ({ phase, note }))),
+    });
+    writer.patch(...activePhases.map(phase => ({ phase, note: null })));
+    await writer.flush();
+
+    if (!clone.pushed) {
+      // Nothing reached the target repo (an empty source, or everything pruned
+      // away). Creating rows now would point every page and deck at a path that
+      // does not exist — a classroom full of broken content, which is worse
+      // than an empty one. Say so and stop.
+      writer.addWarnings(['content: no files were copied — no pages or decks were created']);
+      writer.patch(...activePhases.map(phase => ({ phase, status: 'done' as const, note: null })));
+      await writer.flush();
+      return { pages: 0, slides: 0, pushed: false, files: clone.files };
+    }
+
+    const counts = { pages: 0, slides: 0 };
+    if (wantPages) {
+      counts.pages = await importPageRows({ prisma, job, writer, source, target });
+    }
+    if (wantSlides) {
+      counts.slides = await importSlideRows({ prisma, job, writer });
+    }
+
+    // Rebuilt wholesale from the TARGET's rows — the source's manifest was
+    // deliberately dropped from the pushed tree.
+    if (counts.pages > 0 || counts.slides > 0) {
+      try {
+        await ClassmojiService.contentManifest.saveManifest(job.classroom_id);
+      } catch (error: unknown) {
+        writer.addWarnings([`manifest: failed to refresh target manifest: ${errText(error)}`]);
+      }
+    }
+
+    writer.patch(...activePhases.map(phase => ({ phase, status: 'done' as const, note: null })));
+    writer.mergeCounts(counts);
+    await writer.flush();
+
+    return { ...counts, pushed: clone.pushed, files: clone.files };
+  },
+});
+
+function errText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Create the target Page rows for every source page not already imported.
+ *
+ * `content_path` is copied VERBATIM: the git push already put the files at
+ * exactly those paths in the fresh target repo. Only the header image URL is
+ * rewritten, with the same pure helper that rewrote the pushed files, so a
+ * deleted source repo cannot 404 the imported page's banner.
+ */
+async function importPageRows({
+  prisma,
+  job,
+  writer,
+  source,
+  target,
+}: {
+  prisma: PrismaClient;
+  job: LoadedImportJob;
+  writer: ProgressWriter;
+  source: { orgLogin: string; repo: string };
+  target: { orgLogin: string; repo: string };
+}): Promise<number> {
+  const { rewriteContentUrls } = ClassmojiService.contentImport;
+  const sourcePages = await prisma.page.findMany({
+    where: { classroom_id: job.source_classroom_id },
+    orderBy: { created_at: 'asc' },
+  });
+  const already = importedSourceIds(writer.progress, 'pages');
+  const total = sourcePages.length;
+  writer.patch({ phase: 'pages', status: 'running', done: already.size, total });
+
+  let done = already.size;
+  let created = 0;
+  const warnings: string[] = [];
+  for (const page of sourcePages) {
+    // Resume: this page's row already exists from an earlier attempt. It still
+    // counts as done — it IS imported — and it is not warned about.
+    if (already.has(page.id)) continue;
+    try {
+      const row = await prisma.page.create({
+        data: {
+          classroom_id: job.classroom_id,
+          title: page.title,
+          slug: titleToIdentifier(page.title),
+          content_path: page.content_path,
+          created_by: job.requested_by,
+          is_draft: true,
+          is_public: false,
+          width: page.width,
+          show_in_student_menu: page.show_in_student_menu,
+          menu_order: page.menu_order,
+          header_image_url: page.header_image_url
+            ? rewriteContentUrls(page.header_image_url, {
+                sourceLogin: source.orgLogin,
+                sourceRepo: source.repo,
+                sourcePath: '',
+                targetLogin: target.orgLogin,
+                targetRepo: target.repo,
+                targetPath: '',
+              })
+            : page.header_image_url,
+          header_image_position: page.header_image_position,
+        },
+      });
+      writer.mergeIdMaps({ pages: { [page.id]: row.id } });
+      created++;
+    } catch (error: unknown) {
+      warnings.push(`pages: DB row failed for "${page.title}": ${errText(error)}`);
+    } finally {
+      done++;
+      writer.patch({ phase: 'pages', status: 'running', done, total });
+    }
+  }
+
+  writer.addWarnings(warnings);
+  return created;
+}
+
+/**
+ * Slide-deck equivalent of importPageRows. Takes no repo coordinates: a deck
+ * carries no URL-bearing column of its own (its asset URLs live inside
+ * deck.json, which the push already rewrote), and `slug` is copied verbatim
+ * because it IS the content path segment.
+ */
+async function importSlideRows({
+  prisma,
+  job,
+  writer,
+}: {
+  prisma: PrismaClient;
+  job: LoadedImportJob;
+  writer: ProgressWriter;
+}): Promise<number> {
+  const sourceSlides = await prisma.slide.findMany({
+    where: { classroom_id: job.source_classroom_id },
+    orderBy: { created_at: 'asc' },
+  });
+  const already = importedSourceIds(writer.progress, 'slides');
+  const total = sourceSlides.length;
+  writer.patch({ phase: 'slides', status: 'running', done: already.size, total });
+
+  let done = already.size;
+  let created = 0;
+  const warnings: string[] = [];
+  for (const slide of sourceSlides) {
+    if (already.has(slide.id)) continue;
+    try {
+      const row = await prisma.slide.create({
+        data: {
+          classroom_id: job.classroom_id,
+          title: slide.title,
+          slug: slide.slug,
+          content_path: slide.content_path,
+          created_by: job.requested_by,
+          is_draft: true,
+          is_public: false,
+          allow_team_edit: slide.allow_team_edit,
+          show_speaker_notes: slide.show_speaker_notes,
+        },
+      });
+      writer.mergeIdMaps({ slides: { [slide.id]: row.id } });
+      created++;
+    } catch (error: unknown) {
+      warnings.push(`slides: DB row failed for "${slide.title}": ${errText(error)}`);
+    } finally {
+      done++;
+      writer.patch({ phase: 'slides', status: 'running', done, total });
+    }
+  }
+
+  writer.addWarnings(warnings);
+  return created;
+}
+
+/**
+ * Copy the module containers LAST: their items reference repositories, quizzes,
+ * pages and slides by id, and every one of those maps was minted by an earlier
+ * phase and carried here on the job row.
+ */
+export const importModulesTask = task({
+  id: 'import-modules',
+  retry: { maxAttempts: 1 },
+  maxDuration: 900,
+  run: async ({ importJobId }: { importJobId: string }) => {
+    const prisma = getPrisma();
+    const job = await loadJob(prisma, importJobId);
+    const writer = new ProgressWriter(prisma, job);
+
+    writer.patch({ phase: 'modules', status: 'running' });
+    await writer.flush();
+
+    const idMaps = job.progress.id_maps ?? {};
+    const summary = await ClassmojiService.classroomConfigImport.importModules(
+      job.source_classroom_id,
+      job.classroom_id,
+      {
+        repositories: idMaps.repositories ?? {},
+        quizzes: idMaps.quizzes ?? {},
+        pages: idMaps.pages ?? {},
+        slides: idMaps.slides ?? {},
+      }
+    );
+
+    writer.mergeCounts({ modules: summary.modules });
+    if (summary.skipped_items > 0) {
+      writer.addWarnings([
+        `modules: ${summary.skipped_items} item${summary.skipped_items === 1 ? '' : 's'} could not be remapped and were skipped`,
+      ]);
+    }
+    writer.patch({
+      phase: 'modules',
+      status: 'done',
+      summary: `${summary.modules} module${summary.modules === 1 ? '' : 's'}, ${summary.items} item${summary.items === 1 ? '' : 's'}`,
+    });
+    await writer.flush();
+
+    return summary;
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Every child takes the same bare payload and the orchestrator only reads
+ * `.ok`/`.error` off the result, so the plan is typed on that shape alone —
+ * the children's differing outputs would otherwise have no common type.
+ */
+type ImportChildTask = {
+  triggerAndWait: (payload: {
+    importJobId: string;
+  }) => Promise<{ ok: true } | { ok: false; error: unknown }>;
+};
+
+/** One phase of the run: which child performs it, and which chips it owns. */
+interface PhasePlan {
+  /** Value written to the coarse `ImportJob.phase` column. */
+  name: string;
+  child: ImportChildTask;
+  /** Progress phase keys marked failed if the child fails. */
+  keys: ImportPhaseUpdate['phase'][];
+}
+
+export const classroomImportTask = task({
+  id: 'classroom-import',
+  // A partial import must never be replayed from the top: the per-item creates
+  // are not idempotent. Recovery is the user-driven retry, which resumes.
+  retry: { maxAttempts: 1 },
+  maxDuration: 3600,
+  run: async ({ importJobId }: { importJobId: string }) => {
+    const prisma = getPrisma();
+    try {
+      return await runImport(prisma, importJobId);
+    } catch (error: unknown) {
+      // A throw ANYWHERE in the orchestrator itself — the ownership re-check, a
+      // row re-read, a status write, the finalize — would otherwise leave the
+      // job stuck RUNNING (or PENDING). The banner would poll that forever and
+      // the retry endpoint refuses anything that is not FAILED, so the user
+      // would have no way out at all. Record the failure, then rethrow so the
+      // Trigger run is still marked failed.
+      await prisma.importJob
+        .update({
+          where: { id: importJobId },
+          data: { status: 'FAILED', error: errText(error) },
+        })
+        .catch(() => {});
+      throw error;
+    }
+  },
+});
+
+/** The orchestrator's body, extracted so one catch can cover all of it. */
+async function runImport(prisma: PrismaClient, importJobId: string) {
+  {
+    let job = await loadJob(prisma, importJobId);
+
+    await assertSourceOwnership(prisma, job);
+
+    await prisma.importJob.update({
+      where: { id: job.id },
+      data: { status: 'RUNNING', error: null },
+    });
+
+    const selections = job.selections.content ?? {};
+    const wantsContent =
+      job.progress.phases.pages?.status !== 'skipped' ||
+      job.progress.phases.slides?.status !== 'skipped';
+
+    const plan: PhasePlan[] = [];
+    // Content repo first: it is what the content push needs, and doing its repo
+    // creation before the paced template creates keeps it out of their backoff.
+    if (wantsContent) {
+      plan.push({ name: 'content', child: importContentRepoTask, keys: [...CONTENT_PHASE_KEYS] });
+    }
+    if (selections.duplicateTemplates) {
+      plan.push({ name: 'templates', child: importTemplatesTask, keys: ['templates'] });
+    }
+    if (wantsContent) {
+      plan.push({ name: 'content', child: importContentTask, keys: [...CONTENT_PHASE_KEYS] });
+    }
+    if (selections.modules) {
+      plan.push({ name: 'modules', child: importModulesTask, keys: ['modules'] });
+    }
+
+    for (const step of plan) {
+      // Re-read every time: the previous child wrote id maps and counts this
+      // one needs, and an in-memory copy from before it ran would clobber them.
+      job = await loadJob(prisma, importJobId);
+
+      // Resume: a phase already finished stays finished. The content-repo step
+      // has no chip of its own, so it re-runs (idempotent) whenever the content
+      // phases have not both completed.
+      const allDone = step.keys.every(key => job.progress.phases[key]?.status === 'done');
+      if (allDone) {
+        logger.info('import: phase already complete, skipping', { phase: step.name });
+        continue;
+      }
+
+      await prisma.importJob.update({ where: { id: job.id }, data: { phase: step.name } });
+
+      const result = await step.child.triggerAndWait({ importJobId });
+      if (!result.ok) {
+        return failJob(prisma, importJobId, step, result.error);
+      }
+    }
+
+    // ── Finalize ──────────────────────────────────────────────────────────
+    job = await loadJob(prisma, importJobId);
+    const finished = withSummaryParts(job.progress, buildSummaryParts(job.progress.counts ?? {}));
+    await prisma.importJob.update({
+      where: { id: job.id },
+      data: {
+        status: 'COMPLETED',
+        phase: null,
+        error: null,
+        progress: finished as unknown as object,
+      },
+    });
+
+    logger.info('import: completed', {
+      importJobId,
+      percent: overallPercent(finished),
+      parts: finished.parts,
+    });
+    return { status: 'COMPLETED', parts: finished.parts };
+  }
+}
+
+/**
+ * Record a failed phase and stop: the chips it owns go `failed`, the job goes
+ * FAILED with the error, and every LATER phase is left `pending` — untouched,
+ * so a retry resumes there rather than starting over. Everything already
+ * imported stays imported; nothing is rolled back.
+ */
+async function failJob(
+  prisma: PrismaClient,
+  importJobId: string,
+  step: PhasePlan,
+  error: unknown
+): Promise<{ status: string; phase: string; error: string }> {
+  const message = errText(error);
+  logger.error('import: phase failed', { phase: step.name, error: message });
+
+  const job = await loadJob(prisma, importJobId);
+  const progress = applyPhaseUpdates(
+    job.progress,
+    step.keys
+      .filter(key => job.progress.phases[key]?.status !== 'skipped')
+      .map(key => ({ phase: key, status: 'failed' as const, note: null }))
+  );
+
+  await prisma.importJob.update({
+    where: { id: importJobId },
+    data: {
+      status: 'FAILED',
+      phase: step.name,
+      error: message,
+      progress: progress as unknown as object,
+    },
+  });
+
+  return { status: 'FAILED', phase: step.name, error: message };
+}


### PR DESCRIPTION
## Summary

Classroom import becomes a Trigger.dev task set behind an instant action. The motivating prod run took **55+ minutes** inside a single browser request (tripping GitHub's secondary rate limit along the way, with zero feedback after the proxy timed out); the same import now returns the classroom in **~3 seconds** and completes in **~90 seconds** with a live progress banner.

- **Instant action**: validations + DB-fast phases (settings/scales/calendar, repositories) stay synchronous; everything GitHub-bound runs in a `classroom-import` orchestrator with child tasks (content-repo → templates → content → modules), resumable via id maps persisted on the new `ImportJob` row
- **Whole-repo content copy**: one git clone → local URL rewrite → force-push (711 files in a single push in the E2E) replaces per-file API reads and 1-blob-per-second writes; the >1MB skip limitation disappears
- **Rate-limit hardening from the prod incident**: content repo created before the template burst, 15s pacing between repo creations, bounded Retry-After waits surfaced in the banner as a visible "paused by GitHub" state
- **Progress banner** (admin layout, both themes): per-phase chips with live counts and activity notes, completed summary with auto-hide + reopen pill, failed state with phase-scoped resume-safe **Retry**
- **Delete-plan gap closed**: imported template repos (provenance from the job's `template_map` — never name heuristics) join the delete confirmation and cleanup; today's prod delete orphaned 14 of them
- Foundation commit (9efa41d) carries the ImportJob schema/migration, service progress hooks, pacing/rate-limit parsing, shared progress helpers, and the admin-gated polling API

## Testing
- +79 unit tests across the two commits; services vitest green (pre-existing GitLabProvider failures unchanged); services+tasks+webapp typechecks clean (pre-existing exceptions unchanged)
- **Live E2E on dev**: action 3.0s → COMPLETED ~90s (24 pages, 19 decks, 2 repos, scales, calendar); banner verified in Chrome through running → completed → reopen pill; forced-failure retry resumed to COMPLETED with done-phase skip proven; delete-with-cleanup verified including ImportJob cascade

## Deploy notes
- Additive migration (`import_jobs`); Trigger.dev deploys automatically on `packages/tasks` changes with Infisical-synced secrets
- `resend` was declared in packages/tasks but never installed (broke fresh installs' typecheck); running npm install fixed it with no lockfile change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw