### PR TITLE
fix: banner activity notes read as status, not warnings

### DIFF
--- a/apps/webapp/app/components/features/import/ImportProgressBanner.tsx
+++ b/apps/webapp/app/components/features/import/ImportProgressBanner.tsx
@@ -186,7 +186,13 @@ const ImportProgressBanner = ({ job: initialJob, sourceName }: ImportProgressBan
   // The first phase still reporting a transient note (a GitHub rate-limit wait,
   // repo pacing). Surfacing it is the whole reason `note` exists: without it a
   // 60s backoff is indistinguishable from a dead job.
-  const waitingNote = IMPORT_PHASE_ORDER.map(key => progress.phases?.[key]?.note).find(Boolean);
+  const notedPhase = IMPORT_PHASE_ORDER.map(key => progress.phases?.[key])
+    .filter(Boolean)
+    .find(phase => phase?.note);
+  const waitingNote = notedPhase?.note;
+  // Amber is reserved for genuine limit waits; routine activity (cloning,
+  // pushing) reads as neutral status, not a warning.
+  const noteIsWarn = notedPhase?.note_level === 'warn';
 
   const failed = job.status === 'FAILED';
   const completed = job.status === 'COMPLETED';
@@ -247,7 +253,13 @@ const ImportProgressBanner = ({ job: initialJob, sourceName }: ImportProgressBan
       )}
 
       {waitingNote && !failed && !completed && (
-        <p className="mt-2 rounded-md bg-amber-100 px-2 py-1 text-xs text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+        <p
+          className={`mt-2 rounded-md px-2 py-1 text-xs ${
+            noteIsWarn
+              ? 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300'
+              : 'bg-blue-100/70 text-blue-800 dark:bg-blue-950/60 dark:text-blue-200'
+          }`}
+        >
           {waitingNote}
         </p>
       )}

--- a/packages/services/src/classmoji/importProgress.ts
+++ b/packages/services/src/classmoji/importProgress.ts
@@ -79,6 +79,8 @@ export interface SummaryPhaseProgress {
   status: ImportPhaseStatus;
   summary?: string;
   note?: string;
+  /** 'warn' = an actual limit/backoff wait (amber in the banner); absent = routine activity (neutral). */
+  note_level?: 'info' | 'warn';
 }
 
 /** A phase with fine-grained per-item counts. */
@@ -87,6 +89,8 @@ export interface CountedPhaseProgress {
   done: number;
   total: number;
   note?: string;
+  /** See SummaryPhaseProgress.note_level. */
+  note_level?: 'info' | 'warn';
 }
 
 /**
@@ -228,19 +232,29 @@ export interface ImportPhaseUpdate {
   total?: number;
   summary?: string;
   note?: string | null;
+  /** Rides with `note`; cleared whenever the note clears. */
+  note_level?: 'info' | 'warn';
 }
 
 const isCountedKey = (key: ImportPhaseKey): key is (typeof COUNTED_PHASE_KEYS)[number] =>
   (COUNTED_PHASE_KEYS as readonly string[]).includes(key);
 
-/** Apply `note` (undefined = leave, null = clear) to a phase patch. */
-function applyNote<T extends { note?: string }>(next: T, note: string | null | undefined): T {
+/** Apply `note` (undefined = leave, null = clear) to a phase patch. The level
+ * always follows the note: cleared with it, replaced with it, never orphaned. */
+function applyNote<T extends { note?: string; note_level?: 'info' | 'warn' }>(
+  next: T,
+  note: string | null | undefined,
+  level?: 'info' | 'warn'
+): T {
   if (note === undefined) return next;
   if (note === null) {
     delete next.note;
+    delete next.note_level;
     return next;
   }
   next.note = note;
+  if (level) next.note_level = level;
+  else delete next.note_level;
   return next;
 }
 
@@ -266,13 +280,13 @@ export function applyPhaseUpdate(
     if (update.done !== undefined) next.done = Math.max(0, Math.trunc(update.done));
     // Clamp AFTER both, so a patch that raises total and done together works.
     if (next.total > 0) next.done = Math.min(next.done, next.total);
-    phases[phase] = applyNote(next, update.note);
+    phases[phase] = applyNote(next, update.note, update.note_level);
   } else {
     const current = progress.phases[phase];
     const next: SummaryPhaseProgress = { ...current };
     if (update.status !== undefined) next.status = update.status;
     if (update.summary !== undefined) next.summary = update.summary;
-    phases[phase] = applyNote(next, update.note);
+    phases[phase] = applyNote(next, update.note, update.note_level);
   }
 
   return { ...progress, phases };

--- a/packages/services/src/classmoji/templateImport.service.ts
+++ b/packages/services/src/classmoji/templateImport.service.ts
@@ -74,6 +74,8 @@ export interface TemplateImportOptions {
     total: number;
     /** Transient status (e.g. a rate-limit wait). `null` clears it. */
     note?: string | null;
+    /** 'warn' only for actual limit waits; routine activity omits it. */
+    note_level?: 'info' | 'warn';
   }) => void | Promise<void>;
   /**
    * Templates a PREVIOUS run of this same import already duplicated: source ref
@@ -348,7 +350,7 @@ async function createRepositoryWithBackoff({
   provider: ReturnType<typeof getGitProvider>;
   orgLogin: string;
   name: string;
-  onWait: (note: string | null) => void;
+  onWait: (note: string | null, level?: 'info' | 'warn') => void;
 }): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
@@ -357,7 +359,7 @@ async function createRepositoryWithBackoff({
     } catch (error: unknown) {
       const limit = parseSecondaryRateLimit(error);
       if (!limit || attempt >= MAX_SECONDARY_LIMIT_RETRIES) throw error;
-      onWait(`waiting out GitHub rate limit (~${Math.round(limit.retryAfterMs / 1000)}s)`);
+      onWait(`waiting out GitHub rate limit (~${Math.round(limit.retryAfterMs / 1000)}s)`, 'warn');
       await sleep(limit.retryAfterMs);
       onWait(null);
     }
@@ -556,8 +558,8 @@ export const duplicateImportedTemplates = async (
    * Count/note emit for this phase. An omitted `note` LEAVES the current one
    * alone (the progress reducer's convention); `null` clears it.
    */
-  const emit = (note?: string | null) =>
-    emitProgress(opts.onProgress, { done: consumed, total, note });
+  const emit = (note?: string | null, noteLevel?: 'info' | 'warn') =>
+    emitProgress(opts.onProgress, { done: consumed, total, note, note_level: noteLevel });
   emit();
 
   if (groups.length === 0) return summary;

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -227,9 +227,14 @@ class ProgressWriter {
 function phaseProgress(
   writer: ProgressWriter,
   phase: ImportPhaseUpdate['phase']
-): (update: { done: number; total: number; note?: string | null }) => void {
-  return ({ done, total, note }) => {
-    writer.patch({ phase, status: 'running', done, total, note });
+): (update: {
+  done: number;
+  total: number;
+  note?: string | null;
+  note_level?: 'info' | 'warn';
+}) => void {
+  return ({ done, total, note, note_level }) => {
+    writer.patch({ phase, status: 'running', done, total, note, note_level });
   };
 }
 


### PR DESCRIPTION
Routine activity notes (cloning/pushing) rendered in amber and read as errors. Notes now carry a level — amber is reserved for genuine rate-limit waits; activity renders neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw