### PR TITLE
feat(mcp): TA management, bulk grader assignment, and grading report tools

### DIFF
--- a/apps/mcp/src/suggestions.ts
+++ b/apps/mcp/src/suggestions.ts
@@ -25,6 +25,7 @@ export const FACULTY_SUGGESTIONS: readonly string[] = [
   "What's in my grading queue — any submissions still ungraded?",
   'Are there any open regrade requests I need to resolve?',
   'What assignments are due this week?',
+  'How is grading going across my TAs — who still has submissions outstanding?',
 ];
 
 /** Student-facing starters (upcoming work, grades, tokens, regrades). */

--- a/apps/mcp/src/tools/__tests__/assistants.test.ts
+++ b/apps/mcp/src/tools/__tests__/assistants.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for assistant_add / assistant_update / assistant_remove.
+ *
+ * Security focus: the classroomId handed to every service call comes from the
+ * ToolContext, never from args; the service's caller-fixable failures map onto
+ * the right ToolError kinds (an unknown/foreign assistant is the uniform
+ * scopedNotFound, so a probe cannot enumerate another classroom's staff); and
+ * no mutation is left un-audited — while the no-op "already an assistant" path,
+ * which mutates nothing, writes no audit row.
+ *
+ * `@classmoji/services` is mocked (factory idiom) INCLUDING AssistantServiceError,
+ * so the handlers' `instanceof` mapping runs against the same class the test
+ * throws — no real GitHub invites and no Trigger.dev runs.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  addAssistant: vi.fn(),
+  updateAssistant: vi.fn(),
+  removeAssistant: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => {
+  // Same shape as the real service error; the tools branch on `instanceof`, so
+  // the class the handler imports must be the class the test constructs.
+  class AssistantServiceError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'AssistantServiceError';
+      this.code = code;
+    }
+  }
+  return {
+    AssistantServiceError,
+    ClassmojiService: {
+      assistant: {
+        addAssistant: (...a: unknown[]) => mocks.addAssistant(...a),
+        updateAssistant: (...a: unknown[]) => mocks.updateAssistant(...a),
+        removeAssistant: (...a: unknown[]) => mocks.removeAssistant(...a),
+      },
+      audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+    },
+  };
+});
+
+const { AssistantServiceError } = await import('@classmoji/services');
+const { assistantAddTool, assistantUpdateTool, assistantRemoveTool } =
+  await import('../assistants.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/** The audit row the handler wrote (first call). */
+function auditRow() {
+  return mocks.auditCreate.mock.calls[0][0] as {
+    action: string;
+    classroom_id: string;
+    resource_type: string;
+    resource_id?: string | null;
+    data: Record<string, unknown>;
+  };
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+});
+
+describe('assistant_add', () => {
+  const ARGS = { classroom: 'org/w26', login: 'ta-ann', name: 'Ann', email: 'ann@x.edu' };
+
+  it('adds via the service using ctx classroomId and reports the pending org invite', async () => {
+    mocks.addAssistant.mockResolvedValue({
+      created: true,
+      alreadyExists: false,
+      userId: 'ta-1',
+      login: 'ta-ann',
+      name: 'Ann',
+      alreadyOrgMember: false,
+    });
+
+    const payload = parse(await assistantAddTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      created: true,
+      already_exists: false,
+      login: 'ta-ann',
+      user_id: 'ta-1',
+      github: 'invited',
+      invite_pending: true,
+    });
+
+    // classroomId comes from ctx, never from args.
+    expect(mocks.addAssistant).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      login: 'ta-ann',
+      name: 'Ann',
+      email: 'ann@x.edu',
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('CREATE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.resource_id).toBe('ta-1');
+    expect(audit.data).toMatchObject({ tool: 'assistant_add', login: 'ta-ann' });
+  });
+
+  it('reports a team add (no pending invite) when they were already in the org', async () => {
+    mocks.addAssistant.mockResolvedValue({
+      created: true,
+      alreadyExists: false,
+      userId: 'ta-1',
+      login: 'ta-ann',
+      name: 'Ann',
+      alreadyOrgMember: true,
+    });
+
+    const payload = parse(await assistantAddTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ github: 'team_added', invite_pending: false });
+  });
+
+  it('is idempotent: an existing assistant is a no-op and writes NO audit row', async () => {
+    mocks.addAssistant.mockResolvedValue({
+      created: false,
+      alreadyExists: true,
+      userId: 'ta-1',
+      login: 'ta-ann',
+      name: 'Ann',
+      alreadyOrgMember: true,
+    });
+
+    const payload = parse(await assistantAddTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ success: true, created: false, already_exists: true });
+    // Nothing was mutated (the service short-circuits before any write), so
+    // there is no mutation to audit.
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('maps git_user_not_found to a not_found error and audits nothing', async () => {
+    mocks.addAssistant.mockRejectedValue(
+      new AssistantServiceError('git_user_not_found', '[assistant] git user nope not found')
+    );
+
+    await expect(assistantAddTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'GitHub user not found',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('maps no_org_configured to invalid_params', async () => {
+    mocks.addAssistant.mockRejectedValue(
+      new AssistantServiceError('no_org_configured', '[assistant] no git organization')
+    );
+
+    await expect(assistantAddTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+  });
+
+  it('lets an unexpected service failure through for the generic wrapper', async () => {
+    mocks.addAssistant.mockRejectedValue(new Error('boom'));
+    await expect(assistantAddTool.handler(ARGS, CTX)).rejects.toThrow('boom');
+  });
+});
+
+describe('assistant_update', () => {
+  const ARGS = { classroom: 'org/w26', login: 'ta-ann', is_grader: true };
+
+  it('flips is_grader via the service using ctx classroomId and audits the update', async () => {
+    mocks.updateAssistant.mockResolvedValue({ id: 'm-2', is_grader: true });
+
+    const payload = parse(await assistantUpdateTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ success: true, login: 'ta-ann', is_grader: true });
+
+    expect(mocks.updateAssistant).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      login: 'ta-ann',
+      isGrader: true,
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.data).toMatchObject({ tool: 'assistant_update', is_grader: true });
+  });
+
+  it('refuses someone who is not an assistant here (uniform scopedNotFound)', async () => {
+    mocks.updateAssistant.mockRejectedValue(
+      new AssistantServiceError('assistant_not_found', '[assistant] not an assistant')
+    );
+
+    await expect(assistantUpdateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Assistant not found in this classroom',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('assistant_remove', () => {
+  const ARGS = { classroom: 'org/w26', login: 'ta-ann', confirm: true as const };
+
+  it('queues the removal without waiting for the run and audits the DELETE', async () => {
+    mocks.removeAssistant.mockResolvedValue({ userId: 'ta-1', login: 'ta-ann', runId: 'run-1' });
+
+    const payload = parse(await assistantRemoveTool.handler(ARGS, CTX));
+    // queued:true — the service awaited the ENQUEUE only; unlike the web route
+    // we never waitForRunCompletion, and the run id is not surfaced.
+    expect(payload).toMatchObject({
+      success: true,
+      queued: true,
+      login: 'ta-ann',
+      user_id: 'ta-1',
+    });
+    expect(payload.run_id).toBeUndefined();
+
+    expect(mocks.removeAssistant).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      login: 'ta-ann',
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('DELETE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.resource_id).toBe('ta-1');
+    expect(audit.data).toMatchObject({ tool: 'assistant_remove', login: 'ta-ann' });
+  });
+
+  it('refuses an unknown / cross-classroom assistant and audits nothing', async () => {
+    mocks.removeAssistant.mockRejectedValue(
+      new AssistantServiceError('assistant_not_found', '[assistant] user nope not found')
+    );
+
+    await expect(assistantRemoveTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Assistant not found in this classroom',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('requires confirm:true in the schema (destructive gate)', () => {
+    // The registry validates inputSchema before the handler runs, so the gate
+    // lives in the schema: only the literal `true` is accepted.
+    const confirm = assistantRemoveTool.inputSchema.confirm;
+    expect(confirm.safeParse(true).success).toBe(true);
+    expect(confirm.safeParse(false).success).toBe(false);
+    expect(confirm.safeParse(undefined).success).toBe(false);
+  });
+});

--- a/apps/mcp/src/tools/__tests__/assistants.test.ts
+++ b/apps/mcp/src/tools/__tests__/assistants.test.ts
@@ -174,6 +174,22 @@ describe('assistant_add', () => {
     });
   });
 
+  it('maps login_conflict to invalid_params with a neutral message', async () => {
+    mocks.addAssistant.mockRejectedValue(
+      new AssistantServiceError('login_conflict', '[assistant] login resolves elsewhere')
+    );
+
+    await expect(assistantAddTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: 'This login is associated with a different account — contact support',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('carries a tighter rate-limit bucket than the default (each call can invite)', () => {
+    expect(assistantAddTool.rateLimit).toEqual({ capacity: 5, refillPerSecond: 0.05 });
+  });
+
   it('lets an unexpected service failure through for the generic wrapper', async () => {
     mocks.addAssistant.mockRejectedValue(new Error('boom'));
     await expect(assistantAddTool.handler(ARGS, CTX)).rejects.toThrow('boom');
@@ -184,7 +200,7 @@ describe('assistant_update', () => {
   const ARGS = { classroom: 'org/w26', login: 'ta-ann', is_grader: true };
 
   it('flips is_grader via the service using ctx classroomId and audits the update', async () => {
-    mocks.updateAssistant.mockResolvedValue({ id: 'm-2', is_grader: true });
+    mocks.updateAssistant.mockResolvedValue({ id: 'm-2', user_id: 'ta-1', is_grader: true });
 
     const payload = parse(await assistantUpdateTool.handler(ARGS, CTX));
     expect(payload).toMatchObject({ success: true, login: 'ta-ann', is_grader: true });
@@ -198,7 +214,14 @@ describe('assistant_update', () => {
     const audit = auditRow();
     expect(audit.action).toBe('UPDATE');
     expect(audit.classroom_id).toBe('class-1');
-    expect(audit.data).toMatchObject({ tool: 'assistant_update', is_grader: true });
+    // resource_id names the updated assistant; it is also part of the audit
+    // dedup key, so two updates to DIFFERENT assistants stay two rows.
+    expect(audit.resource_id).toBe('ta-1');
+    expect(audit.data).toMatchObject({
+      tool: 'assistant_update',
+      user_id: 'ta-1',
+      is_grader: true,
+    });
   });
 
   it('refuses someone who is not an assistant here (uniform scopedNotFound)', async () => {

--- a/apps/mcp/src/tools/__tests__/graders.test.ts
+++ b/apps/mcp/src/tools/__tests__/graders.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for grader_assign_bulk.
+ *
+ * Security focus (S1): the assignment — and the EXISTING template assignment —
+ * are resolved through repository.classroom_id BEFORE the service runs. This is
+ * load-bearing rather than defensive: the service fetches submissions by
+ * (assignmentId, classroomSlug), so a foreign or unknown assignment would
+ * silently yield zero submissions and report "success, 0 assigned" instead of
+ * not_found. Missing and cross-classroom therefore throw the SAME uniform
+ * not_found, with zero service calls and no audit row.
+ *
+ * (graders.github.test.ts covers the single-submission tools' GitHub-first
+ * failure mode against a mocked git layer; this file mocks @classmoji/services
+ * with the factory idiom instead, so no Trigger.dev batch ever fires.)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  assignmentFindById: vi.fn(),
+  assignGraders: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => {
+  // Same shape as the real service error; the tool branches on `instanceof`.
+  class AssignGradersError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'AssignGradersError';
+      this.code = code;
+    }
+  }
+  return {
+    AssignGradersError,
+    HelperService: {},
+    ClassmojiService: {
+      assignment: { findById: (...a: unknown[]) => mocks.assignmentFindById(...a) },
+      gitRepoAssignmentGrader: {
+        assignGradersToAssignment: (...a: unknown[]) => mocks.assignGraders(...a),
+      },
+      audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+    },
+  };
+});
+
+const { AssignGradersError } = await import('@classmoji/services');
+const { graderAssignBulkTool } = await import('../graders.ts');
+
+const ASSIGNMENT_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPLATE_ID = '22222222-2222-4222-8222-222222222222';
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/** An assignment row as loadAssignmentInClassroom sees it (repository chain). */
+function assignmentIn(classroomId: string, id: string) {
+  return { id, title: 'PS1', repository: { classroom_id: classroomId } };
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+  mocks.assignmentFindById.mockImplementation(async (id: string) => assignmentIn('class-1', id));
+  mocks.assignGraders.mockResolvedValue({ numAssignmentsToAddGradersTo: 12 });
+});
+
+describe('grader_assign_bulk — RANDOM', () => {
+  const ARGS = { classroom: 'org/w26', assignment_id: ASSIGNMENT_ID, method: 'RANDOM' as const };
+
+  it('distributes graders via the service using ctx classroomId and audits the run', async () => {
+    const payload = parse(await graderAssignBulkTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      queued: true,
+      submissions_assigned: 12,
+      method: 'RANDOM',
+    });
+
+    // classroomId comes from ctx, never args; sessionId is omitted (it only
+    // exists to tag runs for the web route's progress stream).
+    expect(mocks.assignGraders).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      assignmentId: ASSIGNMENT_ID,
+      method: 'RANDOM',
+      templateAssignmentId: null,
+    });
+    expect(mocks.assignGraders.mock.calls[0][0]).not.toHaveProperty('sessionId');
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      classroom_id: string;
+      data: Record<string, unknown>;
+    };
+    expect(audit.action).toBe('CREATE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.data).toMatchObject({
+      tool: 'grader_assign_bulk',
+      method: 'RANDOM',
+      submissions_assigned: 12,
+    });
+  });
+
+  it('maps no_graders to invalid_params and audits nothing', async () => {
+    mocks.assignGraders.mockRejectedValue(
+      new AssignGradersError('no_graders', '[assign-graders] no assistants with is_grader set')
+    );
+
+    await expect(graderAssignBulkTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('lets an unexpected service failure through for the generic wrapper', async () => {
+    mocks.assignGraders.mockRejectedValue(new Error('boom'));
+    await expect(graderAssignBulkTool.handler(ARGS, CTX)).rejects.toThrow('boom');
+  });
+});
+
+describe('grader_assign_bulk — EXISTING', () => {
+  const ARGS = {
+    classroom: 'org/w26',
+    assignment_id: ASSIGNMENT_ID,
+    method: 'EXISTING' as const,
+    template_assignment_id: TEMPLATE_ID,
+  };
+
+  it('passes the template through after classroom-verifying BOTH assignments', async () => {
+    const payload = parse(await graderAssignBulkTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ success: true, method: 'EXISTING' });
+
+    expect(mocks.assignmentFindById).toHaveBeenCalledWith(ASSIGNMENT_ID);
+    expect(mocks.assignmentFindById).toHaveBeenCalledWith(TEMPLATE_ID);
+    expect(mocks.assignGraders).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      assignmentId: ASSIGNMENT_ID,
+      method: 'EXISTING',
+      templateAssignmentId: TEMPLATE_ID,
+    });
+  });
+
+  it('rejects a missing template up front — before any lookup or service call', async () => {
+    const { template_assignment_id: _omitted, ...withoutTemplate } = ARGS;
+
+    await expect(graderAssignBulkTool.handler(withoutTemplate, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+    expect(mocks.assignmentFindById).not.toHaveBeenCalled();
+    expect(mocks.assignGraders).not.toHaveBeenCalled();
+  });
+
+  it('maps the service template_required backstop to invalid_params', async () => {
+    mocks.assignGraders.mockRejectedValue(
+      new AssignGradersError('template_required', '[assign-graders] EXISTING requires a template')
+    );
+
+    await expect(graderAssignBulkTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
+  });
+
+  it('refuses a template from ANOTHER classroom with the uniform not_found', async () => {
+    mocks.assignmentFindById.mockImplementation(async (id: string) =>
+      assignmentIn(id === TEMPLATE_ID ? 'class-2' : 'class-1', id)
+    );
+
+    await expect(graderAssignBulkTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Assignment not found in this classroom',
+    });
+    expect(mocks.assignGraders).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('grader_assign_bulk — S1 assignment scoping', () => {
+  const ARGS = { classroom: 'org/w26', assignment_id: ASSIGNMENT_ID, method: 'RANDOM' as const };
+
+  it('refuses an unknown assignment with zero service calls', async () => {
+    mocks.assignmentFindById.mockResolvedValue(null);
+
+    await expect(graderAssignBulkTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Assignment not found in this classroom',
+    });
+    expect(mocks.assignGraders).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it("refuses another classroom's assignment with the SAME error (no existence leak)", async () => {
+    mocks.assignmentFindById.mockImplementation(async (id: string) => assignmentIn('class-2', id));
+
+    await expect(graderAssignBulkTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Assignment not found in this classroom',
+    });
+    expect(mocks.assignGraders).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/src/tools/__tests__/graders.test.ts
+++ b/apps/mcp/src/tools/__tests__/graders.test.ts
@@ -164,6 +164,18 @@ describe('grader_assign_bulk — EXISTING', () => {
     expect(mocks.assignGraders).not.toHaveBeenCalled();
   });
 
+  it('rejects an assignment used as its own template — before any lookup', async () => {
+    await expect(
+      graderAssignBulkTool.handler({ ...ARGS, template_assignment_id: ASSIGNMENT_ID }, CTX)
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: 'template_assignment_id must be a different assignment than assignment_id',
+    });
+    expect(mocks.assignmentFindById).not.toHaveBeenCalled();
+    expect(mocks.assignGraders).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
   it('maps the service template_required backstop to invalid_params', async () => {
     mocks.assignGraders.mockRejectedValue(
       new AssignGradersError('template_required', '[assign-graders] EXISTING requires a template')

--- a/apps/mcp/src/tools/__tests__/reads.test.ts
+++ b/apps/mcp/src/tools/__tests__/reads.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   findByClassroomId: vi.fn(), // gitRepoAssignment.findByClassroomId
   findEmojiByClassroomId: vi.fn(), // emojiMapping.findByClassroomId
   findAssignedByGrader: vi.fn(), // gitRepoAssignmentGrader.findAssignedByGrader
+  gradingReport: vi.fn(), // gitRepoAssignmentGrader.gradingReport
   findBySlug: vi.fn(), // classroom.findBySlug
   calculateClassLeaderboard: vi.fn(), // helper.calculateClassLeaderboard
   membershipsByClassroom: vi.fn(), // classroomMembership.findByClassroomId
@@ -35,6 +36,7 @@ vi.mock('@classmoji/services', () => ({
     emojiMapping: { findByClassroomId: (...a: unknown[]) => mocks.findEmojiByClassroomId(...a) },
     gitRepoAssignmentGrader: {
       findAssignedByGrader: (...a: unknown[]) => mocks.findAssignedByGrader(...a),
+      gradingReport: (...a: unknown[]) => mocks.gradingReport(...a),
     },
     classroom: { findBySlug: (...a: unknown[]) => mocks.findBySlug(...a) },
     helper: {
@@ -46,7 +48,7 @@ vi.mock('@classmoji/services', () => ({
   },
 }));
 
-const { listSubmissionsTool, getLeaderboardTool, listTeachingTeamTool } =
+const { listSubmissionsTool, getLeaderboardTool, listTeachingTeamTool, gradingReportTool } =
   await import('../reads.ts');
 const { gradingQueueResource, leaderboardResource } = await import('../../resources/grading.ts');
 
@@ -231,5 +233,98 @@ describe('list_teaching_team', () => {
     expect(byId.u3).toBeUndefined(); // students are not teaching team
     // Only id/login/name/roles — no PII (email/school_id) or avatar.
     expect(Object.keys(byId.u1).sort()).toEqual(['id', 'login', 'name', 'roles']);
+  });
+});
+
+describe('grading_report', () => {
+  const GRADER_ID = '33333333-3333-4333-8333-333333333333';
+  const ASSIGNMENT_ID = '44444444-4444-4444-8444-444444444444';
+
+  function reportRows() {
+    return [
+      {
+        grader: { id: 'g-1', login: 'ta-ann', name: 'Ann' },
+        assignment: { id: 'a-1', title: 'HW1', repository_title: 'Lab 1' },
+        assigned_count: 5,
+        graded_count: 3,
+        grade_distribution: { '🟢': 2, '🟡': 1 },
+        last_graded_at: new Date('2026-08-20T15:04:05.000Z'),
+      },
+      {
+        grader: { id: 'g-1', login: 'ta-ann', name: 'Ann' },
+        assignment: { id: 'a-2', title: 'HW2', repository_title: 'Lab 2' },
+        assigned_count: 0, // graded without ever being formally assigned
+        graded_count: 1,
+        grade_distribution: { '🟢': 1 },
+        last_graded_at: null,
+      },
+      {
+        grader: { id: 'g-2', login: 'ta-bob', name: 'Bob' },
+        assignment: { id: 'a-1', title: 'HW1', repository_title: 'Lab 1' },
+        assigned_count: 4,
+        graded_count: 4,
+        grade_distribution: { '🔴': 4 },
+        last_graded_at: new Date('2026-08-21T09:00:00.000Z'),
+      },
+    ];
+  }
+
+  it('summarizes the rows and serializes last_graded_at to ISO', async () => {
+    mocks.gradingReport.mockResolvedValue(reportRows());
+
+    const payload = parse(
+      await gradingReportTool.handler({ classroom: CLASSROOM }, staffCtx('OWNER'))
+    );
+    expect(payload.total_rows).toBe(3);
+    expect(payload.graders).toBe(2); // DISTINCT graders, not row count
+
+    expect(payload.rows[0]).toMatchObject({
+      assigned_count: 5,
+      graded_count: 3,
+      grade_distribution: { '🟢': 2, '🟡': 1 },
+      last_graded_at: '2026-08-20T15:04:05.000Z',
+    });
+    // A grader who graded without being assigned is kept, with assigned_count 0.
+    expect(payload.rows[1]).toMatchObject({ assigned_count: 0, graded_count: 1 });
+    expect(payload.rows[1].last_graded_at).toBeNull();
+
+    // classroomId comes from ctx; absent filters are passed as explicit nulls.
+    expect(mocks.gradingReport).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      assignmentId: null,
+      graderId: null,
+    });
+  });
+
+  it('passes the assignment_id / grader_id filters straight through', async () => {
+    mocks.gradingReport.mockResolvedValue([]);
+
+    await gradingReportTool.handler(
+      { classroom: CLASSROOM, assignment_id: ASSIGNMENT_ID, grader_id: GRADER_ID },
+      staffCtx('OWNER')
+    );
+
+    expect(mocks.gradingReport).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      assignmentId: ASSIGNMENT_ID,
+      graderId: GRADER_ID,
+    });
+  });
+
+  it('returns an empty report (not an error) when nothing matches the filters', async () => {
+    mocks.gradingReport.mockResolvedValue([]);
+
+    const payload = parse(
+      await gradingReportTool.handler(
+        { classroom: CLASSROOM, grader_id: GRADER_ID },
+        staffCtx('OWNER')
+      )
+    );
+    expect(payload).toEqual({ total_rows: 0, graders: 0, rows: [] });
+  });
+
+  it('is gated to OWNER/TEACHER — assistants must not read peers grading stats', () => {
+    expect(gradingReportTool.roles).toEqual(['OWNER', 'TEACHER']);
+    expect(gradingReportTool.scope).toBe('read');
   });
 });

--- a/apps/mcp/src/tools/assistants.ts
+++ b/apps/mcp/src/tools/assistants.ts
@@ -1,0 +1,261 @@
+/**
+ * Assistant (TA) tools — assistant_add / assistant_update / assistant_remove.
+ *
+ * ROUTE-DERIVED TIER: the web actions live in
+ * apps/webapp/app/routes/admin.$class.assistants/action.ts, gated by
+ * requireClassroomAdmin — OWNER only for all three.
+ *
+ * Backbone: ClassmojiService.assistant.* (extracted in phase A so the web route
+ * and these tools take ONE code path — same precedent as roster.service.ts).
+ * The service resolves the GitHub profile SERVER-SIDE from the login, so a tool
+ * caller holding only a login works and no client can choose the provider_id
+ * the account is keyed to.
+ *
+ * S1: classroomId is ALWAYS ctx.classroom.classroomId, never request input, so
+ * every membership lookup inside the service is already classroom-scoped. A
+ * login that names nobody, or someone who is not an ASSISTANT *here*, comes
+ * back as the same `assistant_not_found` → the uniform scopedNotFound, so a
+ * cross-classroom probe cannot enumerate foreign staff.
+ */
+
+import { AssistantServiceError, ClassmojiService } from '@classmoji/services';
+import { z } from 'zod';
+import { ToolError } from '../mcp/errors.ts';
+import type { ToolDefinition } from '../mcp/registry.ts';
+import { ok, OWNER_ONLY, requireClassroomCtx, scopedNotFound, writeAudit } from './shared.ts';
+
+/**
+ * Map the service's caller-fixable failures onto tool errors.
+ *
+ * - `git_user_not_found` → a PLAIN not_found: the miss is on GitHub's user
+ *   lookup, not on a classroom-scoped record, so there is nothing to leak and
+ *   the message should say what actually failed.
+ * - `assistant_not_found` → the uniform scopedNotFound (unknown login and
+ *   "assistant of another classroom" are indistinguishable to the caller).
+ * - `no_org_configured` → invalid_params: the classroom is not linked to a git
+ *   organization, so assistants cannot be managed until that is fixed.
+ * - `classroom_not_found` is unreachable (the id comes from a resolved ctx) and
+ *   anything else is returned unchanged for the registry's generic wrapper.
+ */
+function mapAssistantError(error: unknown): unknown {
+  if (!(error instanceof AssistantServiceError)) return error;
+  switch (error.code) {
+    case 'git_user_not_found':
+      return new ToolError('not_found', 'GitHub user not found');
+    case 'assistant_not_found':
+      return scopedNotFound('Assistant');
+    case 'no_org_configured':
+      return new ToolError(
+        'invalid_params',
+        'This classroom has no linked GitHub organization — assistants cannot be managed'
+      );
+    default:
+      return error;
+  }
+}
+
+interface AssistantAddArgs {
+  classroom: string;
+  login: string;
+  name?: string;
+  email?: string;
+}
+
+export const assistantAddTool: ToolDefinition<AssistantAddArgs> = {
+  name: 'assistant_add',
+  // Sends a REAL GitHub org invite (openWorld). Adds a membership only —
+  // nothing is removed, so not destructive.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Add an assistant (TA)',
+  description:
+    "Adds a TA/assistant to the classroom's teaching team by GitHub username, and invites them " +
+    'to the classroom GitHub organization if they are not already a member (someone already in ' +
+    'the org is added straight to the assistant team instead). Owner only. Idempotent: if they ' +
+    'are already an assistant here it reports already_exists and changes nothing. New assistants ' +
+    'must accept the GitHub org invite before their access is live. Use list_teaching_team to see ' +
+    'current staff, and assistant_update to make them a grader.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    login: z.string().min(1).max(100).describe('The assistant GitHub username'),
+    name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Display name override (defaults to their GitHub profile name)'),
+    email: z.string().email().optional().describe('Contact email override'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let result;
+    try {
+      // classroomId is ALWAYS the authorized classroom, never request input.
+      result = await ClassmojiService.assistant.addAssistant({
+        classroomId: classroom.classroomId,
+        login: args.login,
+        name: args.name,
+        email: args.email,
+      });
+    } catch (error) {
+      throw mapAssistantError(error);
+    }
+
+    // An already-existing assistant short-circuits inside the service BEFORE any
+    // GitHub or DB write — there is no mutation to audit in that case.
+    if (!result.created) {
+      return ok({
+        success: true,
+        created: false,
+        already_exists: true,
+        login: result.login,
+        user_id: result.userId,
+        message: `${result.login} is already an assistant in this classroom — nothing changed.`,
+      });
+    }
+
+    // Audit right after the service call: the membership (and the GitHub team
+    // add / org invite) is already committed, so nothing downstream may leave
+    // the mutation un-audited (plan §5.1).
+    await writeAudit(ctx, {
+      resource_type: 'ASSISTANTS',
+      resource_id: result.userId,
+      action: 'CREATE',
+      data: {
+        tool: 'assistant_add',
+        user_id: result.userId,
+        login: result.login,
+        already_org_member: result.alreadyOrgMember,
+      },
+    });
+
+    return ok({
+      success: true,
+      created: true,
+      already_exists: false,
+      login: result.login,
+      user_id: result.userId,
+      name: result.name,
+      // Already-in-org staff are added straight to the assistant team; everyone
+      // else gets an org invite they must accept before access is live.
+      github: result.alreadyOrgMember ? 'team_added' : 'invited',
+      invite_pending: !result.alreadyOrgMember,
+      message: result.alreadyOrgMember
+        ? `${result.login} was already in the GitHub org and has been added to the assistant team.`
+        : `${result.login} has been invited to the GitHub organization — their access goes live once they accept the invite.`,
+    });
+  },
+};
+
+interface AssistantUpdateArgs {
+  classroom: string;
+  login: string;
+  is_grader: boolean;
+}
+
+export const assistantUpdateTool: ToolDefinition<AssistantUpdateArgs> = {
+  name: 'assistant_update',
+  // Flips one flag on our own DB row: no deletion, no GitHub call, and setting
+  // the same value twice is a no-op → idempotent.
+  annotations: { destructive: false, idempotent: true, openWorld: false },
+  title: 'Update an assistant',
+  description:
+    'Sets whether an assistant is a grader (is_grader) in this classroom. Owner only. Only ' +
+    'grader-flagged assistants take part in grader_assign_bulk RANDOM distribution. Identify ' +
+    'them by GitHub username; list_teaching_team shows the current staff.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    login: z.string().min(1).max(100).describe('The assistant GitHub username'),
+    is_grader: z.boolean().describe('Whether this assistant grades submissions'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    try {
+      // Role-scoped inside the service: a user who is both OWNER and ASSISTANT
+      // here has two membership rows and only the ASSISTANT one is touched.
+      await ClassmojiService.assistant.updateAssistant({
+        classroomId: classroom.classroomId,
+        login: args.login,
+        isGrader: args.is_grader,
+      });
+    } catch (error) {
+      throw mapAssistantError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'ASSISTANTS',
+      action: 'UPDATE',
+      data: { tool: 'assistant_update', login: args.login, is_grader: args.is_grader },
+    });
+
+    return ok({ success: true, login: args.login, is_grader: args.is_grader });
+  },
+};
+
+interface AssistantRemoveArgs {
+  classroom: string;
+  login: string;
+  confirm: true;
+}
+
+export const assistantRemoveTool: ToolDefinition<AssistantRemoveArgs> = {
+  name: 'assistant_remove',
+  // Can remove the user from the GitHub org entirely → destructive + openWorld.
+  // Requires confirm:true (enforced by the schema).
+  annotations: { destructive: true, openWorld: true },
+  title: 'Remove an assistant from the classroom',
+  description:
+    'Removes an assistant from the classroom teaching team. Owner only, destructive, requires ' +
+    'confirm:true. Triggers the standard removal workflow: it removes them from the classroom ' +
+    'assistant team on GitHub and, IF they hold no other role in that GitHub organization, ' +
+    'removes them from the org entirely (revoking their access) — the workflow is role-aware, so ' +
+    'another membership (e.g. they also own or take a class in the same org) keeps them in the ' +
+    'org. Deletes only the ASSISTANT membership row. Runs in the background.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    login: z.string().min(1).max(100).describe('The assistant GitHub username'),
+    confirm: z
+      .literal(true)
+      .describe('Must be true — acknowledges this can remove the user from the GitHub org'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let result;
+    try {
+      // The service resolves the target from the DB by (classroom, login) and
+      // builds the removal-task payload ENTIRELY server-side. It awaits the
+      // ENQUEUE only and hands back the run id; unlike the web route we do not
+      // waitForRunCompletion — the removal finishes in the background.
+      result = await ClassmojiService.assistant.removeAssistant({
+        classroomId: classroom.classroomId,
+        login: args.login,
+      });
+    } catch (error) {
+      throw mapAssistantError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'ASSISTANTS',
+      resource_id: result.userId,
+      action: 'DELETE',
+      data: { tool: 'assistant_remove', user_id: result.userId, login: result.login },
+    });
+
+    return ok({
+      success: true,
+      queued: true,
+      login: result.login,
+      user_id: result.userId,
+      message:
+        'Assistant removal queued — removing the GitHub team membership (and org access if they hold no other role there) in the background.',
+    });
+  },
+};

--- a/apps/mcp/src/tools/assistants.ts
+++ b/apps/mcp/src/tools/assistants.ts
@@ -34,6 +34,9 @@ import { ok, OWNER_ONLY, requireClassroomCtx, scopedNotFound, writeAudit } from 
  *   "assistant of another classroom" are indistinguishable to the caller).
  * - `no_org_configured` → invalid_params: the classroom is not linked to a git
  *   organization, so assistants cannot be managed until that is fixed.
+ * - `login_conflict` → invalid_params with a neutral message: the stored user
+ *   record is keyed to a different account than this login resolves to, which
+ *   only a human with both records in front of them can untangle.
  * - `classroom_not_found` is unreachable (the id comes from a resolved ctx) and
  *   anything else is returned unchanged for the registry's generic wrapper.
  */
@@ -48,6 +51,11 @@ function mapAssistantError(error: unknown): unknown {
       return new ToolError(
         'invalid_params',
         'This classroom has no linked GitHub organization — assistants cannot be managed'
+      );
+    case 'login_conflict':
+      return new ToolError(
+        'invalid_params',
+        'This login is associated with a different account — contact support'
       );
     default:
       return error;
@@ -76,6 +84,9 @@ export const assistantAddTool: ToolDefinition<AssistantAddArgs> = {
     'current staff, and assistant_update to make them a grader.',
   scope: 'write',
   roles: OWNER_ONLY,
+  // Tighter than the default bucket: every call can send a real GitHub org
+  // invitation, so cap it at a burst of 5 and roughly 3 per minute sustained.
+  rateLimit: { capacity: 5, refillPerSecond: 0.05 },
   inputSchema: {
     classroom: z.string().describe("Classroom reference as 'org/slug'"),
     login: z.string().min(1).max(100).describe('The assistant GitHub username'),
@@ -175,10 +186,11 @@ export const assistantUpdateTool: ToolDefinition<AssistantUpdateArgs> = {
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
 
+    let membership;
     try {
       // Role-scoped inside the service: a user who is both OWNER and ASSISTANT
       // here has two membership rows and only the ASSISTANT one is touched.
-      await ClassmojiService.assistant.updateAssistant({
+      membership = await ClassmojiService.assistant.updateAssistant({
         classroomId: classroom.classroomId,
         login: args.login,
         isGrader: args.is_grader,
@@ -187,10 +199,20 @@ export const assistantUpdateTool: ToolDefinition<AssistantUpdateArgs> = {
       throw mapAssistantError(error);
     }
 
+    // resource_id identifies WHICH assistant was updated. It is also what keeps
+    // back-to-back updates to different assistants as separate audit rows: the
+    // audit dedup key includes it, so without it two flips inside the dedup
+    // window would collapse into one record.
     await writeAudit(ctx, {
       resource_type: 'ASSISTANTS',
+      resource_id: membership.user_id,
       action: 'UPDATE',
-      data: { tool: 'assistant_update', login: args.login, is_grader: args.is_grader },
+      data: {
+        tool: 'assistant_update',
+        user_id: membership.user_id,
+        login: args.login,
+        is_grader: args.is_grader,
+      },
     });
 
     return ok({ success: true, login: args.login, is_grader: args.is_grader });
@@ -215,7 +237,9 @@ export const assistantRemoveTool: ToolDefinition<AssistantRemoveArgs> = {
     'assistant team on GitHub and, IF they hold no other role in that GitHub organization, ' +
     'removes them from the org entirely (revoking their access) — the workflow is role-aware, so ' +
     'another membership (e.g. they also own or take a class in the same org) keeps them in the ' +
-    'org. Deletes only the ASSISTANT membership row. Runs in the background.',
+    'org. Deletes only the ASSISTANT membership row. Runs in the background. Because the removal ' +
+    'is processed asynchronously it can still fail after this call reports success — check ' +
+    'list_teaching_team afterwards to confirm they are gone.',
   scope: 'write',
   roles: OWNER_ONLY,
   inputSchema: {

--- a/apps/mcp/src/tools/graders.ts
+++ b/apps/mcp/src/tools/graders.ts
@@ -24,11 +24,12 @@
  * hold a teaching-team membership in THIS classroom.
  */
 
-import { ClassmojiService, HelperService } from '@classmoji/services';
+import { AssignGradersError, ClassmojiService, HelperService } from '@classmoji/services';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolDefinition } from '../mcp/registry.ts';
 import {
+  loadAssignmentInClassroom,
   loadGitRepoAssignmentInClassroom,
   ok,
   OWNER_ONLY,
@@ -154,5 +155,120 @@ export const graderUnassignTool: ToolDefinition<GraderArgs> = {
     });
 
     return ok({ success: true, removed_grader: assigned.grader.login });
+  },
+};
+
+// ─── Bulk grader assignment ──────────────────────────────────────────────────
+
+interface GraderAssignBulkArgs {
+  classroom: string;
+  assignment_id: string;
+  method: 'RANDOM' | 'EXISTING';
+  template_assignment_id?: string;
+}
+
+export const graderAssignBulkTool: ToolDefinition<GraderAssignBulkArgs> = {
+  name: 'grader_assign_bulk',
+  // Fans out GitHub issue-assignee writes (openWorld). Adds grader rows only —
+  // existing assignments are not cleared, so nothing is destroyed.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Bulk-assign graders to an assignment',
+  description:
+    'Distributes graders across ALL submissions of one assignment at once. Owner only. ' +
+    "method=RANDOM shuffles the classroom's assistants that have is_grader set and walks them " +
+    'round-robin, so the load is spread evenly and each submission gets exactly one grader. ' +
+    'method=EXISTING copies the per-student/per-team grader mapping from template_assignment_id ' +
+    '(required for EXISTING, and it must be an assignment in this classroom) — submissions with ' +
+    'no match in the template are skipped. Graders are mirrored onto the GitHub issue assignees. ' +
+    'Runs in the background; `submissions_assigned` is the number of grader-assignment tasks ' +
+    'queued, so with a multi-grader template it can exceed the submission count. Assignment ids ' +
+    'come from list_repos. For one-off changes use grader_assign / grader_unassign instead.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    assignment_id: z.string().uuid().describe('Assignment whose submissions get graders'),
+    method: z
+      .enum(['RANDOM', 'EXISTING'])
+      .describe(
+        'RANDOM = even round-robin over is_grader assistants; EXISTING = copy the grader mapping from template_assignment_id'
+      ),
+    template_assignment_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('Assignment to copy grader assignments from (required when method=EXISTING)'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // Cheapest check first — no lookups needed to know this is unusable.
+    if (args.method === 'EXISTING' && !args.template_assignment_id) {
+      throw new ToolError(
+        'invalid_params',
+        'template_assignment_id is required when method is EXISTING'
+      );
+    }
+
+    // S1 — resolve BOTH assignments through repository.classroom_id before the
+    // service runs. This is load-bearing, not belt-and-braces: the service
+    // fetches submissions by (assignmentId, classroomSlug), so a foreign or
+    // unknown assignment would silently yield zero rows and report "success, 0
+    // assigned" instead of not_found. Missing and cross-classroom throw the
+    // SAME error, so a probe cannot enumerate another classroom's assignments.
+    const assignment = await loadAssignmentInClassroom(args.assignment_id, ctx);
+    if (args.template_assignment_id) {
+      await loadAssignmentInClassroom(args.template_assignment_id, ctx);
+    }
+
+    let result;
+    try {
+      // classroomId is ALWAYS the authorized classroom. sessionId is omitted:
+      // it only exists to tag runs for the web route's progress stream.
+      result = await ClassmojiService.gitRepoAssignmentGrader.assignGradersToAssignment({
+        classroomId: classroom.classroomId,
+        assignmentId: assignment.id,
+        method: args.method,
+        templateAssignmentId: args.template_assignment_id ?? null,
+      });
+    } catch (error) {
+      if (error instanceof AssignGradersError) {
+        if (error.code === 'no_graders') {
+          throw new ToolError(
+            'invalid_params',
+            'No assistants with is_grader=true in this classroom — flag at least one with assistant_update before assigning graders'
+          );
+        }
+        if (error.code === 'template_required') {
+          throw new ToolError(
+            'invalid_params',
+            'template_assignment_id is required when method is EXISTING'
+          );
+        }
+      }
+      // classroom_not_found is unreachable (the id comes from a resolved ctx);
+      // anything else goes to the registry's generic wrapper.
+      throw error;
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'GIT_REPO_ASSIGNMENT_GRADER',
+      resource_id: assignment.id,
+      action: 'CREATE',
+      data: {
+        tool: 'grader_assign_bulk',
+        assignment_id: assignment.id,
+        method: args.method,
+        template_assignment_id: args.template_assignment_id ?? null,
+        submissions_assigned: result.numAssignmentsToAddGradersTo,
+      },
+    });
+
+    return ok({
+      success: true,
+      queued: true,
+      submissions_assigned: result.numAssignmentsToAddGradersTo,
+      method: args.method,
+    });
   },
 };

--- a/apps/mcp/src/tools/graders.ts
+++ b/apps/mcp/src/tools/graders.ts
@@ -202,11 +202,19 @@ export const graderAssignBulkTool: ToolDefinition<GraderAssignBulkArgs> = {
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
 
-    // Cheapest check first — no lookups needed to know this is unusable.
+    // Cheapest checks first — no lookups needed to know these are unusable.
     if (args.method === 'EXISTING' && !args.template_assignment_id) {
       throw new ToolError(
         'invalid_params',
         'template_assignment_id is required when method is EXISTING'
+      );
+    }
+    // Copying an assignment's grader mapping onto itself is a no-op at best;
+    // the web UI filters the target out of the template list for the same reason.
+    if (args.method === 'EXISTING' && args.template_assignment_id === args.assignment_id) {
+      throw new ToolError(
+        'invalid_params',
+        'template_assignment_id must be a different assignment than assignment_id'
       );
     }
 

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -14,7 +14,7 @@ import { registerToolDefinition } from '../mcp/registry.ts';
 import { whoamiTool } from './whoami.ts';
 import { readTools } from './reads.ts';
 import { gradeAddTool, gradeRemoveTool, gradeRemoveAllTool } from './grades.ts';
-import { graderAssignTool, graderUnassignTool } from './graders.ts';
+import { graderAssignTool, graderUnassignTool, graderAssignBulkTool } from './graders.ts';
 import { emojiMappingUpsertTool, letterGradeMappingUpsertTool } from './mappings.ts';
 import { assignmentCreateTool, assignmentUpdateTool, assignmentDeleteTool } from './assignments.ts';
 import { regradeCreateTool, regradeResolveTool } from './regrades.ts';
@@ -49,6 +49,7 @@ import { tokenGrantTool } from './tokens.ts';
 import { extensionPurchaseTool } from './extensions.ts';
 import { repoCreateTool, repoPublishTool, repoUnpublishTool } from './repos.ts';
 import { rosterAddStudentTool, rosterRemoveStudentTool } from './roster.ts';
+import { assistantAddTool, assistantUpdateTool, assistantRemoveTool } from './assistants.ts';
 
 export function registerAllTools(): void {
   // Identity / bootstrap
@@ -64,9 +65,11 @@ export function registerAllTools(): void {
   registerToolDefinition(gradeRemoveTool);
   registerToolDefinition(gradeRemoveAllTool);
 
-  // Grader assignment (OWNER — route-derived)
+  // Grader assignment (OWNER — route-derived); bulk distributes across a whole
+  // assignment in one call.
   registerToolDefinition(graderAssignTool);
   registerToolDefinition(graderUnassignTool);
+  registerToolDefinition(graderAssignBulkTool);
 
   // Grading scale (OWNER)
   registerToolDefinition(emojiMappingUpsertTool);
@@ -126,6 +129,12 @@ export function registerAllTools(): void {
   // Roster (OWNER — add sends real emails; remove is destructive, confirm-gated)
   registerToolDefinition(rosterAddStudentTool);
   registerToolDefinition(rosterRemoveStudentTool);
+
+  // Assistants / TAs (OWNER — add sends a real GitHub org invite; remove is
+  // destructive, confirm-gated, and can drop them from the org)
+  registerToolDefinition(assistantAddTool);
+  registerToolDefinition(assistantUpdateTool);
+  registerToolDefinition(assistantRemoveTool);
 
   // Extensions (STUDENT self)
   registerToolDefinition(extensionPurchaseTool);

--- a/apps/mcp/src/tools/reads.ts
+++ b/apps/mcp/src/tools/reads.ts
@@ -17,11 +17,14 @@
  * serializes it with the same `JSON.stringify(payload, null, 2)` the resource
  * read uses. Resource and tool are therefore byte-identical by construction.
  *
- * Two tools are NOT pure mirrors:
+ * Three tools are NOT pure mirrors:
  *   - list_submissions   adds server-side filters over the grading-queue data
  *     (shares loadGradingQueueData + queueRow with the grading-queue resource).
  *   - list_teaching_team is a NEW capability (no resource lists staff-with-ids)
  *     that resolves the grader_id an agent needs for grader_assign.
+ *   - grading_report     is a NEW capability (per-TA grading oversight) on a
+ *     TIGHTER tier than the rest: OWNER/TEACHER, since it exposes each TA's
+ *     throughput and grading patterns to whoever reads it.
  */
 
 import { UriTemplate } from '@modelcontextprotocol/sdk/shared/uriTemplate.js';
@@ -30,7 +33,7 @@ import { IssueStatus, type Role } from '@prisma/client';
 import { z, type ZodRawShape } from 'zod';
 import type { ResourceDefinition, ToolDefinition } from '../mcp/registry.ts';
 import { parseClassroomRef } from '../authz/pure.ts';
-import { ok, requireClassroomCtx, TEACHING_TEAM } from './shared.ts';
+import { ok, OWNER_TEACHER, requireClassroomCtx, TEACHING_TEAM } from './shared.ts';
 import { orgLogin, type SubmissionLike } from '../resources/shape.ts';
 import { meResource } from '../resources/me.ts';
 import { classroomInfoResource } from '../resources/classroomInfo.ts';
@@ -420,6 +423,55 @@ export const listTeachingTeamTool: ToolDefinition<ListTeachingTeamArgs> = {
   },
 };
 
+// ─── grading_report (TA grading oversight) ──────────────────────────────────
+
+interface GradingReportArgs {
+  classroom: string;
+  assignment_id?: string;
+  grader_id?: string;
+}
+
+export const gradingReportTool: ToolDefinition<GradingReportArgs> = {
+  name: 'grading_report',
+  title: 'Grading report (per TA, per assignment)',
+  description:
+    'Per-TA per-assignment grading oversight: who is assigned to grade what (assigned_count), how ' +
+    'many of those they have actually graded (graded_count), the emoji grade distribution they ' +
+    'are handing out, and when they last graded (last_graded_at). Optional filters: assignment_id ' +
+    '(from list_repos) and grader_id (from list_teaching_team). A grader who graded a submission ' +
+    'without being formally assigned to it still gets a row, with assigned_count 0 — real work is ' +
+    'never hidden. OWNER and TEACHER only.',
+  scope: 'read',
+  // Personnel oversight: this exposes a TA's own throughput and grading
+  // patterns, so assistants must not read their peers' stats through MCP.
+  roles: OWNER_TEACHER,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    assignment_id: z.string().uuid().optional().describe('Limit the report to one Assignment id'),
+    grader_id: z.string().uuid().optional().describe('Limit the report to one grader (user id)'),
+  },
+  handler: async (args, ctx) => {
+    const { classroomId } = requireClassroomCtx(ctx);
+    // The service scopes every query by classroomId, so an unknown or
+    // cross-classroom assignment_id/grader_id simply matches nothing. For a
+    // read that is the right answer — empty rows, no existence signal.
+    const rows = await ClassmojiService.gitRepoAssignmentGrader.gradingReport({
+      classroomId,
+      assignmentId: args.assignment_id ?? null,
+      graderId: args.grader_id ?? null,
+    });
+
+    return ok({
+      total_rows: rows.length,
+      graders: new Set(rows.map(row => row.grader.id)).size,
+      rows: rows.map(row => ({
+        ...row,
+        last_graded_at: row.last_graded_at ? new Date(row.last_graded_at).toISOString() : null,
+      })),
+    });
+  },
+};
+
 // ─── Manifest (registration + listing order) ────────────────────────────────
 
 export const readTools: ToolDefinition<never>[] = [
@@ -435,6 +487,7 @@ export const readTools: ToolDefinition<never>[] = [
   listRegradeRequestsTool,
   myRegradeRequestsTool,
   listTeachingTeamTool,
+  gradingReportTool,
   listQuizzesTool,
   listPagesTool,
   listModulesTool,

--- a/apps/webapp/app/routes/admin.$class.assistants/action.ts
+++ b/apps/webapp/app/routes/admin.$class.assistants/action.ts
@@ -1,33 +1,10 @@
 import { namedAction } from 'remix-utils/named-action';
-import { tasks } from '@trigger.dev/sdk';
 
-import { ClassmojiService, getGitProvider, ensureClassroomTeam } from '@classmoji/services';
-import getPrisma from '@classmoji/database';
+import { ClassmojiService } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import { waitForRunCompletion } from '~/utils/helpers';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
-
-interface AssistantPayload {
-  id: string | number;
-  login: string;
-  name: string;
-  email?: string | null;
-  provider_email?: string | null;
-}
-
-interface AssistantClassroom {
-  id: string;
-  slug: string;
-  git_organization: {
-    id: string;
-    login: string;
-    provider: string;
-    github_installation_id?: string | null;
-    access_token?: string | null;
-    base_url?: string | null;
-  };
-}
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
@@ -43,13 +20,24 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   return namedAction(request, {
     async createAssistant() {
       try {
-        // The classroom `requireClassroomAdmin` authorized above, not a fresh
-        // lookup on the same slug — re-resolving decides a second time which
-        // classroom this membership lands in.
-        await addAssistantHandler({
-          assistant: data,
-          classroom: classroom as unknown as AssistantClassroom,
+        // The GitHub profile is resolved server-side by the service from the
+        // login alone — the form's octokit lookup is UX validation only, so the
+        // client can no longer choose the provider_id we key the account to.
+        // `classroom.id` is the classroom requireClassroomAdmin authorized, not
+        // a fresh lookup on the same slug.
+        const result = await ClassmojiService.assistant.addAssistant({
+          classroomId: classroom.id,
+          login: data.login,
+          name: data.name,
+          email: data.email,
         });
+
+        if (result.alreadyExists) {
+          return {
+            action: ActionTypes.SAVE_USER,
+            error: `${result.login} is already an assistant in this class.`,
+          };
+        }
 
         return {
           success: 'Assistant created',
@@ -65,7 +53,11 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     },
 
     async updateAssistant() {
-      await updateAssistantHandler(classroom.id, data.login, data.isGrader);
+      await ClassmojiService.assistant.updateAssistant({
+        classroomId: classroom.id,
+        login: data.login,
+        isGrader: data.isGrader,
+      });
       return {
         success: 'Assistant updated',
         action: ActionTypes.SAVE_USER,
@@ -74,16 +66,15 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
     async removeAssistant() {
       try {
-        const run = await tasks.trigger('remove_user_from_organization', {
-          payload: {
-            user: data.user,
-            gitOrganization: classroom.git_organization,
-            classroom: classroom,
-            role: 'ASSISTANT',
-          },
+        // The service resolves the target from the DB by (classroom, login) and
+        // builds the task payload entirely server-side; the route keeps awaiting
+        // the run so the UI can report the finished removal.
+        const { runId } = await ClassmojiService.assistant.removeAssistant({
+          classroomId: classroom.id,
+          login: data.user?.login,
         });
 
-        await waitForRunCompletion(run.id);
+        await waitForRunCompletion(runId);
 
         return {
           success: 'Assistant removed',
@@ -98,106 +89,4 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       }
     },
   });
-};
-
-/** `classroomId` is the caller's already-authorized classroom, not a re-resolve. */
-export const updateAssistantHandler = async (
-  classroomId: string,
-  assistantLogin: string,
-  isGrader: boolean
-) => {
-  const assistant = await ClassmojiService.user.findByLogin(assistantLogin);
-
-  return ClassmojiService.classroomMembership.update(classroomId, assistant!.id, {
-    is_grader: isGrader,
-  });
-};
-
-export const addAssistantHandler = async ({
-  assistant,
-  classroom,
-}: {
-  assistant: AssistantPayload;
-  classroom: AssistantClassroom;
-}) => {
-  console.log('assistant', assistant);
-
-  const gitProvider = getGitProvider(classroom.git_organization);
-  const team = await ensureClassroomTeam(
-    gitProvider,
-    classroom.git_organization.login,
-    classroom,
-    'ASSISTANT'
-  );
-
-  // If the assistant is already in the org, a fresh invite 422s and no `member_added`
-  // webhook fires — so just add them to the assistant team and activate them below.
-  // Otherwise send the org invite as usual.
-  const alreadyMember = await gitProvider.isUserMemberOfOrganization(
-    classroom.git_organization.login,
-    assistant.login
-  );
-
-  if (alreadyMember) {
-    await gitProvider.addTeamMember(classroom.git_organization.login, team.slug, assistant.login);
-  } else {
-    try {
-      await gitProvider.inviteToOrganization(
-        classroom.git_organization.login,
-        String(assistant.id),
-        [team.id]
-      );
-    } catch (error: unknown) {
-      console.error('Error inviting assistant to organization:', error);
-    }
-  }
-
-  // Upsert user and membership using connectOrCreate
-  const user = await getPrisma().user.upsert({
-    where: { login: assistant.login },
-    create: {
-      login: assistant.login,
-      name: assistant.name,
-      provider: classroom.git_organization.provider as 'GITHUB' | 'GITLAB' | 'BITBUCKET',
-      provider_id: String(assistant.id),
-      role: 'user',
-      email: assistant.email,
-      provider_email: assistant.provider_email,
-    },
-    update: {
-      role: 'user',
-    },
-  });
-
-  await getPrisma().account.upsert({
-    where: {
-      provider_id_account_id: {
-        provider_id: classroom.git_organization.provider.toLowerCase(),
-        account_id: String(assistant.id),
-      },
-    },
-    create: {
-      provider_id: classroom.git_organization.provider.toLowerCase(),
-      account_id: String(assistant.id),
-      user_id: String(user.id),
-    },
-    update: {},
-  });
-
-  await getPrisma().classroomMembership.create({
-    data: {
-      classroom_id: classroom.id,
-      user_id: user.id,
-      role: 'ASSISTANT',
-    },
-  });
-
-  // Already-in-org assistants get no `member_added` webhook, so flip
-  // has_accepted_invite now that the membership exists.
-  if (alreadyMember) {
-    await tasks.trigger('activate_membership', {
-      login: assistant.login,
-      gitOrganizationId: classroom.git_organization.id,
-    });
-  }
 };

--- a/apps/webapp/app/routes/admin.$class.assistants/action.ts
+++ b/apps/webapp/app/routes/admin.$class.assistants/action.ts
@@ -53,15 +53,25 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     },
 
     async updateAssistant() {
-      await ClassmojiService.assistant.updateAssistant({
-        classroomId: classroom.id,
-        login: data.login,
-        isGrader: data.isGrader,
-      });
-      return {
-        success: 'Assistant updated',
-        action: ActionTypes.SAVE_USER,
-      };
+      try {
+        await ClassmojiService.assistant.updateAssistant({
+          classroomId: classroom.id,
+          login: data.login,
+          isGrader: data.isGrader,
+        });
+        return {
+          success: 'Assistant updated',
+          action: ActionTypes.SAVE_USER,
+        };
+      } catch (error: unknown) {
+        // Same shape as the sibling branches: a service failure becomes a
+        // callout, not a trip through the route error boundary.
+        console.error('updateAssistant failed:', error);
+        return {
+          action: ActionTypes.SAVE_USER,
+          error: 'Failed to update assistant.',
+        };
+      }
     },
 
     async removeAssistant() {

--- a/apps/webapp/app/routes/admin.$class.repos_.$title.assign-graders/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.$title.assign-graders/route.tsx
@@ -131,14 +131,14 @@ const AssignGraders = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const { class: classSlug } = params;
 
-  const { classroom, userId: _userId, membership } = await requireClassroomAdmin(
-    request,
-    classSlug!,
-    {
-      resourceType: 'REPOSITORIES',
-      action: 'assign_graders',
-    }
-  );
+  const {
+    classroom,
+    userId: _userId,
+    membership,
+  } = await requireClassroomAdmin(request, classSlug!, {
+    resourceType: 'REPOSITORIES',
+    action: 'assign_graders',
+  });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
@@ -153,7 +153,7 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   });
 
   const { numAssignmentsToAddGradersTo } = await assignGradersToAssignmentsHandler(
-    { ...data, classroomSlug: classSlug },
+    { ...data, classroomId: classroom.id },
     sessionId
   );
 

--- a/apps/webapp/app/routes/admin.$class.repos_.$title.assign-graders/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.$title.assign-graders/route.tsx
@@ -5,7 +5,7 @@ import { nanoid } from 'nanoid';
 import { auth } from '@trigger.dev/sdk';
 
 import { useDisclosure, useGlobalFetcher } from '~/hooks';
-import { ClassmojiService } from '@classmoji/services';
+import { AssignGradersError, ClassmojiService } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import { assignGradersToAssignmentsHandler } from './utils';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
@@ -152,10 +152,22 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
     },
   });
 
-  const { numAssignmentsToAddGradersTo } = await assignGradersToAssignmentsHandler(
-    { ...data, classroomId: classroom.id },
-    sessionId
-  );
+  let numAssignmentsToAddGradersTo: number;
+  try {
+    ({ numAssignmentsToAddGradersTo } = await assignGradersToAssignmentsHandler(
+      { ...data, classroomId: classroom.id },
+      sessionId
+    ));
+  } catch (error: unknown) {
+    // The service's caller-fixable failures (no graders flagged, missing
+    // template) carry a usable message — surface it as a callout instead of
+    // letting it reach the route error boundary. Anything else still throws.
+    if (error instanceof AssignGradersError) {
+      console.error('assignGraders failed:', error);
+      return { error: error.message };
+    }
+    throw error;
+  }
 
   const triggerSession = {
     accessToken,

--- a/apps/webapp/app/routes/admin.$class.repos_.$title.assign-graders/utils.ts
+++ b/apps/webapp/app/routes/admin.$class.repos_.$title.assign-graders/utils.ts
@@ -1,137 +1,28 @@
-import _ from 'lodash';
-
-import Tasks from '@classmoji/tasks';
 import { ClassmojiService } from '@classmoji/services';
+import type { AssignGradersMethod } from '@classmoji/services';
 
 interface AssignGradersData {
   selectedAssignmentId: string;
-  method: 'RANDOM' | string;
-  classroomSlug: string;
+  method: AssignGradersMethod;
+  classroomId: string;
   templateAssignmentId?: string;
 }
 
-interface GraderInfo {
-  id?: string;
-  login?: string | null;
-  studentId?: string | null;
-  teamId?: string | null;
-  graders?: Array<{ grader: { id: string; login: string | null } }>;
-  [key: string]: unknown;
-}
-
+/**
+ * Thin wrapper over ClassmojiService.gitRepoAssignmentGrader.assignGradersToAssignment
+ * — the RANDOM/EXISTING selection and the task fan-out live in the service so the
+ * web action and the MCP tool take one path. `sessionId` tags the runs for this
+ * route's progress stream.
+ */
 export const assignGradersToAssignmentsHandler = async (
   data: AssignGradersData,
   sessionId: string
 ) => {
-  const { selectedAssignmentId, method, classroomSlug } = data;
-
-  const classroom = await ClassmojiService.classroom.findBySlug(classroomSlug);
-  const gitOrganization = classroom!.git_organization;
-
-  const repoAssignments = await ClassmojiService.gitRepoAssignment.findByAssignmentId(
-    selectedAssignmentId,
-    classroomSlug
-  );
-
-  const graderLoginList = await getGradersList({
-    ...data,
-    repoAssignments: repoAssignments as unknown as Record<string, unknown>[],
-    classroom: classroom!,
+  return ClassmojiService.gitRepoAssignmentGrader.assignGradersToAssignment({
+    classroomId: data.classroomId,
+    assignmentId: data.selectedAssignmentId,
+    method: data.method,
+    templateAssignmentId: data.templateAssignmentId,
+    sessionId,
   });
-
-  const taskPayloads = repoAssignments.map((repoAssignment, index) => {
-    const { git_repo } = repoAssignment;
-
-    if (method === 'RANDOM') {
-      return {
-        payload: {
-          repoName: git_repo.name,
-          gitOrganization,
-          githubIssueNumber: repoAssignment.provider_issue_number,
-          gitRepoAssignmentId: repoAssignment.id,
-          graderLogin: graderLoginList[index].login!,
-          graderId: graderLoginList[index].id!,
-        },
-        options: { tags: [`session_${sessionId}`] },
-      };
-    } else {
-      const isIndividualRepository = git_repo.student_id !== null;
-      let graderMatch;
-
-      if (isIndividualRepository) {
-        graderMatch = graderLoginList.find(grader => grader.studentId === git_repo.student_id);
-      } else {
-        graderMatch = graderLoginList.find(grader => grader.teamId === git_repo.team_id);
-      }
-
-      // Skip if no matching grader assignment found in template
-      if (!graderMatch || !graderMatch.graders?.length) {
-        return [];
-      }
-
-      const payloads = graderMatch.graders.map(
-        ({ grader }: { grader: { id: string; login: string | null } }) => {
-          return {
-            payload: {
-              repoName: git_repo.name,
-              gitOrganization,
-              githubIssueNumber: repoAssignment.provider_issue_number,
-              gitRepoAssignmentId: repoAssignment.id,
-              graderLogin: grader.login,
-              graderId: grader.id,
-            },
-            options: { tags: [`session_${sessionId}`] },
-          };
-        }
-      );
-
-      return payloads;
-    }
-  });
-
-  const flatPayloads = _.flatten(taskPayloads);
-
-  await Tasks.addGraderToRepositoryAssignmentTask.batchTrigger(
-    flatPayloads as Parameters<typeof Tasks.addGraderToRepositoryAssignmentTask.batchTrigger>[0]
-  );
-
-  const numAssignmentsToAddGradersTo = flatPayloads.length;
-
-  return { numAssignmentsToAddGradersTo };
-};
-
-interface GetGradersData extends AssignGradersData {
-  repoAssignments: Array<Record<string, unknown>>;
-  classroom: { id: string };
-}
-
-const getGradersList = async (data: GetGradersData): Promise<GraderInfo[]> => {
-  const { method, templateAssignmentId, classroomSlug, repoAssignments, classroom } = data;
-
-  let graderLoginList: GraderInfo[] = [];
-
-  if (method === 'RANDOM') {
-    const assistants = _.shuffle(
-      await ClassmojiService.classroomMembership.findUsersByRole(classroom.id, 'ASSISTANT', {
-        is_grader: true,
-      })
-    );
-
-    graderLoginList = (repoAssignments as unknown[]).map((_, index: number) => {
-      return assistants[index % assistants.length] as unknown as GraderInfo;
-    });
-  } else {
-    const templateRepoAssignments = await ClassmojiService.gitRepoAssignment.findByAssignmentId(
-      templateAssignmentId!,
-      classroomSlug
-    );
-
-    graderLoginList = templateRepoAssignments.map(repoAssignment => ({
-      studentId: repoAssignment.git_repo.student_id,
-      teamId: repoAssignment.git_repo.team_id,
-      graders: repoAssignment.graders as unknown as GraderInfo['graders'],
-    }));
-  }
-
-  return graderLoginList;
 };

--- a/packages/services/src/classmoji/__tests__/assistant.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/assistant.service.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for assistant.addAssistant / updateAssistant / removeAssistant —
+ * the extracted TA logic shared by the web admin.$class.assistants action and
+ * the MCP assistant tools. Prisma, the git provider, the sibling services and
+ * Trigger.dev are mocked; the tests pin the idempotency short-circuit (no
+ * GitHub writes when the ASSISTANT membership already exists), the server-side
+ * login → profile resolution, and that both role-scoped mutations refuse to
+ * touch a user who holds a different role in the classroom.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const userFindUnique = vi.fn();
+const userUpsert = vi.fn();
+const accountUpsert = vi.fn();
+const membershipCreate = vi.fn();
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    user: {
+      findUnique: (...a: unknown[]) => userFindUnique(...a),
+      upsert: (...a: unknown[]) => userUpsert(...a),
+    },
+    account: { upsert: (...a: unknown[]) => accountUpsert(...a) },
+    classroomMembership: { create: (...a: unknown[]) => membershipCreate(...a) },
+  }),
+}));
+
+const getUserByLogin = vi.fn();
+const isUserMemberOfOrganization = vi.fn();
+const addTeamMember = vi.fn();
+const inviteToOrganization = vi.fn();
+const ensureClassroomTeam = vi.fn();
+vi.mock('../../git/index.ts', () => ({
+  getGitProvider: () => ({
+    getUserByLogin: (...a: unknown[]) => getUserByLogin(...a),
+    isUserMemberOfOrganization: (...a: unknown[]) => isUserMemberOfOrganization(...a),
+    addTeamMember: (...a: unknown[]) => addTeamMember(...a),
+    inviteToOrganization: (...a: unknown[]) => inviteToOrganization(...a),
+  }),
+  ensureClassroomTeam: (...a: unknown[]) => ensureClassroomTeam(...a),
+}));
+
+const classroomFindById = vi.fn();
+vi.mock('../classroom.service.ts', () => ({
+  findById: (...a: unknown[]) => classroomFindById(...a),
+}));
+
+const findByClassroomAndUser = vi.fn();
+const updateById = vi.fn();
+vi.mock('../classroomMembership.service.ts', () => ({
+  findByClassroomAndUser: (...a: unknown[]) => findByClassroomAndUser(...a),
+  updateById: (...a: unknown[]) => updateById(...a),
+}));
+
+const userFindByLogin = vi.fn();
+vi.mock('../user.service.ts', () => ({
+  findByLogin: (...a: unknown[]) => userFindByLogin(...a),
+}));
+
+const triggerTask = vi.fn();
+vi.mock('@trigger.dev/sdk', () => ({
+  tasks: { trigger: (...a: unknown[]) => triggerTask(...a) },
+}));
+
+const assistant = await import('../assistant.service.ts');
+
+const CLASSROOM = {
+  id: 'class-1',
+  slug: 'cs1-25f',
+  git_organization: { id: 'org-1', login: 'cs1-org', provider: 'GITHUB' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  classroomFindById.mockResolvedValue(CLASSROOM);
+  ensureClassroomTeam.mockResolvedValue({ id: 42, slug: 'cs1-25f-assistants' });
+  getUserByLogin.mockResolvedValue({ id: 999, login: 'ada', name: 'Ada L', email: 'ada@gh.dev' });
+  isUserMemberOfOrganization.mockResolvedValue(false);
+  userFindUnique.mockResolvedValue(null);
+  userUpsert.mockResolvedValue({ id: 'u-1', login: 'ada', name: 'Ada L' });
+  triggerTask.mockResolvedValue({ id: 'run-1' });
+});
+
+describe('assistant.addAssistant', () => {
+  it('resolves the git profile server-side, invites, and creates the membership', async () => {
+    const result = await assistant.addAssistant({
+      classroomId: 'class-1',
+      login: '@ada',
+      name: 'Ada Lovelace',
+      email: 'ada@school.edu',
+    });
+
+    // The '@' is stripped and the profile comes from the provider, not the caller.
+    expect(getUserByLogin).toHaveBeenCalledWith('ada');
+    expect(inviteToOrganization).toHaveBeenCalledWith('cs1-org', '999', [42]);
+    expect(addTeamMember).not.toHaveBeenCalled();
+
+    // Instructor-supplied name/email win; the git profile fills provider_email.
+    expect(userUpsert.mock.calls[0][0].create).toMatchObject({
+      login: 'ada',
+      name: 'Ada Lovelace',
+      email: 'ada@school.edu',
+      provider_email: 'ada@gh.dev',
+      provider_id: '999',
+    });
+    expect(membershipCreate).toHaveBeenCalledWith({
+      data: { classroom_id: 'class-1', user_id: 'u-1', role: 'ASSISTANT' },
+    });
+
+    // Not already in the org → no activate_membership (the webhook does it).
+    expect(triggerTask).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ created: true, alreadyExists: false, userId: 'u-1' });
+  });
+
+  it('adds already-org-members to the team and activates them instead of inviting', async () => {
+    isUserMemberOfOrganization.mockResolvedValue(true);
+
+    const result = await assistant.addAssistant({ classroomId: 'class-1', login: 'ada' });
+
+    expect(addTeamMember).toHaveBeenCalledWith('cs1-org', 'cs1-25f-assistants', 'ada');
+    expect(inviteToOrganization).not.toHaveBeenCalled();
+    expect(triggerTask).toHaveBeenCalledWith('activate_membership', {
+      login: 'ada',
+      gitOrganizationId: 'org-1',
+    });
+    expect(result.alreadyOrgMember).toBe(true);
+  });
+
+  it('is idempotent: an existing ASSISTANT membership short-circuits before any GitHub write', async () => {
+    userFindUnique.mockResolvedValue({ id: 'u-1', login: 'ada', name: 'Ada L' });
+    findByClassroomAndUser.mockResolvedValue({ id: 'm-1', role: 'ASSISTANT' });
+
+    const result = await assistant.addAssistant({ classroomId: 'class-1', login: 'ada' });
+
+    expect(result).toMatchObject({ created: false, alreadyExists: true, userId: 'u-1' });
+    expect(getUserByLogin).not.toHaveBeenCalled();
+    expect(ensureClassroomTeam).not.toHaveBeenCalled();
+    expect(inviteToOrganization).not.toHaveBeenCalled();
+    expect(membershipCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('assistant.updateAssistant', () => {
+  it('updates the ASSISTANT membership row specifically', async () => {
+    userFindByLogin.mockResolvedValue({ id: 'u-1', login: 'ada' });
+    findByClassroomAndUser.mockResolvedValue({ id: 'm-1', role: 'ASSISTANT' });
+
+    await assistant.updateAssistant({ classroomId: 'class-1', login: 'ada', isGrader: true });
+
+    // Role-scoped lookup — a multi-role user must not have another row updated.
+    expect(findByClassroomAndUser).toHaveBeenCalledWith('class-1', 'u-1', 'ASSISTANT');
+    expect(updateById).toHaveBeenCalledWith('m-1', { is_grader: true });
+  });
+
+  it('throws when the user holds no ASSISTANT membership here', async () => {
+    userFindByLogin.mockResolvedValue({ id: 'u-1', login: 'ada' });
+    findByClassroomAndUser.mockResolvedValue(null);
+
+    await expect(
+      assistant.updateAssistant({ classroomId: 'class-1', login: 'ada', isGrader: true })
+    ).rejects.toThrow(/not an assistant/);
+    expect(updateById).not.toHaveBeenCalled();
+  });
+});
+
+describe('assistant.removeAssistant', () => {
+  it('builds the task payload from DB records and returns the run handle', async () => {
+    userFindByLogin.mockResolvedValue({ id: 'u-1', login: 'ada' });
+    findByClassroomAndUser.mockResolvedValue({ id: 'm-1', has_accepted_invite: true });
+
+    const result = await assistant.removeAssistant({ classroomId: 'class-1', login: 'ada' });
+
+    expect(triggerTask).toHaveBeenCalledWith('remove_user_from_organization', {
+      payload: {
+        // has_accepted_invite comes from the MEMBERSHIP, not the user record.
+        user: { id: 'u-1', login: 'ada', has_accepted_invite: true },
+        gitOrganization: CLASSROOM.git_organization,
+        classroom: CLASSROOM,
+        role: 'ASSISTANT',
+      },
+    });
+    expect(result).toEqual({ userId: 'u-1', login: 'ada', runId: 'run-1' });
+  });
+
+  it('refuses to remove a user who is not an ASSISTANT in this classroom', async () => {
+    userFindByLogin.mockResolvedValue({ id: 'u-1', login: 'ada' });
+    findByClassroomAndUser.mockResolvedValue(null);
+
+    await expect(
+      assistant.removeAssistant({ classroomId: 'class-1', login: 'ada' })
+    ).rejects.toThrow(/not an assistant/);
+    expect(triggerTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/assistant.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/assistant.service.test.ts
@@ -10,14 +10,14 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const userFindUnique = vi.fn();
+const userFindFirst = vi.fn();
 const userUpsert = vi.fn();
 const accountUpsert = vi.fn();
 const membershipCreate = vi.fn();
 vi.mock('@classmoji/database', () => ({
   default: () => ({
     user: {
-      findUnique: (...a: unknown[]) => userFindUnique(...a),
+      findFirst: (...a: unknown[]) => userFindFirst(...a),
       upsert: (...a: unknown[]) => userUpsert(...a),
     },
     account: { upsert: (...a: unknown[]) => accountUpsert(...a) },
@@ -76,7 +76,7 @@ beforeEach(() => {
   ensureClassroomTeam.mockResolvedValue({ id: 42, slug: 'cs1-25f-assistants' });
   getUserByLogin.mockResolvedValue({ id: 999, login: 'ada', name: 'Ada L', email: 'ada@gh.dev' });
   isUserMemberOfOrganization.mockResolvedValue(false);
-  userFindUnique.mockResolvedValue(null);
+  userFindFirst.mockResolvedValue(null);
   userUpsert.mockResolvedValue({ id: 'u-1', login: 'ada', name: 'Ada L' });
   triggerTask.mockResolvedValue({ id: 'run-1' });
 });
@@ -127,7 +127,7 @@ describe('assistant.addAssistant', () => {
   });
 
   it('is idempotent: an existing ASSISTANT membership short-circuits before any GitHub write', async () => {
-    userFindUnique.mockResolvedValue({ id: 'u-1', login: 'ada', name: 'Ada L' });
+    userFindFirst.mockResolvedValue({ id: 'u-1', login: 'ada', name: 'Ada L' });
     findByClassroomAndUser.mockResolvedValue({ id: 'm-1', role: 'ASSISTANT' });
 
     const result = await assistant.addAssistant({ classroomId: 'class-1', login: 'ada' });
@@ -137,6 +137,87 @@ describe('assistant.addAssistant', () => {
     expect(ensureClassroomTeam).not.toHaveBeenCalled();
     expect(inviteToOrganization).not.toHaveBeenCalled();
     expect(membershipCreate).not.toHaveBeenCalled();
+  });
+
+  it('matches the stored login case-insensitively', async () => {
+    userFindFirst.mockResolvedValue({ id: 'u-1', login: 'ada', name: 'Ada L' });
+    findByClassroomAndUser.mockResolvedValue({ id: 'm-1', role: 'ASSISTANT' });
+
+    await assistant.addAssistant({ classroomId: 'class-1', login: 'Ada' });
+
+    expect(userFindFirst.mock.calls[0][0].where).toEqual({
+      login: { equals: 'Ada', mode: 'insensitive' },
+    });
+  });
+
+  it('leaves an existing user record untouched: the upsert update branch is empty', async () => {
+    await assistant.addAssistant({ classroomId: 'class-1', login: 'ada', name: 'Ada Lovelace' });
+
+    // Adding an assistant must not rewrite any field of a user row that already
+    // exists — every value the service supplies belongs to `create` only.
+    expect(userUpsert.mock.calls[0][0].update).toEqual({});
+  });
+
+  it('re-checks with the canonical casing after resolution and skips the GitHub writes', async () => {
+    // The caller typed 'Ada'; nothing matches until the provider hands back the
+    // canonical 'ada', which the second lookup finds with a live membership.
+    getUserByLogin.mockResolvedValue({ id: 999, login: 'ada', name: 'Ada L' });
+    userFindFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 'u-1',
+      login: 'ada',
+      name: 'Ada L',
+      provider_id: '999',
+    });
+    findByClassroomAndUser.mockResolvedValue({ id: 'm-1', role: 'ASSISTANT' });
+
+    const result = await assistant.addAssistant({ classroomId: 'class-1', login: 'Ada' });
+
+    expect(result).toMatchObject({ created: false, alreadyExists: true, userId: 'u-1' });
+    // Resolution itself is required (it is what yields the canonical casing),
+    // but nothing may be written to GitHub afterwards.
+    expect(getUserByLogin).toHaveBeenCalledWith('Ada');
+    expect(ensureClassroomTeam).not.toHaveBeenCalled();
+    expect(addTeamMember).not.toHaveBeenCalled();
+    expect(inviteToOrganization).not.toHaveBeenCalled();
+    expect(membershipCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the stored row is keyed to a different provider account', async () => {
+    userFindFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 'u-1',
+      login: 'ada',
+      name: 'Ada L',
+      provider_id: '111',
+    });
+
+    await expect(
+      assistant.addAssistant({ classroomId: 'class-1', login: 'ada' })
+    ).rejects.toMatchObject({ code: 'login_conflict' });
+    expect(ensureClassroomTeam).not.toHaveBeenCalled();
+    expect(userUpsert).not.toHaveBeenCalled();
+  });
+
+  it('maps only a 404 to git_user_not_found and propagates everything else', async () => {
+    const rateLimited = Object.assign(new Error('API rate limit exceeded'), { status: 403 });
+    getUserByLogin.mockRejectedValue(rateLimited);
+
+    await expect(assistant.addAssistant({ classroomId: 'class-1', login: 'ada' })).rejects.toThrow(
+      'API rate limit exceeded'
+    );
+    expect(ensureClassroomTeam).not.toHaveBeenCalled();
+
+    getUserByLogin.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }));
+    await expect(
+      assistant.addAssistant({ classroomId: 'class-1', login: 'ada' })
+    ).rejects.toMatchObject({ code: 'git_user_not_found' });
+  });
+
+  it('reports already-exists when the membership row turns up on create', async () => {
+    membershipCreate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
+
+    const result = await assistant.addAssistant({ classroomId: 'class-1', login: 'ada' });
+
+    expect(result).toMatchObject({ created: false, alreadyExists: true, userId: 'u-1' });
   });
 });
 

--- a/packages/services/src/classmoji/__tests__/gitRepoAssignmentGrader.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/gitRepoAssignmentGrader.service.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the two extracted admin functions on
+ * gitRepoAssignmentGrader.service: assignGradersToAssignment (shared by the web
+ * assign-graders action and the MCP tool) and gradingReport. Prisma, the
+ * sibling services and Trigger.dev are mocked; the tests pin RANDOM's
+ * round-robin modulo, EXISTING's student/team matching and skips, that
+ * `sessionId` is what puts tags on the runs, and that gradingReport reports a
+ * grader's work on submissions they were never assigned.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const graderFindMany = vi.fn();
+const gradeFindMany = vi.fn();
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    gitRepoAssignmentGrader: { findMany: (...a: unknown[]) => graderFindMany(...a) },
+    assignmentGrade: { findMany: (...a: unknown[]) => gradeFindMany(...a) },
+  }),
+}));
+
+const classroomFindById = vi.fn();
+vi.mock('../classroom.service.ts', () => ({
+  findById: (...a: unknown[]) => classroomFindById(...a),
+}));
+
+const findUsersByRole = vi.fn();
+vi.mock('../classroomMembership.service.ts', () => ({
+  findUsersByRole: (...a: unknown[]) => findUsersByRole(...a),
+}));
+
+const findByAssignmentId = vi.fn();
+vi.mock('../gitRepoAssignment.service.ts', () => ({
+  findByAssignmentId: (...a: unknown[]) => findByAssignmentId(...a),
+}));
+
+vi.mock('../notification.service.ts', () => ({
+  runSafely: vi.fn(),
+  createNotifications: vi.fn(),
+}));
+
+const batchTrigger = vi.fn();
+vi.mock('@trigger.dev/sdk', () => ({
+  tasks: { batchTrigger: (...a: unknown[]) => batchTrigger(...a) },
+}));
+
+// Keep the round-robin deterministic: shuffle is an ordering detail, not behavior.
+vi.mock('lodash', async importOriginal => {
+  const actual = (await importOriginal()) as { default: Record<string, unknown> };
+  return { default: { ...actual.default, shuffle: (arr: unknown[]) => arr } };
+});
+
+const service = await import('../gitRepoAssignmentGrader.service.ts');
+
+const CLASSROOM = { id: 'class-1', slug: 'cs1-25f', git_organization: { login: 'cs1-org' } };
+
+const repoAssignment = (
+  id: string,
+  name: string,
+  studentId: string | null,
+  teamId: string | null
+) => ({
+  id,
+  provider_issue_number: 7,
+  git_repo: { name, student_id: studentId, team_id: teamId },
+  graders: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  classroomFindById.mockResolvedValue(CLASSROOM);
+  batchTrigger.mockResolvedValue({ id: 'batch-1' });
+});
+
+describe('assignGradersToAssignment — RANDOM', () => {
+  it('walks the is_grader assistants round-robin, one grader per submission', async () => {
+    findByAssignmentId.mockResolvedValue([
+      repoAssignment('ra-1', 'repo-a', 'stu-1', null),
+      repoAssignment('ra-2', 'repo-b', 'stu-2', null),
+      repoAssignment('ra-3', 'repo-c', 'stu-3', null),
+    ]);
+    findUsersByRole.mockResolvedValue([
+      { id: 'ta-1', login: 'ada' },
+      { id: 'ta-2', login: 'grace' },
+    ]);
+
+    const result = await service.assignGradersToAssignment({
+      classroomId: 'class-1',
+      assignmentId: 'a-1',
+      method: 'RANDOM',
+      sessionId: 'sess',
+    });
+
+    expect(findUsersByRole).toHaveBeenCalledWith('class-1', 'ASSISTANT', { is_grader: true });
+    expect(result).toEqual({ numAssignmentsToAddGradersTo: 3 });
+
+    const [taskId, items] = batchTrigger.mock.calls[0];
+    expect(taskId).toBe('add_grader_to_git_repo_assignment');
+    expect(items.map((i: { payload: { graderLogin: string } }) => i.payload.graderLogin)).toEqual([
+      'ada',
+      'grace',
+      'ada',
+    ]);
+    expect(items[0].options).toEqual({ tags: ['session_sess'] });
+  });
+
+  it('omits run tags when no sessionId is supplied (the MCP path)', async () => {
+    findByAssignmentId.mockResolvedValue([repoAssignment('ra-1', 'repo-a', 'stu-1', null)]);
+    findUsersByRole.mockResolvedValue([{ id: 'ta-1', login: 'ada' }]);
+
+    await service.assignGradersToAssignment({
+      classroomId: 'class-1',
+      assignmentId: 'a-1',
+      method: 'RANDOM',
+    });
+
+    expect(batchTrigger.mock.calls[0][1][0].options).toBeUndefined();
+  });
+
+  it('throws instead of dividing by zero when nobody has is_grader', async () => {
+    findByAssignmentId.mockResolvedValue([repoAssignment('ra-1', 'repo-a', 'stu-1', null)]);
+    findUsersByRole.mockResolvedValue([]);
+
+    await expect(
+      service.assignGradersToAssignment({
+        classroomId: 'class-1',
+        assignmentId: 'a-1',
+        method: 'RANDOM',
+      })
+    ).rejects.toThrow(/no assistants with is_grader/);
+    expect(batchTrigger).not.toHaveBeenCalled();
+  });
+});
+
+describe('assignGradersToAssignment — EXISTING', () => {
+  it('copies the template mapping by student/team and skips unmatched submissions', async () => {
+    findByAssignmentId.mockImplementation((assignmentId: string) => {
+      if (assignmentId === 'a-target') {
+        return Promise.resolve([
+          repoAssignment('ra-1', 'repo-a', 'stu-1', null),
+          repoAssignment('ra-2', 'repo-b', null, 'team-1'),
+          repoAssignment('ra-3', 'repo-c', 'stu-missing', null),
+        ]);
+      }
+      return Promise.resolve([
+        {
+          ...repoAssignment('t-1', 'repo-a', 'stu-1', null),
+          graders: [{ grader: { id: 'ta-1', login: 'ada' } }],
+        },
+        {
+          ...repoAssignment('t-2', 'repo-b', null, 'team-1'),
+          // Multiple graders on one template submission → multiple runs.
+          graders: [
+            { grader: { id: 'ta-1', login: 'ada' } },
+            { grader: { id: 'ta-2', login: 'grace' } },
+          ],
+        },
+      ]);
+    });
+
+    const result = await service.assignGradersToAssignment({
+      classroomId: 'class-1',
+      assignmentId: 'a-target',
+      method: 'EXISTING',
+      templateAssignmentId: 'a-template',
+    });
+
+    // 1 (student match) + 2 (team match, two graders) + 0 (no template row).
+    expect(result).toEqual({ numAssignmentsToAddGradersTo: 3 });
+    const items = batchTrigger.mock.calls[0][1];
+    expect(
+      items.map((i: { payload: { gitRepoAssignmentId: string; graderLogin: string } }) => [
+        i.payload.gitRepoAssignmentId,
+        i.payload.graderLogin,
+      ])
+    ).toEqual([
+      ['ra-1', 'ada'],
+      ['ra-2', 'ada'],
+      ['ra-2', 'grace'],
+    ]);
+  });
+
+  it('requires a templateAssignmentId', async () => {
+    await expect(
+      service.assignGradersToAssignment({
+        classroomId: 'class-1',
+        assignmentId: 'a-1',
+        method: 'EXISTING',
+      })
+    ).rejects.toThrow(/requires templateAssignmentId/);
+  });
+});
+
+describe('gradingReport', () => {
+  const assignment = {
+    id: 'a-1',
+    title: 'Lab 1',
+    repository: { title: 'labs' },
+  };
+
+  it('pairs assigned counts with graded counts, distribution and last_graded_at', async () => {
+    graderFindMany.mockResolvedValue([
+      {
+        grader: { id: 'ta-1', login: 'ada', name: 'Ada' },
+        git_repo_assignment: { assignment_id: 'a-1', assignment },
+      },
+      {
+        grader: { id: 'ta-1', login: 'ada', name: 'Ada' },
+        git_repo_assignment: { assignment_id: 'a-1', assignment },
+      },
+    ]);
+    gradeFindMany.mockResolvedValue([
+      {
+        grader_id: 'ta-1',
+        emoji: '🌟',
+        created_at: new Date('2026-01-01'),
+        git_repo_assignment_id: 'ra-1',
+        grader: { id: 'ta-1', login: 'ada', name: 'Ada' },
+        git_repo_assignment: { assignment_id: 'a-1', assignment },
+      },
+      // Second grade on the SAME submission → distribution 2, graded_count 1.
+      {
+        grader_id: 'ta-1',
+        emoji: '✅',
+        created_at: new Date('2026-02-01'),
+        git_repo_assignment_id: 'ra-1',
+        grader: { id: 'ta-1', login: 'ada', name: 'Ada' },
+        git_repo_assignment: { assignment_id: 'a-1', assignment },
+      },
+    ]);
+
+    const rows = await service.gradingReport({ classroomId: 'class-1' });
+
+    expect(rows).toEqual([
+      {
+        grader: { id: 'ta-1', login: 'ada', name: 'Ada' },
+        assignment: { id: 'a-1', title: 'Lab 1', repository_title: 'labs' },
+        assigned_count: 2,
+        graded_count: 1,
+        grade_distribution: { '🌟': 1, '✅': 1 },
+        last_graded_at: new Date('2026-02-01'),
+      },
+    ]);
+  });
+
+  it('reports grading done on submissions the grader was never assigned', async () => {
+    graderFindMany.mockResolvedValue([]);
+    gradeFindMany.mockResolvedValue([
+      {
+        grader_id: 'ta-2',
+        emoji: '🌟',
+        created_at: new Date('2026-01-01'),
+        git_repo_assignment_id: 'ra-9',
+        grader: { id: 'ta-2', login: 'grace', name: 'Grace' },
+        git_repo_assignment: { assignment_id: 'a-1', assignment },
+      },
+    ]);
+
+    const rows = await service.gradingReport({ classroomId: 'class-1' });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ assigned_count: 0, graded_count: 1 });
+  });
+});

--- a/packages/services/src/classmoji/__tests__/gitRepoAssignmentGrader.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/gitRepoAssignmentGrader.service.test.ts
@@ -180,6 +180,45 @@ describe('assignGradersToAssignment — EXISTING', () => {
     ]);
   });
 
+  it('queues nothing when no submission matches the template', async () => {
+    findByAssignmentId.mockImplementation((assignmentId: string) => {
+      if (assignmentId === 'a-target') {
+        return Promise.resolve([repoAssignment('ra-1', 'repo-a', 'stu-1', null)]);
+      }
+      // The template covers a different cohort entirely — nothing lines up.
+      return Promise.resolve([
+        {
+          ...repoAssignment('t-1', 'repo-z', 'stu-other', null),
+          graders: [{ grader: { id: 'ta-1', login: 'ada' } }],
+        },
+      ]);
+    });
+
+    const result = await service.assignGradersToAssignment({
+      classroomId: 'class-1',
+      assignmentId: 'a-target',
+      method: 'EXISTING',
+      templateAssignmentId: 'a-template',
+    });
+
+    expect(result).toEqual({ numAssignmentsToAddGradersTo: 0 });
+    expect(batchTrigger).not.toHaveBeenCalled();
+  });
+
+  it('scopes both submission lookups to the classroom', async () => {
+    findByAssignmentId.mockResolvedValue([]);
+
+    await service.assignGradersToAssignment({
+      classroomId: 'class-1',
+      assignmentId: 'a-target',
+      method: 'EXISTING',
+      templateAssignmentId: 'a-template',
+    });
+
+    expect(findByAssignmentId).toHaveBeenCalledWith('a-target', 'cs1-25f', 'class-1');
+    expect(findByAssignmentId).toHaveBeenCalledWith('a-template', 'cs1-25f', 'class-1');
+  });
+
   it('requires a templateAssignmentId', async () => {
     await expect(
       service.assignGradersToAssignment({
@@ -241,6 +280,38 @@ describe('gradingReport', () => {
         last_graded_at: new Date('2026-02-01'),
       },
     ]);
+  });
+
+  it('narrows both queries to the classroom and skips ungraded rows', async () => {
+    graderFindMany.mockResolvedValue([]);
+    gradeFindMany.mockResolvedValue([]);
+
+    await service.gradingReport({ classroomId: 'class-1' });
+
+    // Both halves of the report must be classroom-scoped through the repo.
+    expect(graderFindMany.mock.calls[0][0].where).toMatchObject({
+      git_repo_assignment: { git_repo: { classroom_id: 'class-1' } },
+    });
+    expect(gradeFindMany.mock.calls[0][0].where).toMatchObject({
+      grader_id: { not: null },
+      git_repo_assignment: { git_repo: { classroom_id: 'class-1' } },
+    });
+  });
+
+  it('filters by grader and assignment when both are supplied', async () => {
+    graderFindMany.mockResolvedValue([]);
+    gradeFindMany.mockResolvedValue([]);
+
+    await service.gradingReport({ classroomId: 'class-1', assignmentId: 'a-1', graderId: 'ta-1' });
+
+    expect(graderFindMany.mock.calls[0][0].where).toMatchObject({
+      grader_id: 'ta-1',
+      git_repo_assignment: { assignment_id: 'a-1', git_repo: { classroom_id: 'class-1' } },
+    });
+    expect(gradeFindMany.mock.calls[0][0].where).toMatchObject({
+      grader_id: 'ta-1',
+      git_repo_assignment: { assignment_id: 'a-1', git_repo: { classroom_id: 'class-1' } },
+    });
   });
 
   it('reports grading done on submissions the grader was never assigned', async () => {

--- a/packages/services/src/classmoji/assistant.service.ts
+++ b/packages/services/src/classmoji/assistant.service.ts
@@ -1,0 +1,320 @@
+/**
+ * Assistant (TA) Service
+ *
+ * Add / update / remove a classroom ASSISTANT. Shared by the web
+ * admin.$class.assistants action and the MCP assistant tools so both take one
+ * code path (same precedent as roster.service.ts).
+ *
+ * The GitHub profile is resolved SERVER-SIDE from the login: the web form used
+ * to resolve it client-side with the instructor's octokit and post the profile,
+ * which an MCP caller cannot do (it only has a login) and which let a client
+ * choose the provider_id the membership is keyed to.
+ *
+ * Trigger.dev tasks are fired via the raw `@trigger.dev/sdk` string ids (this
+ * package cannot import @classmoji/tasks — tasks already depends on services).
+ * `removeAssistant` returns the trigger HANDLE rather than awaiting it: the web
+ * route streams progress with waitForRunCompletion, MCP fires and forgets.
+ */
+import { tasks } from '@trigger.dev/sdk';
+
+import getPrisma from '@classmoji/database';
+import { getGitProvider, ensureClassroomTeam } from '../git/index.ts';
+import * as classroomService from './classroom.service.ts';
+import * as classroomMembershipService from './classroomMembership.service.ts';
+import * as userService from './user.service.ts';
+
+export interface AddAssistantResult {
+  /** false when an ASSISTANT membership already existed (no-op, not an error). */
+  created: boolean;
+  alreadyExists: boolean;
+  userId: string;
+  login: string;
+  name: string | null;
+  /** true when the user was already in the GitHub org (team-added + activated). */
+  alreadyOrgMember: boolean;
+}
+
+export interface RemoveAssistantResult {
+  userId: string;
+  login: string;
+  /** Trigger.dev run handle — await it (waitForRunCompletion) or ignore it. */
+  runId: string;
+}
+
+/** Thrown for every caller-fixable failure so routes/tools can map it to a message. */
+export class AssistantServiceError extends Error {
+  code: 'classroom_not_found' | 'git_user_not_found' | 'assistant_not_found' | 'no_org_configured';
+
+  constructor(code: AssistantServiceError['code'], message: string) {
+    super(message);
+    this.name = 'AssistantServiceError';
+    this.code = code;
+  }
+}
+
+const loadClassroom = async (classroomId: string) => {
+  const classroom = await classroomService.findById(classroomId);
+  if (!classroom) {
+    throw new AssistantServiceError(
+      'classroom_not_found',
+      `[assistant] classroom ${classroomId} not found`
+    );
+  }
+  if (!classroom.git_organization) {
+    throw new AssistantServiceError(
+      'no_org_configured',
+      `[assistant] classroom ${classroomId} has no git organization`
+    );
+  }
+  return classroom;
+};
+
+/**
+ * Add a GitHub user as an ASSISTANT of a classroom.
+ *
+ * Resolves the login against the git provider, ensures the classroom assistant
+ * team exists, adds (already-org-members) or invites (everyone else) them, then
+ * upserts the User + Account and creates the ASSISTANT membership.
+ *
+ * Idempotent: an existing ASSISTANT membership in this classroom returns
+ * `{ created: false, alreadyExists: true }` instead of a unique-constraint
+ * error. `name`/`email` are the instructor-supplied overrides from the web form;
+ * when omitted the git profile's name and email are used.
+ */
+export const addAssistant = async ({
+  classroomId,
+  login,
+  name,
+  email,
+}: {
+  classroomId: string;
+  login: string;
+  name?: string | null;
+  email?: string | null;
+}): Promise<AddAssistantResult> => {
+  const classroom = await loadClassroom(classroomId);
+  const gitOrganization = classroom.git_organization;
+  const cleanLogin = login.replace('@', '').trim();
+
+  // Idempotency BEFORE any GitHub write: re-inviting an existing assistant
+  // would re-add them to the team and then still fail on the unique constraint.
+  const existingUser = await getPrisma().user.findUnique({
+    where: { login: cleanLogin },
+    select: { id: true, login: true, name: true },
+  });
+  if (existingUser) {
+    const existingMembership = await classroomMembershipService.findByClassroomAndUser(
+      classroomId,
+      existingUser.id,
+      'ASSISTANT'
+    );
+    if (existingMembership) {
+      return {
+        created: false,
+        alreadyExists: true,
+        userId: existingUser.id,
+        login: existingUser.login ?? cleanLogin,
+        name: existingUser.name,
+        alreadyOrgMember: true,
+      };
+    }
+  }
+
+  const gitProvider = getGitProvider(gitOrganization);
+
+  let gitUser: { id: number | string; login: string; name?: string | null; email?: string | null };
+  try {
+    gitUser = await gitProvider.getUserByLogin(cleanLogin);
+  } catch (error: unknown) {
+    throw new AssistantServiceError(
+      'git_user_not_found',
+      `[assistant] git user ${cleanLogin} not found: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+  if (!gitUser?.login) {
+    throw new AssistantServiceError(
+      'git_user_not_found',
+      `[assistant] git user ${cleanLogin} not found`
+    );
+  }
+
+  const team = await ensureClassroomTeam(
+    gitProvider,
+    gitOrganization.login,
+    classroom,
+    'ASSISTANT'
+  );
+
+  // If the assistant is already in the org, a fresh invite 422s and no `member_added`
+  // webhook fires — so just add them to the assistant team and activate them below.
+  // Otherwise send the org invite as usual.
+  const alreadyMember = await gitProvider.isUserMemberOfOrganization(
+    gitOrganization.login,
+    gitUser.login
+  );
+
+  if (alreadyMember) {
+    await gitProvider.addTeamMember(gitOrganization.login, team.slug, gitUser.login);
+  } else {
+    try {
+      await gitProvider.inviteToOrganization(gitOrganization.login, String(gitUser.id), [team.id]);
+    } catch (error: unknown) {
+      console.error('Error inviting assistant to organization:', error);
+    }
+  }
+
+  // Upsert user and account, then create the ASSISTANT membership.
+  const user = await getPrisma().user.upsert({
+    where: { login: gitUser.login },
+    create: {
+      login: gitUser.login,
+      name: name || gitUser.name || gitUser.login,
+      provider: gitOrganization.provider as 'GITHUB' | 'GITLAB' | 'BITBUCKET',
+      provider_id: String(gitUser.id),
+      role: 'user',
+      email: email ?? null,
+      provider_email: gitUser.email ?? null,
+    },
+    update: {
+      role: 'user',
+    },
+  });
+
+  await getPrisma().account.upsert({
+    where: {
+      provider_id_account_id: {
+        provider_id: gitOrganization.provider.toLowerCase(),
+        account_id: String(gitUser.id),
+      },
+    },
+    create: {
+      provider_id: gitOrganization.provider.toLowerCase(),
+      account_id: String(gitUser.id),
+      user_id: String(user.id),
+    },
+    update: {},
+  });
+
+  await getPrisma().classroomMembership.create({
+    data: {
+      classroom_id: classroom.id,
+      user_id: user.id,
+      role: 'ASSISTANT',
+    },
+  });
+
+  // Already-in-org assistants get no `member_added` webhook, so flip
+  // has_accepted_invite now that the membership exists.
+  if (alreadyMember) {
+    await tasks.trigger('activate_membership', {
+      login: gitUser.login,
+      gitOrganizationId: gitOrganization.id,
+    });
+  }
+
+  return {
+    created: true,
+    alreadyExists: false,
+    userId: user.id,
+    login: user.login ?? gitUser.login,
+    name: user.name,
+    alreadyOrgMember: alreadyMember,
+  };
+};
+
+/**
+ * Flip the is_grader flag on a user's ASSISTANT membership.
+ *
+ * Role-scoped on purpose: the membership unique key is
+ * (classroom_id, user_id, role), so a user who is both OWNER and ASSISTANT has
+ * two rows and the generic membership update (findFirst, no role filter) could
+ * pick the wrong one.
+ */
+export const updateAssistant = async ({
+  classroomId,
+  login,
+  isGrader,
+}: {
+  classroomId: string;
+  login: string;
+  isGrader: boolean;
+}) => {
+  const user = await userService.findByLogin(login);
+  if (!user) {
+    throw new AssistantServiceError('assistant_not_found', `[assistant] user ${login} not found`);
+  }
+
+  const membership = await classroomMembershipService.findByClassroomAndUser(
+    classroomId,
+    user.id,
+    'ASSISTANT'
+  );
+  if (!membership) {
+    throw new AssistantServiceError(
+      'assistant_not_found',
+      `[assistant] ${login} is not an assistant of classroom ${classroomId}`
+    );
+  }
+
+  return classroomMembershipService.updateById(membership.id, { is_grader: isGrader });
+};
+
+/**
+ * Queue removal of an ASSISTANT from a classroom.
+ *
+ * The `remove_user_from_organization` task is the single source of truth and is
+ * role-aware: it removes the classroom's ASSISTANT team membership, removes the
+ * user from the GitHub org ONLY when they hold no other membership in that org
+ * (the (classroom, ASSISTANT) pair being removed is the only one excluded from
+ * the count — an OWNER/STUDENT row in the same classroom keeps them in), and
+ * deletes only the ASSISTANT membership row.
+ *
+ * The payload is built ENTIRELY from resolved DB records — `has_accepted_invite`
+ * is a MEMBERSHIP field, not a user field. Returns the run handle; the caller
+ * decides whether to await it.
+ */
+export const removeAssistant = async ({
+  classroomId,
+  login,
+}: {
+  classroomId: string;
+  login: string;
+}): Promise<RemoveAssistantResult> => {
+  const classroom = await loadClassroom(classroomId);
+
+  const user = await userService.findByLogin(login);
+  if (!user) {
+    throw new AssistantServiceError('assistant_not_found', `[assistant] user ${login} not found`);
+  }
+
+  // The target must be an ASSISTANT in THIS classroom — never touch the
+  // memberships another role of the same user holds here.
+  const membership = await classroomMembershipService.findByClassroomAndUser(
+    classroomId,
+    user.id,
+    'ASSISTANT'
+  );
+  if (!membership) {
+    throw new AssistantServiceError(
+      'assistant_not_found',
+      `[assistant] ${login} is not an assistant of classroom ${classroomId}`
+    );
+  }
+
+  const run = await tasks.trigger('remove_user_from_organization', {
+    payload: {
+      user: {
+        id: user.id,
+        login: user.login,
+        has_accepted_invite: membership.has_accepted_invite,
+      },
+      gitOrganization: classroom.git_organization,
+      classroom,
+      role: 'ASSISTANT',
+    },
+  });
+
+  return { userId: user.id, login: user.login ?? login, runId: run.id };
+};

--- a/packages/services/src/classmoji/assistant.service.ts
+++ b/packages/services/src/classmoji/assistant.service.ts
@@ -43,7 +43,12 @@ export interface RemoveAssistantResult {
 
 /** Thrown for every caller-fixable failure so routes/tools can map it to a message. */
 export class AssistantServiceError extends Error {
-  code: 'classroom_not_found' | 'git_user_not_found' | 'assistant_not_found' | 'no_org_configured';
+  code:
+    | 'classroom_not_found'
+    | 'git_user_not_found'
+    | 'assistant_not_found'
+    | 'no_org_configured'
+    | 'login_conflict';
 
   constructor(code: AssistantServiceError['code'], message: string) {
     super(message);
@@ -51,6 +56,16 @@ export class AssistantServiceError extends Error {
     this.code = code;
   }
 }
+
+/** A git provider 404 — the login genuinely names nobody (same shape the providers throw). */
+const isProviderNotFound = (error: unknown): boolean =>
+  error instanceof Error &&
+  'status' in error &&
+  (error as Error & { status: number }).status === 404;
+
+/** A Prisma unique-constraint violation (e.g. the membership already exists). */
+const isUniqueViolation = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'P2002';
 
 const loadClassroom = async (classroomId: string) => {
   const classroom = await classroomService.findById(classroomId);
@@ -98,8 +113,10 @@ export const addAssistant = async ({
 
   // Idempotency BEFORE any GitHub write: re-inviting an existing assistant
   // would re-add them to the team and then still fail on the unique constraint.
-  const existingUser = await getPrisma().user.findUnique({
-    where: { login: cleanLogin },
+  // Git logins are case-insensitive while Postgres is not, so match the stored
+  // login insensitively — 'Ada' and 'ada' are the same person.
+  const existingUser = await getPrisma().user.findFirst({
+    where: { login: { equals: cleanLogin, mode: 'insensitive' } },
     select: { id: true, login: true, name: true },
   });
   if (existingUser) {
@@ -126,11 +143,13 @@ export const addAssistant = async ({
   try {
     gitUser = await gitProvider.getUserByLogin(cleanLogin);
   } catch (error: unknown) {
+    // Only a 404 means the username is wrong. A rate limit, a network blip or a
+    // bad token must surface as itself — telling the operator "no such user"
+    // would send them off fixing a name that was never the problem.
+    if (!isProviderNotFound(error)) throw error;
     throw new AssistantServiceError(
       'git_user_not_found',
-      `[assistant] git user ${cleanLogin} not found: ${
-        error instanceof Error ? error.message : String(error)
-      }`
+      `[assistant] git user ${cleanLogin} not found`
     );
   }
   if (!gitUser?.login) {
@@ -138,6 +157,41 @@ export const addAssistant = async ({
       'git_user_not_found',
       `[assistant] git user ${cleanLogin} not found`
     );
+  }
+
+  // The provider hands back the canonical casing, which may differ from what the
+  // caller typed. Re-check with it BEFORE any GitHub write (ensureClassroomTeam
+  // creates the team) so a differently-cased login is still a no-op.
+  const canonicalUser = await getPrisma().user.findFirst({
+    where: { login: { equals: gitUser.login, mode: 'insensitive' } },
+    select: { id: true, login: true, name: true, provider_id: true },
+  });
+
+  if (canonicalUser) {
+    // The stored row is keyed to a different provider account than the one this
+    // login resolves to today — refuse rather than relink the existing record.
+    if (canonicalUser.provider_id && canonicalUser.provider_id !== String(gitUser.id)) {
+      throw new AssistantServiceError(
+        'login_conflict',
+        `[assistant] login ${gitUser.login} resolves to a different provider account than the stored user record`
+      );
+    }
+
+    const existingMembership = await classroomMembershipService.findByClassroomAndUser(
+      classroomId,
+      canonicalUser.id,
+      'ASSISTANT'
+    );
+    if (existingMembership) {
+      return {
+        created: false,
+        alreadyExists: true,
+        userId: canonicalUser.id,
+        login: canonicalUser.login ?? gitUser.login,
+        name: canonicalUser.name,
+        alreadyOrgMember: true,
+      };
+    }
   }
 
   const team = await ensureClassroomTeam(
@@ -166,8 +220,12 @@ export const addAssistant = async ({
   }
 
   // Upsert user and account, then create the ASSISTANT membership.
+  // Target an already-known row by id: `where: { login }` is an exact match, so
+  // a row stored under different casing would be missed and duplicated.
+  // `update: {}` on purpose — adding someone as an assistant must not rewrite
+  // any field of a user record that already exists.
   const user = await getPrisma().user.upsert({
-    where: { login: gitUser.login },
+    where: canonicalUser ? { id: canonicalUser.id } : { login: gitUser.login },
     create: {
       login: gitUser.login,
       name: name || gitUser.name || gitUser.login,
@@ -177,9 +235,7 @@ export const addAssistant = async ({
       email: email ?? null,
       provider_email: gitUser.email ?? null,
     },
-    update: {
-      role: 'user',
-    },
+    update: {},
   });
 
   await getPrisma().account.upsert({
@@ -197,13 +253,28 @@ export const addAssistant = async ({
     update: {},
   });
 
-  await getPrisma().classroomMembership.create({
-    data: {
-      classroom_id: classroom.id,
-      user_id: user.id,
-      role: 'ASSISTANT',
-    },
-  });
+  try {
+    await getPrisma().classroomMembership.create({
+      data: {
+        classroom_id: classroom.id,
+        user_id: user.id,
+        role: 'ASSISTANT',
+      },
+    });
+  } catch (error: unknown) {
+    // Last line of defence for the idempotency contract: if the membership row
+    // turned up anyway (a concurrent add, or a lookup that missed it), report
+    // the same already-exists result rather than a generic failure.
+    if (!isUniqueViolation(error)) throw error;
+    return {
+      created: false,
+      alreadyExists: true,
+      userId: user.id,
+      login: user.login ?? gitUser.login,
+      name: user.name,
+      alreadyOrgMember: alreadyMember,
+    };
+  }
 
   // Already-in-org assistants get no `member_added` webhook, so flip
   // has_accepted_invite now that the membership exists.

--- a/packages/services/src/classmoji/gitRepoAssignment.service.ts
+++ b/packages/services/src/classmoji/gitRepoAssignment.service.ts
@@ -142,17 +142,22 @@ export const findByClassroomId = async (classroomId: string) => {
  * Find all GitRepoAssignments for an Assignment
  * @param {string} assignmentId - UUID of the Assignment
  * @param {string} [classroomSlug] - Optional classroom slug filter
+ * @param {string} [classroomId] - Optional classroom id filter. Preferred by
+ *   callers that already hold the id: it scopes on the primary key rather than
+ *   on a slug, and combines with the slug filter when both are supplied.
  * @returns {Promise<Object[]>}
  */
 export const findByAssignmentId = async (
   assignmentId: string,
-  classroomSlug: string | null = null
+  classroomSlug: string | null = null,
+  classroomId: string | null = null
 ) => {
   const where: Prisma.GitRepoAssignmentWhereInput = { assignment_id: assignmentId };
 
-  if (classroomSlug) {
+  if (classroomSlug || classroomId) {
     where.git_repo = {
-      classroom: { slug: classroomSlug },
+      ...(classroomSlug ? { classroom: { slug: classroomSlug } } : {}),
+      ...(classroomId ? { classroom_id: classroomId } : {}),
     };
   }
 

--- a/packages/services/src/classmoji/gitRepoAssignmentGrader.service.ts
+++ b/packages/services/src/classmoji/gitRepoAssignmentGrader.service.ts
@@ -306,9 +306,12 @@ export const assignGradersToAssignment = async ({
   const gitOrganization = classroom.git_organization;
   const classroomSlug = classroom.slug;
 
+  // Scope on the classroom id as well as the slug — we already hold the id, and
+  // the primary key is the stronger of the two filters.
   const repoAssignments = await gitRepoAssignmentService.findByAssignmentId(
     assignmentId,
-    classroomSlug
+    classroomSlug,
+    classroom.id
   );
 
   let graderLoginList: GraderInfo[] = [];
@@ -335,7 +338,8 @@ export const assignGradersToAssignment = async ({
   } else {
     const templateRepoAssignments = await gitRepoAssignmentService.findByAssignmentId(
       templateAssignmentId!,
-      classroomSlug
+      classroomSlug,
+      classroom.id
     );
 
     graderLoginList = templateRepoAssignments.map(repoAssignment => ({

--- a/packages/services/src/classmoji/gitRepoAssignmentGrader.service.ts
+++ b/packages/services/src/classmoji/gitRepoAssignmentGrader.service.ts
@@ -3,7 +3,13 @@
  *
  * Manages grader assignments to GitRepoAssignments
  */
+import _ from 'lodash';
+import { tasks } from '@trigger.dev/sdk';
+
 import getPrisma from '@classmoji/database';
+import * as classroomService from './classroom.service.ts';
+import * as classroomMembershipService from './classroomMembership.service.ts';
+import * as gitRepoAssignmentService from './gitRepoAssignment.service.ts';
 import * as notificationService from './notification.service.ts';
 
 const notifyGraderAssigned = async (repositoryAssignmentId: string, graderIds: string[]) => {
@@ -225,4 +231,312 @@ export const removeAllGraders = async (repositoryAssignmentId: string) => {
       git_repo_assignment_id: repositoryAssignmentId,
     },
   });
+};
+
+// ─── Bulk grader assignment ──────────────────────────────────────────────────
+
+export type AssignGradersMethod = 'RANDOM' | 'EXISTING';
+
+export interface AssignGradersResult {
+  numAssignmentsToAddGradersTo: number;
+}
+
+/** Thrown for caller-fixable failures so routes/tools can map them to a message. */
+export class AssignGradersError extends Error {
+  code: 'classroom_not_found' | 'no_graders' | 'template_required';
+
+  constructor(code: AssignGradersError['code'], message: string) {
+    super(message);
+    this.name = 'AssignGradersError';
+    this.code = code;
+  }
+}
+
+interface GraderInfo {
+  id?: string;
+  login?: string | null;
+  studentId?: string | null;
+  teamId?: string | null;
+  graders?: Array<{ grader: { id: string; login: string | null } }>;
+  [key: string]: unknown;
+}
+
+/**
+ * Bulk-assign graders to every submission of an assignment. Shared by the web
+ * admin.$class.repos_.$title.assign-graders action and the MCP tool.
+ *
+ * RANDOM: shuffles the classroom's is_grader ASSISTANTs and walks them
+ * round-robin (`assistants[index % length]`) — exactly one grader per submission.
+ * EXISTING: copies the grader mapping from `templateAssignmentId` in the same
+ * repository, matched by student_id (individual repos) or team_id (team repos);
+ * a submission with no match in the template is skipped, and a template
+ * submission with several graders yields several assignments.
+ *
+ * Fans out one `add_grader_to_git_repo_assignment` run per (submission, grader).
+ * `sessionId` is optional: the web route passes one so the run tags can drive
+ * its progress stream; MCP omits it and the runs go out untagged.
+ */
+export const assignGradersToAssignment = async ({
+  classroomId,
+  assignmentId,
+  method,
+  templateAssignmentId,
+  sessionId,
+}: {
+  classroomId: string;
+  assignmentId: string;
+  method: AssignGradersMethod;
+  templateAssignmentId?: string | null;
+  sessionId?: string | null;
+}): Promise<AssignGradersResult> => {
+  const classroom = await classroomService.findById(classroomId);
+  if (!classroom) {
+    throw new AssignGradersError(
+      'classroom_not_found',
+      `[assign-graders] classroom ${classroomId} not found`
+    );
+  }
+  if (method === 'EXISTING' && !templateAssignmentId) {
+    throw new AssignGradersError(
+      'template_required',
+      '[assign-graders] EXISTING requires templateAssignmentId'
+    );
+  }
+
+  const gitOrganization = classroom.git_organization;
+  const classroomSlug = classroom.slug;
+
+  const repoAssignments = await gitRepoAssignmentService.findByAssignmentId(
+    assignmentId,
+    classroomSlug
+  );
+
+  let graderLoginList: GraderInfo[] = [];
+
+  if (method === 'RANDOM') {
+    const assistants = _.shuffle(
+      await classroomMembershipService.findUsersByRole(classroomId, 'ASSISTANT', {
+        is_grader: true,
+      })
+    );
+
+    // The original modulo indexing divided by zero here and produced
+    // `Cannot read properties of undefined` — fail with something actionable.
+    if (assistants.length === 0) {
+      throw new AssignGradersError(
+        'no_graders',
+        '[assign-graders] no assistants with is_grader set in this classroom'
+      );
+    }
+
+    graderLoginList = repoAssignments.map(
+      (_repoAssignment, index) => assistants[index % assistants.length] as unknown as GraderInfo
+    );
+  } else {
+    const templateRepoAssignments = await gitRepoAssignmentService.findByAssignmentId(
+      templateAssignmentId!,
+      classroomSlug
+    );
+
+    graderLoginList = templateRepoAssignments.map(repoAssignment => ({
+      studentId: repoAssignment.git_repo.student_id,
+      teamId: repoAssignment.git_repo.team_id,
+      graders: repoAssignment.graders as unknown as GraderInfo['graders'],
+    }));
+  }
+
+  const options = sessionId ? { tags: [`session_${sessionId}`] } : undefined;
+
+  const taskPayloads = repoAssignments.map((repoAssignment, index) => {
+    const { git_repo } = repoAssignment;
+
+    if (method === 'RANDOM') {
+      return {
+        payload: {
+          repoName: git_repo.name,
+          gitOrganization,
+          githubIssueNumber: repoAssignment.provider_issue_number,
+          gitRepoAssignmentId: repoAssignment.id,
+          graderLogin: graderLoginList[index].login!,
+          graderId: graderLoginList[index].id!,
+        },
+        options,
+      };
+    }
+
+    const isIndividualRepository = git_repo.student_id !== null;
+    const graderMatch = isIndividualRepository
+      ? graderLoginList.find(grader => grader.studentId === git_repo.student_id)
+      : graderLoginList.find(grader => grader.teamId === git_repo.team_id);
+
+    // Skip if no matching grader assignment found in template
+    if (!graderMatch || !graderMatch.graders?.length) {
+      return [];
+    }
+
+    return graderMatch.graders.map(({ grader }) => ({
+      payload: {
+        repoName: git_repo.name,
+        gitOrganization,
+        githubIssueNumber: repoAssignment.provider_issue_number,
+        gitRepoAssignmentId: repoAssignment.id,
+        graderLogin: grader.login,
+        graderId: grader.id,
+      },
+      options,
+    }));
+  });
+
+  const flatPayloads = _.flatten(taskPayloads);
+
+  if (flatPayloads.length > 0) {
+    await tasks.batchTrigger('add_grader_to_git_repo_assignment', flatPayloads);
+  }
+
+  return { numAssignmentsToAddGradersTo: flatPayloads.length };
+};
+
+// ─── Grading report ──────────────────────────────────────────────────────────
+
+export interface GradingReportRow {
+  grader: { id: string; login: string | null; name: string | null };
+  assignment: { id: string; title: string; repository_title: string | null };
+  assigned_count: number;
+  graded_count: number;
+  grade_distribution: Record<string, number>;
+  last_graded_at: Date | null;
+}
+
+/**
+ * Per-grader-per-assignment grading report for a classroom, optionally narrowed
+ * to one assignment and/or one grader.
+ *
+ * `assigned_count` counts GitRepoAssignmentGrader rows (submissions handed to
+ * that grader); `graded_count` counts DISTINCT submissions that carry at least
+ * one AssignmentGrade from that grader. Because AssignmentGrade.grader_id is
+ * independent of the grader join table, a grader can have graded a submission
+ * they were never assigned — those pairs still get a row, with
+ * `assigned_count: 0`, so real grading work is never hidden.
+ *
+ * Two grouped queries plus in-memory grouping (same shape as dashboard.taOps) —
+ * never one query per grader or per submission.
+ */
+export const gradingReport = async ({
+  classroomId,
+  assignmentId,
+  graderId,
+}: {
+  classroomId: string;
+  assignmentId?: string | null;
+  graderId?: string | null;
+}): Promise<GradingReportRow[]> => {
+  const prisma = getPrisma();
+
+  const assignmentFilter = assignmentId ? { assignment_id: assignmentId } : {};
+  const graderFilter = graderId ? { grader_id: graderId } : {};
+
+  const [assignedRows, gradeRows] = await Promise.all([
+    prisma.gitRepoAssignmentGrader.findMany({
+      where: {
+        ...graderFilter,
+        git_repo_assignment: {
+          ...assignmentFilter,
+          git_repo: { classroom_id: classroomId },
+        },
+      },
+      select: {
+        grader: { select: { id: true, login: true, name: true } },
+        git_repo_assignment: {
+          select: {
+            assignment_id: true,
+            assignment: {
+              select: { id: true, title: true, repository: { select: { title: true } } },
+            },
+          },
+        },
+      },
+    }),
+    prisma.assignmentGrade.findMany({
+      where: {
+        ...(graderId ? { grader_id: graderId } : { grader_id: { not: null } }),
+        git_repo_assignment: {
+          ...assignmentFilter,
+          git_repo: { classroom_id: classroomId },
+        },
+      },
+      select: {
+        grader_id: true,
+        emoji: true,
+        created_at: true,
+        git_repo_assignment_id: true,
+        grader: { select: { id: true, login: true, name: true } },
+        git_repo_assignment: {
+          select: {
+            assignment_id: true,
+            assignment: {
+              select: { id: true, title: true, repository: { select: { title: true } } },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  interface Bucket extends GradingReportRow {
+    gradedSubmissionIds: Set<string>;
+  }
+  const rows = new Map<string, Bucket>();
+
+  const bucketFor = (
+    grader: { id: string; login: string | null; name: string | null },
+    assignment: { id: string; title: string; repository: { title: string | null } | null }
+  ): Bucket => {
+    const key = `${grader.id}:${assignment.id}`;
+    let bucket = rows.get(key);
+    if (!bucket) {
+      bucket = {
+        grader: { id: grader.id, login: grader.login, name: grader.name },
+        assignment: {
+          id: assignment.id,
+          title: assignment.title,
+          repository_title: assignment.repository?.title ?? null,
+        },
+        assigned_count: 0,
+        graded_count: 0,
+        grade_distribution: {},
+        last_graded_at: null,
+        gradedSubmissionIds: new Set<string>(),
+      };
+      rows.set(key, bucket);
+    }
+    return bucket;
+  };
+
+  for (const row of assignedRows) {
+    const assignment = row.git_repo_assignment.assignment;
+    if (!assignment) continue;
+    bucketFor(row.grader, assignment).assigned_count += 1;
+  }
+
+  for (const grade of gradeRows) {
+    const assignment = grade.git_repo_assignment.assignment;
+    if (!assignment || !grade.grader) continue;
+    const bucket = bucketFor(grade.grader, assignment);
+    bucket.gradedSubmissionIds.add(grade.git_repo_assignment_id);
+    bucket.grade_distribution[grade.emoji] = (bucket.grade_distribution[grade.emoji] ?? 0) + 1;
+    if (!bucket.last_graded_at || grade.created_at > bucket.last_graded_at) {
+      bucket.last_graded_at = grade.created_at;
+    }
+  }
+
+  return Array.from(rows.values())
+    .map(({ gradedSubmissionIds, ...row }) => ({
+      ...row,
+      graded_count: gradedSubmissionIds.size,
+    }))
+    .sort(
+      (a, b) =>
+        (a.grader.login ?? '').localeCompare(b.grader.login ?? '') ||
+        a.assignment.title.localeCompare(b.assignment.title)
+    );
 };

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -3,6 +3,7 @@ import * as gitOrganizationService from './gitOrganization.service.ts';
 import * as classroomService from './classroom.service.ts';
 import * as classroomMembershipService from './classroomMembership.service.ts';
 import * as rosterService from './roster.service.ts';
+import * as assistantService from './assistant.service.ts';
 import * as moduleService from './module.service.ts';
 import * as repositoryService from './repository.service.ts';
 import * as autogradingTestService from './autogradingTest.service.ts';
@@ -54,6 +55,7 @@ const ClassmojiService = {
   classroom: classroomService,
   classroomMembership: classroomMembershipService,
   roster: rosterService,
+  assistant: assistantService,
   module: moduleService,
   repository: repositoryService,
   autogradingTest: autogradingTestService,
@@ -109,6 +111,8 @@ export {
   gitOrganizationService,
   classroomService,
   classroomMembershipService,
+  rosterService,
+  assistantService,
   moduleService,
   repositoryService,
   autogradingTestService,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -51,6 +51,16 @@ export {
 
 export { ClassmojiService, HelperService, StripeService, FlyCertService, MarkdownImporter };
 
+// Admin service result/error shapes shared by the web routes and the MCP tools.
+export { AssistantServiceError } from './classmoji/assistant.service.ts';
+export type { AddAssistantResult, RemoveAssistantResult } from './classmoji/assistant.service.ts';
+export { AssignGradersError } from './classmoji/gitRepoAssignmentGrader.service.ts';
+export type {
+  AssignGradersMethod,
+  AssignGradersResult,
+  GradingReportRow,
+} from './classmoji/gitRepoAssignmentGrader.service.ts';
+
 // Fly certificate automation for class-site custom domains. Every method throws
 // a typed FlyCertError when the credentials are absent, so importing this in a
 // deployment that has none is safe.


### PR DESCRIPTION
## Summary

Adds teaching-team (TA) management to the MCP server, exposes bulk grader assignment, and adds a per-TA grading oversight report. 5 new tools (62 → 67).

### New MCP tools

| Tool | Scope | Roles | What it does |
|---|---|---|---|
| `assistant_add` | write | OWNER | Add a TA by GitHub login — resolves the profile server-side, adds them to the org's Assistants team (or sends an org invite), creates the ASSISTANT membership. Idempotent: re-adding reports `already_exists` and performs no writes. |
| `assistant_update` | write | OWNER | Toggle a TA's `is_grader` flag. |
| `assistant_remove` | write | OWNER | Remove a TA (requires `confirm: true`). Queues the role-aware org-removal task — other memberships in the same GitHub org keep the user's access. |
| `grader_assign_bulk` | write | OWNER | Distribute graders across all submissions of an assignment: `RANDOM` (even shuffle round-robin over `is_grader` assistants) or `EXISTING` (copy the per-student/team grader mapping from a template assignment). |
| `grading_report` | read | OWNER, TEACHER | Per-TA per-assignment oversight: assigned vs graded counts, emoji grade distribution, last activity. Optional `assignment_id` / `grader_id` filters. |

### Service extraction (one shared code path)

The webapp's inline assistant handlers (`admin.$class.assistants/action.ts`) and the assign-graders logic are now in `packages/services` (`assistant.service.ts`, additions to `gitRepoAssignmentGrader.service.ts`), mirroring the `roster.service.ts` precedent — the web routes and MCP tools call the same functions. Along the way the shared services picked up hardening the old inline code lacked: case-insensitive GitHub login matching, role-scoped membership updates (multi-role users get the right row), no field overwrites on existing users during upsert, typed errors surfaced as callouts instead of error boundaries, and a guard against binding a login to a mismatched provider account.

### Tests

- `packages/services`: 639 pass (+24 new across assistant + grader services)
- `apps/mcp`: 342 pass (+27 new tool tests, incl. cross-classroom scoping and role-matrix cases)
- `apps/webapp`: 217 unit tests pass; typecheck clean (one pre-existing unrelated error)

### Test steps

1. As a classroom owner over MCP: `assistant_add` with a GitHub login → user appears in `list_teaching_team`, gets an org invite (or immediate team add if already a member). Re-run → `already_exists`, no duplicate invite.
2. `assistant_update` `is_grader: true`, then `grader_assign_bulk` with `method: RANDOM` on an assignment → graders appear as issue assignees across the assignment's repos.
3. `grading_report` → rows per TA per assignment with counts and grade distribution.
4. Webapp: `admin/$class/assistants` add/toggle/remove still work (now via the shared service).

### Follow-up candidates (admin gap catalog, not in this PR)

MCP still has no write tools for: quizzes (create/update/publish), teams (create/rename/members/tags), module delete/reorder/site-visibility, repo delete + template-sync + release-now, resource linking (pages/slides ↔ assignments), mapping deletes/defaults, classroom settings (general/content/LLM/website/status), membership letter-grade/comment, and bulk token grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
