### PR TITLE
fix(repos): publish before students enrol, and provision joiners for real

### DIFF
--- a/apps/mcp/src/tools/__tests__/repos.test.ts
+++ b/apps/mcp/src/tools/__tests__/repos.test.ts
@@ -16,12 +16,26 @@ const mocks = vi.hoisted(() => ({
   saveManifest: vi.fn(),
   auditCreate: vi.fn(),
   createRepositoriesTrigger: vi.fn(),
+  repositoryFindById: vi.fn(),
+  setPublished: vi.fn(),
+  findUsersByRole: vi.fn(),
+  findTeamsByTag: vi.fn(),
+  findGitReposByRepository: vi.fn(),
 }));
 
 vi.mock('@classmoji/services', () => ({
   ClassmojiService: {
-    repository: { create: (...a: unknown[]) => mocks.repositoryCreate(...a) },
-    organizationTag: { findByClassroomId: (...a: unknown[]) => mocks.findByClassroomId(...a) },
+    repository: {
+      create: (...a: unknown[]) => mocks.repositoryCreate(...a),
+      findById: (...a: unknown[]) => mocks.repositoryFindById(...a),
+      setPublished: (...a: unknown[]) => mocks.setPublished(...a),
+    },
+    organizationTag: {
+      findByClassroomId: (...a: unknown[]) => mocks.findByClassroomId(...a),
+      findTeamsByTag: (...a: unknown[]) => mocks.findTeamsByTag(...a),
+    },
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => mocks.findUsersByRole(...a) },
+    gitRepo: { findByRepository: (...a: unknown[]) => mocks.findGitReposByRepository(...a) },
     contentManifest: { saveManifest: (...a: unknown[]) => mocks.saveManifest(...a) },
     audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
   },
@@ -35,7 +49,7 @@ vi.mock('@classmoji/tasks', () => ({
   },
 }));
 
-const { repoCreateTool } = await import('../repos.ts');
+const { repoCreateTool, repoPublishTool } = await import('../repos.ts');
 
 const CTX: ToolContext = {
   viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
@@ -136,5 +150,128 @@ describe('repo_create', () => {
     });
     expect(mocks.saveManifest).not.toHaveBeenCalled();
     expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * repo_publish must stay usable before a course starts. Publishing an INDIVIDUAL
+ * repo used to throw `No students found.` on an empty roster, which blocked
+ * pre-term staging entirely — the instructor could not mark anything published
+ * until at least one student had enrolled. Publish now flips visibility and
+ * defers provisioning: joiners are provisioned by activate_membership, and Sync
+ * backfills anyone that missed. These specs pin route parity with
+ * admin.$class.repos/helpers.ts.
+ */
+describe('repo_publish — publishing before students enrol', () => {
+  const PUBLISH_ARGS = { classroom: 'dev-org/cs1-w26', repository_id: 'repo-1' };
+
+  const repositoryRow = (overrides: Record<string, unknown> = {}) => ({
+    id: 'repo-1',
+    classroom_id: 'class-1',
+    title: 'Lab 1',
+    slug: 'lab-1',
+    type: 'INDIVIDUAL',
+    is_published: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mocks.repositoryFindById.mockResolvedValue(repositoryRow());
+    mocks.setPublished.mockResolvedValue(undefined);
+    mocks.findUsersByRole.mockResolvedValue([]);
+    mocks.findTeamsByTag.mockResolvedValue([]);
+    mocks.findGitReposByRepository.mockResolvedValue([]);
+    // Provisioning is fire-and-forget with a `.catch` attached, so the handle
+    // has to be a real promise.
+    mocks.createRepositoriesTrigger.mockResolvedValue({ id: 'run-1' });
+  });
+
+  it('publishes an INDIVIDUAL repo with an empty roster instead of erroring', async () => {
+    const result = await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.setPublished).toHaveBeenCalledWith('repo-1', true, 'class-1');
+    expect(parse(result as { content: Array<{ text: string }> })).toMatchObject({
+      success: true,
+      is_published: true,
+      provisioning: { repos_to_create: 0 },
+    });
+  });
+
+  it('triggers no provisioning when there is nobody to provision for', async () => {
+    await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('publishes when every enrolled student is still missing a GitHub login', async () => {
+    // Roster is non-empty but nobody has accepted their org invite yet, so there
+    // is no login to create a repo under. The old length check passed here and
+    // then silently provisioned nothing.
+    mocks.findUsersByRole.mockResolvedValue([{ id: 'u-1', login: null }]);
+
+    await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.setPublished).toHaveBeenCalledWith('repo-1', true, 'class-1');
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('audits the empty-roster publish as a flip with no provisioning', async () => {
+    await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.auditCreate.mock.calls[0][0]).toMatchObject({
+      resource_type: 'REPOSITORIES',
+      resource_id: 'repo-1',
+      action: 'UPDATE',
+      data: { tool: 'repo_publish', is_published: true, provisioning_triggered: false },
+    });
+  });
+
+  it('publishes an instructor-assigned GROUP repo that has no teams yet', async () => {
+    mocks.repositoryFindById.mockResolvedValue(
+      repositoryRow({ type: 'GROUP', team_formation_mode: 'INSTRUCTOR', tag_id: 'tag-1' })
+    );
+
+    await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.setPublished).toHaveBeenCalledWith('repo-1', true, 'class-1');
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('still fans out normally when students are enrolled (no regression)', async () => {
+    mocks.findUsersByRole.mockResolvedValue([
+      { id: 'u-1', login: 'student-a' },
+      { id: 'u-2', login: 'student-b' },
+    ]);
+
+    const result = await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(1);
+    expect(mocks.createRepositoriesTrigger.mock.calls[0][0]).toMatchObject({
+      logins: ['student-a', 'student-b'],
+      assignmentTitle: 'Lab 1',
+      org: 'cs1-w26',
+    });
+    expect(parse(result as { content: Array<{ text: string }> })).toMatchObject({
+      provisioning: { repos_to_create: 2 },
+    });
+  });
+
+  it('re-publish with existing repos still flips without provisioning', async () => {
+    mocks.findGitReposByRepository.mockResolvedValue([{ id: 'gitrepo-1' }]);
+
+    await repoPublishTool.handler(PUBLISH_ARGS, CTX);
+
+    expect(mocks.setPublished).toHaveBeenCalledWith('repo-1', true, 'class-1');
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('refuses a repository belonging to another classroom (S1)', async () => {
+    mocks.repositoryFindById.mockResolvedValue(repositoryRow({ classroom_id: 'other-class' }));
+
+    await expect(repoPublishTool.handler(PUBLISH_ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+    expect(mocks.setPublished).not.toHaveBeenCalled();
   });
 });

--- a/apps/mcp/src/tools/repos.ts
+++ b/apps/mcp/src/tools/repos.ts
@@ -13,8 +13,12 @@
  * provisioning is never reimplemented here. Branches mirrored:
  *   - repos already exist (re-publish after unpublish): flip only.
  *   - INDIVIDUAL: trigger repo creation for every enrolled student, flip.
+ *   - INDIVIDUAL with no provisionable logins (empty roster / all invites still
+ *     pending): flip only — publishing before students enrol is a supported
+ *     pre-term state, and joiners are provisioned by activate_membership.
  *   - SELF_FORMED teams: flip only (repos created when students form teams).
  *   - instructor-assigned teams: trigger repo creation per tagged team, flip.
+ *   - instructor-assigned teams with no teams yet: flip only.
  * The web additionally mints a Trigger.dev public token so its UI can render
  * a live progress bar — that is a web-UI session concern and is not exposed
  * here (counts are returned instead).
@@ -94,6 +98,8 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
     'Publishes a repo (assignment container) to students and provisions their git repositories ' +
     'in the background (per-student for individual repos, per-team for instructor-assigned ' +
     'teams; self-formed team repos are created when students form teams). Owner only. ' +
+    'Works before anyone has enrolled — publishing an empty classroom marks the repo available ' +
+    'and provisions nothing; students who join later get their repos on join. ' +
     'Re-publishing a previously published repo just restores visibility — use the web Sync to ' +
     'backfill missing repositories.',
   scope: 'write',
@@ -135,10 +141,22 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
         classroom.classroomId,
         'STUDENT'
       );
-      if (students.length === 0) {
-        throw new ToolError('invalid_params', 'No students found.');
-      }
       const logins = students.map(user => user.login || '').filter(login => login !== '');
+
+      // Nobody to provision for yet — empty roster (pre-term staging) or every
+      // invite still pending, so there is no GitHub login to create a repo under.
+      // Publish still succeeds (route parity): joining students are provisioned
+      // on join, and Sync backfills anyone the join path missed.
+      if (logins.length === 0) {
+        await ClassmojiService.repository.setPublished(repository.id, true, classroom.classroomId);
+        await audit({ is_published: true, provisioning_triggered: false, repos_to_create: 0 });
+        return ok({
+          success: true,
+          is_published: true,
+          provisioning: { repos_to_create: 0 },
+          message: 'Repository published. Student repositories are created as students join.',
+        });
+      }
 
       const sessionId = randomUUID();
       triggerRepoProvisioning(logins, repository.title, classroomSlug, sessionId);
@@ -174,8 +192,17 @@ export const repoPublishTool: ToolDefinition<RepoPublishArgs> = {
 
     // Instructor-assigned teams.
     const teams = await ClassmojiService.organizationTag.findTeamsByTag(repository.tag_id!);
+
+    // No teams tagged yet — same pre-term staging case as INDIVIDUAL above.
     if (teams.length === 0) {
-      throw new ToolError('invalid_params', 'No team(s) found.');
+      await ClassmojiService.repository.setPublished(repository.id, true, classroom.classroomId);
+      await audit({ is_published: true, provisioning_triggered: false, repos_to_create: 0 });
+      return ok({
+        success: true,
+        is_published: true,
+        provisioning: { repos_to_create: 0 },
+        message: 'Repository published. Team repositories are created once teams exist.',
+      });
     }
 
     const sessionId = randomUUID();

--- a/apps/webapp/app/routes/admin.$class.repos/__tests__/publishAssignment.test.ts
+++ b/apps/webapp/app/routes/admin.$class.repos/__tests__/publishAssignment.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for `publishAssignment`, the ?/publish named action behind the
+ * Publish button on the repos list.
+ *
+ * Publishing before students enrol is a real workflow: an instructor stages a
+ * course pre-term (no roster yet) and expects the repo to be marked published.
+ * This used to return `{ error: 'No students found.' }` and leave the repo a
+ * draft, so the class could not be staged at all until somebody enrolled —
+ * even though the SELF_FORMED branch has always published with nobody enrolled.
+ *
+ * Publish means "make available to students". Provisioning is deliberately
+ * decoupled: joiners get their repos from activate_membership, and Sync
+ * backfills. So the assertions are (a) the flag flips, (b) no provisioning is
+ * triggered when there is nobody to provision for, and (c) the response is NOT
+ * a progress session — the UI renders a progress bar off those counts and must
+ * not be handed a zero-work session.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  classroomFindById: vi.fn(),
+  repositoryFindById: vi.fn(),
+  setPublished: vi.fn(),
+  findUsersByRole: vi.fn(),
+  findTeamsByTag: vi.fn(),
+  findGitReposByRepository: vi.fn(),
+  createRepositoriesTrigger: vi.fn(),
+  createPublicToken: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroom: { findById: (...a: unknown[]) => mocks.classroomFindById(...a) },
+    repository: {
+      findById: (...a: unknown[]) => mocks.repositoryFindById(...a),
+      setPublished: (...a: unknown[]) => mocks.setPublished(...a),
+    },
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => mocks.findUsersByRole(...a) },
+    organizationTag: { findTeamsByTag: (...a: unknown[]) => mocks.findTeamsByTag(...a) },
+    gitRepo: { findByRepository: (...a: unknown[]) => mocks.findGitReposByRepository(...a) },
+  },
+}));
+
+vi.mock('@classmoji/tasks', () => ({
+  default: {
+    createRepositoriesTask: { trigger: (...a: unknown[]) => mocks.createRepositoriesTrigger(...a) },
+  },
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  auth: { createPublicToken: (...a: unknown[]) => mocks.createPublicToken(...a) },
+}));
+
+const { publishAssignment } = await import('../helpers.ts');
+
+const CLASSROOM_SLUG = 'cs52-26f';
+const CLASSROOM_ID = 'class-1';
+const REPOSITORY_ID = 'repo-1';
+
+const repositoryRow = (overrides: Record<string, unknown> = {}) => ({
+  id: REPOSITORY_ID,
+  classroom_id: CLASSROOM_ID,
+  title: 'Lab 1',
+  slug: 'lab-1',
+  type: 'INDIVIDUAL',
+  is_published: false,
+  assignments: [],
+  ...overrides,
+});
+
+const publish = () =>
+  publishAssignment(CLASSROOM_SLUG, CLASSROOM_ID, REPOSITORY_ID, 'user-1') as Promise<{
+    error?: string;
+    info?: string;
+    success?: string;
+    triggerSession?: unknown;
+  }>;
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+
+  mocks.classroomFindById.mockResolvedValue({ id: CLASSROOM_ID, slug: CLASSROOM_SLUG });
+  mocks.repositoryFindById.mockResolvedValue(repositoryRow());
+  mocks.setPublished.mockResolvedValue(undefined);
+  mocks.findUsersByRole.mockResolvedValue([]);
+  mocks.findTeamsByTag.mockResolvedValue([]);
+  mocks.findGitReposByRepository.mockResolvedValue([]);
+  mocks.createRepositoriesTrigger.mockResolvedValue({ id: 'run-1' });
+  mocks.createPublicToken.mockResolvedValue('token-1');
+});
+
+describe('publishAssignment — empty roster (pre-term staging)', () => {
+  it('publishes an INDIVIDUAL repo with no students instead of erroring', async () => {
+    const result = await publish();
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBeDefined();
+    expect(mocks.setPublished).toHaveBeenCalledWith(REPOSITORY_ID, true, CLASSROOM_ID);
+  });
+
+  it('triggers no repo provisioning when there is nobody to provision for', async () => {
+    await publish();
+
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('does not hand the UI a progress session with no work in it', async () => {
+    const result = await publish();
+
+    expect(result.triggerSession).toBeUndefined();
+  });
+
+  it('publishes when enrolled students have no GitHub login yet', async () => {
+    // Roster is non-empty but every invite is still pending, so there is no
+    // login to create a repo under. The old `students.length` check passed here
+    // and then provisioned nothing, silently.
+    mocks.findUsersByRole.mockResolvedValue([
+      { id: 'u-1', login: null },
+      { id: 'u-2', login: '' },
+    ]);
+
+    const result = await publish();
+
+    expect(mocks.setPublished).toHaveBeenCalledWith(REPOSITORY_ID, true, CLASSROOM_ID);
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+    expect(result.success).toBeDefined();
+  });
+
+  it('publishes an instructor-assigned GROUP repo with no teams yet', async () => {
+    mocks.repositoryFindById.mockResolvedValue(
+      repositoryRow({ type: 'GROUP', team_formation_mode: 'INSTRUCTOR', tag_id: 'tag-1' })
+    );
+
+    const result = await publish();
+
+    expect(result.info).toBeUndefined();
+    expect(mocks.setPublished).toHaveBeenCalledWith(REPOSITORY_ID, true, CLASSROOM_ID);
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('publishes a SELF_FORMED repo with no students (unchanged behaviour)', async () => {
+    mocks.repositoryFindById.mockResolvedValue(
+      repositoryRow({ type: 'GROUP', team_formation_mode: 'SELF_FORMED' })
+    );
+
+    const result = await publish();
+
+    expect(result.success).toBeDefined();
+    expect(mocks.setPublished).toHaveBeenCalledWith(REPOSITORY_ID, true, CLASSROOM_ID);
+  });
+});
+
+describe('publishAssignment — populated roster (no regression)', () => {
+  it('provisions every enrolled student and publishes', async () => {
+    mocks.findUsersByRole.mockResolvedValue([
+      { id: 'u-1', login: 'student-a' },
+      { id: 'u-2', login: 'student-b' },
+    ]);
+
+    const result = await publish();
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(1);
+    expect(mocks.createRepositoriesTrigger.mock.calls[0][0]).toMatchObject({
+      logins: ['student-a', 'student-b'],
+      assignmentTitle: 'Lab 1',
+      org: CLASSROOM_SLUG,
+    });
+    expect(mocks.setPublished).toHaveBeenCalledWith(REPOSITORY_ID, true, CLASSROOM_ID);
+    expect(result.triggerSession).toBeDefined();
+  });
+
+  it('re-publishes without provisioning when repos already exist', async () => {
+    mocks.findGitReposByRepository.mockResolvedValue([{ id: 'gitrepo-1' }]);
+
+    const result = await publish();
+
+    expect(result.success).toContain('re-published');
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('refuses a repository belonging to another classroom', async () => {
+    mocks.repositoryFindById.mockResolvedValue(repositoryRow({ classroom_id: 'other-class' }));
+
+    await expect(publish()).rejects.toThrow();
+    expect(mocks.setPublished).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.repos/helpers.ts
+++ b/apps/webapp/app/routes/admin.$class.repos/helpers.ts
@@ -47,12 +47,21 @@ export const publishAssignment = async (
         'STUDENT'
       );
 
-      if (students.length === 0)
-        return {
-          error: 'No students found.',
-        };
-
       const studentList = students.map(user => user.login || '').filter(login => login !== '');
+
+      // Nobody to provision for yet — an empty roster (pre-term staging) or a
+      // roster whose invites are all still pending, so no GitHub login to create
+      // a repo under. Publish is "make available to students", so it must still
+      // succeed: students who join later are provisioned on join, and Sync
+      // backfills anyone the join path missed. Returning early also avoids
+      // handing the UI a progress session with nothing to report.
+      if (studentList.length === 0) {
+        await ClassmojiService.repository.setPublished(repositoryId, true, classroomId);
+
+        return {
+          success: 'Repository published! Student repositories are created as students join.',
+        };
+      }
 
       numReposToCreate = studentList.length;
       numIssuesToCreate =
@@ -89,9 +98,14 @@ export const publishAssignment = async (
       // Instructor-assigned teams
       const teams = await ClassmojiService.organizationTag.findTeamsByTag(repository.tag_id!);
 
+      // No teams tagged yet — same pre-term staging case as the INDIVIDUAL
+      // branch above. Publish the container; team repos are created by Sync once
+      // the teams exist.
       if (teams.length === 0) {
+        await ClassmojiService.repository.setPublished(repositoryId, true, classroomId);
+
         return {
-          info: 'No team(s) found.',
+          success: 'Repository published! Team repositories are created once teams exist.',
         };
       }
 

--- a/apps/webapp/tests/owner/assignments/publish-lifecycle.spec.ts
+++ b/apps/webapp/tests/owner/assignments/publish-lifecycle.spec.ts
@@ -15,10 +15,12 @@ import { repositoryRow } from '../../helpers/repos.helpers';
 /**
  * Assignment publish / unpublish round-trips and persists in the DB.
  *
- * publishAssignment only flips is_published directly when a GitRepo row already
- * exists for the repository; otherwise it enqueues a Trigger.dev task. Every spec
- * here seeds the repository with a backing GitRepo so publish takes the
- * deterministic flag-flip branch.
+ * publishAssignment flips is_published directly when a GitRepo row already
+ * exists for the repository, or when there is nobody to provision for (empty
+ * roster / no tagged teams); otherwise it enqueues a Trigger.dev task. Every
+ * spec here seeds the repository with a backing GitRepo so publish takes the
+ * deterministic flag-flip branch. The empty-roster branch is covered by the
+ * unit specs in app/routes/admin.$class.repos/__tests__/publishAssignment.test.ts.
  *
  * UI shape (AssignmentsTable): the primary action is an inline button — "Publish"
  * for drafts, "Sync" for published. Secondary/destructive actions (Unpublish,

--- a/packages/tasks/src/workflows/__tests__/gitRepo.provisionOnly.test.ts
+++ b/packages/tasks/src/workflows/__tests__/gitRepo.provisionOnly.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for `provisionOnly`, the flag that makes join-time provisioning
+ * read-only with respect to publish state.
+ *
+ * The shared `create_git_repos` pipeline has two publish side effects that are
+ * correct for an instructor clicking Publish and wrong for a student accepting
+ * an org invite:
+ *
+ *  1. `createRepositoriesTask` ends by calling `repository.setPublished(true)`.
+ *     Join runs sit in a concurrency-1 queue, so an instructor who unpublishes
+ *     while one is queued would have it silently re-published — and
+ *     `setPublished` notifies the ENTIRE roster on a false→true transition.
+ *  2. `createRepositoryTask` files issues for every assignment whose
+ *     `release_at` has passed and flips each to `is_published: true`. On a join
+ *     that lets the first student to arrive accelerate the nightly release cron
+ *     and reveal a draft the instructor had not released yet.
+ *
+ * Neither is reachable from a student action until the join path routes through
+ * this pipeline, so both are pinned here: with the flag nothing writes publish
+ * state, without it the instructor-driven behaviour is unchanged (the daily
+ * release cron depends on both side effects).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findBySlugAndTitle: vi.fn(),
+  findClassroomBySlug: vi.fn(),
+  findUsersByRole: vi.fn(),
+  findTeamsByClassroomId: vi.fn(),
+  setPublished: vi.fn(),
+  assignmentUpdate: vi.fn(),
+  getAccessToken: vi.fn(),
+  getOrganization: vi.fn(),
+  createRepository: vi.fn(),
+  provisionAutograde: vi.fn(),
+  batchTriggerCreateRepo: vi.fn(),
+  batchTriggerAssignments: vi.fn(),
+  addCollaborators: vi.fn(),
+  createRepoInDatabase: vi.fn(),
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  task: (config: unknown) => config,
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    repository: {
+      findBySlugAndTitle: (...a: unknown[]) => mocks.findBySlugAndTitle(...a),
+      setPublished: (...a: unknown[]) => mocks.setPublished(...a),
+    },
+    classroom: { findBySlug: (...a: unknown[]) => mocks.findClassroomBySlug(...a) },
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => mocks.findUsersByRole(...a) },
+    team: { findByClassroomId: (...a: unknown[]) => mocks.findTeamsByClassroomId(...a) },
+    assignment: { update: (...a: unknown[]) => mocks.assignmentUpdate(...a) },
+  },
+  HelperService: {},
+  ensureClassroomTeam: vi.fn(),
+  getGitProvider: () => ({
+    getAccessToken: (...a: unknown[]) => mocks.getAccessToken(...a),
+    getOrganization: (...a: unknown[]) => mocks.getOrganization(...a),
+  }),
+}));
+
+vi.mock('@classmoji/utils', () => ({
+  titleToIdentifier: (title: string) => title.toLowerCase().replace(/\s+/g, '-'),
+}));
+
+vi.mock('../gitRepoAssignment.ts', () => ({
+  createGithubRepositoryAssignmentTask: {
+    batchTriggerAndWait: (...a: unknown[]) => mocks.batchTriggerAssignments(...a),
+  },
+}));
+
+vi.mock('../../helpers/createRepository.ts', () => ({
+  createRepository: (...a: unknown[]) => mocks.createRepository(...a),
+}));
+
+vi.mock('../../helpers/updateRepository.ts', () => ({ updateRepository: vi.fn() }));
+
+vi.mock('../autograde.ts', () => ({
+  provisionAutogradeWorkflowForRepo: (...a: unknown[]) => mocks.provisionAutograde(...a),
+}));
+
+const gitRepo = await import('../gitRepo.ts');
+
+// Sibling tasks in this module are invoked through their trigger handles.
+(gitRepo.createRepositoryTask as unknown as { batchTriggerAndWait: unknown }).batchTriggerAndWait =
+  (...a: unknown[]) => mocks.batchTriggerCreateRepo(...a);
+(gitRepo.addCollaboratorsToRepoTask as unknown as { triggerAndWait: unknown }).triggerAndWait = (
+  ...a: unknown[]
+) => mocks.addCollaborators(...a);
+(gitRepo.createRepoInDatabaseTask as unknown as { triggerAndWait: unknown }).triggerAndWait = (
+  ...a: unknown[]
+) => mocks.createRepoInDatabase(...a);
+
+const { createRepositoriesTask, createRepositoryTask } = gitRepo;
+
+const PAST = new Date('2020-01-01T00:00:00Z');
+
+const assignment = (id: string, isPublished: boolean, releaseAt: Date | null = PAST) => ({
+  id,
+  title: `Assignment ${id}`,
+  release_at: releaseAt,
+  is_published: isPublished,
+});
+
+const repositoryRow = (assignments: ReturnType<typeof assignment>[] = []) => ({
+  id: 'repo-1',
+  title: 'Lab 1',
+  slug: 'lab-1',
+  type: 'INDIVIDUAL',
+  template: 'dev-org/template',
+  project_template_id: null,
+  assignments,
+});
+
+const classroomRow = {
+  id: 'class-1',
+  slug: 'cs52-26f',
+  git_organization: { login: 'dev-org' },
+};
+
+const runCreateRepositories = (provisionOnly?: boolean): Promise<unknown> =>
+  (
+    createRepositoriesTask as unknown as {
+      run: (p: Record<string, unknown>) => Promise<unknown>;
+    }
+  ).run({
+    logins: ['student-a'],
+    assignmentTitle: 'Lab 1',
+    org: 'cs52-26f',
+    sessionId: 'session-1',
+    ...(provisionOnly === undefined ? {} : { provisionOnly }),
+  });
+
+const runCreateRepository = (
+  assignments: ReturnType<typeof assignment>[],
+  provisionOnly?: boolean
+): Promise<unknown> =>
+  (
+    createRepositoryTask as unknown as {
+      run: (
+        p: Record<string, unknown>,
+        c: { ctx: { run: { tags: string[] } } }
+      ) => Promise<unknown>;
+    }
+  ).run(
+    {
+      repoName: 'lab-1-student-a',
+      classroom: classroomRow,
+      repository: repositoryRow(assignments),
+      templateOwner: 'dev-org',
+      templateRepo: 'template',
+      token: 'tok',
+      organizationGithubPlan: 'free',
+      student: { id: 'u-1', login: 'student-a' },
+      ...(provisionOnly === undefined ? {} : { provisionOnly }),
+    },
+    { ctx: { run: { tags: [] } } }
+  );
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+
+  mocks.findBySlugAndTitle.mockResolvedValue(repositoryRow());
+  mocks.findClassroomBySlug.mockResolvedValue(classroomRow);
+  mocks.findUsersByRole.mockResolvedValue([{ id: 'u-1', login: 'student-a' }]);
+  mocks.findTeamsByClassroomId.mockResolvedValue([]);
+  mocks.setPublished.mockResolvedValue(undefined);
+  mocks.assignmentUpdate.mockResolvedValue(undefined);
+  mocks.getAccessToken.mockResolvedValue('tok');
+  mocks.getOrganization.mockResolvedValue({ plan: { name: 'free' } });
+  mocks.createRepository.mockResolvedValue('gh-repo-1');
+  mocks.provisionAutograde.mockResolvedValue(undefined);
+  mocks.batchTriggerCreateRepo.mockResolvedValue(undefined);
+  mocks.batchTriggerAssignments.mockResolvedValue(undefined);
+  mocks.addCollaborators.mockResolvedValue(undefined);
+  mocks.createRepoInDatabase.mockResolvedValue({
+    ok: true,
+    output: { id: 'gitrepo-1', project_id: null },
+  });
+});
+
+describe('create_git_repos — repository publish side effect', () => {
+  it('does NOT publish the repository when provisionOnly is set', async () => {
+    await runCreateRepositories(true);
+
+    expect(mocks.batchTriggerCreateRepo).toHaveBeenCalledTimes(1);
+    expect(mocks.setPublished).not.toHaveBeenCalled();
+  });
+
+  it('publishes the repository on an instructor-driven run (no regression)', async () => {
+    await runCreateRepositories();
+
+    expect(mocks.setPublished).toHaveBeenCalledWith('repo-1', true, 'class-1');
+  });
+
+  it('forwards provisionOnly to each per-repo payload', async () => {
+    await runCreateRepositories(true);
+
+    const [reposData] = mocks.batchTriggerCreateRepo.mock.calls[0] as [
+      Array<{ payload: { provisionOnly?: boolean } }>,
+    ];
+    expect(reposData).toHaveLength(1);
+    expect(reposData[0].payload.provisionOnly).toBe(true);
+  });
+});
+
+describe('gh-create_git_repo — assignment release side effect', () => {
+  it('files issues only for ALREADY published assignments when provisionOnly is set', async () => {
+    await runCreateRepository([assignment('a-1', true), assignment('a-2', false)], true);
+
+    expect(mocks.batchTriggerAssignments).toHaveBeenCalledTimes(1);
+    const [payloads] = mocks.batchTriggerAssignments.mock.calls[0] as [
+      Array<{ payload: { assignment: { id: string } } }>,
+    ];
+    expect(payloads.map(p => p.payload.assignment.id)).toEqual(['a-1']);
+  });
+
+  it('never flips assignment publish state when provisionOnly is set', async () => {
+    await runCreateRepository([assignment('a-1', true), assignment('a-2', false)], true);
+
+    expect(mocks.assignmentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('files no issues at all when every released assignment is still a draft', async () => {
+    await runCreateRepository([assignment('a-2', false)], true);
+
+    expect(mocks.batchTriggerAssignments).not.toHaveBeenCalled();
+    expect(mocks.assignmentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('releases drafts whose release_at has passed on an instructor run (no regression)', async () => {
+    await runCreateRepository([assignment('a-1', true), assignment('a-2', false)]);
+
+    const [payloads] = mocks.batchTriggerAssignments.mock.calls[0] as [
+      Array<{ payload: { assignment: { id: string } } }>,
+    ];
+    expect(payloads.map(p => p.payload.assignment.id)).toEqual(['a-1', 'a-2']);
+    expect(mocks.assignmentUpdate).toHaveBeenCalledWith('a-1', { is_published: true });
+    expect(mocks.assignmentUpdate).toHaveBeenCalledWith('a-2', { is_published: true });
+  });
+
+  it('still excludes unreleased assignments regardless of the flag', async () => {
+    const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    await runCreateRepository([assignment('a-1', true, future)], true);
+
+    expect(mocks.batchTriggerAssignments).not.toHaveBeenCalled();
+  });
+
+  it('excludes an assignment with no release_at at all', async () => {
+    await runCreateRepository([assignment('a-1', true, null)], true);
+
+    expect(mocks.batchTriggerAssignments).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tasks/src/workflows/__tests__/gitRepoAssignment.releaseNow.test.ts
+++ b/packages/tasks/src/workflows/__tests__/gitRepoAssignment.releaseNow.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for on-demand assignment release (`release_git_repo_assignments_now`),
+ * the task behind the repo detail page's "Release now" action.
+ *
+ * The load-bearing case is an EMPTY roster. Publishing before students enrol is
+ * a real pre-term workflow, and `is_published` is the flag that makes an
+ * assignment visible to whoever joins later — so release must still set it when
+ * there is nobody to fan out to. Bailing early instead left the assignment in
+ * draft while the UI reported "Releasing assignment…", a silent no-op with no
+ * error anywhere.
+ *
+ * What is asserted:
+ *  - zero recipients still marks every targeted assignment published, and
+ *    triggers no GitHub fanout;
+ *  - a normal roster is unaffected (fanout happens, assignments published);
+ *  - assignments already carrying the issue are not re-issued (re-run safety).
+ *
+ * `@trigger.dev/sdk`, `@classmoji/services` and the repo-provisioning pipeline
+ * are mocked, so `run` is invoked directly and nothing reaches GitHub.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findForReleaseByRepository: vi.fn(),
+  findUsersByRole: vi.fn(),
+  findTeamsByTag: vi.fn(),
+  findGitReposByRepository: vi.fn(),
+  findFirstGitRepoAssignment: vi.fn(),
+  updateAssignment: vi.fn(),
+  batchTriggerAndWait: vi.fn(),
+  createRepositoriesTriggerAndWait: vi.fn(),
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  task: (config: unknown) => config,
+  schedules: { task: (config: unknown) => config },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    assignment: {
+      findForReleaseByRepository: (...a: unknown[]) => mocks.findForReleaseByRepository(...a),
+      findReadyForRelease: vi.fn(),
+      update: (...a: unknown[]) => mocks.updateAssignment(...a),
+    },
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => mocks.findUsersByRole(...a) },
+    organizationTag: { findTeamsByTag: (...a: unknown[]) => mocks.findTeamsByTag(...a) },
+    gitRepo: { findByRepository: (...a: unknown[]) => mocks.findGitReposByRepository(...a) },
+    gitRepoAssignment: { findFirst: (...a: unknown[]) => mocks.findFirstGitRepoAssignment(...a) },
+  },
+  HelperService: {},
+  getGitProvider: vi.fn(),
+}));
+
+vi.mock('@classmoji/utils', () => ({
+  titleToIdentifier: (title: string) => title.toLowerCase().replace(/\s+/g, '-'),
+}));
+
+vi.mock('../gitRepo.ts', () => ({
+  createRepositoriesTask: {
+    triggerAndWait: (...a: unknown[]) => mocks.createRepositoriesTriggerAndWait(...a),
+  },
+}));
+
+const gitRepoAssignment = await import('../gitRepoAssignment.ts');
+
+// The task under test fans out to a sibling task in the same module; stub that
+// handle so nothing reaches GitHub.
+(
+  gitRepoAssignment.createGithubRepositoryAssignmentTask as unknown as {
+    batchTriggerAndWait: unknown;
+  }
+).batchTriggerAndWait = (...a: unknown[]) => mocks.batchTriggerAndWait(...a);
+
+const { releaseAssignmentsNowTask } = gitRepoAssignment;
+
+const REPOSITORY_ID = 'repo-1';
+
+const assignmentRow = (id: string, title: string) => ({
+  id,
+  title,
+  is_published: false,
+  repository: {
+    id: REPOSITORY_ID,
+    title: 'Lab 1',
+    slug: 'lab-1',
+    type: 'INDIVIDUAL',
+    classroom: {
+      id: 'class-1',
+      slug: 'cs52-26f',
+      git_organization: { login: 'dev-org' },
+    },
+  },
+});
+
+const run = (): Promise<void> =>
+  (
+    releaseAssignmentsNowTask as unknown as {
+      run: (
+        p: { repositoryId: string; assignmentIds?: string[] },
+        c: { ctx: { run: { tags: string[] } } }
+      ) => Promise<void>;
+    }
+  ).run({ repositoryId: REPOSITORY_ID }, { ctx: { run: { tags: [] } } });
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+
+  mocks.findForReleaseByRepository.mockResolvedValue([assignmentRow('a-1', 'Part 1')]);
+  mocks.findUsersByRole.mockResolvedValue([]);
+  mocks.findTeamsByTag.mockResolvedValue([]);
+  mocks.findGitReposByRepository.mockResolvedValue([]);
+  mocks.findFirstGitRepoAssignment.mockResolvedValue(null);
+  mocks.updateAssignment.mockResolvedValue(undefined);
+  mocks.batchTriggerAndWait.mockResolvedValue(undefined);
+  mocks.createRepositoriesTriggerAndWait.mockResolvedValue(undefined);
+});
+
+describe('release_git_repo_assignments_now — empty roster', () => {
+  it('marks the assignment published when there are no students to release to', async () => {
+    await run();
+
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-1', { is_published: true });
+  });
+
+  it('creates no repos and files no issues when there are no students', async () => {
+    await run();
+
+    expect(mocks.createRepositoriesTriggerAndWait).not.toHaveBeenCalled();
+    expect(mocks.batchTriggerAndWait).not.toHaveBeenCalled();
+  });
+
+  it('publishes every targeted assignment, not just the first', async () => {
+    mocks.findForReleaseByRepository.mockResolvedValue([
+      assignmentRow('a-1', 'Part 1'),
+      assignmentRow('a-2', 'Part 2'),
+    ]);
+
+    await run();
+
+    expect(mocks.updateAssignment).toHaveBeenCalledTimes(2);
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-1', { is_published: true });
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-2', { is_published: true });
+  });
+
+  it('publishes an empty-roster GROUP repository with no tagged teams', async () => {
+    mocks.findForReleaseByRepository.mockResolvedValue([
+      {
+        ...assignmentRow('a-1', 'Part 1'),
+        repository: {
+          ...assignmentRow('a-1', 'Part 1').repository,
+          type: 'GROUP',
+          tag_id: 'tag-1',
+        },
+      },
+    ]);
+
+    await run();
+
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-1', { is_published: true });
+    expect(mocks.batchTriggerAndWait).not.toHaveBeenCalled();
+  });
+});
+
+describe('release_git_repo_assignments_now — normal roster (no regression)', () => {
+  beforeEach(() => {
+    mocks.findUsersByRole.mockResolvedValue([{ id: 'u-1', login: 'student-a' }]);
+    mocks.findGitReposByRepository.mockResolvedValue([
+      { id: 'gitrepo-1', name: 'lab-1-student-a', student_id: 'u-1' },
+    ]);
+  });
+
+  it('fans out the assignment issue and marks it published', async () => {
+    await run();
+
+    expect(mocks.batchTriggerAndWait).toHaveBeenCalledTimes(1);
+    const [payloads] = mocks.batchTriggerAndWait.mock.calls[0] as [Array<{ payload: unknown }>];
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].payload).toMatchObject({ repoName: 'lab-1-student-a' });
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-1', { is_published: true });
+  });
+
+  it('does not re-file an issue a repo already has, but still publishes', async () => {
+    mocks.findFirstGitRepoAssignment.mockResolvedValue({ id: 'existing-1' });
+
+    await run();
+
+    expect(mocks.batchTriggerAndWait).not.toHaveBeenCalled();
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-1', { is_published: true });
+  });
+
+  it('provisions a missing student repo before filing the issue', async () => {
+    // No repo exists yet for the enrolled student: the task must create it
+    // first, then fan out against the freshly provisioned repo.
+    mocks.findGitReposByRepository
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ id: 'gitrepo-1', name: 'lab-1-student-a', student_id: 'u-1' }]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTriggerAndWait).toHaveBeenCalledTimes(1);
+    expect(mocks.batchTriggerAndWait).toHaveBeenCalledTimes(1);
+    expect(mocks.updateAssignment).toHaveBeenCalledWith('a-1', { is_published: true });
+  });
+});

--- a/packages/tasks/src/workflows/__tests__/organization.activateMembership.test.ts
+++ b/packages/tasks/src/workflows/__tests__/organization.activateMembership.test.ts
@@ -121,6 +121,20 @@ describe('activate_membership — join after publish', () => {
     expect(options).toMatchObject({ concurrencyKey: CLASSROOM_SLUG });
   });
 
+  it('provisions read-only: a joiner never writes publish state', async () => {
+    // Without provisionOnly the shared pipeline would re-publish a repository
+    // the instructor unpublished while this run sat in the queue — notifying
+    // the whole roster — and would release any draft assignment whose
+    // release_at has already passed.
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository()]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger.mock.calls[0][0]).toMatchObject({
+      provisionOnly: true,
+    });
+  });
+
   it('provisions a published repository that has no assignments yet (pre-term staging)', async () => {
     // The exact shape of Tim's case: publish the container before the course
     // starts, add assignments later. The student still needs the repo.

--- a/packages/tasks/src/workflows/__tests__/organization.activateMembership.test.ts
+++ b/packages/tasks/src/workflows/__tests__/organization.activateMembership.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for join-time repo provisioning (`activate_membership`).
+ *
+ * This is the path that makes "publish before anyone has enrolled" coherent: an
+ * instructor stages the course pre-term, students join later, and each joiner
+ * must be provisioned for everything already published. Both entry points —
+ * the GitHub `member_added` webhook and the self-join flow for users already in
+ * the org — funnel through the same `activateMembership`.
+ *
+ * What matters here:
+ *  - the selection is per REPOSITORY (`Repository.type`), not per assignment.
+ *    `type` does not exist on Assignment, so the previous per-assignment test
+ *    was always false and this path provisioned nothing at all;
+ *  - a published repository with NO assignments yet still provisions, because
+ *    the student needs the repo before any assignment releases;
+ *  - drafts and GROUP repos are never provisioned individually;
+ *  - it stays idempotent — a student who already has the repo is skipped, so
+ *    webhook redelivery and re-joins don't duplicate;
+ *  - `has_accepted_invite` is flipped regardless of provisioning outcome.
+ *
+ * `@trigger.dev/sdk`, `@classmoji/services` and the repo-provisioning pipeline
+ * are mocked, so `run` is invoked directly and nothing reaches GitHub.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findByLogin: vi.fn(),
+  findGitOrgById: vi.fn(),
+  findMembershipsByUserId: vi.fn(),
+  updateMembership: vi.fn(),
+  findRepositoriesByClassroomSlug: vi.fn(),
+  findGitReposByRepository: vi.fn(),
+  createRepositoriesTrigger: vi.fn(),
+}));
+
+// `task()` normally returns a trigger handle; return the config so the test can
+// call `run` directly.
+vi.mock('@trigger.dev/sdk', () => ({
+  task: (config: unknown) => config,
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    user: { findByLogin: (...a: unknown[]) => mocks.findByLogin(...a) },
+    gitOrganization: { findById: (...a: unknown[]) => mocks.findGitOrgById(...a) },
+    classroomMembership: {
+      findByUserId: (...a: unknown[]) => mocks.findMembershipsByUserId(...a),
+      update: (...a: unknown[]) => mocks.updateMembership(...a),
+    },
+    repository: {
+      findByClassroomSlug: (...a: unknown[]) => mocks.findRepositoriesByClassroomSlug(...a),
+    },
+    gitRepo: { findByRepository: (...a: unknown[]) => mocks.findGitReposByRepository(...a) },
+  },
+  getGitProvider: vi.fn(),
+  getTeamNameForClassroom: vi.fn(),
+}));
+
+// Provisioning is orchestrated by the shared pipeline publish and Sync drive —
+// never reimplemented on the join path, so it is stubbed wholesale here.
+vi.mock('../gitRepo.ts', () => ({
+  createRepositoriesTask: { trigger: (...a: unknown[]) => mocks.createRepositoriesTrigger(...a) },
+}));
+
+const { activateMembershipTask } = await import('../organization.ts');
+
+const CLASSROOM_SLUG = 'cs52-26f';
+const GIT_ORG_ID = 'git-org-1';
+
+const repository = (overrides: Record<string, unknown> = {}) => ({
+  id: 'repo-1',
+  title: 'Lab 1',
+  slug: 'lab-1',
+  template: 'dev-org/template',
+  type: 'INDIVIDUAL',
+  is_published: true,
+  assignments: [],
+  ...overrides,
+});
+
+const run = (login = 'newstudent'): Promise<void> =>
+  (
+    activateMembershipTask as unknown as {
+      run: (p: { login: string; gitOrganizationId: string }) => Promise<void>;
+    }
+  ).run({ login, gitOrganizationId: GIT_ORG_ID });
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+
+  mocks.findByLogin.mockResolvedValue({ id: 'user-1', login: 'newstudent' });
+  mocks.findGitOrgById.mockResolvedValue({ id: GIT_ORG_ID, login: 'dev-org' });
+  mocks.findMembershipsByUserId.mockResolvedValue([
+    {
+      classroom_id: 'class-1',
+      role: 'STUDENT',
+      classroom: { git_org_id: GIT_ORG_ID, slug: CLASSROOM_SLUG },
+    },
+  ]);
+  mocks.updateMembership.mockResolvedValue(undefined);
+  mocks.findRepositoriesByClassroomSlug.mockResolvedValue([]);
+  mocks.findGitReposByRepository.mockResolvedValue([]);
+  mocks.createRepositoriesTrigger.mockResolvedValue({ id: 'run-1' });
+});
+
+describe('activate_membership — join after publish', () => {
+  it('provisions a repo for a published INDIVIDUAL repository the joiner lacks', async () => {
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository()]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(1);
+    const [payload, options] = mocks.createRepositoriesTrigger.mock.calls[0];
+    expect(payload).toMatchObject({
+      logins: ['newstudent'],
+      assignmentTitle: 'Lab 1',
+      org: CLASSROOM_SLUG,
+    });
+    expect(options).toMatchObject({ concurrencyKey: CLASSROOM_SLUG });
+  });
+
+  it('provisions a published repository that has no assignments yet (pre-term staging)', async () => {
+    // The exact shape of Tim's case: publish the container before the course
+    // starts, add assignments later. The student still needs the repo.
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository({ assignments: [] })]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('provisions per repository, not per assignment (no duplicate repo creation)', async () => {
+    // Two published assignments in one repository must still yield ONE repo:
+    // the repo name is per-repository, so fanning out per assignment would race
+    // two creations of the same repo.
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([
+      repository({
+        assignments: [
+          { id: 'a-1', is_published: true },
+          { id: 'a-2', is_published: true },
+        ],
+      }),
+    ]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a repository the student already has (idempotent on redelivery)', async () => {
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository()]);
+    mocks.findGitReposByRepository.mockResolvedValue([{ student_id: 'user-1' }]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('still provisions when the repository has repos for OTHER students', async () => {
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository()]);
+    mocks.findGitReposByRepository.mockResolvedValue([{ student_id: 'someone-else' }]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('never provisions an unpublished (draft) repository', async () => {
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository({ is_published: false })]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('never individually provisions a GROUP repository', async () => {
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository({ type: 'GROUP' })]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('provisions each published INDIVIDUAL repository the joiner lacks', async () => {
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([
+      repository({ id: 'repo-1', title: 'Lab 1' }),
+      repository({ id: 'repo-2', title: 'Lab 2' }),
+      repository({ id: 'repo-3', title: 'Draft Lab', is_published: false }),
+    ]);
+
+    await run();
+
+    expect(mocks.createRepositoriesTrigger).toHaveBeenCalledTimes(2);
+    const titles = mocks.createRepositoriesTrigger.mock.calls.map(
+      ([payload]) => (payload as { assignmentTitle: string }).assignmentTitle
+    );
+    expect(titles).toEqual(['Lab 1', 'Lab 2']);
+  });
+
+  it('marks the membership accepted even when there is nothing to provision', async () => {
+    await run();
+
+    expect(mocks.updateMembership).toHaveBeenCalledWith('class-1', 'user-1', {
+      has_accepted_invite: true,
+    });
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('activates the membership but provisions nothing for a non-student role', async () => {
+    mocks.findMembershipsByUserId.mockResolvedValue([
+      {
+        classroom_id: 'class-1',
+        role: 'ASSISTANT',
+        classroom: { git_org_id: GIT_ORG_ID, slug: CLASSROOM_SLUG },
+      },
+    ]);
+    mocks.findRepositoriesByClassroomSlug.mockResolvedValue([repository()]);
+
+    await run();
+
+    expect(mocks.updateMembership).toHaveBeenCalledWith('class-1', 'user-1', {
+      has_accepted_invite: true,
+    });
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+
+  it('ignores memberships in classrooms belonging to a different git organization', async () => {
+    mocks.findMembershipsByUserId.mockResolvedValue([
+      {
+        classroom_id: 'class-other',
+        role: 'STUDENT',
+        classroom: { git_org_id: 'some-other-org', slug: 'other-class' },
+      },
+    ]);
+
+    await run();
+
+    expect(mocks.updateMembership).not.toHaveBeenCalled();
+    expect(mocks.createRepositoriesTrigger).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tasks/src/workflows/gitRepo.ts
+++ b/packages/tasks/src/workflows/gitRepo.ts
@@ -25,6 +25,7 @@ interface RepositoryAssignmentRecord {
   body?: string | null;
   description?: string | null;
   release_at: Date | string | null;
+  is_published?: boolean;
 }
 
 interface RepositoryRecord {
@@ -66,6 +67,18 @@ interface CreateRepositoriesTaskPayload {
   assignmentTitle: string;
   org: string;
   sessionId: string;
+  /**
+   * Provision repos WITHOUT writing any publish state. Set by the join path
+   * (activateMembership), where a student accepting an org invite must never
+   * decide what is published: the trailing repository `setPublished(true)`
+   * would re-publish a repo the instructor unpublished while the run sat in
+   * the concurrency-1 queue — notifying the whole roster — and the assignment
+   * release below would flip drafts whose `release_at` has already passed. A
+   * joiner receives what is already published and publishes nothing itself.
+   * Omitted on the instructor-driven publish/sync paths, which rely on both
+   * side effects (the daily release cron publishes the repository this way).
+   */
+  provisionOnly?: boolean;
 }
 
 interface StandardCreateRepositoryTaskPayload extends Omit<CreateRepositoryPayload, 'classroom'> {
@@ -73,6 +86,8 @@ interface StandardCreateRepositoryTaskPayload extends Omit<CreateRepositoryPaylo
   repository: RepositoryRecord;
   student?: StudentRecord;
   team?: TeamRecord;
+  /** See CreateRepositoriesTaskPayload.provisionOnly. */
+  provisionOnly?: boolean;
 }
 
 interface LegacyCreateRepositoryTaskPayload {
@@ -134,7 +149,7 @@ export const createRepositoriesTask = task({
     concurrencyLimit: 1,
   },
   run: async (payload: CreateRepositoriesTaskPayload) => {
-    const { logins, assignmentTitle, org, sessionId } = payload;
+    const { logins, assignmentTitle, org, sessionId, provisionOnly } = payload;
     const uniqueLogins = [...new Set(logins.map(login => login.trim()).filter(Boolean))];
 
     const repository = await ClassmojiService.repository.findBySlugAndTitle(org, assignmentTitle);
@@ -169,6 +184,7 @@ export const createRepositoriesTask = task({
         templateRepo,
         token,
         organizationGithubPlan,
+        provisionOnly,
       };
 
       if (repository.type === 'INDIVIDUAL') {
@@ -219,7 +235,10 @@ export const createRepositoriesTask = task({
 
     await createRepositoryTask.batchTriggerAndWait(reposData);
 
-    await ClassmojiService.repository.setPublished(repository.id, true, classroom.id);
+    // Join-time provisioning never writes publish state — see provisionOnly.
+    if (!provisionOnly) {
+      await ClassmojiService.repository.setPublished(repository.id, true, classroom.id);
+    }
   },
 });
 
@@ -307,8 +326,15 @@ export const createRepositoryTask = task({
         );
       }
 
-      const filteredAssignments = normalizedPayload.repository.assignments.filter(assignment =>
-        dayjs(assignment.release_at).isSameOrBefore(dayjs())
+      // A joining student gets issues for assignments that are ALREADY
+      // published; releasing on their behalf is not theirs to do. Without the
+      // extra predicate a joiner would accelerate the nightly cron and release
+      // any draft whose release_at has passed. Instructor-driven runs keep the
+      // release semantics the daily cron and Publish depend on.
+      const filteredAssignments = normalizedPayload.repository.assignments.filter(
+        assignment =>
+          dayjs(assignment.release_at).isSameOrBefore(dayjs()) &&
+          (!normalizedPayload.provisionOnly || assignment.is_published === true)
       );
 
       const assignmentPayloads = filteredAssignments.map(assignment => ({
@@ -324,10 +350,12 @@ export const createRepositoryTask = task({
       if (assignmentPayloads.length) {
         await createGithubRepositoryAssignmentTask.batchTriggerAndWait(assignmentPayloads);
 
-        for (const assignmentPayload of assignmentPayloads) {
-          ClassmojiService.assignment.update(assignmentPayload.payload.assignment.id, {
-            is_published: true,
-          });
+        if (!normalizedPayload.provisionOnly) {
+          for (const assignmentPayload of assignmentPayloads) {
+            await ClassmojiService.assignment.update(assignmentPayload.payload.assignment.id, {
+              is_published: true,
+            });
+          }
         }
       }
     } catch (error: unknown) {

--- a/packages/tasks/src/workflows/gitRepo.ts
+++ b/packages/tasks/src/workflows/gitRepo.ts
@@ -249,6 +249,13 @@ export const createRepositoryTask = task({
   },
   run: async (payload: CreateRepositoryTaskPayload, { ctx }: RepositoryTaskContext) => {
     try {
+      // NOTE: this branch rebuilds the standard payload field-by-field and so
+      // silently DROPS `provisionOnly` — a legacy payload always normalizes to
+      // the publish-writing behaviour. Harmless today because nothing that emits
+      // the legacy shape is join-triggered (activateMembership goes through
+      // createRepositoriesTask, which builds the standard payload directly). If
+      // you ever route join-time provisioning through a legacy payload, forward
+      // the flag here or the joiner will re-publish repos and release drafts.
       const normalizedPayload = isLegacyCreateRepositoryPayload(payload)
         ? await (async (): Promise<StandardCreateRepositoryTaskPayload> => {
             const classroom = payload.organization;

--- a/packages/tasks/src/workflows/gitRepoAssignment.ts
+++ b/packages/tasks/src/workflows/gitRepoAssignment.ts
@@ -548,9 +548,16 @@ export const releaseAssignmentsNowTask = task({
 
     const recipients = uniqueLogins(logins);
 
+    // An empty roster is a valid pre-term state — the instructor is staging the
+    // course before anyone enrols. Releasing still has to mark the assignments
+    // published, because that flag is what makes them visible to whoever joins
+    // later; only the per-student fanout is skipped. Returning here instead left
+    // the assignment stuck in draft while the UI reported success. Late joiners
+    // are provisioned by activateMembership, and Sync backfills either way.
     if (recipients.length === 0) {
-      logger.info('No recipients to release to', { repositoryId: payload.repositoryId });
-      return;
+      logger.info('No recipients yet — releasing assignments without fanout', {
+        repositoryId: payload.repositoryId,
+      });
     }
 
     const repositorySlug = repository.slug || titleToIdentifier(repository.title);

--- a/packages/tasks/src/workflows/organization.ts
+++ b/packages/tasks/src/workflows/organization.ts
@@ -1,6 +1,7 @@
 import { task } from '@trigger.dev/sdk';
 import { ClassmojiService, getGitProvider, getTeamNameForClassroom } from '@classmoji/services';
-import { createRepositoryTask } from './gitRepo.ts';
+import { nanoid } from 'nanoid';
+import { createRepositoriesTask } from './gitRepo.ts';
 import invariant from 'tiny-invariant';
 
 interface MemberAddedPayload {
@@ -83,46 +84,50 @@ async function activateMembership({
       continue;
     }
 
+    // Published INDIVIDUAL repositories are what a joining student owes work on.
+    // `type` is a field on Repository and never on Assignment, so the previous
+    // per-assignment `'type' in assignment` test was always false at runtime and
+    // this branch silently provisioned nothing. Selecting on the repository also
+    // covers a repository published before any assignment exists (pre-term
+    // staging): the student still needs the repo, and the assignment issues are
+    // filed later when each assignment releases.
     const repositories = await ClassmojiService.repository.findByClassroomSlug(
       membership.classroom.slug
     );
-    const assignments = repositories.flatMap(repository =>
-      repository.assignments
-        .filter(a => a.is_published === true && 'type' in a && a.type === 'INDIVIDUAL')
-        .map(assignment => ({ ...assignment, repository }))
+    const publishedIndividualRepositories = repositories.filter(
+      repository => repository.is_published === true && repository.type === 'INDIVIDUAL'
     );
 
-    // Skip assignments whose student repo already exists so re-runs (and users who
-    // were already in the org) don't try to re-create repos they already have.
-    const existingByRepository = new Map<string, { student_id: string | null }[]>();
-    for (const { repository } of assignments) {
-      if (!existingByRepository.has(repository.id)) {
-        existingByRepository.set(
-          repository.id,
-          await ClassmojiService.gitRepo.findByRepository(membership.classroom.slug, repository.id)
-        );
+    // Skip repositories whose student repo already exists so re-runs (webhook
+    // redelivery, retries, re-joins, users already in the org) don't re-create
+    // repos they already have.
+    const missingRepositories = [];
+    for (const repository of publishedIndividualRepositories) {
+      const existingRepos = await ClassmojiService.gitRepo.findByRepository(
+        membership.classroom.slug,
+        repository.id
+      );
+      if (!existingRepos.some(repo => repo.student_id === user.id)) {
+        missingRepositories.push(repository);
       }
     }
-    const missingAssignments = assignments.filter(assignment => {
-      const existing = existingByRepository.get(assignment.repository.id) ?? [];
-      return !existing.some(repo => repo.student_id === user.id);
-    });
 
+    // Reuse the same provisioning pipeline that publish and Sync drive, scoped to
+    // this one student, rather than re-implementing the fanout here. It resolves
+    // the template, token and org plan itself and files issues for assignments
+    // that have already released.
     await Promise.all(
-      missingAssignments.map(assignment => {
-        const [templateOwner, templateRepo] = assignment.repository.template.split('/');
-        return createRepositoryTask.trigger(
+      missingRepositories.map(repository =>
+        createRepositoriesTask.trigger(
           {
-            templateOwner,
-            templateRepo,
-            organization: membership.classroom,
-            repoName: `${assignment.repository.slug}-${user.login}`,
-            assignment,
-            student: user,
+            logins: [user.login as string],
+            assignmentTitle: repository.title,
+            org: membership.classroom.slug,
+            sessionId: nanoid(),
           },
-          { concurrencyKey: gitOrganization.login }
-        );
-      })
+          { concurrencyKey: membership.classroom.slug }
+        )
+      )
     );
   }
 }

--- a/packages/tasks/src/workflows/organization.ts
+++ b/packages/tasks/src/workflows/organization.ts
@@ -115,7 +115,9 @@ async function activateMembership({
     // Reuse the same provisioning pipeline that publish and Sync drive, scoped to
     // this one student, rather than re-implementing the fanout here. It resolves
     // the template, token and org plan itself and files issues for assignments
-    // that have already released.
+    // that have already released. `provisionOnly` keeps the run read-only with
+    // respect to publish state: a student joining must never re-publish a repo
+    // the instructor unpublished, nor release a draft assignment.
     await Promise.all(
       missingRepositories.map(repository =>
         createRepositoriesTask.trigger(
@@ -124,6 +126,7 @@ async function activateMembership({
             assignmentTitle: repository.title,
             org: membership.classroom.slug,
             sessionId: nanoid(),
+            provisionOnly: true,
           },
           { concurrencyKey: membership.classroom.slug }
         )


### PR DESCRIPTION
## What

Makes it possible to publish a repo/assignment **before any students are enrolled** (pre-term course staging), and fixes the join-time provisioning that was supposed to make that safe.

## Why

Publishing an INDIVIDUAL repo with an empty roster returned `No students found.` and left it a draft — a class could not be staged until somebody enrolled. SELF_FORMED team repos have always published with nobody enrolled, so the restriction was never coherent.

Four separate defects on that path:

1. **`publishAssignment`** (`admin.$class.repos/helpers.ts`) — hard-returned `{ error: 'No students found.' }` and never called `setPublished`. Instructor saw a red toast; repo stayed Draft.
2. **`repo_publish`** (MCP) — same case, threw `ToolError`.
3. **`release_git_repo_assignments_now`** — returned early on zero recipients *before* the loop that sets `is_published: true`. "Release now" reported success while the assignment stayed in draft: a silent no-op with no error anywhere.
4. **`activateMembership`** — the join-time provisioning both the GitHub `member_added` webhook and the self-join flow rely on was **dead code**. It filtered `repository.assignments` on `'type' in a && a.type === 'INDIVIDUAL'`, but `type` is a field on the `Repository` model and does not exist on `Assignment` — so the test was always false at runtime and no joining student has ever been auto-provisioned. Only a manual **Sync** backfilled them.

## Changes

**Commit 1 — publish before students enrol**

- Publish (web + MCP) now flips visibility when there is nobody to provision for — empty roster, a roster whose invites are all still pending (no GitHub login to create a repo under), or an instructor-assigned repo with no teams tagged yet. Returns a plain success rather than a progress session containing no work.
- `releaseAssignmentsNowTask` marks assignments published regardless of roster size; only the fanout is skipped.
- `activateMembership` selects **published INDIVIDUAL repositories**, skips those the student already has, and delegates to the same `create_git_repos` pipeline publish and Sync use — provisioning is not reimplemented on the join path. Fanning out per repository rather than per assignment also removes a latent double-create: repo names are `{repository.slug}-{login}`, so two published assignments in one repository raced two creations of the same repo.
- `students.length` → `studentList.length` so a roster of pending-invite-only students no longer passes the gate and then silently provisions nothing.

**Commit 2 — keep join provisioning read-only (review follow-up)**

Routing joins through the shared pipeline made two of its publish side effects reachable from a *student* action for the first time. Both are right for an instructor clicking Publish and wrong for someone accepting an invite:

- `createRepositoriesTask` ends by calling `repository.setPublished(true)`. Join runs queue behind concurrency-1, so an instructor who unpublishes while one is queued would have it silently re-published — and `setPublished` notifies the **entire roster** on a false→true transition.
- `createRepositoryTask` files issues for every assignment whose `release_at` has passed and flips each to `is_published`. On a join, the first student to arrive could accelerate the nightly release cron and surface a draft the instructor had not released. (That draft was already destined for release by the cron, so this is acceleration rather than new exposure — but it is not a joiner's call.)

Adds an optional `provisionOnly` flag, set only by `activateMembership`, that skips both writes and narrows the issue filter to already-published assignments. Instructor-driven paths omit the flag and are unchanged — the daily cron depends on both side effects. Legacy serialized payloads default to `undefined`, so in-flight runs keep current behaviour. Also awaits an `assignment.update` loop that was a floating promise.

## Tests

45 new specs. The 22 asserting changed behaviour were each run against the previous code and confirmed to fail there; the rest pin no-regression and negative cases (drafts, GROUP repos, wrong-classroom scoping, idempotent re-delivery, populated-roster fanout, both `provisionOnly` states).

| Suite | Result |
|---|---|
| `@classmoji/tasks` | 73/73 |
| `@classmoji/mcp` | 315/315 |
| `@classmoji/web` (unit) | 194/194 |

`tsc --noEmit` clean on tasks + mcp; eslint clean (0 errors) on every changed file.

Pre-existing on `staging` and untouched here: webapp `tsc` error in `RequireGitProvider.tsx` (`useGitProvider` not exported), and 12 failing `@classmoji/services` specs — both verified identical on a clean checkout.

## Known deferral — throughput, not correctness

Join-time provisioning triggers one `create_git_repos` run per repository per joiner against a `concurrencyLimit: 1` queue keyed on classroom slug, and each run re-fetches the roster, mints a GitHub token and does a clone/push. A cohort accepting invites at once on day one of term will serialize behind that, sharing the queue key with the instructor's own Publish/Sync runs.

This is a **throughput** limit, not a correctness one, and it degrades gracefully: repos arrive late rather than wrong, nothing is lost or duplicated (the existing-repo check keeps it idempotent), and **Sync backfills** anything an instructor doesn't want to wait for. Batching joiners into a single run is separate scope.

## Test steps

1. Create a classroom with no students; create a repo. Publish it → succeeds, shows Published (previously: "No students found.", stayed Draft).
2. Open the repo, Release now on an assignment → assignment shows Published (previously: success toast, stayed draft).
3. Have a student join the org → their repo is provisioned automatically for each published INDIVIDUAL repo, with issues for any already-released assignments.
4. Unpublish a repo, then have a student join → repo stays unpublished, no notification sent to the class.
5. Publish a repo in a classroom that *does* have students → unchanged: repos fan out as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01382gDyiikn6yZmiH2vh2Pe
