### PR TITLE
fix(pages): ship server/ in the Docker image + /health check

### DIFF
--- a/apps/pages/Dockerfile
+++ b/apps/pages/Dockerfile
@@ -32,6 +32,9 @@ RUN apk add --no-cache openssl libc6-compat
 
 COPY --from=build /app/apps/pages/build ./apps/pages/build
 COPY --from=build /app/apps/pages/server.ts ./apps/pages/server.ts
+# server.ts imports from server/ (the site-host middleware) — skipping this
+# directory crash-loops the app at boot with ERR_MODULE_NOT_FOUND.
+COPY --from=build /app/apps/pages/server ./apps/pages/server
 COPY --from=build /app/apps/pages/package.json ./apps/pages/package.json
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./

--- a/apps/pages/fly.toml
+++ b/apps/pages/fly.toml
@@ -19,6 +19,17 @@ primary_region = 'iad'
   auto_start_machines = true
   min_machines_running = 1
 
+  # Without a check, a boot crash still reads as a green deploy (learned the
+  # hard way: the image once shipped without server/ and crash-looped while
+  # the deploy job passed). /health is answered before host classification,
+  # so it works on any Host header.
+  [[http_service.checks]]
+    interval = '15s'
+    timeout = '5s'
+    grace_period = '30s'
+    method = 'GET'
+    path = '/health'
+
 [[vm]]
   memory = '1gb'
   cpus = 1


### PR DESCRIPTION
Hotfix for the #215 staging deploy: the pages Dockerfile's production stage cherry-picks files and never copied the new `apps/pages/server/` directory, so `classmoji-pages-staging` crash-looped at boot (`ERR_MODULE_NOT_FOUND: server/siteHost.ts`) and hit its max-restart cap — while the deploy job reported success, because pages had no health check.

Two lines of fix:
- `Dockerfile`: copy `apps/pages/server/` into the runtime stage.
- `fly.toml`: add the `[[http_service.checks]]` `/health` block (same as slides) so a boot crash fails the deploy loudly. `/health` is answered before host classification, so it works on any Host.

Verified the module graph is otherwise self-contained: `server.ts` imports only `server/siteHost.ts` beyond what the image already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01382gDyiikn6yZmiH2vh2Pe