### PR TITLE
fix: size the content-import worker for real content repos

### DIFF
--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -247,7 +247,9 @@ export const cloneContentRepo = async (
       return { pushed: false, rewritten: 0, files: 0 };
     }
 
-    onStep?.(`pushing ${files} files to ${target.orgLogin}/${target.repo}`);
+    onStep?.(
+      `pushing to ${target.orgLogin}/${target.repo} — one commit (${files} files), a single git push`
+    );
     const freshGit = simpleGit(localPath);
     await freshGit.init();
     await freshGit.addConfig('user.name', 'Classmoji Bot');

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -393,6 +393,9 @@ export const importContentTask = task({
   id: 'import-content',
   retry: { maxAttempts: 1 },
   maxDuration: 3600,
+  // Content repos carry full course assets (CS52 26W is 813MB); git's pack
+  // compression during the whole-repo push OOMs the default small-2x (1GB).
+  machine: 'large-1x',
   run: async ({ importJobId }: { importJobId: string }) => {
     const prisma = getPrisma();
     const job = await loadJob(prisma, importJobId);


### PR DESCRIPTION
Prod's first real run OOM'd pushing an 813MB content repo — git pack compression needs more than the default 1GB worker. `import-content` now runs on `large-1x`; also rewords the push note ('one commit, single git push') that read as per-file work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw