### PR TITLE
fix(db): make classroom slug globally unique; scope writes by classroom id

### DIFF
--- a/apps/mcp/src/tools/repos.ts
+++ b/apps/mcp/src/tools/repos.ts
@@ -19,10 +19,9 @@
  * a live progress bar — that is a web-UI session concern and is not exposed
  * here (counts are returned instead).
  *
- * S1: the web helper flips by repository id WITHOUT re-verifying the
- * repository's classroom (the URL-derived slug only scopes the git-repo
- * lookups); MCP does NOT mirror that hole — the Repository is loaded and its
- * classroom_id compared to the authorized classroom before anything runs.
+ * S1: the Repository is loaded and its classroom_id compared to the authorized
+ * classroom before anything runs, and the authorized classroom id is passed
+ * into repository.setPublished so the write itself is scoped.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -122,7 +121,7 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
       repository.id
     );
     if (existingRepos.length > 0) {
-      await ClassmojiService.repository.setPublished(repository.id, true);
+      await ClassmojiService.repository.setPublished(repository.id, true, classroom.classroomId);
       await audit({ is_published: true, provisioning_triggered: false, republished: true });
       return ok({
         success: true,
@@ -146,7 +145,7 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
 
       // Publish = "make available to students" — flip visibility immediately;
       // per-student GitHub repos provision in the background (route parity).
-      await ClassmojiService.repository.setPublished(repository.id, true);
+      await ClassmojiService.repository.setPublished(repository.id, true, classroom.classroomId);
       await audit({
         is_published: true,
         provisioning_triggered: true,
@@ -164,7 +163,7 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
     if (repository.team_formation_mode === 'SELF_FORMED') {
       // For self-formed teams, just mark the repository as published — teams
       // and repos are created when students form their teams.
-      await ClassmojiService.repository.setPublished(repository.id, true);
+      await ClassmojiService.repository.setPublished(repository.id, true, classroom.classroomId);
       await audit({ is_published: true, provisioning_triggered: false });
       return ok({
         success: true,
@@ -187,7 +186,7 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
       sessionId
     );
 
-    await ClassmojiService.repository.setPublished(repository.id, true);
+    await ClassmojiService.repository.setPublished(repository.id, true, classroom.classroomId);
     await audit({
       is_published: true,
       provisioning_triggered: true,
@@ -224,9 +223,10 @@ export const repoUnpublishTool: ToolDefinition<RepoUnpublishArgs> = {
     repository_id: z.string().uuid().describe('Repository (assignment container) id'),
   },
   handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
     const repository = await loadRepositoryInClassroom(args.repository_id, ctx);
 
-    await ClassmojiService.repository.setPublished(repository.id, false);
+    await ClassmojiService.repository.setPublished(repository.id, false, classroom.classroomId);
 
     await writeAudit(ctx, {
       resource_type: 'REPOSITORIES',

--- a/apps/pages/tests/helpers/prisma.helpers.ts
+++ b/apps/pages/tests/helpers/prisma.helpers.ts
@@ -57,7 +57,7 @@ export interface PageRow {
  */
 export async function getClassroomIdBySlug(slug: string): Promise<string> {
   const prisma = await getTestPrisma();
-  const classroom = await prisma.classroom.findFirst({
+  const classroom = await prisma.classroom.findUnique({
     where: { slug },
     select: { id: true },
   });

--- a/apps/slides/app/routes/$classroomSlug.new/route.tsx
+++ b/apps/slides/app/routes/$classroomSlug.new/route.tsx
@@ -28,7 +28,7 @@ export const loader = async ({
   });
 
   // Get classroom with git_organization
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });
@@ -82,7 +82,7 @@ export const action = async ({
   });
 
   // Get classroom with git_organization for GitHub API calls
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });

--- a/apps/slides/app/routes/api.slides.import.start/route.ts
+++ b/apps/slides/app/routes/api.slides.import.start/route.ts
@@ -80,7 +80,7 @@ export const action = async ({ request }: { request: Request }) => {
   }
 
   // Get classroom with git_organization
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });

--- a/apps/slides/app/routes/import/route.tsx
+++ b/apps/slides/app/routes/import/route.tsx
@@ -42,7 +42,7 @@ export const loader = async ({ request }: { request: Request }) => {
   });
 
   // Get classroom with git_organization
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     include: { git_organization: true },
   });

--- a/apps/slides/tests/helpers/prisma.helpers.ts
+++ b/apps/slides/tests/helpers/prisma.helpers.ts
@@ -80,7 +80,7 @@ export async function getSlideById(slideId: string): Promise<SlideRow | null> {
  */
 export async function getClassroomIdBySlug(slug: string): Promise<string> {
   const prisma = await getTestPrisma();
-  const classroom = await prisma.classroom.findFirst({
+  const classroom = await prisma.classroom.findUnique({
     where: { slug },
     select: { id: true },
   });

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -2,7 +2,9 @@ import { getAuthSession } from '@classmoji/auth/server';
 import { checkAuth } from '~/utils/helpers';
 import {
   ClassmojiService,
+  ClassroomSlugUnavailableError,
   GitHubProvider,
+  createWithUniqueClassroomSlug,
   describeTokenMintError,
   getGitProvider,
   ensureClassroomTeam,
@@ -166,9 +168,28 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   }
 
   // Slug: prefer client-provided (user override / suggestion) when present, else derive from name.
+  // The slug is globally unique, so this is only the FIRST candidate — the
+  // create below retries down `slug`, `slug-{org}`, `slug-N` and the row's own
+  // slug is what gets returned.
   const slug = slugInput && typeof slugInput === 'string' ? slugify(slugInput) : slugify(name);
 
+  // An empty slug is not a URL. Refuse here rather than store one and let the
+  // global unique index reject the next classroom that also slugifies to ''.
+  if (!slug) {
+    return {
+      error: 'That name has no letters or numbers to build a URL from — add some, or set a slug',
+    };
+  }
+
   // Internal identifier only — names no repo, and no longer user-editable.
+  //
+  // Deliberately pinned to the ORIGINAL slug and NOT re-derived if the slug
+  // retry suffixes it. Both this and `content_repo` below are unique PER ORG,
+  // while the slug suffix answers a GLOBAL collision — so the values picked
+  // here stay free whatever the slug ends up as. More importantly, `contentRepo`
+  // is validated against GitHub further down ("content repos must be created
+  // fresh") and may be a name the user typed; re-deriving it inside the retry
+  // would create a classroom pointing at a repo name that gate never saw.
   const contentNamespace = await pickContentNamespace(git_org_id, gitOrg.login, slug);
 
   // Content repo: the user's name when supplied, else `content-{namespace}`.
@@ -298,43 +319,58 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     }
   }
 
-  // Create Classroom, Settings, and Membership in transaction
+  // Create Classroom, Settings, and Membership in transaction.
+  //
+  // The slug guard wraps the WHOLE `$transaction` call: a P2002 inside an
+  // interactive transaction aborts it (Postgres 25P02), so retrying from within
+  // would fail every remaining candidate. `classroom.slug` below is therefore
+  // the slug that actually won, which is what the response redirects on.
   let classroom;
   try {
-    classroom = await getPrisma().$transaction(async tx => {
-      const created = await tx.classroom.create({
-        data: {
-          git_org_id,
-          slug,
-          name,
-          content_namespace: contentNamespace,
-          content_repo: contentRepo,
-        },
-      });
+    const created = await createWithUniqueClassroomSlug(
+      { slug, orgLogin: gitOrg.login },
+      classroomSlug =>
+        getPrisma().$transaction(async tx => {
+          const row = await tx.classroom.create({
+            data: {
+              git_org_id,
+              slug: classroomSlug,
+              name,
+              content_namespace: contentNamespace,
+              content_repo: contentRepo,
+            },
+          });
 
-      await tx.classroomSettings.create({
-        data: { classroom_id: created.id },
-      });
+          await tx.classroomSettings.create({
+            data: { classroom_id: row.id },
+          });
 
-      await tx.classroomMembership.create({
-        data: {
-          classroom_id: created.id,
-          user_id: user.id,
-          role: 'OWNER',
-          has_accepted_invite: true,
-        },
-      });
+          await tx.classroomMembership.create({
+            data: {
+              classroom_id: row.id,
+              user_id: user.id,
+              role: 'OWNER',
+              has_accepted_invite: true,
+            },
+          });
 
-      return created;
-    });
+          return row;
+        })
+    );
+    classroom = created.result;
   } catch (error: unknown) {
-    // Unique-constraint race (slug, content repo, or the internal namespace
-    // claimed between the pre-checks and the insert) — refuse cleanly
-    // instead of a 500.
+    if (error instanceof ClassroomSlugUnavailableError) {
+      return {
+        error: `'${slug}' and every variation of it are already taken — pick a different slug`,
+      };
+    }
+    // Unique-constraint race on something the guard does NOT retry: the content
+    // repo or the internal namespace, claimed between the pre-checks and the
+    // insert. A slug collision is no longer one of these, and the collision can
+    // be with a classroom in any organization — the slug is globally unique.
     if ((error as { code?: string })?.code === 'P2002') {
       return {
-        error:
-          'That classroom slug or content repo was just taken in this organization — adjust and try again',
+        error: 'That content repo name was just taken in this organization — adjust and try again',
       };
     }
     throw error;

--- a/apps/webapp/app/routes/_user.import-classroom/StepProgress.tsx
+++ b/apps/webapp/app/routes/_user.import-classroom/StepProgress.tsx
@@ -36,7 +36,8 @@ interface Props {
   accessToken: string;
   sessionId: string;
   expected: number;
-  singleSlug: string | null;
+  /** One classroom imported → land on it; several → back to the org picker. */
+  single: boolean;
 }
 
 /**
@@ -45,15 +46,15 @@ interface Props {
  * everything finishes, offers a button to the new classroom (single import) or
  * back to the org picker (multiple).
  */
-export default function StepProgress({ accessToken, sessionId, expected, singleSlug }: Props) {
+export default function StepProgress({ accessToken, sessionId, expected, single }: Props) {
   return (
     <TriggerAuthContext.Provider value={{ accessToken }}>
-      <ProgressInner sessionId={sessionId} expected={expected} singleSlug={singleSlug} />
+      <ProgressInner sessionId={sessionId} expected={expected} single={single} />
     </TriggerAuthContext.Provider>
   );
 }
 
-function ProgressInner({ sessionId, expected, singleSlug }: Omit<Props, 'accessToken'>) {
+function ProgressInner({ sessionId, expected, single }: Omit<Props, 'accessToken'>) {
   const navigate = useNavigate();
   const { runs, error } = useRealtimeRunsWithTag(`session_${sessionId}`);
 
@@ -67,10 +68,15 @@ function ProgressInner({ sessionId, expected, singleSlug }: Omit<Props, 'accessT
   const allDone = terminal.length >= expected && importRuns.length >= expected;
   const percent = Math.min(100, Math.floor((terminal.length / Math.max(1, expected)) * 100));
 
+  // Only the finished run knows the destination: the importer normalizes the
+  // requested slug and suffixes it on a global collision, so the slug the
+  // wizard submitted is not necessarily the one that got stored. With no run
+  // output there is no slug to trust, and the org picker is the safe landing.
+  const destinationSlug = single ? (succeeded[0]?.output?.classroomSlug ?? null) : null;
+
   const goToDestination = () => {
-    if (singleSlug && succeeded.length > 0) {
-      const slug = succeeded[0].output?.classroomSlug ?? singleSlug;
-      navigate(`/admin/${slug}/dashboard`);
+    if (destinationSlug) {
+      navigate(`/admin/${destinationSlug}/dashboard`);
     } else {
       navigate('/select-organization');
     }
@@ -156,7 +162,7 @@ function ProgressInner({ sessionId, expected, singleSlug }: Omit<Props, 'accessT
       {allDone && (
         <div className="mt-6 flex justify-end">
           <Button type="primary" onClick={goToDestination}>
-            {singleSlug && succeeded.length > 0 ? 'Go to classroom' : 'Done'}
+            {destinationSlug ? 'Go to classroom' : 'Done'}
           </Button>
         </div>
       )}

--- a/apps/webapp/app/routes/_user.import-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.import-classroom/StepReview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Input, Tag } from 'antd';
-import type { ListedClassroom } from './utils';
+import { slugify, type ListedClassroom } from './utils';
 
 interface Props {
   classrooms: ListedClassroom[]; // only the selected ones
@@ -12,12 +12,18 @@ interface SlugStatus {
   checking: boolean;
   available: boolean;
   suggestion?: string;
+  /** The check itself failed — say nothing rather than guess either way. */
+  unknown?: boolean;
 }
 
 /**
- * Step 3 — review each selected classroom, edit its slug, and confirm. Slug
- * availability is checked per classroom against the (possibly not-yet-created)
- * GitHub org via the availability endpoint's `org_provider_id` path.
+ * Step 3 — review each selected classroom, edit its slug, and confirm.
+ *
+ * Slug availability is GLOBAL (the slug is the sole key in every app URL), so
+ * the check can fail against a classroom in an organization the teacher has
+ * never seen. The org is still passed along — as `org_provider_id` plus the
+ * login, since the org row usually doesn't exist until import time — so the
+ * suggestion comes back org-qualified rather than as a bare `slug-2`.
  */
 export default function StepReview({ classrooms, slugByClassroom, onSlugChange }: Props) {
   const [status, setStatus] = useState<Map<number, SlugStatus>>(new Map());
@@ -36,9 +42,11 @@ export default function StepReview({ classrooms, slugByClassroom, onSlugChange }
           try {
             const params = new URLSearchParams({
               org_provider_id: String(c.organization.id),
+              org_login: c.organization.login,
               slug,
             });
             const res = await fetch(`/api/classrooms/availability?${params.toString()}`);
+            if (!res.ok) throw new Error(String(res.status));
             const data = (await res.json()) as {
               slug_available: boolean;
               slug_suggestion?: string;
@@ -49,8 +57,10 @@ export default function StepReview({ classrooms, slugByClassroom, onSlugChange }
               suggestion: data.slug_suggestion,
             });
           } catch {
-            // Network hiccup — don't block import; treat as available.
-            next.set(c.githubId, { checking: false, available: true });
+            // The check failed (network, 500). Don't block the import — the
+            // importer's own slug guard will suffix a real collision — but
+            // don't claim the slug is free either.
+            next.set(c.githubId, { checking: false, available: false, unknown: true });
           }
         })
       );
@@ -72,7 +82,7 @@ export default function StepReview({ classrooms, slugByClassroom, onSlugChange }
         {classrooms.map(c => {
           const slug = slugByClassroom.get(c.githubId) ?? '';
           const st = status.get(c.githubId);
-          const taken = st && !st.checking && !st.available;
+          const taken = st && !st.checking && !st.available && !st.unknown;
           return (
             <div
               key={c.githubId}
@@ -90,6 +100,11 @@ export default function StepReview({ classrooms, slugByClassroom, onSlugChange }
                   status={taken ? 'error' : undefined}
                   style={{ maxWidth: 320 }}
                   onChange={e => onSlugChange(c.githubId, e.target.value)}
+                  // Normalized on blur rather than per keystroke: the server
+                  // slugifies whatever arrives, so the field has to show the
+                  // slug that will actually be stored — but trimming edge
+                  // dashes mid-word would fight the typist.
+                  onBlur={e => onSlugChange(c.githubId, slugify(e.target.value))}
                 />
                 {taken && st?.suggestion && (
                   <Tag
@@ -103,7 +118,14 @@ export default function StepReview({ classrooms, slugByClassroom, onSlugChange }
               </div>
               {taken && (
                 <div className="text-xs text-red-500 mt-1">
-                  A classroom with this slug already exists in {c.organization?.login}.
+                  A classroom with this slug already exists. Slugs are shared across all
+                  organizations, so pick another.
+                </div>
+              )}
+              {st?.unknown && !st.checking && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Couldn&apos;t check this slug. The import will pick a variation if it turns out to
+                  be taken.
                 </div>
               )}
             </div>

--- a/apps/webapp/app/routes/_user.import-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.import-classroom/action.ts
@@ -72,9 +72,11 @@ export const action = checkAuth(async ({ request, user }) => {
       accessToken,
       id: sessionId,
       expected: selections.length,
-      // For a single import we know the destination slug up front (the importer
-      // uses it verbatim); multi-import lands back on the org picker.
-      singleSlug: selections.length === 1 ? selections[0].slug : null,
+      // A single import lands on the new classroom, multiple land back on the
+      // org picker. Only WHICH destination is known here, never the slug: the
+      // importer normalizes the requested slug and suffixes it on a global
+      // collision, so the destination comes off the finished run.
+      single: selections.length === 1,
     },
   };
 });

--- a/apps/webapp/app/routes/_user.import-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.import-classroom/route.tsx
@@ -25,7 +25,8 @@ interface TriggerSession {
   accessToken: string;
   id: string;
   expected: number;
-  singleSlug: string | null;
+  /** One classroom imported → land on it; several → back to the org picker. */
+  single: boolean;
 }
 
 interface ImportActionData {
@@ -121,7 +122,7 @@ const ImportClassroom = ({ loaderData }: Route.ComponentProps) => {
             accessToken={session.accessToken}
             sessionId={session.id}
             expected={session.expected}
-            singleSlug={session.singleSlug}
+            single={session.single}
           />
         )}
 

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -270,7 +270,7 @@ const SelectOrganization = ({ loaderData }: Route.ComponentProps) => {
     if (!organization || !user.login) return;
     notify(ActionTypes.SEND_INVITATION, 'Sending you Github invite...');
     fetcher?.submit(
-      { student_login: user.login, organization_login: organization.login },
+      { classroom_id: organization.id },
       {
         method: 'post',
         encType: 'application/json',
@@ -359,69 +359,85 @@ const SelectOrganization = ({ loaderData }: Route.ComponentProps) => {
   );
 };
 
-export const action = checkAuth(async ({ request }: { request: Request }) => {
-  const { student_login, organization_login } = (await request.json()) as {
-    student_login: string;
-    organization_login: string;
-  };
+export const action = checkAuth(
+  async ({ request, user }: { request: Request; user: { userId: string } }) => {
+    const { classroom_id } = (await request.json()) as { classroom_id?: string };
 
-  const classroom = await getPrisma().classroom.findFirst({
-    where: { slug: organization_login },
-    include: { git_organization: true },
-  });
-
-  if (!classroom) {
-    return { error: 'Classroom not found' };
-  }
-
-  const gitProvider = getGitProvider(
-    classroom.git_organization as {
-      provider: string;
-      github_installation_id?: string;
-      access_token?: string;
-      base_url?: string;
-      login?: string;
+    if (typeof classroom_id !== 'string' || !classroom_id) {
+      return { error: 'Classroom not found' };
     }
-  );
-  const team = await ensureClassroomTeam(
-    gitProvider,
-    classroom.git_organization.login,
-    classroom,
-    'STUDENT'
-  );
-  // If the student is ALREADY a member of the GitHub org (common when migrating
-  // from GitHub Classroom), GitHub rejects a fresh org invitation with a 422,
-  // which used to error the whole join. In that case skip the invite and add them
-  // straight to the class team — they're already in the org.
-  const alreadyMember = await gitProvider.isUserMemberOfOrganization(
-    classroom.git_organization.login,
-    student_login
-  );
 
-  if (alreadyMember) {
-    await gitProvider.addTeamMember(classroom.git_organization.login, team.slug, student_login);
-    // No `member_added` webhook fires for users already in the org, so activate the
-    // membership here (flip has_accepted_invite + provision repos) — otherwise they
-    // stay stuck pending and never receive their assignment repos.
-    await tasks.trigger('activate_membership', {
-      login: student_login,
-      gitOrganizationId: classroom.git_organization.id,
+    const membership = await getPrisma().classroomMembership.findFirst({
+      where: { classroom_id, user_id: user.userId },
+      include: {
+        user: true,
+        classroom: { include: { git_organization: true } },
+      },
     });
+
+    if (!membership) {
+      return { error: 'Classroom not found' };
+    }
+
+    const student_login = membership.user.login;
+
+    if (!student_login) {
+      return { error: 'Your account has no linked GitHub login.' };
+    }
+
+    const classroom = membership.classroom;
+
+    const gitProvider = getGitProvider(
+      classroom.git_organization as {
+        provider: string;
+        github_installation_id?: string;
+        access_token?: string;
+        base_url?: string;
+        login?: string;
+      }
+    );
+    const team = await ensureClassroomTeam(
+      gitProvider,
+      classroom.git_organization.login,
+      classroom,
+      'STUDENT'
+    );
+    // If the student is ALREADY a member of the GitHub org (common when migrating
+    // from GitHub Classroom), GitHub rejects a fresh org invitation with a 422,
+    // which used to error the whole join. In that case skip the invite and add them
+    // straight to the class team — they're already in the org.
+    const alreadyMember = await gitProvider.isUserMemberOfOrganization(
+      classroom.git_organization.login,
+      student_login
+    );
+
+    if (alreadyMember) {
+      await gitProvider.addTeamMember(classroom.git_organization.login, team.slug, student_login);
+      // No `member_added` webhook fires for users already in the org, so activate the
+      // membership here (flip has_accepted_invite + provision repos) — otherwise they
+      // stay stuck pending and never receive their assignment repos.
+      await tasks.trigger('activate_membership', {
+        login: student_login,
+        gitOrganizationId: classroom.git_organization.id,
+      });
+      return {
+        success: 'Already in the organization — added you to the class.',
+        action: ActionTypes.SEND_INVITATION,
+      };
+    }
+
+    const githubUser = await gitProvider.getUserByLogin(student_login);
+    await gitProvider.inviteToOrganization(
+      classroom.git_organization.login,
+      String(githubUser.id),
+      [team.id]
+    );
+
     return {
-      success: 'Already in the organization — added you to the class.',
+      success: 'Successfully sent invite.',
       action: ActionTypes.SEND_INVITATION,
     };
   }
-
-  const githubUser = await gitProvider.getUserByLogin(student_login);
-  await gitProvider.inviteToOrganization(classroom.git_organization.login, String(githubUser.id), [
-    team.id,
-  ]);
-
-  return {
-    success: 'Successfully sent invite.',
-    action: ActionTypes.SEND_INVITATION,
-  };
-});
+);
 
 export default SelectOrganization;

--- a/apps/webapp/app/routes/admin.$class.assistants/action.ts
+++ b/apps/webapp/app/routes/admin.$class.assistants/action.ts
@@ -43,10 +43,13 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   return namedAction(request, {
     async createAssistant() {
       try {
-        const classroom = (await ClassmojiService.classroom.findBySlug(
-          classSlug
-        )) as AssistantClassroom | null;
-        await addAssistantHandler({ assistant: data, classroom: classroom! });
+        // The classroom `requireClassroomAdmin` authorized above, not a fresh
+        // lookup on the same slug — re-resolving decides a second time which
+        // classroom this membership lands in.
+        await addAssistantHandler({
+          assistant: data,
+          classroom: classroom as unknown as AssistantClassroom,
+        });
 
         return {
           success: 'Assistant created',
@@ -62,7 +65,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     },
 
     async updateAssistant() {
-      await updateAssistantHandler(classSlug, data.login, data.isGrader);
+      await updateAssistantHandler(classroom.id, data.login, data.isGrader);
       return {
         success: 'Assistant updated',
         action: ActionTypes.SAVE_USER,
@@ -97,15 +100,15 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   });
 };
 
+/** `classroomId` is the caller's already-authorized classroom, not a re-resolve. */
 export const updateAssistantHandler = async (
-  classSlug: string,
+  classroomId: string,
   assistantLogin: string,
   isGrader: boolean
 ) => {
-  const classroom = await ClassmojiService.classroom.findBySlug(classSlug);
   const assistant = await ClassmojiService.user.findByLogin(assistantLogin);
 
-  return ClassmojiService.classroomMembership.update(classroom!.id, assistant!.id, {
+  return ClassmojiService.classroomMembership.update(classroomId, assistant!.id, {
     is_grader: isGrader,
   });
 };

--- a/apps/webapp/app/routes/admin.$class.gitrepos/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.gitrepos/route.tsx
@@ -546,11 +546,21 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       const data = await request.json();
       const repo = await ClassmojiService.gitRepo.findByName(classSlug, data.name);
 
+      // `data.name` is client-supplied, and the payload below deletes the repo on
+      // GitHub and then drops the GitRepo row by bare id. Refuse unless the
+      // resolved repo belongs to the classroom the caller was authorized for.
+      if (!repo || repo.classroom_id !== classroom.id) {
+        return {
+          action: ActionTypes.DELETE_REPO,
+          error: 'Repository not found',
+        };
+      }
+
       const payload = {
         name: data.name,
         gitOrganization: classroom.git_organization,
         deleteFromGithub: true,
-        id: repo?.id,
+        id: repo.id,
       };
 
       try {

--- a/apps/webapp/app/routes/admin.$class.repos/action.ts
+++ b/apps/webapp/app/routes/admin.$class.repos/action.ts
@@ -20,7 +20,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async delete() {
-      await ClassmojiService.repository.deleteById(assignmentId);
+      await ClassmojiService.repository.deleteById(assignmentId, classroom.id);
 
       return {
         success: 'Repository deleted',
@@ -29,16 +29,16 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     },
 
     async publish() {
-      return publishAssignment(classSlug, assignmentId, userId);
+      return publishAssignment(classSlug, classroom.id, assignmentId, userId);
     },
 
     async unpublish() {
-      await ClassmojiService.repository.setPublished(assignmentId, false);
+      await ClassmojiService.repository.setPublished(assignmentId, false, classroom.id);
       return { success: 'Repository unpublished' };
     },
 
     async sync() {
-      const res = await syncAssignment(classSlug, assignmentId, userId);
+      const res = await syncAssignment(classSlug, classroom.id, assignmentId, userId);
       const {
         triggerSession: { numReposToCreate, numIssuesToCreate },
       } = res;

--- a/apps/webapp/app/routes/admin.$class.repos/action.ts
+++ b/apps/webapp/app/routes/admin.$class.repos/action.ts
@@ -54,7 +54,11 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     async updateAssignment() {
       const { weight } = data;
 
-      const result = await ClassmojiService.repository.update(assignmentId, { weight });
+      const result = await ClassmojiService.repository.update(
+        assignmentId,
+        { weight },
+        classroom.id
+      );
 
       return result;
     },

--- a/apps/webapp/app/routes/admin.$class.repos/helpers.ts
+++ b/apps/webapp/app/routes/admin.$class.repos/helpers.ts
@@ -11,22 +11,29 @@ type Classroom = NonNullable<Awaited<ReturnType<typeof ClassmojiService.classroo
 type Repository = NonNullable<Awaited<ReturnType<typeof ClassmojiService.repository.findById>>>;
 type GitRepo = Awaited<ReturnType<typeof ClassmojiService.gitRepo.findByRepository>>[number];
 
+/**
+ * `classroomId` is the classroom the CALLER was authorized for. The classroom is
+ * resolved from it rather than from the slug, and the repository — addressed by
+ * a body-supplied id — is checked against it before anything is published.
+ */
 export const publishAssignment = async (
   classroomSlug: string,
+  classroomId: string,
   repositoryId: string,
   _userId: string | null = null
 ) => {
   try {
     const sessionId = nanoid();
-    const classroom = await ClassmojiService.classroom.findBySlug(classroomSlug);
+    const classroom = await ClassmojiService.classroom.findById(classroomId);
     const repository = await ClassmojiService.repository.findById(repositoryId);
 
     invariant(repository != null, 'Repository not found');
+    invariant(repository.classroom_id === classroomId, 'Repository not found in classroom');
 
     // If repos already exist (re-publish after unpublish), just flip the flag
     const existingRepos = await ClassmojiService.gitRepo.findByRepository(classroomSlug, repositoryId);
     if (existingRepos.length > 0) {
-      await ClassmojiService.repository.setPublished(repositoryId, true);
+      await ClassmojiService.repository.setPublished(repositoryId, true, classroomId);
       return { success: 'Repository re-published. Use Sync to update repositories.' };
     }
 
@@ -69,11 +76,11 @@ export const publishAssignment = async (
       // that job is slow or partially fails, the repository is still visible
       // (instructors can re-run Sync to fill in missing repos). Mirrors the
       // SELF_FORMED branch below, which already publishes up front.
-      await ClassmojiService.repository.setPublished(repositoryId, true);
+      await ClassmojiService.repository.setPublished(repositoryId, true, classroomId);
     } else if (repository.team_formation_mode === 'SELF_FORMED') {
       // For self-formed teams, just mark repository as published
       // Teams and repos will be created when students form their teams
-      await ClassmojiService.repository.setPublished(repositoryId, true);
+      await ClassmojiService.repository.setPublished(repositoryId, true, classroomId);
 
       return {
         success: 'Repository published! Students can now form teams.',
@@ -107,7 +114,7 @@ export const publishAssignment = async (
       // Publish = "make available to students" — flip visibility immediately
       // (see the INDIVIDUAL branch above). Team repos provision in the
       // background; the repository stays visible regardless.
-      await ClassmojiService.repository.setPublished(repositoryId, true);
+      await ClassmojiService.repository.setPublished(repositoryId, true, classroomId);
     }
 
     const accessToken = await auth.createPublicToken({
@@ -132,14 +139,19 @@ export const publishAssignment = async (
   }
 };
 
+/** `classroomId` scopes the body-supplied repository — see `publishAssignment`. */
 export const syncAssignment = async (
   classroomSlug: string,
+  classroomId: string,
   repositoryId: string,
   _userId: string | null = null
 ) => {
-  const classroom = await ClassmojiService.classroom.findBySlug(classroomSlug);
+  const classroom = await ClassmojiService.classroom.findById(classroomId);
   const repository = await ClassmojiService.repository.findById(repositoryId);
   const sessionId = nanoid();
+
+  invariant(repository != null, 'Repository not found');
+  invariant(repository.classroom_id === classroomId, 'Repository not found in classroom');
 
   const accessToken = await auth.createPublicToken({
     scopes: {

--- a/apps/webapp/app/routes/admin.$class.resources/__tests__/removeLink.test.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/__tests__/removeLink.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * removeLink deletes by a `linkId` that arrives in an untyped JSON body, scoped
+ * by a compound `where`. That compound only narrows the delete while `linkId` is
+ * a real string: Prisma drops an `undefined` value from a `where`, and the id
+ * field accepts a `StringFilter` object, either of which would leave
+ * `deleteMany` matching every link in the classroom.
+ *
+ * Driven directly, like the api.quiz gating test: the auth seam and Prisma are
+ * mocked, so the assertion is that the delete is never ISSUED.
+ */
+
+const pageLinkDeleteMany = vi.fn();
+const slideLinkDeleteMany = vi.fn();
+const saveManifest = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    pageLink: { deleteMany: pageLinkDeleteMany },
+    slideLink: { deleteMany: slideLinkDeleteMany },
+    page: { findFirst: vi.fn() },
+    slide: { findFirst: vi.fn() },
+    repository: { findFirst: vi.fn() },
+    assignment: { findFirst: vi.fn() },
+  }),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    contentManifest: { saveManifest: (...a: unknown[]) => saveManifest(...a) },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: vi.fn(async () => ({
+    classroom: { id: 'classroom-1', status: 'ACTIVE' },
+    membership: { role: 'OWNER' },
+  })),
+  assertClassroomMutationAllowed: vi.fn(),
+}));
+
+const { action } = await import('../action.ts');
+
+const removeLink = (body: unknown) =>
+  action({
+    request: new Request('http://localhost/admin/cs52/resources?/removeLink', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    params: { class: 'cs52' },
+    context: {},
+  } as never);
+
+/** Values that survive `if (!linkId)` but widen the scoped `where`. */
+const unusableIds: [string, unknown][] = [
+  ['undefined', undefined],
+  ['null', null],
+  ['a StringFilter object', { not: '' }],
+  ['a number', 7],
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('admin.$class.resources removeLink', () => {
+  it.each(unusableIds)('rejects %s as a page linkId without deleting', async (_l, linkId) => {
+    const res = (await removeLink({ linkId, resourceType: 'page' }).catch(
+      (e: unknown) => e
+    )) as Response;
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(400);
+    expect(pageLinkDeleteMany).not.toHaveBeenCalled();
+    expect(slideLinkDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it.each(unusableIds)('rejects %s as a slide linkId without deleting', async (_l, linkId) => {
+    const res = (await removeLink({ linkId, resourceType: 'slide' }).catch(
+      (e: unknown) => e
+    )) as Response;
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(400);
+    expect(pageLinkDeleteMany).not.toHaveBeenCalled();
+    expect(slideLinkDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it('deletes a real page link scoped to the classroom and saves the manifest', async () => {
+    pageLinkDeleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(removeLink({ linkId: 'link-1', resourceType: 'page' })).resolves.toEqual({
+      success: true,
+    });
+    expect(pageLinkDeleteMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: 'link-1', page: { classroom_id: 'classroom-1' } },
+    });
+    expect(saveManifest).toHaveBeenCalledWith('classroom-1');
+  });
+
+  it('leaves the manifest alone when the link was not this classroom', async () => {
+    slideLinkDeleteMany.mockResolvedValue({ count: 0 });
+
+    const res = (await removeLink({ linkId: 'link-1', resourceType: 'slide' }).catch(
+      (e: unknown) => e
+    )) as Response;
+
+    expect(res.status).toBe(404);
+    // `id` is the primary key, so count 0 means nothing was deleted — the
+    // manifest cannot end up describing links that are gone.
+    expect(saveManifest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.resources/action.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/action.ts
@@ -16,12 +16,51 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
+  // `resourceId`, `targetId` and `linkId` all arrive in the request body, so each
+  // has to be proven to live in the authorized classroom before it is joined or
+  // deleted. Page, Slide and Repository carry `classroom_id` directly; Assignment
+  // does not, and is reached through its Repository.
+  const prisma = getPrisma();
+
+  const assertFound = (what: string, found: { id: string } | null) => {
+    if (!found) throw new Response(`${what} not found in classroom`, { status: 404 });
+  };
+
+  const assertTargetInClassroom = async (targetType: string, targetId: string) => {
+    if (targetType === 'repository') {
+      assertFound(
+        'Repository',
+        await prisma.repository.findFirst({
+          where: { id: targetId, classroom_id: classroom.id },
+          select: { id: true },
+        })
+      );
+      return;
+    }
+    assertFound(
+      'Assignment',
+      await prisma.assignment.findFirst({
+        where: { id: targetId, repository: { classroom_id: classroom.id } },
+        select: { id: true },
+      })
+    );
+  };
+
   return namedAction(request, {
     async addLink() {
       const { resourceId, resourceType, targetType, targetId } = await request.json();
 
+      await assertTargetInClassroom(targetType, targetId);
+
       if (resourceType === 'page') {
-        await getPrisma().pageLink.create({
+        assertFound(
+          'Page',
+          await prisma.page.findFirst({
+            where: { id: resourceId, classroom_id: classroom.id },
+            select: { id: true },
+          })
+        );
+        await prisma.pageLink.create({
           data: {
             page_id: resourceId,
             repository_id: targetType === 'repository' ? targetId : null,
@@ -29,7 +68,14 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
           },
         });
       } else {
-        await getPrisma().slideLink.create({
+        assertFound(
+          'Slide',
+          await prisma.slide.findFirst({
+            where: { id: resourceId, classroom_id: classroom.id },
+            select: { id: true },
+          })
+        );
+        await prisma.slideLink.create({
           data: {
             slide_id: resourceId,
             repository_id: targetType === 'repository' ? targetId : null,
@@ -47,10 +93,19 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     async removeLink() {
       const { linkId, resourceType } = await request.json();
 
-      if (resourceType === 'page') {
-        await getPrisma().pageLink.delete({ where: { id: linkId } });
-      } else {
-        await getPrisma().slideLink.delete({ where: { id: linkId } });
+      // deleteMany takes the compound that `delete` cannot; a count other than 1
+      // means the link was not this classroom's, which fails rather than no-ops.
+      const { count } =
+        resourceType === 'page'
+          ? await prisma.pageLink.deleteMany({
+              where: { id: linkId, page: { classroom_id: classroom.id } },
+            })
+          : await prisma.slideLink.deleteMany({
+              where: { id: linkId, slide: { classroom_id: classroom.id } },
+            });
+
+      if (count !== 1) {
+        throw new Response('Link not found in classroom', { status: 404 });
       }
 
       // Update manifest after removing link

--- a/apps/webapp/app/routes/admin.$class.resources/action.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/action.ts
@@ -50,6 +50,17 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     async addLink() {
       const { resourceId, resourceType, targetType, targetId } = await request.json();
 
+      // Same untyped-body hazard as removeLink: an `undefined` id is dropped from
+      // the `where` rather than rejected, so the scope checks below would match an
+      // arbitrary row in the classroom, pass, and then create a link pointing at
+      // nothing.
+      if (typeof resourceId !== 'string' || !resourceId) {
+        throw new Response('Invalid resource id', { status: 400 });
+      }
+      if (typeof targetId !== 'string' || !targetId) {
+        throw new Response('Invalid target id', { status: 400 });
+      }
+
       await assertTargetInClassroom(targetType, targetId);
 
       if (resourceType === 'page') {
@@ -93,8 +104,20 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     async removeLink() {
       const { linkId, resourceType } = await request.json();
 
-      // deleteMany takes the compound that `delete` cannot; a count other than 1
-      // means the link was not this classroom's, which fails rather than no-ops.
+      // `linkId` is untyped request-body data, and the compound below only
+      // narrows the delete while it is a real string: Prisma drops an
+      // `undefined` value from a `where` rather than rejecting it, and the id
+      // field also accepts a filter object, so `undefined` or `{ not: '' }`
+      // would leave `deleteMany` matching every link in the classroom.
+      if (typeof linkId !== 'string' || !linkId) {
+        throw new Response('Invalid link id', { status: 400 });
+      }
+
+      // deleteMany takes the compound that `delete` cannot. Past the guard `id`
+      // is the primary key, so the compound matches at most one row: a count
+      // other than 1 means zero rows matched, the link was not this classroom's,
+      // and nothing was deleted — so the throw below cannot leave the manifest
+      // describing links that are gone.
       const { count } =
         resourceType === 'page'
           ? await prisma.pageLink.deleteMany({

--- a/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.general/route.tsx
@@ -81,6 +81,22 @@ const SettingsGeneral = ({ loaderData }: Route.ComponentProps) => {
   );
 };
 
+/**
+ * The only Classroom columns `saveProfile` may write.
+ *
+ * The request body reaches `classroom.update` as a whole object, so without
+ * this every column on the model is settable by anyone who can POST here —
+ * including `slug`, which is the sole key in every app URL and two HMAC
+ * credentials and is set once at creation (schema comment on `Classroom.slug`),
+ * and `git_org_id`, which would move the classroom to another organization.
+ */
+const PROFILE_FIELDS = ['name'] as const;
+
+const pickProfileFields = (data: Record<string, unknown>) =>
+  Object.fromEntries(
+    PROFILE_FIELDS.filter(field => data[field] !== undefined).map(field => [field, data[field]])
+  );
+
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
@@ -98,7 +114,11 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async saveProfile() {
-      await ClassmojiService.classroom.update(classroom.id, data);
+      const fields = pickProfileFields(data);
+      if (Object.keys(fields).length === 0) {
+        return { error: 'Nothing to update' };
+      }
+      await ClassmojiService.classroom.update(classroom.id, fields);
       return {
         success: 'Classroom profile updated',
         action: ActionTypes.SAVE_PROFILE,

--- a/apps/webapp/app/routes/api.$operation/route.ts
+++ b/apps/webapp/app/routes/api.$operation/route.ts
@@ -110,15 +110,13 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
         return data({ error: 'Regrade request not found' }, { status: 404 });
       }
 
-      const classroom = await ClassmojiService.classroom.findById(regradeRequest.classroom_id);
-
-      if (!classroom) {
-        return data({ error: 'Classroom not found' }, { status: 404 });
-      }
-
+      // Authorize on the record's classroom_id. Loading the classroom and then
+      // authorizing against its slug would re-resolve through a second lookup,
+      // leaving nothing that ties the authorized classroom to the regrade
+      // request being updated below.
       await assertClassroomAccess({
         request,
-        classroomSlug: classroom.slug,
+        classroomId: regradeRequest.classroom_id,
         allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
         resourceType: 'REGRADE_REQUEST',
         attemptedAction: 'update_regrade_request',
@@ -178,13 +176,11 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
         return data({ error: 'Transaction not found' }, { status: 404 });
       }
 
-      const classroom = await ClassmojiService.classroom.findById(storedTransaction.classroom_id);
-
-      if (!classroom) {
-        return data({ error: 'Classroom not found' }, { status: 404 });
-      }
-
-      // Check authorization: OWNER can cancel any, STUDENT can cancel their own
+      // Check authorization: OWNER can cancel any, STUDENT can cancel their own.
+      // Bound to the transaction's own classroom_id — a slug read back off the
+      // classroom record would be re-resolved by the auth layer, so the refund
+      // below could be issued against a row in a classroom the caller was never
+      // authorized for.
       const {
         userId: _userId,
         membership: _membership,
@@ -192,7 +188,7 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
         accessGrantedVia: _accessGrantedVia,
       } = await assertClassroomAccess({
         request,
-        classroomSlug: classroom.slug,
+        classroomId: storedTransaction.classroom_id,
         allowedRoles: ['OWNER'], // OWNER can cancel any transaction
         resourceType: 'TOKEN_TRANSACTION',
         attemptedAction: 'cancel_transaction',
@@ -220,20 +216,19 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
 
     async deleteRepositories() {
       const { deleteFromGithub, repositories, classSlug } = body;
-      const classroom = await ClassmojiService.classroom.findBySlug(classSlug);
 
-      if (!classroom) {
-        return data({ error: 'Classroom not found' }, { status: 404 });
-      }
-
-      const { classroom: accessClassroom, membership } = await assertClassroomAccess({
+      // No pre-auth lookup: the previous shape resolved the slug, then handed
+      // the SAME slug to the auth helper to resolve a second time, and used the
+      // first result for the git org and repo scoping. One resolution, and
+      // everything below reads off the classroom the auth helper authorized.
+      const { classroom, membership } = await assertClassroomAccess({
         request,
-        classroomSlug: classroom.slug,
+        classroomSlug: classSlug,
         allowedRoles: ['OWNER'],
         resourceType: 'REPOSITORY',
         attemptedAction: 'delete_repositories',
       });
-      assertClassroomMutationAllowed({ status: accessClassroom.status, role: membership!.role });
+      assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
       const sessionId = nanoid();
       const payloads = await Promise.all(

--- a/apps/webapp/app/routes/api.classrooms.$id.archive/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$id.archive/route.ts
@@ -6,7 +6,6 @@
  * Only OWNER. Returns `{ is_archived: boolean }`.
  */
 
-import { ClassmojiService } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
 import { assertClassroomAccess } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
@@ -26,14 +25,12 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     return new Response('Invalid body', { status: 400 });
   }
 
-  const classroom = await ClassmojiService.classroom.findById(classroomId);
-  if (!classroom) {
-    return new Response('Classroom not found', { status: 404 });
-  }
-
+  // Authorize on the id, not on a slug read back off the record — see the
+  // sibling status route: binding to the id is what makes the classroom that was
+  // authorized and the row updated below provably the same one.
   await assertClassroomAccess({
     request,
-    classroomSlug: classroom.slug,
+    classroomId,
     allowedRoles: ['OWNER'],
     resourceType: 'CLASSROOM',
     attemptedAction: body.is_archived ? 'archive_classroom' : 'unarchive_classroom',

--- a/apps/webapp/app/routes/api.classrooms.$id.status/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$id.status/route.ts
@@ -6,7 +6,6 @@
  * Only OWNER. Returns `{ status }`.
  */
 
-import { ClassmojiService } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
 import { assertClassroomAccess } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
@@ -29,14 +28,15 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     return new Response('Invalid status', { status: 400 });
   }
 
-  const classroom = await ClassmojiService.classroom.findById(classroomId);
-  if (!classroom) {
-    return new Response('Classroom not found', { status: 404 });
-  }
-
+  // Authorize on the id, not on a slug read back off the record: resolving the
+  // classroom and then authorizing against its slug sends the auth layer through
+  // a second lookup, and nothing ties the classroom it lands on to the row
+  // updated below. `classroomId` makes them the same row by construction. It
+  // also 404s an unknown id only after the session check, so ids stay
+  // unenumerable to anonymous callers.
   await assertClassroomAccess({
     request,
-    classroomSlug: classroom.slug,
+    classroomId,
     allowedRoles: ['OWNER'],
     resourceType: 'CLASSROOM',
     attemptedAction: 'change_classroom_status',

--- a/apps/webapp/app/routes/api.classrooms.availability/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.availability/route.ts
@@ -1,19 +1,27 @@
 /**
- * Classroom availability check.
+ * Classroom slug availability check.
  *
- * GET /api/classrooms/availability?git_org_id=...&slug=...
- * GET /api/classrooms/availability?org_provider_id=...&slug=...
+ * GET /api/classrooms/availability?slug=...
+ *   &git_org_id=...       our GitOrganization UUID (the create flow), or
+ *   &org_provider_id=...  the GitHub org id (the import flow — that org row is
+ *                         only created at import time), optionally with
+ *   &org_login=...        the GitHub org login, so the suggestion can still be
+ *                         org-qualified before that row exists.
  *
- * Returns `{ slug_available, slug_suggestion? }`. When the slug is already taken
- * inside the org, the loader returns the first free `slug-N` suggestion (N up to 99).
+ * Returns `{ slug_available, slug_suggestion? }`.
  *
- * `git_org_id` is our GitOrganization UUID. The GitHub Classroom import flow
- * doesn't have one yet (the org row is created at import time), so it can pass
- * `org_provider_id` (the GitHub org id) instead — we resolve it to a git_org_id,
- * and treat an as-yet-unknown org as fully available (no classrooms under it).
+ * The check is GLOBAL, not org-scoped: `Classroom.slug` is globally unique
+ * because it is the sole key in every app URL. An unknown org, or no org at
+ * all, therefore no longer means "available" — the org is used only to build
+ * the suggestion.
+ *
+ * The slug is normalized before checking. The create and import paths both
+ * store a slugified value, so checking the raw text would report `CS 101` free
+ * and then store a colliding `cs-101`.
  */
 
 import { requireAuth } from '@classmoji/auth/server';
+import { classroomSlugCandidates, slugify } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
 import type { Route } from './+types/route';
 
@@ -21,45 +29,48 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   await requireAuth(request);
 
   const url = new URL(request.url);
-  let git_org_id = url.searchParams.get('git_org_id') ?? '';
+  const git_org_id = url.searchParams.get('git_org_id') ?? '';
   const org_provider_id = url.searchParams.get('org_provider_id') ?? '';
-  const slug = url.searchParams.get('slug') ?? '';
+  const slug = slugify(url.searchParams.get('slug') ?? '');
+
+  // Nothing typed yet — no claim to make either way.
+  if (!slug) return Response.json({ slug_available: true });
 
   const prisma = getPrisma();
 
-  // Resolve a GitHub org id to our GitOrganization UUID when given.
-  if (!git_org_id && org_provider_id) {
-    const org = await prisma.gitOrganization.findUnique({
-      where: { provider_provider_id: { provider: 'GITHUB', provider_id: org_provider_id } },
-      select: { id: true },
-    });
-    // No org row yet → nothing can collide → slug is available.
-    if (!org) return Response.json({ slug_available: true });
-    git_org_id = org.id;
-  }
+  // Resolve the org for the SUGGESTION only. A missing row is fine: the import
+  // flow can pass the login directly, and without either we fall back to
+  // numeric suggestions.
+  const org = git_org_id
+    ? await prisma.gitOrganization.findUnique({
+        where: { id: git_org_id },
+        select: { login: true },
+      })
+    : org_provider_id
+      ? await prisma.gitOrganization.findUnique({
+          where: { provider_provider_id: { provider: 'GITHUB', provider_id: org_provider_id } },
+          select: { login: true },
+        })
+      : null;
+  const orgLogin = org?.login ?? url.searchParams.get('org_login') ?? '';
 
-  if (!git_org_id || !slug) {
-    return Response.json({ slug_available: true });
-  }
-  const bySlug = await prisma.classroom.findFirst({
-    where: { git_org_id, slug },
-    select: { id: true },
+  // One query for the whole candidate list. Candidate 0 is the bare slug, so
+  // this answers availability and picks the suggestion at the same time — and
+  // because the list comes from the same helper the create retries on, the
+  // suggestion is the slug a create would actually land on.
+  const candidates = classroomSlugCandidates(slug, orgLogin);
+  const taken = new Set(
+    (
+      await prisma.classroom.findMany({
+        where: { slug: { in: candidates } },
+        select: { slug: true },
+      })
+    ).map(c => c.slug)
+  );
+
+  const slug_available = !taken.has(slug);
+  return Response.json({
+    slug_available,
+    slug_suggestion: slug_available ? undefined : candidates.find(c => !taken.has(c)),
   });
-
-  let slug_suggestion: string | undefined;
-  if (bySlug) {
-    for (let n = 2; n < 100; n++) {
-      const candidate = `${slug}-${n}`;
-      const hit = await prisma.classroom.findFirst({
-        where: { git_org_id, slug: candidate },
-        select: { id: true },
-      });
-      if (!hit) {
-        slug_suggestion = candidate;
-        break;
-      }
-    }
-  }
-
-  return Response.json({ slug_available: !bySlug, slug_suggestion });
 };

--- a/apps/webapp/app/routes/api.import-jobs.$jobId/route.ts
+++ b/apps/webapp/app/routes/api.import-jobs.$jobId/route.ts
@@ -5,7 +5,7 @@ import {
   type ImportProgress,
 } from '@classmoji/services/import-progress';
 import Tasks from '@classmoji/tasks';
-import { requireClassroomAdmin } from '~/utils/routeAuth.server';
+import { assertClassroomAccess } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
 /** Lifecycle of an `ImportJob` row (mirrors the `ImportJobStatus` enum). */
@@ -64,18 +64,21 @@ const toView = (job: {
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const jobId = params.jobId!;
 
-  const job = await getPrisma().importJob.findUnique({
-    where: { id: jobId },
-    include: { classroom: { select: { slug: true } } },
-  });
+  const job = await getPrisma().importJob.findUnique({ where: { id: jobId } });
 
   if (!job) {
     throw new Response('Not found', { status: 404 });
   }
 
-  await requireClassroomAdmin(request, job.classroom.slug, {
+  // The row's own `classroom_id` is the authorization key. Going through
+  // `job.classroom.slug` had the auth layer resolve a classroom by slug a second
+  // time, and nothing then proved that classroom is the one owning this job.
+  await assertClassroomAccess({
+    request,
+    classroomId: job.classroom_id,
+    allowedRoles: ['OWNER'],
     resourceType: 'IMPORT_JOB',
-    action: 'view_import_job',
+    attemptedAction: 'view_import_job',
   });
 
   return Response.json(toView(job));
@@ -102,18 +105,19 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     throw new Response('Method not allowed', { status: 405 });
   }
 
-  const job = await getPrisma().importJob.findUnique({
-    where: { id: jobId },
-    include: { classroom: { select: { slug: true } } },
-  });
+  const job = await getPrisma().importJob.findUnique({ where: { id: jobId } });
 
   if (!job) {
     throw new Response('Not found', { status: 404 });
   }
 
-  await requireClassroomAdmin(request, job.classroom.slug, {
+  // Authorize on the row's `classroom_id` — see the loader.
+  await assertClassroomAccess({
+    request,
+    classroomId: job.classroom_id,
+    allowedRoles: ['OWNER'],
     resourceType: 'IMPORT_JOB',
-    action: 'retry_import_job',
+    attemptedAction: 'retry_import_job',
   });
 
   if (job.status !== 'FAILED') {
@@ -133,17 +137,30 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     }))
   );
 
+  // Claim the row with `status: 'FAILED'` in the WHERE, not just the read above:
+  // the import pipeline is not idempotent, and two POSTs arriving together would
+  // both see FAILED and both trigger it. Exactly one `updateMany` can move the
+  // row off FAILED, and only that one goes on to trigger.
+  //
   // PENDING before the trigger: if the trigger throws, the row is left claiming
   // a run that never started, which the caller sees and can retry again.
-  const updated = await getPrisma().importJob.update({
-    where: { id: job.id },
+  const { count } = await getPrisma().importJob.updateMany({
+    where: { id: job.id, status: 'FAILED' },
     data: {
       status: 'PENDING',
       error: null,
       progress: reset as unknown as object,
     },
-    include: { classroom: { select: { slug: true } } },
   });
+
+  if (count !== 1) {
+    return Response.json(
+      { error: 'This import was already retried — poll for its current status.' },
+      { status: 409 }
+    );
+  }
+
+  const updated = await getPrisma().importJob.findUniqueOrThrow({ where: { id: job.id } });
 
   try {
     await Tasks.classroomImportTask.trigger({ importJobId: job.id });

--- a/apps/webapp/app/routes/api.quiz/__tests__/ai-gating.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/ai-gating.test.ts
@@ -72,7 +72,7 @@ describe('api.quiz AI gating', () => {
     // Pass the authorization + pro-tier gates so we reach the config check.
     assertClassroomAccessMock.mockResolvedValue({
       userId: 'student-1',
-      classroom: { status: 'ACTIVE' },
+      classroom: { id: 'c-1', slug: 'test-class', status: 'ACTIVE' },
       membership: { role: 'STUDENT' },
     });
     assertClassroomMutationAllowedMock.mockReturnValue(undefined);

--- a/apps/webapp/app/routes/api.quiz/route.ts
+++ b/apps/webapp/app/routes/api.quiz/route.ts
@@ -90,13 +90,9 @@ export async function action({ request }: Route.ActionArgs) {
             return { response: jsonResponse(404, 'Quiz not found') };
           }
 
-          const classroomSlug =
-            quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(quiz.classroom_id))!.slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: quiz.classroom_id,
               quiz,
               metadata: { quiz_id: data.quizId },
             },
@@ -113,14 +109,9 @@ export async function action({ request }: Route.ActionArgs) {
             return { response: jsonResponse(404, 'Attempt not found') };
           }
 
-          const classroomSlug =
-            attemptData.attempt.quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(attemptData.attempt.quiz.classroom_id))!
-              .slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: attemptData.attempt.quiz.classroom_id,
               attemptData,
               metadata: {
                 attempt_id: data.attemptId,
@@ -140,13 +131,9 @@ export async function action({ request }: Route.ActionArgs) {
             return { response: jsonResponse(404, 'Attempt not found') };
           }
 
-          const classroomSlug =
-            attempt.quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(attempt.quiz.classroom_id))!.slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: attempt.quiz.classroom_id,
               attempt,
               metadata: {
                 attempt_id: data.attemptId,
@@ -166,13 +153,9 @@ export async function action({ request }: Route.ActionArgs) {
             return { response: jsonResponse(404, 'Quiz not found') };
           }
 
-          const classroomSlug =
-            quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(quiz.classroom_id))!.slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: quiz.classroom_id,
               quiz,
               metadata: { quiz_id: data.quizId },
             },
@@ -195,13 +178,9 @@ export async function action({ request }: Route.ActionArgs) {
             };
           }
 
-          const classroomSlug =
-            attempt.quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(attempt.quiz.classroom_id))!.slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: attempt.quiz.classroom_id,
               attempt,
               metadata: {
                 attempt_id: data.attemptId,
@@ -226,13 +205,9 @@ export async function action({ request }: Route.ActionArgs) {
             };
           }
 
-          const classroomSlug =
-            attempt.quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(attempt.quiz.classroom_id))!.slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: attempt.quiz.classroom_id,
               attempt,
               metadata: {
                 attempt_id: data.attemptId,
@@ -257,13 +232,9 @@ export async function action({ request }: Route.ActionArgs) {
             };
           }
 
-          const classroomSlug =
-            attempt.quiz.classroom?.slug ||
-            (await ClassmojiService.classroom.findById(attempt.quiz.classroom_id))!.slug;
-
           return {
             context: {
-              classroomSlug,
+              classroomId: attempt.quiz.classroom_id,
               attempt,
               metadata: {
                 attempt_id: data.attemptId,
@@ -283,16 +254,21 @@ export async function action({ request }: Route.ActionArgs) {
       return contextResponse;
     }
 
+    // Every branch above addresses its record by a body-supplied id, so the
+    // classroom id carried out of that record is what authorizes the call. The
+    // previous shape read a slug off the record and let the auth layer resolve it
+    // again, which left nothing tying the authorized classroom to the quiz or
+    // attempt mutated below. `access.classroom` is that same row.
     const access = await assertClassroomAccess({
       request,
-      classroomSlug: context.classroomSlug,
+      classroomId: context.classroomId,
       allowedRoles,
       resourceType: 'QUIZ_API_ACTION',
       attemptedAction: data._action,
       metadata: context.metadata,
     });
     assertClassroomMutationAllowed({ status: access.classroom.status, role: access.membership!.role });
-    await assertProTier(context.classroomSlug);
+    await assertProTier(access.classroom.slug);
 
     // Check AI agent availability AFTER auth (preserves audit logging)
     if (!isAIAgentConfigured()) {

--- a/apps/webapp/app/routes/api.repos.$id.analytics/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.analytics/route.ts
@@ -19,7 +19,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     include: {
       assignment: true,
       git_repo: {
-        select: { id: true, classroom_id: true, classroom: { select: { slug: true } } },
+        select: { id: true, classroom_id: true },
       },
       analytics_snapshot: true,
     },
@@ -32,9 +32,12 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     });
   }
 
+  // Authorize on the repo's own classroom id. Authorizing against its slug had
+  // the auth layer resolve a classroom a second time, so the roster and snapshot
+  // returned below were never proven to belong to the classroom that was checked.
   await assertClassroomAccess({
     request,
-    classroomSlug: repoAssignment.git_repo.classroom.slug,
+    classroomId: repoAssignment.git_repo.classroom_id,
     allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
     resourceType: 'REPOSITORY_ASSIGNMENT',
     attemptedAction: 'view_submission_analytics',

--- a/apps/webapp/app/routes/api.repos.$id.contributor-link/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.contributor-link/route.ts
@@ -25,10 +25,10 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   const repositoryId = params.id!;
 
-  // Resolve the owning classroom so we can run auth against its slug.
+  // Load the repo so its OWN classroom id can authorize the link.
   const repo = await getPrisma().gitRepo.findUnique({
     where: { id: repositoryId },
-    select: { id: true, classroom: { select: { id: true, slug: true } } },
+    select: { id: true, classroom_id: true },
   });
 
   if (!repo) {
@@ -38,9 +38,12 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     });
   }
 
+  // Authorize on the id, not on the repo's classroom slug: a slug sends the auth
+  // layer through a second lookup, leaving nothing that ties the authorized
+  // classroom to the repo whose contributor mapping is written below.
   const { classroom, membership } = await assertClassroomAccess({
     request,
-    classroomSlug: repo.classroom.slug,
+    classroomId: repo.classroom_id,
     allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
     resourceType: 'REPOSITORY',
     attemptedAction: 'link_contributor',

--- a/apps/webapp/app/routes/api.repos.$id.refresh/route.ts
+++ b/apps/webapp/app/routes/api.repos.$id.refresh/route.ts
@@ -20,7 +20,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
   const repositoryAssignmentId = params.id!;
 
-  // Resolve the owning classroom so we can run auth against its slug.
+  // Load the assignment so its OWN classroom id can authorize the refresh.
   const repoAssignment =
     await ClassmojiService.gitRepoAssignment.findById(repositoryAssignmentId);
 
@@ -31,20 +31,13 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     });
   }
 
-  const classroom = await ClassmojiService.classroom.findById(
-    repoAssignment.git_repo.classroom_id
-  );
-
-  if (!classroom) {
-    return new Response('Classroom not found', {
-      status: 404,
-      headers: { 'Content-Type': 'text/plain' },
-    });
-  }
-
+  // Authorize on the id, not on a slug read back off a classroom record:
+  // resolving the classroom and then handing its slug to the auth layer sent it
+  // through a second lookup, so nothing tied the authorized classroom to the
+  // assignment refreshed below.
   const { classroom: accessClassroom, membership } = await assertClassroomAccess({
     request,
-    classroomSlug: classroom.slug,
+    classroomId: repoAssignment.git_repo.classroom_id,
     allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT'],
     resourceType: 'REPOSITORY_ASSIGNMENT',
     attemptedAction: 'refresh_repo_analytics',

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -45,7 +45,16 @@ interface AccessOptions {
 
 interface AssertClassroomAccessOptions {
   request: Request;
-  classroomSlug: string;
+  /** Slug of the classroom being accessed. Omit when `classroomId` is given. */
+  classroomSlug?: string;
+  /**
+   * Id of the classroom being acted on. Endpoints keyed on a record id (rather
+   * than on a slug in the URL) MUST authorize with this: resolving the record
+   * by id and then authorizing against that record's slug re-resolves through a
+   * second lookup, so nothing proves the authorized classroom is the row being
+   * mutated. Passing the id binds the two together.
+   */
+  classroomId?: string;
   allowedRoles?: Role[];
   resourceType?: string;
   attemptedAction?: string;
@@ -537,9 +546,14 @@ export async function requireAuth(request: Request): Promise<AuthSessionResult> 
  * Assert that the user has access to a classroom with the specified role(s).
  * Supports ownership-based access patterns and audit logging for denied access.
  *
+ * Pass EITHER `classroomSlug` (routes whose URL carries the slug) OR
+ * `classroomId` (endpoints keyed on a record id — the id binds the authorization
+ * to the exact row being acted on), never both.
+ *
  * @param {Object} options
  * @param {Request} options.request - The request object
  * @param {string} options.classroomSlug - Classroom slug
+ * @param {string} options.classroomId - Classroom id (alternative to classroomSlug)
  * @param {string[]} options.allowedRoles - Roles with blanket access (e.g., ['OWNER', 'TEACHER'])
  * @param {string} options.resourceType - Type for audit logging
  * @param {string} options.attemptedAction - Action for audit logging
@@ -552,6 +566,7 @@ export async function requireAuth(request: Request): Promise<AuthSessionResult> 
 export const assertClassroomAccess = async ({
   request,
   classroomSlug,
+  classroomId,
   allowedRoles = [],
   resourceType = 'CLASSROOM_ACCESS',
   attemptedAction = 'access',
@@ -561,6 +576,22 @@ export const assertClassroomAccess = async ({
   requireOwnership = false,
 }: AssertClassroomAccessOptions): Promise<ClassroomAccessResult> => {
   // SECURITY: Validate parameter combinations to prevent misconfigurations
+  if (!classroomSlug && !classroomId) {
+    throw new Error(
+      '[assertClassroomAccess] Configuration error: one of classroomSlug or classroomId is required. ' +
+        `Context: resourceType="${resourceType}", attemptedAction="${attemptedAction}"`
+    );
+  }
+
+  if (classroomSlug && classroomId) {
+    throw new Error(
+      '[assertClassroomAccess] Configuration error: pass either classroomSlug or classroomId, not both. ' +
+        'Accepting both would silently ignore one of them and hide a mismatch between the classroom ' +
+        'that was authorized and the record being acted on. ' +
+        `Context: resourceType="${resourceType}", attemptedAction="${attemptedAction}"`
+    );
+  }
+
   if (requireOwnership && !resourceOwnerId) {
     throw new Error(
       '[assertClassroomAccess] Configuration error: requireOwnership is true but resourceOwnerId is not provided. ' +
@@ -586,7 +617,12 @@ export const assertClassroomAccess = async ({
     });
   }
 
-  const classroom = await ClassmojiService.classroom.findBySlug(classroomSlug);
+  // Resolving by id is what makes the authorization bind to the record the
+  // caller is acting on. The 404 body is identical either way, so an id probe
+  // leaks no more than a slug probe.
+  const classroom = classroomId
+    ? await ClassmojiService.classroom.findById(classroomId)
+    : await ClassmojiService.classroom.findBySlug(classroomSlug!);
 
   if (!classroom) {
     throw new Response('Classroom not found', {

--- a/packages/database/migrations/20260818103726_classroom_slug_global_unique/migration.sql
+++ b/packages/database/migrations/20260818103726_classroom_slug_global_unique/migration.sql
@@ -11,13 +11,38 @@
 -- logically redundant, but it is the compound key live upserts select on.
 
 -- ---------------------------------------------------------------------------
--- Pass 1: repair existing duplicate slugs.
+-- Repair existing duplicate slugs.
 --
--- Winner keeps the slug; every loser is renamed to {slug}-{sanitized org login}.
--- Winner precedence: most memberships, then most git_repos, then oldest
--- created_at, then lowest id. ROW_NUMBER (not a self-referencing EXISTS
--- predicate) is required here: with a 4-key rule an EXISTS comparison renames
--- both rows or neither whenever the leading keys tie.
+-- Winner keeps the slug; every loser is renamed. Winner precedence: most
+-- memberships, then most git_repos, then oldest created_at, then lowest id.
+-- ROW_NUMBER (not a self-referencing EXISTS predicate) is required here: with a
+-- 4-key rule an EXISTS comparison renames both rows or neither whenever the
+-- leading keys tie.
+--
+-- Each loser WALKS A CANDIDATE LIST and takes the first slug no other row
+-- holds, mirroring `classroomSlugCandidates()` in
+-- packages/services/src/classmoji/classroomSlug.ts: org-qualified first (the
+-- bare slug is the winner's), then id-suffixed as the always-free fallback. A
+-- row renamed here and a row created by the app are therefore named by the same
+-- rule.
+--
+-- Choosing the candidate INSIDE the walk — rather than renaming first and
+-- disambiguating afterwards — is what makes this safe. The composite unique
+-- (git_org_id, slug) is live throughout, so a blind `{slug}-{org}` rename
+-- raises 23505 the moment a loser's target is already held by a classroom in
+-- its OWN org ("Acme" owning both `cs500` and `cs500-acme`), and the repair
+-- would abort before any after-the-fact fixup could run.
+--
+-- The invariant: immediately before each UPDATE, no other row holds `chosen`,
+-- so neither the retained composite nor the incoming global unique can fire.
+-- The freeness check reads LIVE state, so it sees every rename already granted
+-- in this loop. It is deliberately conservative in the other direction — a slug
+-- still held by a loser that has not been processed yet reads as taken even
+-- though it will be vacated — which can only push a loser onto a later
+-- candidate, never onto a colliding one.
+--
+-- Winners and never-duplicated incumbents are not in the loop's row set at all,
+-- so they are never touched.
 --
 -- git_organizations.login preserves GitHub's case (~100 of 159 prod orgs have
 -- uppercase logins), so it is lowercased and sanitized to [a-z0-9-] with runs
@@ -25,82 +50,108 @@
 -- the app. Anything else would mint a slug no code path can reproduce and a URL
 -- that only resolves with exact case.
 -- ---------------------------------------------------------------------------
-DROP TABLE IF EXISTS "_classroom_slug_repair";
+DO $$
+DECLARE
+  loser  RECORD;
+  cand   TEXT;
+  chosen TEXT;
+BEGIN
+  FOR loser IN
+    WITH dupes AS (
+      SELECT "slug" FROM "classrooms" GROUP BY "slug" HAVING COUNT(*) > 1
+    ),
+    scored AS (
+      SELECT
+        c."id",
+        c."slug",
+        c."git_org_id",
+        c."created_at",
+        (SELECT COUNT(*) FROM "classroom_memberships" m WHERE m."classroom_id" = c."id") AS member_count,
+        (SELECT COUNT(*) FROM "git_repos" g WHERE g."classroom_id" = c."id") AS repo_count,
+        -- Empty fallback covers logins with no alphanumerics (e.g. the mock orgs
+        -- backing example classrooms).
+        COALESCE(
+          NULLIF(
+            regexp_replace(
+              regexp_replace(lower(o."login"), '[^a-z0-9]+', '-', 'g'),
+              '^-+|-+$', '', 'g'
+            ),
+            ''
+          ),
+          substr(c."id"::text, 1, 8)
+        ) AS org_suffix
+      FROM "classrooms" c
+      JOIN "git_organizations" o ON o."id" = c."git_org_id"
+      WHERE c."slug" IN (SELECT "slug" FROM dupes)
+    ),
+    ranked AS (
+      SELECT
+        s.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY s."slug"
+          ORDER BY s.member_count DESC, s.repo_count DESC, s."created_at" ASC, s."id" ASC
+        ) AS rn
+      FROM scored s
+    )
+    -- Ordered so the run is reproducible: when two losers from different groups
+    -- want the same candidate, processing order decides who gets it, and that
+    -- must be the same on a dry run, on staging, and in production.
+    SELECT
+      r."id"         AS id,
+      r."slug"       AS old_slug,
+      r."git_org_id" AS git_org_id,
+      r.org_suffix   AS org_suffix
+    FROM ranked r
+    WHERE r.rn > 1
+    ORDER BY r."slug", r.rn
+  LOOP
+    chosen := NULL;
 
-CREATE TEMP TABLE "_classroom_slug_repair" AS
-WITH dupes AS (
-  SELECT "slug" FROM "classrooms" GROUP BY "slug" HAVING COUNT(*) > 1
-),
-scored AS (
-  SELECT
-    c."id",
-    c."slug",
-    c."git_org_id",
-    c."created_at",
-    (SELECT COUNT(*) FROM "classroom_memberships" m WHERE m."classroom_id" = c."id") AS member_count,
-    (SELECT COUNT(*) FROM "git_repos" g WHERE g."classroom_id" = c."id") AS repo_count,
-    -- Empty fallback covers logins with no alphanumerics (e.g. the mock orgs
-    -- backing example classrooms).
-    COALESCE(
-      NULLIF(
-        regexp_replace(
-          regexp_replace(lower(o."login"), '[^a-z0-9]+', '-', 'g'),
-          '^-+|-+$', '', 'g'
-        ),
-        ''
-      ),
-      substr(c."id"::text, 1, 8)
-    ) AS org_suffix
-  FROM "classrooms" c
-  JOIN "git_organizations" o ON o."id" = c."git_org_id"
-  WHERE c."slug" IN (SELECT "slug" FROM dupes)
-),
-ranked AS (
-  SELECT
-    s.*,
-    ROW_NUMBER() OVER (
-      PARTITION BY s."slug"
-      ORDER BY s.member_count DESC, s.repo_count DESC, s."created_at" ASC, s."id" ASC
-    ) AS rn
-  FROM scored s
-)
-SELECT "id", "slug" AS old_slug, "slug" || '-' || org_suffix AS new_slug
-FROM ranked
-WHERE rn > 1;
+    FOREACH cand IN ARRAY ARRAY[
+      -- 1. `{slug}-{org login}` — the app's first collision candidate.
+      loser.old_slug || '-' || loser.org_suffix,
+      -- 2. id-suffixed. `id` is a uuid, so the first 8 hex chars are random;
+      --    this is free in every realistic shape.
+      loser.old_slug || '-' || loser.org_suffix || '-' || substr(loser.id::text, 1, 8),
+      -- 3. full id. Insurance only: unreachable unless some row already holds
+      --    candidate 2, which requires an 8-hex-char birthday collision inside
+      --    one group.
+      loser.old_slug || '-' || loser.org_suffix || '-' || loser.id::text
+    ]
+    LOOP
+      IF NOT EXISTS (
+        SELECT 1 FROM "classrooms" other
+        WHERE other."id" <> loser.id
+          AND (
+            -- incoming global unique
+            other."slug" = cand
+            -- retained (git_org_id, slug) composite; spelled out deliberately
+            -- even though equal (git_org_id, slug) implies equal slug, so that
+            -- narrowing the branch above can never silently drop the in-org
+            -- guarantee. This is the constraint the un-walked rename hit.
+            OR (other."git_org_id" = loser.git_org_id AND other."slug" = cand)
+          )
+      ) THEN
+        chosen := cand;
+        EXIT;
+      END IF;
+    END LOOP;
 
-UPDATE "classrooms" c
-SET "slug" = r.new_slug
-FROM "_classroom_slug_repair" r
-WHERE c."id" = r."id";
+    IF chosen IS NULL THEN
+      RAISE EXCEPTION
+        'Cannot repair duplicate classroom slug %: every candidate is taken (classroom id %, org suffix %)',
+        loser.old_slug, loser.id, loser.org_suffix;
+    END IF;
 
--- ---------------------------------------------------------------------------
--- Pass 2 (defensive): a renamed slug can still collide — with an unrelated
--- classroom that already used that exact string, or with another loser whose
--- org login sanitizes to the same suffix. Only rows renamed in pass 1 are
--- eligible, so incumbents are never touched; because BOTH colliding losers are
--- in the repair table, both get a distinct id suffix rather than one being left
--- to fight the other. Checks the incoming global unique AND the retained
--- (git_org_id, slug) composite, since a rename can collide inside its own org.
--- ---------------------------------------------------------------------------
-UPDATE "classrooms" c
-SET "slug" = c."slug" || '-' || substr(c."id"::text, 1, 8)
-WHERE c."id" IN (SELECT "id" FROM "_classroom_slug_repair")
-  AND EXISTS (
-    SELECT 1 FROM "classrooms" other
-    WHERE other."id" <> c."id"
-      AND (
-        -- incoming global unique
-        other."slug" = c."slug"
-        -- retained (git_org_id, slug) composite; spelled out deliberately even
-        -- though equal (git_org_id, slug) implies equal slug, so that narrowing
-        -- the branch above can never silently drop the in-org guarantee.
-        OR (other."git_org_id" = c."git_org_id" AND other."slug" = c."slug")
-      )
-  );
+    UPDATE "classrooms" SET "slug" = chosen WHERE "id" = loser.id;
+  END LOOP;
+END $$;
 
-DROP TABLE "_classroom_slug_repair";
-
--- Guard: fail loudly with the offending slugs rather than on a bare index error.
+-- Guard: fail loudly with the offending slugs rather than on a bare index
+-- error. Unreachable by construction now that the repair never writes a slug
+-- another row holds — kept because it costs one query and is the only thing
+-- standing between a future edit to the walk above and an opaque 23505 in a
+-- release command.
 DO $$
 DECLARE dup_slugs TEXT;
 BEGIN

--- a/packages/database/migrations/20260818103726_classroom_slug_global_unique/migration.sql
+++ b/packages/database/migrations/20260818103726_classroom_slug_global_unique/migration.sql
@@ -1,0 +1,137 @@
+-- Restore GLOBAL uniqueness on classrooms.slug.
+--
+-- The slug is the sole key in every app URL (/admin/:class, /student/:class,
+-- the ICS calendar feed, the autograde callback) and in two HMAC credentials;
+-- none of them carry an org segment. `classrooms_slug_key` existed from the
+-- init migration until 20260521124056_remove_terms dropped it in favour of a
+-- per-org composite, which let two orgs claim the same URL and read each
+-- other's classroom. This migration is the reverse of that drop.
+--
+-- The composite unique (git_org_id, slug) is deliberately KEPT: it is now
+-- logically redundant, but it is the compound key live upserts select on.
+
+-- ---------------------------------------------------------------------------
+-- Pass 1: repair existing duplicate slugs.
+--
+-- Winner keeps the slug; every loser is renamed to {slug}-{sanitized org login}.
+-- Winner precedence: most memberships, then most git_repos, then oldest
+-- created_at, then lowest id. ROW_NUMBER (not a self-referencing EXISTS
+-- predicate) is required here: with a 4-key rule an EXISTS comparison renames
+-- both rows or neither whenever the leading keys tie.
+--
+-- git_organizations.login preserves GitHub's case (~100 of 159 prod orgs have
+-- uppercase logins), so it is lowercased and sanitized to [a-z0-9-] with runs
+-- collapsed and edges trimmed — matching all three slugify() implementations in
+-- the app. Anything else would mint a slug no code path can reproduce and a URL
+-- that only resolves with exact case.
+-- ---------------------------------------------------------------------------
+DROP TABLE IF EXISTS "_classroom_slug_repair";
+
+CREATE TEMP TABLE "_classroom_slug_repair" AS
+WITH dupes AS (
+  SELECT "slug" FROM "classrooms" GROUP BY "slug" HAVING COUNT(*) > 1
+),
+scored AS (
+  SELECT
+    c."id",
+    c."slug",
+    c."git_org_id",
+    c."created_at",
+    (SELECT COUNT(*) FROM "classroom_memberships" m WHERE m."classroom_id" = c."id") AS member_count,
+    (SELECT COUNT(*) FROM "git_repos" g WHERE g."classroom_id" = c."id") AS repo_count,
+    -- Empty fallback covers logins with no alphanumerics (e.g. the mock orgs
+    -- backing example classrooms).
+    COALESCE(
+      NULLIF(
+        regexp_replace(
+          regexp_replace(lower(o."login"), '[^a-z0-9]+', '-', 'g'),
+          '^-+|-+$', '', 'g'
+        ),
+        ''
+      ),
+      substr(c."id"::text, 1, 8)
+    ) AS org_suffix
+  FROM "classrooms" c
+  JOIN "git_organizations" o ON o."id" = c."git_org_id"
+  WHERE c."slug" IN (SELECT "slug" FROM dupes)
+),
+ranked AS (
+  SELECT
+    s.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY s."slug"
+      ORDER BY s.member_count DESC, s.repo_count DESC, s."created_at" ASC, s."id" ASC
+    ) AS rn
+  FROM scored s
+)
+SELECT "id", "slug" AS old_slug, "slug" || '-' || org_suffix AS new_slug
+FROM ranked
+WHERE rn > 1;
+
+UPDATE "classrooms" c
+SET "slug" = r.new_slug
+FROM "_classroom_slug_repair" r
+WHERE c."id" = r."id";
+
+-- ---------------------------------------------------------------------------
+-- Pass 2 (defensive): a renamed slug can still collide — with an unrelated
+-- classroom that already used that exact string, or with another loser whose
+-- org login sanitizes to the same suffix. Only rows renamed in pass 1 are
+-- eligible, so incumbents are never touched; because BOTH colliding losers are
+-- in the repair table, both get a distinct id suffix rather than one being left
+-- to fight the other. Checks the incoming global unique AND the retained
+-- (git_org_id, slug) composite, since a rename can collide inside its own org.
+-- ---------------------------------------------------------------------------
+UPDATE "classrooms" c
+SET "slug" = c."slug" || '-' || substr(c."id"::text, 1, 8)
+WHERE c."id" IN (SELECT "id" FROM "_classroom_slug_repair")
+  AND EXISTS (
+    SELECT 1 FROM "classrooms" other
+    WHERE other."id" <> c."id"
+      AND (
+        -- incoming global unique
+        other."slug" = c."slug"
+        -- retained (git_org_id, slug) composite; spelled out deliberately even
+        -- though equal (git_org_id, slug) implies equal slug, so that narrowing
+        -- the branch above can never silently drop the in-org guarantee.
+        OR (other."git_org_id" = c."git_org_id" AND other."slug" = c."slug")
+      )
+  );
+
+DROP TABLE "_classroom_slug_repair";
+
+-- Guard: fail loudly with the offending slugs rather than on a bare index error.
+DO $$
+DECLARE dup_slugs TEXT;
+BEGIN
+  SELECT string_agg("slug", ', ') INTO dup_slugs FROM (
+    SELECT "slug" FROM "classrooms" GROUP BY "slug" HAVING COUNT(*) > 1
+  ) x;
+  IF dup_slugs IS NOT NULL THEN
+    RAISE EXCEPTION 'Cannot apply unique(slug): duplicates remain after repair: %', dup_slugs;
+  END IF;
+END $$;
+
+-- CreateIndex
+-- Non-concurrent by necessity: Prisma wraps each migration file in a
+-- transaction and CREATE INDEX CONCURRENTLY cannot run inside one. The table is
+-- ~900 rows in production, so the lock window is negligible.
+CREATE UNIQUE INDEX "classrooms_slug_key" ON "classrooms"("slug");
+
+-- ---------------------------------------------------------------------------
+-- GitHub Classroom course id.
+--
+-- Nullable and NOT backfilled: classrooms created directly in Classmoji never
+-- have one, and already-imported rows can't be recovered (the id is fetched and
+-- then dropped today). Postgres permits many NULLs under a unique index, which
+-- is exactly the semantics wanted.
+--
+-- Unique because one GitHub Classroom course maps to at most one Classmoji
+-- classroom. That makes it the stable idempotency key for re-import, which the
+-- slug can no longer be now that a colliding slug may carry an org suffix.
+-- ---------------------------------------------------------------------------
+-- AlterTable
+ALTER TABLE "classrooms" ADD COLUMN "github_classroom_id" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "classrooms_github_classroom_id_key" ON "classrooms"("github_classroom_id");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -343,26 +343,37 @@ model GitOrganization {
 }
 
 model Classroom {
-  id                String          @id @default(uuid())
-  slug              String // URL slug: "cs101-fall-2025"
-  git_org_id        String
-  name              String
+  id                  String          @id @default(uuid())
+  // GLOBALLY unique. The slug is the sole key in every app URL — /admin/:class,
+  // /student/:class, the ICS calendar feed, and the autograde callback — and
+  // none of them carry an org segment, so a slug reused across orgs resolves to
+  // the wrong classroom. e.g. "cs101-fall-2025".
+  slug                String          @unique
+  git_org_id          String
+  name                String
   // Internal identifier only. Historically the content repo name was derived
   // as content-{orgLogin}-{content_namespace}; it no longer names any repo.
-  content_namespace String
+  content_namespace   String
   // The GitHub repo (in git_organization) holding this classroom's pages &
   // slides content. STORED and fully user-editable — never re-derived. Set at
   // creation for every classroom; defaults to `content-{content_namespace}`.
   // NOT the same as ClassroomSettings.content_repo_name, which is a legacy
   // ORG-level content repo override (`content-{login}`) for a DIFFERENT repo.
-  content_repo      String
-  status            ClassroomStatus @default(ACTIVE)
-  is_archived       Boolean         @default(false)
+  content_repo        String
+  // GitHub Classroom course id, set on import; null for classrooms created
+  // directly in Classmoji. Unique because one GitHub Classroom course maps to at
+  // most one Classmoji classroom, which makes it the stable idempotency key for
+  // re-imports — the slug can be suffixed on collision, so it can't be.
+  // (Postgres allows many NULLs under a unique index, which is the semantics we
+  // want: existing imported rows stay null and never collide.)
+  github_classroom_id Int?            @unique
+  status              ClassroomStatus @default(ACTIVE)
+  is_archived         Boolean         @default(false)
   // True for the auto-provisioned per-user "Example Course" sandbox used by the
   // in-classroom onboarding tour. Backed by a mock GitOrganization (no live GitHub).
-  is_example        Boolean         @default(false)
-  created_at        DateTime        @default(now())
-  updated_at        DateTime        @default(now()) @updatedAt
+  is_example          Boolean         @default(false)
+  created_at          DateTime        @default(now())
+  updated_at          DateTime        @default(now()) @updatedAt
 
   git_organization      GitOrganization       @relation(fields: [git_org_id], references: [id], onDelete: Cascade)
   settings              ClassroomSettings?
@@ -387,6 +398,9 @@ model Classroom {
   notifications         Notification[]
   import_job            ImportJob?
 
+  // Logically redundant now that slug is globally unique, but retained: it is
+  // the compound key live upserts select on (githubClassroomImport, example
+  // classroom provisioning, seed fixtures).
   @@unique([git_org_id, slug])
   // content_namespace no longer names the content repo, but stays unique
   // per-org: it is the internal identifier legacy rows were named from.

--- a/packages/services/src/classmoji/__tests__/githubClassroomImport.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/githubClassroomImport.service.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { buildImportedMetadata, deriveTeamSlug } from '../githubClassroomImport.service.ts';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildImportedMetadata,
+  deriveTeamSlug,
+  resolveImportedClassroom,
+} from '../githubClassroomImport.service.ts';
 import type { ImportAcceptance } from '../githubClassroomImport.service.ts';
 
 const baseAcc = (over: Partial<ImportAcceptance> = {}): ImportAcceptance => ({
@@ -138,5 +142,103 @@ describe('deriveTeamSlug', () => {
 
   it('returns null when there is no repo name and no members', () => {
     expect(deriveTeamSlug('', '', [])).toBeNull();
+  });
+});
+
+describe('resolveImportedClassroom', () => {
+  type Tx = Parameters<typeof resolveImportedClassroom>[0];
+
+  const makeTx = (rows: { byCourse?: unknown; legacy?: unknown }) => {
+    const findUnique = vi.fn(async () => rows.byCourse ?? null);
+    const findFirst = vi.fn(async () => rows.legacy ?? null);
+    const update = vi.fn(async (args: { where: { id: string } }) => ({ id: args.where.id }));
+    const create = vi.fn(async () => ({ id: 'created' }));
+    const tx = { classroom: { findUnique, findFirst, update, create } } as unknown as Tx;
+    return { tx, findUnique, findFirst, update, create };
+  };
+
+  const args = {
+    gitOrgId: 'org-1',
+    githubClassroomId: 222,
+    requestedSlug: 'cs-52',
+    candidateSlug: 'cs-52',
+    name: 'CS 52 Full Stack',
+  };
+
+  it('matches on the course id first and never touches the slug', async () => {
+    const { tx, findUnique, findFirst, update, create } = makeTx({ byCourse: { id: 'existing' } });
+
+    await resolveImportedClassroom(tx, args);
+
+    expect(findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { github_classroom_id: 222 } })
+    );
+    expect(findFirst).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ where: { id: 'existing' }, data: { name: args.name } })
+    );
+  });
+
+  it('restricts the legacy probe to rows with no github_classroom_id', async () => {
+    const { tx, findFirst } = makeTx({});
+
+    await resolveImportedClassroom(tx, args);
+
+    // The predicate is the fix: without `github_classroom_id: null`, a second
+    // course whose name slugifies to an already-imported slug would match that
+    // classroom's row and overwrite its name and course id.
+    expect(findFirst).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        where: { git_org_id: 'org-1', slug: 'cs-52', github_classroom_id: null },
+      })
+    );
+  });
+
+  it('creates on the candidate slug when no legacy row matches', async () => {
+    const { tx, update, create } = makeTx({});
+
+    await resolveImportedClassroom(tx, { ...args, candidateSlug: 'cs-52-2' });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          git_org_id: 'org-1',
+          slug: 'cs-52-2',
+          github_classroom_id: 222,
+        }),
+      })
+    );
+  });
+
+  it('self-heals a legacy row by stamping the course id onto it', async () => {
+    const { tx, update, create } = makeTx({ legacy: { id: 'legacy-row' } });
+
+    await resolveImportedClassroom(tx, args);
+
+    expect(create).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        where: { id: 'legacy-row' },
+        data: { name: args.name, github_classroom_id: 222 },
+      })
+    );
+  });
+
+  it('skips the course-id lookup, but still filters the legacy probe, without a course id', async () => {
+    const { tx, findUnique, findFirst, update } = makeTx({ legacy: { id: 'legacy-row' } });
+
+    await resolveImportedClassroom(tx, { ...args, githubClassroomId: null });
+
+    expect(findUnique).not.toHaveBeenCalled();
+    expect(findFirst).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        where: { git_org_id: 'org-1', slug: 'cs-52', github_classroom_id: null },
+      })
+    );
+    expect(update).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ where: { id: 'legacy-row' }, data: { name: args.name } })
+    );
   });
 });

--- a/packages/services/src/classmoji/__tests__/module.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/module.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const classroomFindFirst = vi.fn();
+const classroomFindUnique = vi.fn();
 const moduleFindMany = vi.fn();
 const itemFindFirst = vi.fn();
 const itemFindMany = vi.fn();
@@ -10,7 +10,7 @@ const transaction = vi.fn();
 
 vi.mock('@classmoji/database', () => ({
   default: () => ({
-    classroom: { findFirst: classroomFindFirst },
+    classroom: { findUnique: classroomFindUnique },
     module: { findMany: moduleFindMany },
     moduleItem: {
       findFirst: itemFindFirst,
@@ -128,7 +128,7 @@ describe('reorderItems', () => {
 
 describe('listForClassroom', () => {
   beforeEach(() => {
-    classroomFindFirst.mockResolvedValue({ id: 'c1' });
+    classroomFindUnique.mockResolvedValue({ id: 'c1' });
   });
 
   it('filters out unpublished items for students', async () => {
@@ -166,7 +166,7 @@ describe('listForClassroom', () => {
   });
 
   it('returns [] when the classroom does not exist', async () => {
-    classroomFindFirst.mockResolvedValue(null);
+    classroomFindUnique.mockResolvedValue(null);
     expect(await listForClassroom('missing')).toEqual([]);
   });
 });

--- a/packages/services/src/classmoji/__tests__/repository.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/repository.service.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const deleteMany = vi.fn();
+const updateMany = vi.fn();
+const findFirst = vi.fn();
+const findUniqueOrThrow = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    repository: { deleteMany, updateMany, findFirst, findUniqueOrThrow },
+  }),
+}));
+
+vi.mock('@classmoji/utils', () => ({ titleToIdentifier: (s: string) => s.toLowerCase() }));
+
+vi.mock('../notification.service.ts', () => ({
+  runSafely: vi.fn(),
+  getStudentsInClassroom: vi.fn(async () => []),
+  createNotifications: vi.fn(),
+}));
+
+const { deleteById, setPublished, update } = await import('../repository.service.ts');
+
+/** Every prisma method the service could reach — asserted untouched by the guard. */
+const allPrismaCalls = () => [deleteMany, updateMany, findFirst, findUniqueOrThrow];
+
+/** Ids that survive `if (!id)` but widen a scoped `where` to the whole classroom. */
+const unusableIds: [string, unknown][] = [
+  ['undefined', undefined],
+  ['null', null],
+  ['a StringFilter object', { not: '' }],
+  ['an empty string', ''],
+  ['a number', 7],
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('deleteById', () => {
+  it.each(unusableIds)('rejects %s as an id before issuing any query', async (_label, id) => {
+    await expect(deleteById(id as string, 'classroom-1')).rejects.toThrow('Invalid repository id');
+    for (const fn of allPrismaCalls()) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it.each(unusableIds)('rejects %s as a classroom id before any query', async (_label, cid) => {
+    await expect(deleteById('repo-1', cid as string)).rejects.toThrow('Invalid classroom id');
+    for (const fn of allPrismaCalls()) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('scopes the delete to the authorized classroom', async () => {
+    deleteMany.mockResolvedValue({ count: 1 });
+    await expect(deleteById('repo-1', 'classroom-1')).resolves.toEqual({ id: 'repo-1' });
+    expect(deleteMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: 'repo-1', classroom_id: 'classroom-1' },
+    });
+  });
+
+  it('throws when the id did not belong to the classroom', async () => {
+    deleteMany.mockResolvedValue({ count: 0 });
+    await expect(deleteById('repo-1', 'other-classroom')).rejects.toThrow(
+      'Repository not found in classroom'
+    );
+    expect(deleteMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setPublished', () => {
+  it.each(unusableIds)('rejects %s as an id before the pre-read', async (_label, id) => {
+    await expect(setPublished(id as string, true, 'classroom-1')).rejects.toThrow(
+      'Invalid repository id'
+    );
+    // The pre-read matters as much as the write: an unusable id would make it
+    // return an arbitrary repository in the classroom.
+    for (const fn of allPrismaCalls()) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it.each(unusableIds)('rejects %s as a classroom id before the pre-read', async (_label, cid) => {
+    await expect(setPublished('repo-1', true, cid as string)).rejects.toThrow(
+      'Invalid classroom id'
+    );
+    for (const fn of allPrismaCalls()) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('scopes the flip to the authorized classroom', async () => {
+    findFirst.mockResolvedValue({ is_published: false });
+    updateMany.mockResolvedValue({ count: 1 });
+    findUniqueOrThrow.mockResolvedValue({
+      id: 'repo-1',
+      classroom_id: 'classroom-1',
+      title: 'HW1',
+    });
+
+    await expect(setPublished('repo-1', true, 'classroom-1')).resolves.toMatchObject({
+      id: 'repo-1',
+    });
+    expect(updateMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: 'repo-1', classroom_id: 'classroom-1' },
+      data: { is_published: true },
+    });
+  });
+
+  it('throws without reading the row back when the repo was another classroom', async () => {
+    findFirst.mockResolvedValue(null);
+    updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(setPublished('repo-1', true, 'other-classroom')).rejects.toThrow(
+      'Repository not found in classroom'
+    );
+    expect(findUniqueOrThrow).not.toHaveBeenCalled();
+  });
+});
+
+describe('update', () => {
+  it.each(unusableIds)('rejects %s as an id before issuing any query', async (_label, id) => {
+    await expect(update(id as string, { weight: 50 }, 'classroom-1')).rejects.toThrow(
+      'Invalid repository id'
+    );
+    for (const fn of allPrismaCalls()) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it.each(unusableIds)('rejects %s as a classroom id before any query', async (_label, cid) => {
+    await expect(update('repo-1', { weight: 50 }, cid as string)).rejects.toThrow(
+      'Invalid classroom id'
+    );
+    for (const fn of allPrismaCalls()) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('scopes the write to the authorized classroom and returns the row', async () => {
+    updateMany.mockResolvedValue({ count: 1 });
+    findFirst.mockResolvedValue({ id: 'repo-1', weight: 50, assignments: [], tag: null });
+
+    await expect(update('repo-1', { weight: 50 }, 'classroom-1')).resolves.toMatchObject({
+      id: 'repo-1',
+      weight: 50,
+    });
+    expect(updateMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: 'repo-1', classroom_id: 'classroom-1' },
+      data: { weight: 50 },
+    });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'repo-1', classroom_id: 'classroom-1' } })
+    );
+  });
+
+  it('throws when the repository lives in another classroom', async () => {
+    updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(update('repo-1', { weight: 50 }, 'other-classroom')).rejects.toThrow(
+      'Repository not found in classroom'
+    );
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -45,12 +45,17 @@ export const findById = async (id: string) => {
 };
 
 /**
- * Find a Classroom by its unique slug
+ * Find a Classroom by its slug.
+ *
+ * Classroom.slug is GLOBALLY unique (not just per git organization): it is the
+ * sole key in every app URL — /admin/:class, /student/:class, the ICS calendar
+ * feed, the autograde callback — and none of those carry an org segment, so a
+ * slug shared across orgs would resolve to the wrong classroom.
  * @param {string} slug - URL-friendly slug (e.g., "cs101-fall-2025")
  * @returns {Promise<Object|null>}
  */
 export const findBySlug = async (slug: string) => {
-  return getPrisma().classroom.findFirst({
+  return getPrisma().classroom.findUnique({
     where: { slug },
     include: {
       git_organization: true,
@@ -187,30 +192,6 @@ export const createWithSettings = async (
 export const update = async (id: string, updates: Prisma.ClassroomUpdateInput) => {
   return getPrisma().classroom.update({
     where: { id },
-    data: updates,
-    include: {
-      git_organization: true,
-      settings: true,
-    },
-  });
-};
-
-/**
- * Update a Classroom by slug
- * @param {string} slug - Classroom slug
- * @param {Object} updates - Fields to update
- * @returns {Promise<Object>}
- */
-export const updateBySlug = async (slug: string, updates: Prisma.ClassroomUpdateInput) => {
-  const classroom = await getPrisma().classroom.findFirst({
-    where: { slug },
-    select: { id: true },
-  });
-  if (!classroom) {
-    throw new Error(`Classroom with slug "${slug}" not found`);
-  }
-  return getPrisma().classroom.update({
-    where: { id: classroom.id },
     data: updates,
     include: {
       git_organization: true,
@@ -611,24 +592,6 @@ export const deleteGitHubArtifacts = async (
   }
 
   return summary;
-};
-
-/**
- * Delete a Classroom by slug
- * @param {string} slug - Classroom slug
- * @returns {Promise<Object>}
- */
-export const deleteBySlug = async (slug: string) => {
-  const classroom = await getPrisma().classroom.findFirst({
-    where: { slug },
-    select: { id: true },
-  });
-  if (!classroom) {
-    throw new Error(`Classroom with slug "${slug}" not found`);
-  }
-  return getPrisma().classroom.delete({
-    where: { id: classroom.id },
-  });
 };
 
 /**

--- a/packages/services/src/classmoji/classroomSlug.ts
+++ b/packages/services/src/classmoji/classroomSlug.ts
@@ -1,0 +1,156 @@
+/**
+ * Classroom slug: normalization, deterministic collision candidates, and the
+ * constraint-and-retry wrapper that every slug-creating path goes through.
+ *
+ * `Classroom.slug` is GLOBALLY unique — it is the sole key in every app URL
+ * (/admin/:class, /student/:class, the ICS feed, the autograde callback), none
+ * of which carry an org segment. Two orgs can therefore legitimately want the
+ * same slug. Rather than refuse the second one, a create walks a candidate list
+ * and retries on the unique violation.
+ *
+ * The candidate order is DETERMINISTIC on purpose. A re-import has to land on
+ * the slug it landed on last time, or idempotency is gone and every re-run
+ * mints another classroom; a random or uuid tail would be unreproducible. The
+ * order (bare slug → org-qualified → numeric) also mirrors what the
+ * 20260818103726_classroom_slug_global_unique migration did to repair existing
+ * duplicates, so a row renamed by that migration and a row created here are
+ * named by the same rule.
+ *
+ * Pure: no Prisma import. The write is supplied by the caller.
+ */
+
+/** Highest numeric fallback: `{slug}-2` … `{slug}-11`. */
+export const MAX_CLASSROOM_SLUG_SUFFIX = 11;
+
+/**
+ * Normalize a string into a classroom slug.
+ *
+ * Byte-for-byte the rule used by the create wizard, the import wizard, and the
+ * slug-repair migration's org-login sanitizer (`lower()`, non-`[a-z0-9]` runs
+ * collapse to `-`, edges trimmed). Anything else would mint a slug some other
+ * code path cannot reproduce. Doubles as the org-login sanitizer below — the
+ * two rules are identical, so they are deliberately one function.
+ */
+export const slugify = (str: string): string =>
+  String(str ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+/**
+ * The slugs to try, in order, for a new classroom: the bare slug, then
+ * `{slug}-{org login}`, then `{slug}-2` … `{slug}-N`.
+ *
+ * Org-qualified BEFORE numeric: a global collision is almost always two
+ * different schools naming a course the same thing, and `cs101-dartmouth-cs52`
+ * says which one this is where `cs101-2` says nothing. Returns `[]` when the
+ * input has no slug-usable characters at all.
+ */
+export function classroomSlugCandidates(slug: string, orgLogin: string): string[] {
+  const base = slugify(slug);
+  if (!base) return [];
+
+  const candidates = [base];
+  const org = slugify(orgLogin);
+  if (org) candidates.push(`${base}-${org}`);
+  for (let n = 2; n <= MAX_CLASSROOM_SLUG_SUFFIX; n++) candidates.push(`${base}-${n}`);
+  return candidates;
+}
+
+/** Every candidate was taken (or the input had no usable characters). */
+export class ClassroomSlugUnavailableError extends Error {
+  readonly requestedSlug: string;
+  readonly candidates: string[];
+
+  constructor(requestedSlug: string, candidates: string[]) {
+    super(
+      candidates.length === 0
+        ? `'${requestedSlug}' contains no characters usable in a classroom slug.`
+        : `No free classroom slug for '${requestedSlug}' — all ${candidates.length} candidates are taken (${candidates.join(', ')}).`
+    );
+    this.name = 'ClassroomSlugUnavailableError';
+    this.requestedSlug = requestedSlug;
+    this.candidates = candidates;
+  }
+}
+
+/**
+ * The two unique indexes that a colliding classroom slug can violate, and the
+ * field sets Prisma reports for them.
+ *
+ * Prisma does not pin the shape of `meta.target`: depending on driver and
+ * version it is an array of field names (`['git_org_id', 'slug']`), the raw
+ * constraint name (`'classrooms_slug_key'`), or that name inside a one-element
+ * array. All three are handled.
+ *
+ * Matching is EXACT on the field set, never "contains slug" — `Team` and
+ * `Slide` are both `@@unique([classroom_id, slug])`, and the importer writes
+ * both inside the same transaction. A substring match would replay an entire
+ * import because one team name collided.
+ */
+const SLUG_INDEX_NAMES = new Set(['classrooms_slug_key', 'classrooms_git_org_id_slug_key']);
+const SLUG_FIELD_SETS = new Set(['slug', 'git_org_id,slug']);
+
+const targetTokens = (target: unknown): string[] => {
+  const raw = Array.isArray(target) ? target : typeof target === 'string' ? target.split(',') : [];
+  return raw.map(t => String(t).trim().toLowerCase()).filter(Boolean);
+};
+
+/**
+ * Is this error a unique violation on a CLASSROOM SLUG index specifically?
+ *
+ * A bare `code === 'P2002'` test is wrong twice over: in create-classroom it
+ * would turn the friendly content-repo-collision error into silent slug
+ * suffixing, and in the importer it would re-run the whole roster because a
+ * user login or a team slug collided. An unrecognized target is treated as NOT
+ * a slug conflict — failing loudly beats retrying blind.
+ */
+export function isClassroomSlugConflict(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  if ((error as { code?: unknown }).code !== 'P2002') return false;
+
+  const tokens = targetTokens((error as { meta?: { target?: unknown } }).meta?.target);
+  if (tokens.length === 0) return false;
+  if (tokens.length === 1 && SLUG_INDEX_NAMES.has(tokens[0])) return true;
+  return SLUG_FIELD_SETS.has([...tokens].sort().join(','));
+}
+
+/**
+ * Run `write` with the first classroom slug that isn't already taken.
+ *
+ * `write` receives the candidate slug and MUST perform the whole write — if it
+ * opens an interactive transaction, the `prisma.$transaction(...)` call itself
+ * belongs INSIDE this callback, never the other way around. A P2002 raised
+ * inside an interactive transaction aborts the whole transaction (Postgres
+ * 25P02), so a retry attempted from within it fails every remaining candidate
+ * with "current transaction is aborted"; the same reasoning is spelled out at
+ * `githubClassroomImport.service.ts` (`resolveImportedUser`). Because the
+ * transaction rolls back completely, replaying the callback is safe — but any
+ * accumulator the callback mutates (counters, warning lists) must be created
+ * INSIDE it so a retry starts from zero.
+ *
+ * Returns the candidate the successful write used. A callback that may instead
+ * update a PRE-EXISTING row (import re-runs) must read the slug off the
+ * persisted row rather than trusting this value.
+ *
+ * @throws ClassroomSlugUnavailableError when every candidate is taken.
+ */
+export async function createWithUniqueClassroomSlug<T>(
+  params: { slug: string; orgLogin: string },
+  write: (slug: string) => Promise<T>
+): Promise<{ slug: string; result: T }> {
+  const candidates = classroomSlugCandidates(params.slug, params.orgLogin);
+  if (candidates.length === 0) {
+    throw new ClassroomSlugUnavailableError(params.slug, candidates);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      return { slug: candidate, result: await write(candidate) };
+    } catch (error: unknown) {
+      if (!isClassroomSlugConflict(error)) throw error;
+    }
+  }
+
+  throw new ClassroomSlugUnavailableError(params.slug, candidates);
+}

--- a/packages/services/src/classmoji/exampleClassroom.service.ts
+++ b/packages/services/src/classmoji/exampleClassroom.service.ts
@@ -14,6 +14,10 @@
  *    unique across every user's sandbox.
  *
  * Idempotent: if the user's example classroom already exists, it returns early.
+ * Keyed on the owner's membership in an is_example classroom under the mock
+ * org, NOT on the `example-{login}` slug — that slug can take a collision
+ * suffix, after which a slug lookup would miss forever and re-provision the
+ * sandbox on every call.
  * Shared demo personas (TA + 3 students) are upserted once and reused across all
  * sandboxes; their memberships, repos, and grades are created per classroom.
  *
@@ -24,6 +28,7 @@
 
 import getPrisma from '@classmoji/database';
 import { defaultContentRepoName } from '@classmoji/utils';
+import { createWithUniqueClassroomSlug } from './classroomSlug.ts';
 
 const EXAMPLE_ORG = {
   provider: 'GITHUB' as const,
@@ -72,9 +77,19 @@ export async function provisionExampleClassroom(params: {
 
   const slug = `example-${ownerLogin}`.toLowerCase();
 
-  // Idempotent: if this user's example classroom already exists, do nothing.
-  const existing = await prisma.classroom.findUnique({
-    where: { git_org_id_slug: { git_org_id: org.id, slug } },
+  // Idempotent, keyed on IDENTITY rather than on the slug.
+  //
+  // `example-{login}` is globally unique only because GitHub logins are — one
+  // real classroom slugged `example-tim` and this user's sandbox has to take a
+  // suffix. A slug lookup would then miss forever and re-provision on every
+  // call. The owner's membership in an is_example classroom under the shared
+  // mock org is the thing that is actually stable.
+  const existing = await prisma.classroom.findFirst({
+    where: {
+      git_org_id: org.id,
+      is_example: true,
+      memberships: { some: { user_id: ownerUserId, role: 'OWNER' } },
+    },
     select: { id: true, slug: true },
   });
   if (existing) return existing;
@@ -84,11 +99,39 @@ export async function provisionExampleClassroom(params: {
   // strand a user in (and the idempotency check above stays accurate, so the next
   // signup retries from a clean slate). Timeout is raised for the ~30 sequential
   // writes; all of them go through `tx`, never `prisma`.
+  //
+  // The slug guard wraps the transaction from OUTSIDE: a P2002 raised inside an
+  // interactive transaction aborts the whole thing (Postgres 25P02), so a retry
+  // attempted from within would fail every remaining candidate.
+  const { result } = await createWithUniqueClassroomSlug(
+    { slug, orgLogin: EXAMPLE_ORG.login },
+    classroomSlug =>
+      buildExampleSandbox({ ownerUserId, ownerLogin, gitOrgId: org.id, slug: classroomSlug })
+  );
+  return result;
+}
+
+/**
+ * Build one example sandbox on one candidate slug.
+ *
+ * Split out from `provisionExampleClassroom` so the slug retry can wrap the
+ * whole `$transaction` call — a retry attempted from inside an aborted
+ * transaction fails every remaining candidate.
+ */
+function buildExampleSandbox(args: {
+  ownerUserId: string;
+  ownerLogin: string;
+  gitOrgId: string;
+  slug: string;
+}): Promise<{ id: string; slug: string }> {
+  const { ownerUserId, ownerLogin, gitOrgId, slug } = args;
+  const prisma = getPrisma();
+
   return prisma.$transaction(
     async tx => {
       const classroom = await tx.classroom.create({
         data: {
-          git_org_id: org.id,
+          git_org_id: gitOrgId,
           slug,
           name: 'Example Course',
           content_namespace: slug,

--- a/packages/services/src/classmoji/githubClassroomApi.service.ts
+++ b/packages/services/src/classmoji/githubClassroomApi.service.ts
@@ -19,6 +19,7 @@
 
 import getPrisma from '@classmoji/database';
 import { GitHubProvider } from '../git/index.ts';
+import { slugify } from './classroomSlug.ts';
 import type {
   ImportClassroom,
   ImportClassroomInput,
@@ -93,17 +94,9 @@ export interface ListedClassroom {
   archived: boolean;
   /** null only if the classroom has no organization (can't be imported). */
   organization: { id: number; login: string } | null;
-  /** True if a Classmoji classroom already exists for this one (org + default slug). */
+  /** True if a Classmoji classroom already exists for this GitHub Classroom course. */
   alreadyImported: boolean;
 }
-
-/** Slugify a classroom name. MUST match the webapp's `slugify` (and create-classroom),
- * because that's the slug the importer keys on. */
-const slugifyName = (str: string): string =>
-  str
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
 
 /**
  * List the classrooms the authenticated user administers, enriched with their
@@ -149,19 +142,44 @@ export async function listAdminClassrooms(token: string): Promise<ListedClassroo
 }
 
 /**
- * Mark which listed classrooms already exist in Classmoji. A classroom is
- * "already imported" when a Classroom row exists under the matching
- * GitOrganization with the default slug (slugify of the name) — the same natural
- * key the importer upserts on. Imports under a custom slug aren't detected (rare);
- * re-importing with the default slug would update in place anyway.
+ * Mark which listed classrooms already exist in Classmoji.
+ *
+ * Primary key: `Classroom.github_classroom_id`, the GitHub Classroom course id
+ * — the same key the importer keys idempotency on, so it holds however the
+ * classroom's slug was named.
+ *
+ * Fallback: the org + default-slug match, for LEGACY rows imported before that
+ * column existed (the importer stamps the course id onto those on the next
+ * re-import, after which they match on the primary key). The fallback is a
+ * guess, and it goes wrong in both directions once slugs can be suffixed: a
+ * course imported under a suffixed or custom slug looks fresh, and a slug that
+ * happens to match an unrelated classroom looks imported. Only the course-id
+ * match is authoritative.
  */
 async function annotateAlreadyImported(classrooms: ListedClassroom[]): Promise<void> {
   const orgProviderIds = [
     ...new Set(classrooms.flatMap(c => (c.organization ? [String(c.organization.id)] : []))),
   ];
-  if (orgProviderIds.length === 0) return;
+  const courseIds = classrooms.map(c => c.githubId).filter(id => Number.isInteger(id) && id > 0);
 
   const prisma = getPrisma();
+  const importedCourseIds = new Set(
+    courseIds.length === 0
+      ? []
+      : (
+          await prisma.classroom.findMany({
+            where: { github_classroom_id: { in: courseIds } },
+            select: { github_classroom_id: true },
+          })
+        ).flatMap(c => (c.github_classroom_id == null ? [] : [c.github_classroom_id]))
+  );
+
+  for (const c of classrooms) {
+    if (importedCourseIds.has(c.githubId)) c.alreadyImported = true;
+  }
+
+  if (orgProviderIds.length === 0) return;
+
   const orgs = await prisma.gitOrganization.findMany({
     where: { provider: 'GITHUB', provider_id: { in: orgProviderIds } },
     select: { id: true, provider_id: true },
@@ -170,15 +188,15 @@ async function annotateAlreadyImported(classrooms: ListedClassroom[]): Promise<v
 
   const gitOrgIdByProvider = new Map(orgs.map(o => [o.provider_id, o.id]));
   const existing = await prisma.classroom.findMany({
-    where: { git_org_id: { in: orgs.map(o => o.id) } },
+    where: { git_org_id: { in: orgs.map(o => o.id) }, github_classroom_id: null },
     select: { git_org_id: true, slug: true },
   });
   const existingKey = new Set(existing.map(c => `${c.git_org_id}::${c.slug}`));
 
   for (const c of classrooms) {
-    if (!c.organization) continue;
+    if (c.alreadyImported || !c.organization) continue;
     const gitOrgId = gitOrgIdByProvider.get(String(c.organization.id));
-    if (gitOrgId && existingKey.has(`${gitOrgId}::${slugifyName(c.name)}`)) {
+    if (gitOrgId && existingKey.has(`${gitOrgId}::${slugify(c.name)}`)) {
       c.alreadyImported = true;
     }
   }

--- a/packages/services/src/classmoji/githubClassroomImport.service.ts
+++ b/packages/services/src/classmoji/githubClassroomImport.service.ts
@@ -273,18 +273,31 @@ export async function importGithubClassroom(
  *  1. `github_classroom_id` — the GitHub Classroom course id, the stable key.
  *     Its slug is deliberately NOT touched: it may carry a collision suffix and
  *     it is a live URL.
- *  2. `(git_org_id, slug)` — LEGACY rows imported before that column existed.
+ *  2. `(git_org_id, slug)` on a row that carries NO `github_classroom_id` —
+ *     LEGACY rows imported before that column existed. The null predicate is
+ *     load-bearing, not decoration: two courses in one org whose names slugify
+ *     identically ("CS 52: Full-Stack" and "CS 52 Full Stack" both give `cs-52`)
+ *     are both auto-selected by the wizard, and without it the second import
+ *     would match the first one's row by slug and overwrite its name and course
+ *     id — one classroom holding both rosters, the first course id lost. It is
+ *     also the same predicate `annotateAlreadyImported` uses for its fallback,
+ *     so the two agree on what "legacy" means.
  *     Matched on the REQUESTED slug, never the retry candidate: a candidate such
  *     as `cs101-2` can belong to an unrelated classroom in this org, and
  *     updating that would pour this roster into someone else's course. The
  *     course id is stamped on as a side effect, so the row self-heals and the
  *     next re-import matches on step 1 instead.
- *  3. Otherwise create, on the candidate slug the retry wrapper supplied.
+ *  3. Otherwise create, on the candidate slug the retry wrapper supplied. An
+ *     already-imported row holding the requested slug falls through to here,
+ *     where the globally unique slug raises P2002 and the retry wrapper moves
+ *     on to the next candidate — a correctly suffixed second classroom.
  *
  * Steps 1 and 2 are attempt-invariant, which is what makes a retried attempt
  * take the same branch as the first one.
+ *
+ * Exported for tests only; the importer is its sole caller.
  */
-async function resolveImportedClassroom(
+export async function resolveImportedClassroom(
   tx: ImportTx,
   args: {
     gitOrgId: string;
@@ -310,8 +323,12 @@ async function resolveImportedClassroom(
     }
   }
 
-  const legacy = await tx.classroom.findUnique({
-    where: { git_org_id_slug: { git_org_id: gitOrgId, slug: requestedSlug } },
+  // `findFirst`, not `findUnique`: the compound unique cannot carry the
+  // `github_classroom_id` predicate. It is still a single-row lookup — the
+  // `@@unique([git_org_id, slug])` index caps the match at one — so no ordering
+  // is needed to make the result deterministic.
+  const legacy = await tx.classroom.findFirst({
+    where: { git_org_id: gitOrgId, slug: requestedSlug, github_classroom_id: null },
     select: { id: true },
   });
   if (legacy) {

--- a/packages/services/src/classmoji/githubClassroomImport.service.ts
+++ b/packages/services/src/classmoji/githubClassroomImport.service.ts
@@ -19,11 +19,15 @@
  * on their imported repo — for viewing only, never feeding live grading.
  *
  * Every write is an upsert on a natural key, so re-importing the same bundle is
- * idempotent (updates in place, never duplicates).
+ * idempotent (updates in place, never duplicates). The classroom itself is the
+ * one exception to "upsert": it is matched on TWO keys, because a slug can be
+ * suffixed on a global collision and so can no longer carry idempotency alone.
+ * See `resolveImportedClassroom`.
  */
 
 import getPrisma from '@classmoji/database';
 import { defaultContentRepoName, titleToIdentifier } from '@classmoji/utils';
+import { createWithUniqueClassroomSlug, slugify } from './classroomSlug.ts';
 
 // ---------------------------------------------------------------------------
 // Input shape (structural subset of the webapp parser's ParsedClassroom).
@@ -191,13 +195,24 @@ export const deriveTeamSlug = (
 // Import a single classroom.
 // ---------------------------------------------------------------------------
 
+/** The transaction client handed to an interactive `prisma.$transaction`. */
+type ImportTx = Parameters<Parameters<ReturnType<typeof getPrisma>['$transaction']>[0]>[0];
+
 export async function importGithubClassroom(
   ownerUserId: string,
   input: ImportClassroomInput
 ): Promise<ImportSummary> {
   const prisma = getPrisma();
-  const { classroom: gh, slug } = input;
-  const warnings: string[] = [];
+  const { classroom: gh } = input;
+
+  // Normalize the slug HERE rather than only in the HTTP action: the wizard's
+  // slug field is free text that reaches the job verbatim, and a Trigger.dev
+  // REPLAY re-enters at this function with the original payload. An input that
+  // sanitizes away entirely falls back to the classroom name.
+  const requestedSlug = slugify(input.slug) || slugify(gh.name);
+  if (!requestedSlug) {
+    throw new Error(`Classroom "${gh.name}" has no usable slug and can't be imported.`);
+  }
 
   // Org upsert lives OUTSIDE the transaction. github_installation_id is left
   // untouched: NULL on first import (GitHub-free), preserved if the teacher
@@ -215,7 +230,8 @@ export async function importGithubClassroom(
   });
 
   // Index imported scores by (github_username, assignment) so each student's repo
-  // can pick up its own grade for its own assignment.
+  // can pick up its own grade for its own assignment. Read-only for the rest of
+  // the import, so it is built once and survives a retried attempt untouched.
   const gradeByUserAssignment = new Map<string, ImportGradeRow>();
   const gradedLogins = new Set<string>();
   for (const row of gh.grades ?? []) {
@@ -224,12 +240,144 @@ export async function importGithubClassroom(
     gradeByUserAssignment.set(`${login}::${row.assignmentTitle}`, row);
   }
 
+  // The retry wraps the WHOLE transaction. A P2002 raised inside an interactive
+  // transaction aborts it (Postgres 25P02 — see `resolveImportedUser` below),
+  // so a slug retry attempted from within would fail every remaining candidate
+  // with "current transaction is aborted". Each attempt therefore builds its own
+  // summary and warning list, so a replay counts the roster once, not twice.
+  const { result: summary } = await createWithUniqueClassroomSlug(
+    { slug: requestedSlug, orgLogin: gh.organization.login },
+    candidateSlug =>
+      importClassroomAttempt({
+        ownerUserId,
+        gh,
+        gitOrgId: org.id,
+        appInstalled: Boolean(org.github_installation_id),
+        requestedSlug,
+        candidateSlug,
+        gradeByUserAssignment,
+        gradedLogins,
+      })
+  );
+
+  return summary;
+}
+
+/**
+ * Find (or create) the Classmoji classroom this GitHub Classroom course maps to.
+ *
+ * TWO keys, in order, because the slug alone can no longer carry idempotency —
+ * a global collision suffixes it, and a suffixed slug never matches the default
+ * one a re-import asks for:
+ *
+ *  1. `github_classroom_id` — the GitHub Classroom course id, the stable key.
+ *     Its slug is deliberately NOT touched: it may carry a collision suffix and
+ *     it is a live URL.
+ *  2. `(git_org_id, slug)` — LEGACY rows imported before that column existed.
+ *     Matched on the REQUESTED slug, never the retry candidate: a candidate such
+ *     as `cs101-2` can belong to an unrelated classroom in this org, and
+ *     updating that would pour this roster into someone else's course. The
+ *     course id is stamped on as a side effect, so the row self-heals and the
+ *     next re-import matches on step 1 instead.
+ *  3. Otherwise create, on the candidate slug the retry wrapper supplied.
+ *
+ * Steps 1 and 2 are attempt-invariant, which is what makes a retried attempt
+ * take the same branch as the first one.
+ */
+async function resolveImportedClassroom(
+  tx: ImportTx,
+  args: {
+    gitOrgId: string;
+    githubClassroomId: number | null;
+    requestedSlug: string;
+    candidateSlug: string;
+    name: string;
+  }
+) {
+  const { gitOrgId, githubClassroomId, requestedSlug, candidateSlug, name } = args;
+
+  if (githubClassroomId != null) {
+    const byCourse = await tx.classroom.findUnique({
+      where: { github_classroom_id: githubClassroomId },
+      select: { id: true },
+    });
+    if (byCourse) {
+      return tx.classroom.update({
+        where: { id: byCourse.id },
+        data: { name },
+        include: { settings: true },
+      });
+    }
+  }
+
+  const legacy = await tx.classroom.findUnique({
+    where: { git_org_id_slug: { git_org_id: gitOrgId, slug: requestedSlug } },
+    select: { id: true },
+  });
+  if (legacy) {
+    return tx.classroom.update({
+      where: { id: legacy.id },
+      data: {
+        name,
+        ...(githubClassroomId != null ? { github_classroom_id: githubClassroomId } : {}),
+      },
+      include: { settings: true },
+    });
+  }
+
+  return tx.classroom.create({
+    data: {
+      git_org_id: gitOrgId,
+      slug: candidateSlug,
+      name,
+      content_namespace: candidateSlug,
+      content_repo: defaultContentRepoName(candidateSlug),
+      github_classroom_id: githubClassroomId,
+      settings: { create: { show_grades_to_students: true, quizzes_enabled: true } },
+    },
+    include: { settings: true },
+  });
+}
+
+/**
+ * One import attempt against one candidate slug.
+ *
+ * Everything mutable lives here rather than in the caller, so the slug retry can
+ * replay it from a clean slate: the transaction rolls back completely, and the
+ * counters and warnings roll back with it.
+ */
+async function importClassroomAttempt(args: {
+  ownerUserId: string;
+  gh: ImportClassroom;
+  gitOrgId: string;
+  appInstalled: boolean;
+  requestedSlug: string;
+  candidateSlug: string;
+  gradeByUserAssignment: Map<string, ImportGradeRow>;
+  gradedLogins: Set<string>;
+}): Promise<ImportSummary> {
+  const prisma = getPrisma();
+  const {
+    ownerUserId,
+    gh,
+    gitOrgId,
+    appInstalled,
+    requestedSlug,
+    candidateSlug,
+    gradeByUserAssignment,
+    gradedLogins,
+  } = args;
+  const warnings: string[] = [];
+
+  // The GitHub Classroom course id, when the source actually carried one.
+  const githubClassroomId = Number.isInteger(gh.githubId) && gh.githubId > 0 ? gh.githubId : null;
+
   const summary: ImportSummary = {
     classroomId: '',
-    classroomSlug: slug,
+    classroomSlug: candidateSlug,
     classroomName: gh.name,
     organizationLogin: gh.organization.login,
-    appInstalled: Boolean(org.github_installation_id),
+    appInstalled,
     repositoriesImported: 0,
     assignmentsImported: 0,
     studentsEnrolled: 0,
@@ -245,20 +393,18 @@ export async function importGithubClassroom(
   // Timeout is raised because large rosters mean many sequential upserts.
   await prisma.$transaction(
     async tx => {
-      const classroom = await tx.classroom.upsert({
-        where: { git_org_id_slug: { git_org_id: org.id, slug } },
-        create: {
-          git_org_id: org.id,
-          slug,
-          name: gh.name,
-          content_namespace: slug,
-          content_repo: defaultContentRepoName(slug),
-          settings: { create: { show_grades_to_students: true, quizzes_enabled: true } },
-        },
-        update: { name: gh.name },
-        include: { settings: true },
+      const classroom = await resolveImportedClassroom(tx, {
+        gitOrgId,
+        githubClassroomId,
+        requestedSlug,
+        candidateSlug,
+        name: gh.name,
       });
       summary.classroomId = classroom.id;
+      // The PERSISTED slug, not the candidate: a re-import updates a row in
+      // place, and that row may already carry a collision suffix. This is what
+      // the wizard's "Go to classroom" link is built from.
+      summary.classroomSlug = classroom.slug;
 
       // A re-import onto an existing classroom may predate settings; ensure they exist.
       if (!classroom.settings) {
@@ -518,11 +664,7 @@ export async function importGithubClassroom(
  * The one mutable unique field, `login`, is only changed when the target is free.
  * Never writes `email` (unique and absent from the export).
  */
-async function resolveImportedUser(
-  tx: Parameters<Parameters<ReturnType<typeof getPrisma>['$transaction']>[0]>[0],
-  s: ImportStudent,
-  warnings: string[]
-) {
+async function resolveImportedUser(tx: ImportTx, s: ImportStudent, warnings: string[]) {
   // 1) Canonical match: the GitHub user id.
   const byProvider = await tx.user.findUnique({
     where: { provider_provider_id: { provider: 'GITHUB', provider_id: s.providerId } },

--- a/packages/services/src/classmoji/module.service.ts
+++ b/packages/services/src/classmoji/module.service.ts
@@ -77,7 +77,7 @@ const isItemTargetInClassroom = (item: ModuleItemWithTargets, classroomId: strin
 };
 
 const findClassroomIdBySlug = async (classroomSlug: string) => {
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     select: { id: true },
   });

--- a/packages/services/src/classmoji/repository.service.ts
+++ b/packages/services/src/classmoji/repository.service.ts
@@ -343,15 +343,46 @@ export const createFromForm = async (values: RepositoryFormValues) => {
 };
 
 /**
- * Update a Repository
+ * Reject ids that cannot safely stand in a scoped `where` clause.
+ *
+ * The scoped writes below pair the repository id with `classroom_id` so the
+ * write itself can only touch the authorized classroom, but that pairing only
+ * holds while both values are real strings. Prisma drops an `undefined` value
+ * from a `where` instead of rejecting it, and these id fields also accept a
+ * `StringFilter` object — so `undefined` or `{ not: '' }` would leave a
+ * `deleteMany`/`updateMany` matching EVERY row in the classroom. Ids reach these
+ * functions from untyped request bodies, so the check has to be a runtime one.
+ */
+const assertScopedIds = (id: unknown, classroomId: unknown): void => {
+  if (typeof id !== 'string' || !id) throw new Error('Invalid repository id');
+  if (typeof classroomId !== 'string' || !classroomId) throw new Error('Invalid classroom id');
+};
+
+/**
+ * Update a Repository.
+ *
+ * `classroomId` is REQUIRED and scopes the write — see `deleteById` below.
+ *
  * @param {string} id - UUID of the Repository
  * @param {Object} updates - Fields to update
+ * @param {string} classroomId - UUID of the authorized Classroom
  * @returns {Promise<Object>}
  */
-export const update = async (id: string, updates: Prisma.RepositoryUncheckedUpdateInput) => {
-  return getPrisma().repository.update({
-    where: { id },
+export const update = async (
+  id: string,
+  updates: Prisma.RepositoryUpdateManyMutationInput,
+  classroomId: string
+) => {
+  assertScopedIds(id, classroomId);
+
+  const { count } = await getPrisma().repository.updateMany({
+    where: { id, classroom_id: classroomId },
     data: updates,
+  });
+  if (count !== 1) throw new Error('Repository not found in classroom');
+
+  return getPrisma().repository.findFirst({
+    where: { id, classroom_id: classroomId },
     include: {
       assignments: true,
       tag: true,
@@ -443,14 +474,21 @@ export const updateWithAssignments = async (values: RepositoryUpdateValues) => {
  * `classroomId` is REQUIRED and is part of the write itself rather than a check
  * performed beforehand: `delete({ where: { id } })` would destroy any repository
  * whose id a caller can name, in any classroom. `deleteMany` accepts the
- * non-unique compound, and a count other than 1 means the id did not belong to
- * the authorized classroom — which throws rather than passing as a silent no-op.
+ * non-unique compound.
+ *
+ * `assertScopedIds` runs FIRST because the compound only narrows the write while
+ * both halves are real strings — see its docblock. Past that guard `id` is the
+ * primary key, so the compound matches at most one row: a count other than 1
+ * means zero rows matched, the id did not belong to the authorized classroom,
+ * and nothing was written — which throws rather than passing as a silent no-op.
  *
  * @param {string} id - UUID of the Repository
  * @param {string} classroomId - UUID of the authorized Classroom
  * @returns {Promise<Object>}
  */
 export const deleteById = async (id: string, classroomId: string) => {
+  assertScopedIds(id, classroomId);
+
   const { count } = await getPrisma().repository.deleteMany({
     where: { id, classroom_id: classroomId },
   });
@@ -469,6 +507,11 @@ export const deleteById = async (id: string, classroomId: string) => {
  * @returns {Promise<Object>}
  */
 export const setPublished = async (id: string, isPublished: boolean, classroomId: string) => {
+  // Before the read as well as the write: an unusable id would make the lookup
+  // below return an arbitrary repository in the classroom, and the notification
+  // would then be decided by one row while another was flipped.
+  assertScopedIds(id, classroomId);
+
   const previous = await getPrisma().repository.findFirst({
     where: { id, classroom_id: classroomId },
     select: { is_published: true },

--- a/packages/services/src/classmoji/repository.service.ts
+++ b/packages/services/src/classmoji/repository.service.ts
@@ -105,7 +105,7 @@ export const findBySlugAndTitle = async (
   title: string,
   options: RepositoryQueryOptions = {}
 ) => {
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     select: { id: true },
   });
@@ -149,7 +149,7 @@ export const findByClassroomSlugAndModuleSlug = async (
   repositorySlug: string,
   options: RepositoryQueryOptions = {}
 ) => {
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     select: { id: true },
   });
@@ -306,7 +306,7 @@ export const createFromForm = async (values: RepositoryFormValues) => {
     branch,
   } = values;
 
-  const classroom = await getPrisma().classroom.findFirst({
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
   });
 
@@ -438,31 +438,52 @@ export const updateWithAssignments = async (values: RepositoryUpdateValues) => {
 };
 
 /**
- * Delete a Repository
+ * Delete a Repository.
+ *
+ * `classroomId` is REQUIRED and is part of the write itself rather than a check
+ * performed beforehand: `delete({ where: { id } })` would destroy any repository
+ * whose id a caller can name, in any classroom. `deleteMany` accepts the
+ * non-unique compound, and a count other than 1 means the id did not belong to
+ * the authorized classroom — which throws rather than passing as a silent no-op.
+ *
  * @param {string} id - UUID of the Repository
+ * @param {string} classroomId - UUID of the authorized Classroom
  * @returns {Promise<Object>}
  */
-export const deleteById = async (id: string) => {
-  return getPrisma().repository.delete({
-    where: { id },
+export const deleteById = async (id: string, classroomId: string) => {
+  const { count } = await getPrisma().repository.deleteMany({
+    where: { id, classroom_id: classroomId },
   });
+  if (count !== 1) throw new Error('Repository not found in classroom');
+  return { id };
 };
 
 /**
- * Publish or unpublish a Repository
+ * Publish or unpublish a Repository.
+ *
+ * `classroomId` is REQUIRED and scopes the write — see `deleteById` above.
+ *
  * @param {string} id - UUID of the Repository
  * @param {boolean} isPublished - Whether to publish
+ * @param {string} classroomId - UUID of the authorized Classroom
  * @returns {Promise<Object>}
  */
-export const setPublished = async (id: string, isPublished: boolean) => {
-  const previous = await getPrisma().repository.findUnique({
-    where: { id },
+export const setPublished = async (id: string, isPublished: boolean, classroomId: string) => {
+  const previous = await getPrisma().repository.findFirst({
+    where: { id, classroom_id: classroomId },
     select: { is_published: true },
   });
 
-  const mod = await getPrisma().repository.update({
-    where: { id },
+  const { count } = await getPrisma().repository.updateMany({
+    where: { id, classroom_id: classroomId },
     data: { is_published: isPublished },
+  });
+  if (count !== 1) throw new Error('Repository not found in classroom');
+
+  // `updateMany` returns a count, not the row, and the notification below needs
+  // the record. The scoped write above has already proven it exists.
+  const mod = await getPrisma().repository.findUniqueOrThrow({
+    where: { id },
   });
 
   if (previous && previous.is_published !== isPublished) {

--- a/packages/services/src/classmoji/subscription.service.ts
+++ b/packages/services/src/classmoji/subscription.service.ts
@@ -82,11 +82,10 @@ export const deleteByUserId = async (userId: string): Promise<SubscriptionRecord
 };
 
 export const getByClassroom = async (classroomSlug: string): Promise<CurrentSubscription> => {
-  // Classroom slug is unique per git_organization (compound unique), not globally,
-  // so we use findFirst here. Callers reach this via authenticated routes that have
-  // already constrained the user to a specific classroom, making a same-slug
-  // collision in another org irrelevant to the result.
-  const classroom = await getPrisma().classroom.findFirst({
+  // Classroom slug is globally unique, so this resolves to exactly one classroom.
+  // The tier is the OWNER's most recent subscription — billing follows the person
+  // who owns the classroom, not the caller.
+  const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
     include: {
       memberships: {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -66,6 +66,18 @@ export {
 // Example-classroom provisioning (server-only; touches Prisma)
 export { provisionExampleClassroom } from './classmoji/exampleClassroom.service.ts';
 
+// Classroom slug rules: normalization, deterministic collision candidates, and
+// the constraint-and-retry wrapper every slug-creating path goes through
+// (pure — no Prisma; the caller supplies the write).
+export {
+  slugify,
+  classroomSlugCandidates,
+  createWithUniqueClassroomSlug,
+  isClassroomSlugConflict,
+  ClassroomSlugUnavailableError,
+  MAX_CLASSROOM_SLUG_SUFFIX,
+} from './classmoji/classroomSlug.ts';
+
 // Models list (moved from @classmoji/llm)
 export { getAllModels, getAnthropicModels } from './classmoji/modelsList.ts';
 

--- a/packages/tasks/src/workflows/gitRepo.ts
+++ b/packages/tasks/src/workflows/gitRepo.ts
@@ -219,7 +219,7 @@ export const createRepositoriesTask = task({
 
     await createRepositoryTask.batchTriggerAndWait(reposData);
 
-    await ClassmojiService.repository.setPublished(repository.id, true);
+    await ClassmojiService.repository.setPublished(repository.id, true, classroom.id);
   },
 });
 


### PR DESCRIPTION
## What

`Classroom.slug` is unique only per git organization (`@@unique([git_org_id, slug])`), but every app URL, the auth resolver, and both HMAC-signed capability URLs (ICS calendar, autograde callback) treat it as a global key — none of those routes carry an org segment. Two classrooms sharing a slug can therefore resolve to each other.

This restores global uniqueness and makes the surrounding code correct locally rather than by relying on a constraint several tables away.

## Why now

The global index existed from the initial migration until `20260521124056_remove_terms` dropped it. That change removed term/year from classroom creation, so slugs went from `cs101-fall-2026` to bare course codes — which made a global namespace a land grab, and the constraint was loosened. The URL layer was never adapted.

Because slugs are now generic course codes, suffixing is the expected outcome during the GitHub Classroom import wave, not an edge case — the second org to import "CS 101" collides by construction. That's why import idempotency is part of this PR rather than a follow-up.

## Changes

**Schema + migration**
- `slug` is globally `@unique`. `@@unique([git_org_id, slug])` is retained — it's the compound key live upserts still select on.
- The migration repairs existing duplicates before adding the index. Winner ranks by memberships → repos → age → id via `ROW_NUMBER()`; losers become `{slug}-{sanitized-lowercased-org-login}`, with an id-suffix pass for any residual conflict against *either* index. Lowercasing matters: most org logins carry uppercase, and every slugify path in the repo emits `[a-z0-9-]`.
- New `Classroom.github_classroom_id` (nullable, unique). Postgres treats NULLs as distinct, so it constrains imported rows without a backfill.

**Import idempotency**
- Imports key on the GitHub Classroom course id, so re-import updates in place even when the slug was suffixed. Legacy rows are stamped opportunistically on next import.
- The already-imported check keys on that id instead of a re-derived slug.
- Slugs are normalized server-side, covering the Trigger replay path as well as the HTTP action.

**Creation guards**
- `createWithUniqueClassroomSlug`: constraint-and-retry with a deterministic candidate order (bare → org-qualified → numeric). It matches the violated index *by name*, so unrelated unique violations aren't swallowed, and wraps the transaction rather than running inside it, since a P2002 aborts the whole transaction.
- Availability checks are global; suggestions follow the same candidate order.

**Scoping**
- `repository.deleteById` / `setPublished` require a `classroomId` and throw when the scoped write matches nothing.
- Where a record is fetched by id, authorization now binds to that id, so the authorized classroom and the acted-on record can't diverge.
- Settings updates use a field allowlist; `slug` is set once at creation.
- The import-job retry claims its row conditionally instead of read-then-write.

## Migration impact

The detection query was run read-only against production: **2 duplicate groups, 4 rows renamed**, all empty test classrooms (1 member, 0 repos each). Winners are unambiguous — memberships, repos, and age agree in both groups. No classroom with student data is renamed.

## Verification

- Migration applies clean from scratch, and the repair was tested against a database containing a real collision plus adversarial cases: an org login sanitizing to empty, two orgs sanitizing to the same suffix, a pre-existing squatter on the target slug, and a perfect four-key tie.
- Typecheck clean across webapp, mcp, slides, pages, services, tasks, auth.
- Tests: webapp 55/55, mcp 306/306, services 833 pass. The 12 services failures are pre-existing GitLab provider tests, identical on an untouched checkout.
- Two test fixtures corrected: one stubbed `findFirst`, one mocked a classroom without a `slug`.

## Review notes

- `classroom.service.ts` `create` / `createWithSettings` have no callers but remain on the public export surface, so they were left in place — every real creation path calls Prisma directly.
- Relation-filter queries (`where: { classroom: { slug } }`) were deliberately left alone; the unique index makes them correct by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA