### PR TITLE
fix(import): a source classroom with no content repo must not fail the import

### DIFF
--- a/apps/webapp/app/components/features/import/ImportProgressBanner.tsx
+++ b/apps/webapp/app/components/features/import/ImportProgressBanner.tsx
@@ -153,13 +153,17 @@ const ImportProgressBanner = ({ job: initialJob, sourceName }: ImportProgressBan
 
   // A finished import tidies itself away, but stays reopenable for a while —
   // the summary line is the only place the final counts are shown.
+  //
+  // A completed-with-warnings import does NOT tidy itself away. Something the
+  // user asked for was not imported, and collapsing that after 8 seconds is how
+  // an empty classroom goes unnoticed until the term starts. They dismiss it.
   useEffect(() => {
-    if (job.status !== 'COMPLETED') return;
+    if (job.status !== 'COMPLETED' || job.warnings?.length > 0) return;
     autoHideRef.current = setTimeout(() => setCollapsed(true), COMPLETED_AUTOHIDE_MS);
     return () => {
       if (autoHideRef.current) clearTimeout(autoHideRef.current);
     };
-  }, [job.status]);
+  }, [job.status, job.warnings?.length]);
 
   if (dismissed) return null;
 
@@ -293,9 +297,28 @@ const ImportProgressBanner = ({ job: initialJob, sourceName }: ImportProgressBan
       )}
 
       {job.warnings?.length > 0 && (
-        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          {job.warnings.length} item{job.warnings.length === 1 ? '' : 's'} skipped.
-        </p>
+        <div className="mt-2">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {job.warnings.length} item{job.warnings.length === 1 ? '' : 's'} skipped.
+          </p>
+          {/*
+            The count alone is not actionable: a whole content phase can copy
+            nothing and report "1 item skipped", which reads as a rounding error
+            rather than an empty classroom. Show the text, as the sibling
+            _user.import-classroom/StepProgress does. Capped at 6 — per-item
+            warnings on a large course can run to dozens.
+          */}
+          <ul className="ml-5 mt-1 list-disc text-xs text-amber-600 dark:text-amber-400">
+            {job.warnings.slice(0, 6).map((warning, i) => (
+              <li key={i}>{warning}</li>
+            ))}
+          </ul>
+          {job.warnings.length > 6 && (
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              …and {job.warnings.length - 6} more.
+            </p>
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/tasks/src/helpers/__tests__/cloneContentRepo.test.ts
+++ b/packages/tasks/src/helpers/__tests__/cloneContentRepo.test.ts
@@ -18,13 +18,18 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
 
 const mocks = vi.hoisted(() => ({
   clone: vi.fn(),
+  raw: vi.fn(),
 }));
 
 vi.mock('simple-git', () => ({
-  simpleGit: () => ({ clone: (...a: unknown[]) => mocks.clone(...a) }),
+  simpleGit: () => ({
+    clone: (...a: unknown[]) => mocks.clone(...a),
+    raw: (...a: unknown[]) => mocks.raw(...a),
+  }),
 }));
 
 vi.mock('@trigger.dev/sdk', () => ({
@@ -75,6 +80,28 @@ describe('cloneContentRepo — source repo that is not there', () => {
     });
   });
 
+  /**
+   * Pins WHAT is cloned, not just how failure is classified. Without this the
+   * suite stays green if the SOURCE url is swapped for the target's — and that
+   * mutation is quietly catastrophic rather than loud: the target was just
+   * auto-init'd with a README, so cloning it succeeds, pushes the README back,
+   * and returns pushed:true. Every page and slide row is then created against
+   * content paths that do not exist, and the instructor is told it worked.
+   * Also pins --depth 1: a full-history clone of an 800MB content repo is the
+   * difference between a minute and a timeout.
+   */
+  it('clones the SOURCE repo, shallow', async () => {
+    mocks.clone.mockRejectedValue(new Error(SERVER_LINE));
+
+    await clone();
+
+    expect(mocks.clone).toHaveBeenCalledWith(
+      `https://x-access-token:${SOURCE.token}@github.com/${SOURCE.orgLogin}/${SOURCE.repo}.git`,
+      expect.any(String),
+      ['--depth', '1']
+    );
+  });
+
   it.each([
     ['the server line alone', SERVER_LINE],
     ['the client line alone', CLIENT_LINE],
@@ -103,5 +130,57 @@ describe('cloneContentRepo — source repo that is not there', () => {
 
     await expect(clone()).rejects.toThrow(/x-access-token:\*\*\*@/);
     await expect(clone()).rejects.not.toThrow(/ghs_src/);
+  });
+});
+
+/**
+ * The other two ways a copy ends up empty. Each reason reaches the caller and
+ * becomes a different sentence in the instructor's banner, so a return path
+ * that dropped or mislabeled its reason would state something confidently
+ * false — 'pruned' silently reported as 'empty' tells the user to go look at
+ * the source classroom when the cause was their own pages/slides selection.
+ *
+ * These drive the real filesystem branch, so `clone` creates its directory the
+ * way a real clone does; the helper's `finally` removes it.
+ */
+describe('cloneContentRepo — the other empty outcomes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clone.mockImplementation(async (_url: string, dir: string) => {
+      fs.mkdirSync(dir, { recursive: true });
+    });
+  });
+
+  it('reports a source repo with no commits as empty', async () => {
+    // `rev-parse --verify HEAD` is what fails on a repo with no commits.
+    mocks.raw.mockRejectedValue(new Error("fatal: Needed a single revision'"));
+
+    await expect(clone()).resolves.toEqual({
+      pushed: false,
+      rewritten: 0,
+      files: 0,
+      skipped: 'empty',
+    });
+  });
+
+  it('reports an all-pruned tree as pruned, not empty', async () => {
+    mocks.raw.mockResolvedValue('abc123'); // HEAD exists — the repo has commits.
+
+    // The cloned tree holds nothing the selection keeps, so pruning empties it.
+    await expect(clone()).resolves.toEqual({
+      pushed: false,
+      rewritten: 0,
+      files: 0,
+      skipped: 'pruned',
+    });
+  });
+
+  it('leaves no working directory behind', async () => {
+    mocks.raw.mockResolvedValue('abc123');
+
+    await clone();
+
+    const dir = mocks.clone.mock.calls[0][1] as string;
+    expect(fs.existsSync(dir)).toBe(false);
   });
 });

--- a/packages/tasks/src/helpers/__tests__/cloneContentRepo.test.ts
+++ b/packages/tasks/src/helpers/__tests__/cloneContentRepo.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for cloneContentRepo's classification of a failed source clone.
+ *
+ * Focus: "the source repo is not there" must NOT fail the import. A classroom
+ * carries a content repo NAME from the moment it is created (the column is NOT
+ * NULL) while the repo itself is only created on the first content write, so a
+ * source that never had a page or deck clones a repo that does not exist. That
+ * used to throw and fail the whole content phase, leaving an import the user
+ * could only retry into the same error (prod run 06g1u10i, 2026-08-20).
+ *
+ * The classification is a regex over git's stderr, so it is pinned in both
+ * directions: not-found is absorbed, everything else still throws — and still
+ * throws with the installation token stripped out.
+ *
+ * `simple-git`, `@trigger.dev/sdk` and `@classmoji/services` are mocked — no
+ * network, no git, no filesystem (every case here returns before the working
+ * directory is touched).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  clone: vi.fn(),
+}));
+
+vi.mock('simple-git', () => ({
+  simpleGit: () => ({ clone: (...a: unknown[]) => mocks.clone(...a) }),
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: { contentImport: { rewriteContentUrls: vi.fn(), isTextContentPath: vi.fn() } },
+  // The real one strips `x-access-token:<token>@`; that behavior is covered in
+  // services. Here it only has to prove gitFailure routes the text through it.
+  redactAccessTokens: (text: string) =>
+    text.replace(/x-access-token:[^@]+@/g, 'x-access-token:***@'),
+}));
+
+const { cloneContentRepo } = await import('../cloneContentRepo.ts');
+
+const SOURCE = { orgLogin: 'uniglos', repo: 'content-game-technologies-2025-26', token: 'ghs_src' };
+const TARGET = { orgLogin: 'uniglos', repo: 'content-games-technologies-26-27', token: 'ghs_tgt' };
+
+const clone = () =>
+  cloneContentRepo({
+    source: SOURCE,
+    target: TARGET,
+    keepPages: true,
+    keepSlides: true,
+    commitMessage: 'Import content from content-game-technologies-2025-26',
+  });
+
+/** git prints both lines for one missing repo; either alone must still match. */
+const SERVER_LINE = 'remote: Repository not found.';
+const CLIENT_LINE = `fatal: repository 'https://x-access-token:ghs_src@github.com/${SOURCE.orgLogin}/${SOURCE.repo}.git/' not found`;
+
+describe('cloneContentRepo — source repo that is not there', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('absorbs a missing source repo instead of failing the import', async () => {
+    mocks.clone.mockRejectedValue(
+      new Error(`Cloning into '/app/repos/x'...\n${SERVER_LINE}\n${CLIENT_LINE}\n`)
+    );
+
+    await expect(clone()).resolves.toEqual({
+      pushed: false,
+      rewritten: 0,
+      files: 0,
+      skipped: 'missing',
+    });
+  });
+
+  it.each([
+    ['the server line alone', SERVER_LINE],
+    ['the client line alone', CLIENT_LINE],
+  ])('recognizes %s', async (_label, message) => {
+    mocks.clone.mockRejectedValue(new Error(message));
+
+    await expect(clone()).resolves.toMatchObject({ pushed: false, skipped: 'missing' });
+  });
+
+  it.each([
+    ['auth failure', 'fatal: Authentication failed for https://github.com/uniglos/x.git/'],
+    ['network failure', 'fatal: unable to access: Could not resolve host: github.com'],
+    ['a bare not-found that is not about a repository', 'fatal: pathspec main not found'],
+  ])('still throws on %s', async (_label, message) => {
+    mocks.clone.mockRejectedValue(new Error(message));
+
+    await expect(clone()).rejects.toThrow(/cloning uniglos\//);
+  });
+
+  it('strips the installation token out of a thrown clone failure', async () => {
+    mocks.clone.mockRejectedValue(
+      new Error(
+        "fatal: Authentication failed for 'https://x-access-token:ghs_src@github.com/o/r.git/'"
+      )
+    );
+
+    await expect(clone()).rejects.toThrow(/x-access-token:\*\*\*@/);
+    await expect(clone()).rejects.not.toThrow(/ghs_src/);
+  });
+});

--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -66,13 +66,24 @@ export interface CloneContentRepoPayload {
   onStep?: (note: string) => void;
 }
 
+/** Why nothing reached the target. Set whenever `pushed` is false. */
+export type CloneSkipReason =
+  /** The source repo does not exist, or this installation cannot see it. */
+  | 'missing'
+  /** The source repo exists but has no commits. */
+  | 'empty'
+  /** Everything the source had was pruned away by the pages/slides selection. */
+  | 'pruned';
+
 export interface CloneContentRepoResult {
-  /** false when the source repo had no commits — nothing to copy, not an error. */
+  /** false when there was nothing to copy — see `skipped`. Not an error. */
   pushed: boolean;
   /** Files whose absolute source-repo URLs were repointed at the target repo. */
   rewritten: number;
   /** Files in the pushed tree (excluding .git). */
   files: number;
+  /** Present only when `pushed` is false: which of the empty cases it was. */
+  skipped?: CloneSkipReason;
 }
 
 const cloneUrl = ({ orgLogin, repo, token }: ContentRepoCoordinates): string =>
@@ -99,6 +110,26 @@ function gitFailure(
 ): Error {
   const detail = error instanceof Error ? error.message : String(error);
   return new Error(`${action} ${orgLogin}/${repo} failed: ${redactAccessTokens(detail)}`);
+}
+
+/**
+ * Does this clone failure mean "there is no such repo"?
+ *
+ * Git says it two ways for the same condition — `remote: Repository not found.`
+ * from the server, then `fatal: repository '<url>' not found` from the client —
+ * and both land in one message, so either alternative matching is enough.
+ *
+ * Deliberately narrow: anything broader (a bare /not found/) would swallow
+ * unrelated git failures and silently import a classroom with no content. Auth
+ * and network failures must still throw.
+ *
+ * Note that GitHub answers 404 both for a repo that does not exist AND for one
+ * the installation cannot see, and does not distinguish them on purpose. The
+ * caller's warning has to name both possibilities, because we cannot tell.
+ */
+function isRepoNotFound(error: unknown): boolean {
+  const detail = error instanceof Error ? error.message : String(error);
+  return /remote: Repository not found|repository '[^']*' not found/i.test(detail);
 }
 
 /** Every file under `dir`, recursively, as absolute paths. Skips `.git`. */
@@ -208,6 +239,20 @@ export const cloneContentRepo = async (
     try {
       await simpleGit().clone(cloneUrl(source), localPath, ['--depth', '1']);
     } catch (error: unknown) {
+      // A source classroom that never had a page or deck still carries a
+      // content repo NAME: `Classroom.content_repo` is NOT NULL and every
+      // creation path fills it with a derived default, while the repo itself is
+      // only created on the first content write. "Named but absent" is
+      // therefore the ordinary shape of a source with no content — the same
+      // situation as the no-commits case below, and it has to behave the same
+      // way. Throwing here failed the whole content phase and left the user
+      // with an unretryable import (Trigger run 06g1u10i, 2026-08-20).
+      if (isRepoNotFound(error)) {
+        logger.warn('content import: source content repo not found — nothing to copy', {
+          repo: `${source.orgLogin}/${source.repo}`,
+        });
+        return { pushed: false, rewritten: 0, files: 0, skipped: 'missing' };
+      }
       throw gitFailure('cloning', source, error);
     }
 
@@ -222,7 +267,7 @@ export const cloneContentRepo = async (
       logger.warn('content import: source content repo has no commits — nothing to copy', {
         repo: `${source.orgLogin}/${source.repo}`,
       });
-      return { pushed: false, rewritten: 0, files: 0 };
+      return { pushed: false, rewritten: 0, files: 0, skipped: 'empty' };
     }
 
     // Discard the source's history: the target gets one fresh commit.
@@ -244,7 +289,7 @@ export const cloneContentRepo = async (
         keepPages,
         keepSlides,
       });
-      return { pushed: false, rewritten: 0, files: 0 };
+      return { pushed: false, rewritten: 0, files: 0, skipped: 'pruned' };
     }
 
     onStep?.(

--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -75,16 +75,28 @@ export type CloneSkipReason =
   /** Everything the source had was pruned away by the pages/slides selection. */
   | 'pruned';
 
-export interface CloneContentRepoResult {
-  /** false when there was nothing to copy — see `skipped`. Not an error. */
-  pushed: boolean;
-  /** Files whose absolute source-repo URLs were repointed at the target repo. */
-  rewritten: number;
-  /** Files in the pushed tree (excluding .git). */
-  files: number;
-  /** Present only when `pushed` is false: which of the empty cases it was. */
-  skipped?: CloneSkipReason;
-}
+/**
+ * A discriminated union rather than an optional field: "nothing was copied"
+ * always carries its reason, and tsc — not a comment — is what guarantees it.
+ * The caller turns the reason into user-facing text, so a return path that
+ * forgot to set one would silently describe the wrong situation.
+ */
+export type CloneContentRepoResult =
+  | {
+      pushed: true;
+      /** Files whose absolute source-repo URLs were repointed at the target repo. */
+      rewritten: number;
+      /** Files in the pushed tree (excluding .git). */
+      files: number;
+      skipped?: never;
+    }
+  | {
+      /** Nothing reached the target. Not an error — see `skipped`. */
+      pushed: false;
+      rewritten: number;
+      files: number;
+      skipped: CloneSkipReason;
+    };
 
 const cloneUrl = ({ orgLogin, repo, token }: ContentRepoCoordinates): string =>
   `https://x-access-token:${token}@github.com/${orgLogin}/${repo}.git`;

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -448,6 +448,35 @@ export const importContentTask = task({
     writer.patch(...activePhases.map(phase => ({ phase, note: null })));
     await writer.flush();
 
+    if (clone.skipped === 'missing') {
+      // GitHub answers 404 both for a repo that never existed and for one this
+      // installation cannot see — but here the DB breaks the tie. Every page
+      // and slide row is created only after `ensureContentRepo` (page.service
+      // `createPage`, slide.service `create`), so a single source row proves
+      // the repo was created at some point. Rows present + a 404 therefore
+      // means deleted, renamed, or out of the installation's reach: a real
+      // failure, and one the user can act on.
+      //
+      // It has to THROW rather than warn. Warning marks the phases `done`,
+      // which finalizes the job COMPLETED — and a completed job cannot be
+      // retried (the retry endpoint refuses anything but FAILED) while a
+      // `done` phase is skipped on resume. That would strand an instructor
+      // with an empty term-rollover classroom and no way back. Failing keeps
+      // the job retryable, so granting access and retrying recovers content.
+      const [sourcePages, sourceSlides] = await Promise.all([
+        wantPages ? prisma.page.count({ where: { classroom_id: job.source_classroom_id } }) : 0,
+        wantSlides ? prisma.slide.count({ where: { classroom_id: job.source_classroom_id } }) : 0,
+      ]);
+      if (sourcePages + sourceSlides > 0) {
+        throw new Error(
+          `source content repository ${source.orgLogin}/${source.repo} could not be cloned, but ` +
+            `the source classroom has ${sourcePages + sourceSlides} item(s) of content to copy. ` +
+            `The repository may have been deleted or renamed, or the Classmoji GitHub App may no ` +
+            `longer have access to it. Nothing was changed — fix the access and retry.`
+        );
+      }
+    }
+
     if (!clone.pushed) {
       // Nothing reached the target repo. Creating rows now would point every
       // page and deck at a path that does not exist — a classroom full of
@@ -491,23 +520,21 @@ function errText(error: unknown): string {
 /**
  * The banner line for a content copy that moved nothing.
  *
- * Worth distinguishing, because only one of these is ever the user's to act on.
- * A missing source repo usually means the source classroom simply never had
- * content — a classroom gets no content repo until its first page or deck — but
- * GitHub returns the same 404 for a repo the installation cannot see, and does
- * not let us tell which. So the text names both rather than asserting either.
+ * Worth distinguishing, because only one of these is the user's to act on. The
+ * 'missing' wording can state plainly that the source never had content: the
+ * caller has already proven it, by failing instead of warning whenever the
+ * source classroom still owns page or slide rows.
  */
 function describeEmptyCopy(
   source: { orgLogin: string; repo: string },
-  skipped?: CloneSkipReason
+  skipped: CloneSkipReason
 ): string {
   const repo = `${source.orgLogin}/${source.repo}`;
-  const reason =
-    skipped === 'missing'
-      ? `the source content repository ${repo} was not found — it was most likely never created, or the Classmoji GitHub App cannot see it`
-      : skipped === 'pruned'
-        ? 'the source had no content of the types you selected'
-        : `the source content repository ${repo} is empty`;
+  const reason = {
+    missing: `the source classroom never published any content (it has no ${repo} repository)`,
+    empty: `the source content repository ${repo} is empty`,
+    pruned: 'the source had no content of the types you selected',
+  }[skipped];
   return `content: nothing was copied — ${reason}. No pages or decks were created.`;
 }
 

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -53,7 +53,7 @@ import {
   type ImportSummaryCounts,
 } from '@classmoji/services/import-progress'; // eslint-disable-line import/no-unresolved
 import { titleToIdentifier } from '@classmoji/utils';
-import { cloneContentRepo } from '../helpers/cloneContentRepo.ts';
+import { cloneContentRepo, type CloneSkipReason } from '../helpers/cloneContentRepo.ts';
 
 /**
  * Minimum spacing between `progress` writes.
@@ -449,11 +449,10 @@ export const importContentTask = task({
     await writer.flush();
 
     if (!clone.pushed) {
-      // Nothing reached the target repo (an empty source, or everything pruned
-      // away). Creating rows now would point every page and deck at a path that
-      // does not exist — a classroom full of broken content, which is worse
-      // than an empty one. Say so and stop.
-      writer.addWarnings(['content: no files were copied — no pages or decks were created']);
+      // Nothing reached the target repo. Creating rows now would point every
+      // page and deck at a path that does not exist — a classroom full of
+      // broken content, which is worse than an empty one. Say why and stop.
+      writer.addWarnings([describeEmptyCopy(source, clone.skipped)]);
       writer.patch(...activePhases.map(phase => ({ phase, status: 'done' as const, note: null })));
       await writer.flush();
       return { pages: 0, slides: 0, pushed: false, files: clone.files };
@@ -487,6 +486,29 @@ export const importContentTask = task({
 
 function errText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The banner line for a content copy that moved nothing.
+ *
+ * Worth distinguishing, because only one of these is ever the user's to act on.
+ * A missing source repo usually means the source classroom simply never had
+ * content — a classroom gets no content repo until its first page or deck — but
+ * GitHub returns the same 404 for a repo the installation cannot see, and does
+ * not let us tell which. So the text names both rather than asserting either.
+ */
+function describeEmptyCopy(
+  source: { orgLogin: string; repo: string },
+  skipped?: CloneSkipReason
+): string {
+  const repo = `${source.orgLogin}/${source.repo}`;
+  const reason =
+    skipped === 'missing'
+      ? `the source content repository ${repo} was not found — it was most likely never created, or the Classmoji GitHub App cannot see it`
+      : skipped === 'pruned'
+        ? 'the source had no content of the types you selected'
+        : `the source content repository ${repo} is empty`;
+  return `content: nothing was copied — ${reason}. No pages or decks were created.`;
 }
 
 /**


### PR DESCRIPTION
## Problem

Two production imports failed this morning (Trigger runs `06g1ttli`, `06g1u10i`), same instructor, 15 minutes apart:

```
cloning uniglos/content-uniglos-game-technologies-2025-26 failed:
remote: Repository not found.
```

Not a permissions issue — the source classroom's content repo was never created. `Classroom.content_repo` is `NOT NULL` and every creation path fills it with a derived default, while the repo itself is only created lazily on the first page/deck write. A classroom that never had content therefore names a repo that does not exist.

The import handled the wrong version of "no content":

| case | before |
|---|---|
| `content_repo` is null | graceful skip — **unreachable**, the column is `NOT NULL` |
| repo exists, no commits | graceful skip |
| repo does not exist | **threw, failed the whole content phase** |

All three are the same situation to the instructor. The result: **you could not import from any classroom that never had pages or slides**, and the failed job could only be retried into the same error.

## Fix

Treat "not found" like the no-commits case already beside it — warn, copy nothing, let the import finish — but only when that is provably the right call.

`ensureContentRepo` runs before every page and slide row is created, so a single source row proves the repo once existed. If the source still has content rows and the clone 404s, the repo was deleted, renamed, or put out of the App installation's reach: that throws, keeping the job `FAILED` and therefore retryable, so fixing access and retrying recovers the content. Only a genuinely contentless source warns and completes.

This distinction matters because warning is not a soft option here: it marks the phases `done`, which finalizes the job `COMPLETED` — and a completed job cannot be retried, while a `done` phase is skipped on resume.

The clone error is classified narrowly (both of git's not-found phrasings, nothing broader) so auth and network failures still fail loudly.

## Also in this PR

- **The banner rendered a warning count and discarded the text** — a whole phase copying nothing showed as "1 item skipped". It now renders the lines (as the sibling `StepProgress` already does) and no longer auto-hides a completed import that has warnings.
- Each empty case carries a reason (`missing` / `empty` / `pruned`) as a **discriminated union**, so tsc guarantees a skip explains itself rather than a comment promising it.
- **Tests asserted only return values, never the clone arguments.** A source/target URL swap survived the suite while being worse than the original bug: the target is auto-init'd, so cloning it succeeds, pushes its README back, and reports success — every page and deck row then created against paths that do not exist. Args are now pinned, and the `empty` / `pruned` reasons have coverage they previously lacked.

## Test steps

1. Create a classroom, add no pages or decks.
2. Import from it into a new classroom, selecting pages and slides.
3. Import completes; banner shows "content: nothing was copied — the source classroom never published any content…" and stays open.
4. Repeat with a source that *has* pages, after removing the App's access to its content repo: the import fails with an actionable message and the Retry button works once access is restored.

## Verification

- 30 tests pass in `packages/tasks` (11 new)
- Mutation-checked: breaking the classifier fails 3 tests; the source/target clone swap fails the new args assertion
- `tsc --noEmit` and eslint clean in `packages/tasks` and `apps/webapp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA