### PR TITLE
fix: import pre-flight for unreachable source orgs + clean error surfaces

### DIFF
--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -3,6 +3,7 @@ import { checkAuth } from '~/utils/helpers';
 import {
   ClassmojiService,
   GitHubProvider,
+  describeTokenMintError,
   getGitProvider,
   ensureClassroomTeam,
 } from '@classmoji/services';
@@ -30,6 +31,52 @@ import { slugify } from './utils';
 /** Background work needs Trigger.dev; without it the async phases can't run. */
 const isTriggerConfigured = () =>
   Boolean(process.env.TRIGGER_SECRET_KEY || process.env.TRIGGER_ACCESS_TOKEN);
+
+/**
+ * Cap on the import pre-flight's token mint.
+ *
+ * The check runs inside the create request, so it must never be the thing that
+ * makes "create classroom" hang. `GitHubProvider.getAccessToken` accepts no
+ * AbortSignal, so a race is the only timeout available — and a mint that has
+ * not answered in this long is treated as a refusal, because an import that
+ * cannot get a source token now will not finish the copy either.
+ */
+const PREFLIGHT_TOKEN_TIMEOUT_MS = 5000;
+
+/**
+ * Can this environment mint an installation token for `org`?
+ *
+ * Staging runs against production-cloned GitOrganization rows whose
+ * installation ids belong to the PRODUCTION GitHub App, so the mint 404s there
+ * for orgs that look perfectly valid in the database. Answering this before the
+ * import starts is what turns a mid-run failure into a skipped-content warning.
+ */
+async function canMintOrgToken(org: Parameters<typeof getGitProvider>[0]): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Inside the try: getGitProvider throws SYNCHRONOUSLY when the row carries
+    // no installation id (or names a provider with no token support at all).
+    const mint = getGitProvider(org).getAccessToken();
+    // If the timeout wins the race, this rejection still arrives later — with
+    // no handler it would surface as an unhandled rejection.
+    mint.catch(() => {});
+    await Promise.race([
+      mint,
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`timed out after ${PREFLIGHT_TOKEN_TIMEOUT_MS}ms`)),
+          PREFLIGHT_TOKEN_TIMEOUT_MS
+        );
+      }),
+    ]);
+    return true;
+  } catch (error: unknown) {
+    console.warn(`Import pre-flight: ${describeTokenMintError(org.login, error)}`);
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 /**
  * Pick a free internal content namespace for a new classroom in this org.
@@ -170,13 +217,24 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   // a same-slug retry. Source-ownership for imports is part of that gate.
   const sourceClassroomId: string | undefined = importConfig?.sourceClassroomId;
   const configSelections = importConfig?.config ?? {};
-  const contentSelections = importConfig?.content ?? {};
+  // A COPY of the request's content toggles: the GitHub pre-flight below drops
+  // the ones this environment cannot honor, and everything downstream (the
+  // `wants*` flags, the phase totals, whether a job is created at all, and the
+  // selections persisted on the job for a later retry) reads them from here.
+  const contentSelections: Record<string, boolean> = { ...(importConfig?.content ?? {}) };
   const anyConfigSelected = Object.values(configSelections).some(Boolean);
   const anyContentSelected = Object.values(contentSelections).some(Boolean);
   const requestedRepos: Array<{ id: string; includeQuizzes?: boolean }> =
     importConfig?.repositories ?? [];
   const importRequested =
     !!sourceClassroomId && (requestedRepos.length > 0 || anyConfigSelected || anyContentSelected);
+
+  /** Per-item notes; surfaced on the response and seeded onto the job row. */
+  const importWarnings: string[] = [];
+  /** Source org this environment can't read, when the pre-flight below says so. */
+  let unreachableSourceOrg: string | null = null;
+  /** The one sentence that explains the skipped content to the user. */
+  let githubUnavailableNote: string | null = null;
 
   if (importRequested) {
     // The picker only OFFERS owned classrooms, but every id here arrives from
@@ -188,6 +246,55 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     });
     if (!sourceMembership) {
       return { error: 'You must own the source classroom to import from it' };
+    }
+
+    // ── GitHub pre-flight ────────────────────────────────────────────────────
+    // Template duplication and the page/deck copy all READ the source org, so
+    // each needs an installation token for it. When that token cannot be minted
+    // the import used to die mid-run with a bare "Failed to retrieve GitHub
+    // installation token (404)" in the banner — a half-built classroom and an
+    // error naming neither the org nor the cause. Finding out here turns it into
+    // a warning on an otherwise successful create.
+    //
+    // Deliberately NOT run for creates without an import, or for imports whose
+    // selections are all pure DB (settings, repos, quizzes, modules): those
+    // never touch the source org, and this would be a GitHub round-trip charged
+    // to every one of them.
+    const githubBoundSelected = !!(
+      contentSelections.duplicateTemplates ||
+      contentSelections.pages ||
+      contentSelections.slides
+    );
+    if (githubBoundSelected) {
+      const sourceClassroom = await getPrisma().classroom.findUnique({
+        where: { id: sourceClassroomId },
+        include: { git_organization: true },
+      });
+      const sourceOrg = sourceClassroom?.git_organization;
+      // A source with no org configured needs no pre-flight: the content phase
+      // already handles that case gracefully (zeros plus a warning).
+      if (sourceOrg?.login && !(await canMintOrgToken(sourceOrg))) {
+        unreachableSourceOrg = sourceOrg.login;
+        // Named while the flags are still set — the message lists only what the
+        // user actually asked for.
+        const dropped = [
+          contentSelections.pages ? 'pages' : null,
+          contentSelections.slides ? 'slide decks' : null,
+          contentSelections.duplicateTemplates ? 'template copies' : null,
+        ].filter(Boolean);
+
+        // Drop ONLY the source-org-bound selections. The classroom is still
+        // created and the pure-DB phases (settings, scales, calendar,
+        // repositories, quizzes, and the modules that reference them) still run.
+        contentSelections.pages = false;
+        contentSelections.slides = false;
+        contentSelections.duplicateTemplates = false;
+
+        githubUnavailableNote =
+          `GitHub org '${sourceOrg.login}' isn't accessible from this environment — ` +
+          `${dropped.join(', ')} ${dropped.length === 1 ? 'was' : 'were'} skipped.`;
+        importWarnings.push(githubUnavailableNote);
+      }
     }
   }
 
@@ -249,7 +356,6 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     letter_grade_mappings: number;
     calendar_events: number;
   } | null = null;
-  const importWarnings: string[] = [];
   /** Source repositories that survived the ownership filter (drives templates). */
   let repoConfigs: Array<{ id: string; includeQuizzes?: boolean }> = [];
 
@@ -473,6 +579,11 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     syncParts.length > 0
       ? `Classroom created with ${syncParts.join(', ')} imported!`
       : 'Classroom created successfully!';
+  // Stated outright, not folded into the generic "N items skipped" count: the
+  // user selected content that will not be there, and has to know why.
+  if (githubUnavailableNote) {
+    successMessage += ` ${githubUnavailableNote}`;
+  }
   if (importJobId) {
     successMessage += ' Import continuing in the background.';
   }
@@ -486,5 +597,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     classroomSlug: classroom.slug,
     import_job_id: importJobId,
     import_warnings: importWarnings,
+    /** Source org login when its GitHub App installation was unreachable, else null. */
+    import_github_unavailable: unreachableSourceOrg,
   };
 });

--- a/packages/services/src/git/__tests__/tokenErrors.test.ts
+++ b/packages/services/src/git/__tests__/tokenErrors.test.ts
@@ -1,0 +1,106 @@
+/**
+ * tokenErrors: describeTokenMintError, redactAccessTokens. Pure string
+ * functions — no GitHub, no DB, nothing to stub.
+ *
+ * What these guard:
+ *
+ * - An import that cannot mint a token for an org must SAY WHICH ORG. The
+ *   incident these came from showed a bare "Failed to retrieve GitHub
+ *   installation token (404)" in the progress banner, which named neither the
+ *   org nor the real cause (an installation id belonging to a different
+ *   environment's GitHub App).
+ * - A git failure must never carry an installation token into `ImportJob.error`,
+ *   which is persisted and rendered to the user. Git echoes the remote URL —
+ *   credentials included — in its own error output.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { describeTokenMintError, redactAccessTokens } from '../tokenErrors.ts';
+
+describe('describeTokenMintError', () => {
+  it("names the org and the status from GitHubProvider's own error message", () => {
+    // The exact shape GitHubProvider.getAccessToken throws: a plain Error whose
+    // only record of the status is the trailing "(404)".
+    const message = describeTokenMintError(
+      'dartmouth-cs52',
+      new Error('Failed to retrieve GitHub installation token (404)')
+    );
+
+    expect(message).toContain("'dartmouth-cs52'");
+    expect(message).toContain('(404)');
+    expect(message).toContain("this environment's GitHub App may not be installed on that org");
+  });
+
+  it('prefers a structured status over anything in the message', () => {
+    const octokitError = Object.assign(new Error('Not Found'), { status: 401 });
+    expect(describeTokenMintError('brown-cs32', octokitError)).toContain('(401)');
+  });
+
+  it('reads the status off a response object', () => {
+    const error = Object.assign(new Error('Not Found'), { response: { status: 403 } });
+    expect(describeTokenMintError('brown-cs32', error)).toContain('(403)');
+  });
+
+  it('still explains itself when there is no status at all', () => {
+    // A DNS/network failure rejects with a statusless TypeError.
+    const message = describeTokenMintError('brown-cs32', new TypeError('fetch failed'));
+
+    expect(message).toContain("'brown-cs32'");
+    expect(message).toContain('fetch failed');
+    expect(message).toContain("this environment's GitHub App may not be installed on that org");
+  });
+
+  it('handles a missing org login and a non-Error throw', () => {
+    expect(describeTokenMintError(null, 'kaboom')).toContain("'unknown org'");
+    expect(describeTokenMintError('cs52', undefined)).toContain("'cs52'");
+  });
+
+  it('never lets a token in a statusless message through', () => {
+    const message = describeTokenMintError(
+      'cs52',
+      new Error('could not read https://x-access-token:ghs_aaaaaaaaaaaaaaaaaaaaaa@github.com/x.git')
+    );
+    expect(message).not.toContain('ghs_aaaaaaaaaaaaaaaaaaaaaa');
+    expect(message).toContain('***');
+  });
+
+  it('bounds the detail so a huge dump cannot become the message', () => {
+    const message = describeTokenMintError('cs52', new Error('x'.repeat(5000)));
+    expect(message.length).toBeLessThan(400);
+  });
+});
+
+describe('redactAccessTokens', () => {
+  it("strips the credential from git's echoed remote URL", () => {
+    const gitError =
+      "fatal: repository 'https://x-access-token:ghs_16CharsMinimumAAAA@github.com/cs52/content-cs52.git/' not found";
+    const redacted = redactAccessTokens(gitError);
+
+    expect(redacted).not.toContain('ghs_16CharsMinimumAAAA');
+    expect(redacted).toContain('https://x-access-token:***@github.com/cs52/content-cs52.git');
+    // The useful half of the message survives.
+    expect(redacted).toContain('not found');
+  });
+
+  it('strips bare token literals with no URL around them', () => {
+    expect(redactAccessTokens('token ghp_abcdefghijklmnopqrstuvwxyz012345 expired')).toBe(
+      'token *** expired'
+    );
+    expect(
+      redactAccessTokens('using github_pat_11ABCDEFG0123456789_abcdefghijklmnop for auth')
+    ).toBe('using *** for auth');
+  });
+
+  it('is idempotent — redacting redacted text changes nothing', () => {
+    const once = redactAccessTokens(
+      'https://x-access-token:ghs_16CharsMinimumAAAA@github.com/cs52/x.git'
+    );
+    expect(redactAccessTokens(once)).toBe(once);
+  });
+
+  it('leaves credential-free text alone', () => {
+    const clean = 'fatal: repository https://github.com/cs52/content-cs52.git not found';
+    expect(redactAccessTokens(clean)).toBe(clean);
+    expect(redactAccessTokens('')).toBe('');
+  });
+});

--- a/packages/services/src/git/index.ts
+++ b/packages/services/src/git/index.ts
@@ -131,4 +131,7 @@ export async function ensureClassroomTeam(
 // Re-export Octokit for direct use when needed
 export { Octokit } from 'octokit';
 
+// Installation-token failure formatters (pure; safe to import anywhere).
+export { describeTokenMintError, redactAccessTokens } from './tokenErrors.ts';
+
 export { GitProvider, GitHubProvider, GitLabProvider };

--- a/packages/services/src/git/tokenErrors.ts
+++ b/packages/services/src/git/tokenErrors.ts
@@ -1,0 +1,88 @@
+/**
+ * tokenErrors.ts — pure formatters for GitHub App installation-token failures.
+ *
+ * Two problems, both first seen when an import ran against a staging database
+ * holding production-cloned org rows:
+ *
+ * 1. `GitHubProvider.getAccessToken()` throws a bare "Failed to retrieve GitHub
+ *    installation token (404)". That message reaches the user through
+ *    `ImportJob.error` and the progress banner, where it names neither the org
+ *    nor the actual cause — the installation id on the row belongs to a DIFFERENT
+ *    GitHub App than the one this environment is configured with, so no amount of
+ *    retrying will help. `describeTokenMintError` names the org and says so.
+ *
+ * 2. Installation tokens are embedded in git remote URLs
+ *    (`https://x-access-token:<token>@github.com/...`), and git echoes the full
+ *    remote back in its failure output ("fatal: repository '<url>' not found").
+ *    That output is what a task rethrows, which is what gets PERSISTED to
+ *    `ImportJob.error` and rendered in the banner. `redactAccessTokens` strips
+ *    the credential before any such text can be stored or displayed.
+ *
+ * Pure string functions with no imports on purpose: they run in the webapp
+ * request path, in Trigger.dev tasks, and in tests, and must never drag GitHub
+ * or database machinery along with them.
+ */
+
+/** Guard against pasting an entire git/octokit dump into a DB column. */
+const MAX_DETAIL_LENGTH = 200;
+
+/**
+ * Best-effort HTTP status for a failed token mint.
+ *
+ * Covers the three shapes this can arrive in: an Octokit `RequestError`
+ * (`.status`), a fetch-response-derived error (`.response.status`), and
+ * `GitHubProvider.getAccessToken`'s own plain `Error` whose only record of the
+ * status is the trailing `(404)` in its message.
+ */
+function extractStatus(error: unknown): number | null {
+  if (error && typeof error === 'object') {
+    const candidate = error as { status?: unknown; response?: { status?: unknown } };
+    if (typeof candidate.status === 'number') return candidate.status;
+    if (typeof candidate.response?.status === 'number') return candidate.response.status;
+  }
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const matched = message.match(/\((\d{3})\)/);
+  return matched ? Number(matched[1]) : null;
+}
+
+/**
+ * Replace embedded credentials with `***`, in place, anywhere in a string.
+ *
+ * Handles the `user:secret@host` URL form git prints (the `x-access-token:`
+ * clone URLs this codebase builds, and any other userinfo pair), plus bare
+ * GitHub token literals in case one reaches a message without a URL around it.
+ * Idempotent: redacting already-redacted text is a no-op.
+ */
+export function redactAccessTokens(text: string): string {
+  if (!text) return text;
+  return (
+    text
+      // https://x-access-token:ghs_xxx@github.com/... → https://x-access-token:***@github.com/...
+      .replace(/(:\/\/[^/\s:@]+):[^/\s@]+@/g, '$1:***@')
+      // Bare token literals (ghp_/ghs_/gho_/ghu_/ghr_ and fine-grained PATs).
+      .replace(/\bgh[psour]_[A-Za-z0-9]{16,}/g, '***')
+      .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}/g, '***')
+  );
+}
+
+/**
+ * The user-facing message for "this environment cannot mint a token for that
+ * org" — the org is named, so a multi-org import says WHICH side failed.
+ *
+ * @param orgLogin - Organization the token was being minted for.
+ * @param error - Whatever the provider threw.
+ */
+export function describeTokenMintError(orgLogin: string | null | undefined, error: unknown): string {
+  const org = orgLogin || 'unknown org';
+  const status = extractStatus(error);
+  const rawDetail = error instanceof Error ? error.message : String(error ?? '');
+  const detail =
+    status !== null
+      ? String(status)
+      : redactAccessTokens(rawDetail).slice(0, MAX_DETAIL_LENGTH) || 'unknown error';
+
+  return (
+    `GitHub App installation for '${org}' is not accessible (${detail}) — ` +
+    "this environment's GitHub App may not be installed on that org"
+  );
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -31,6 +31,8 @@ export {
   getGitHubProvider,
   getTeamNameForClassroom,
   ensureClassroomTeam,
+  describeTokenMintError,
+  redactAccessTokens,
   Octokit,
 } from './git/index.ts';
 

--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -31,7 +31,7 @@ import { logger } from '@trigger.dev/sdk';
 import path from 'path';
 import fs from 'fs';
 
-import { ClassmojiService } from '@classmoji/services';
+import { ClassmojiService, redactAccessTokens } from '@classmoji/services';
 
 /** Top-level folders the content repo organizes managed content under. */
 const PAGES_DIR = 'pages';
@@ -77,6 +77,29 @@ export interface CloneContentRepoResult {
 
 const cloneUrl = ({ orgLogin, repo, token }: ContentRepoCoordinates): string =>
   `https://x-access-token:${token}@github.com/${orgLogin}/${repo}.git`;
+
+/**
+ * Rethrow a git failure with the repo named and the installation token stripped.
+ *
+ * Both halves matter. Git echoes the remote URL verbatim on failure ("fatal:
+ * repository 'https://x-access-token:<token>@github.com/...' not found"), and
+ * that text is rethrown → recorded in `ImportJob.error` → rendered in the
+ * progress banner, which would persist a live installation token in the
+ * database. And a raw git error names no org, so an unreachable source org
+ * reads as an unexplained clone failure.
+ *
+ * No token is minted in this file — the caller passes them in
+ * (classroomImport's `contentRepoCoordinates`, which names the org on a mint
+ * failure of its own).
+ */
+function gitFailure(
+  action: string,
+  { orgLogin, repo }: ContentRepoCoordinates,
+  error: unknown
+): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(`${action} ${orgLogin}/${repo} failed: ${redactAccessTokens(detail)}`);
+}
 
 /** Every file under `dir`, recursively, as absolute paths. Skips `.git`. */
 function listFilesRecursive(dir: string): string[] {
@@ -182,7 +205,11 @@ export const cloneContentRepo = async (
     // --depth 1: only the current tree is wanted, and the history is dropped
     // below anyway. On a content repo with years of commits this is the
     // difference between seconds and minutes.
-    await simpleGit().clone(cloneUrl(source), localPath, ['--depth', '1']);
+    try {
+      await simpleGit().clone(cloneUrl(source), localPath, ['--depth', '1']);
+    } catch (error: unknown) {
+      throw gitFailure('cloning', source, error);
+    }
 
     const repoGit = simpleGit(localPath);
     let sourceHasCommits = true;
@@ -231,9 +258,15 @@ export const cloneContentRepo = async (
     await freshGit.checkoutLocalBranch('main');
     await freshGit.add('.');
     await freshGit.commit(commitMessage);
-    await freshGit.addRemote('origin', cloneUrl(target));
-    // Overwrites ONLY the auto-init scaffold ensureContentRepo just created.
-    await freshGit.push('origin', 'main', ['--force']);
+    // Only these two carry the credentialed remote URL — the local operations
+    // above cannot leak a token, so they are left to throw as they are.
+    try {
+      await freshGit.addRemote('origin', cloneUrl(target));
+      // Overwrites ONLY the auto-init scaffold ensureContentRepo just created.
+      await freshGit.push('origin', 'main', ['--force']);
+    } catch (error: unknown) {
+      throw gitFailure('pushing to', target, error);
+    }
 
     logger.info('content import: pushed content repo copy', {
       from: `${source.orgLogin}/${source.repo}`,

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -31,7 +31,7 @@
 
 import { task, logger } from '@trigger.dev/sdk';
 import getPrisma from '@classmoji/database';
-import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { ClassmojiService, describeTokenMintError, getGitProvider } from '@classmoji/services';
 /*
  * The zero-import progress module, via its package subpath export. The eslint
  * resolver here does not follow "exports" subpaths (the same reason
@@ -267,8 +267,20 @@ async function contentRepoCoordinates(
   });
   const org = classroom?.git_organization;
   if (!classroom || !org?.login || !classroom.content_repo) return null;
-  const token = await getGitProvider(org).getAccessToken();
-  return { orgLogin: org.login, repo: classroom.content_repo, token };
+
+  // Name the org on a mint failure. The provider's own error is a bare "Failed
+  // to retrieve GitHub installation token (404)", which as a phase error in the
+  // banner tells the user nothing — least of all that the real cause is an
+  // installation id belonging to a different environment's GitHub App. Both the
+  // source and target org come through here, so the org login is what
+  // identifies which side is unreachable. getGitProvider is inside the try: it
+  // throws synchronously when the row has no installation id.
+  try {
+    const token = await getGitProvider(org).getAccessToken();
+    return { orgLogin: org.login, repo: classroom.content_repo, token };
+  } catch (error: unknown) {
+    throw new Error(describeTokenMintError(org.login, error));
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up hardening from staging testing of the background import:

- **Pre-flight**: creating a classroom with a GitHub-bound import selection now checks the source org's installation accessibility up front (5s cap). Unreachable (e.g. staging's prod-cloned org rows) → the classroom is still created, GitHub-bound selections are dropped with a clear message naming the org, and the DB-only phases proceed — no failed banner for a permanently-unreachable source
- Token-mint failures inside the job now name the org and side (source/target) instead of a bare 404
- Git clone/push error text is sanitized before being persisted to the job record

## Testing
- 11 new unit tests; tasks + webapp typechecks clean (pre-existing exceptions unchanged); services suite unchanged apart from new passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw