### PR TITLE
feat(mcp): teams management, quiz CRUD, and classroom settings tools

### DIFF
--- a/apps/mcp/src/resources/content.ts
+++ b/apps/mcp/src/resources/content.ts
@@ -208,8 +208,12 @@ interface QuizRow {
  * The `ends_at` test is NOT reimplemented here. It lives once, in
  * `subscription.getProStateForClassroomId`, precisely so this file and the
  * webapp cannot drift into gating on different definitions of "active".
+ *
+ * EXPORTED because the quiz WRITE tools (tools/quizzes.ts) apply the same gate
+ * the webapp's quiz action applies before every mutation. One definition, one
+ * import — the read resource and the write tools cannot drift apart.
  */
-async function assertProTier(classroomId: string): Promise<void> {
+export async function assertProTier(classroomId: string): Promise<void> {
   const proState = await ClassmojiService.subscription.getProStateForClassroomId(classroomId);
   if (!proState.isPro) {
     throw new ToolError('forbidden', 'This feature requires a Pro subscription');

--- a/apps/mcp/src/suggestions.ts
+++ b/apps/mcp/src/suggestions.ts
@@ -26,6 +26,7 @@ export const FACULTY_SUGGESTIONS: readonly string[] = [
   'Are there any open regrade requests I need to resolve?',
   'What assignments are due this week?',
   'How is grading going across my TAs — who still has submissions outstanding?',
+  'Draft a quiz on this week’s material, then publish it when I say so.',
 ];
 
 /** Student-facing starters (upcoming work, grades, tokens, regrades). */

--- a/apps/mcp/src/tools/__tests__/quizzes.test.ts
+++ b/apps/mcp/src/tools/__tests__/quizzes.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Unit tests for quiz_create / quiz_update / quiz_publish / quiz_delete.
+ *
+ * Security focus:
+ *   - S1: every tool resolves its target (and any linked repository) against
+ *     the ctx classroom, and refuses missing/foreign records with the uniform
+ *     scopedNotFound BEFORE any service call.
+ *   - The two in-handler gates the registry cannot apply — Pro tier and
+ *     quizzes_enabled — deny before mutating.
+ *   - The notification invariant: publishing is quiz.publish's job only, so
+ *     the update schema must refuse PUBLISHED (and ARCHIVED, which is not even
+ *     in the Prisma enum).
+ * Only the service boundary is mocked — these tools fire no external effects.
+ *
+ * Schema-level rules (clamps, the status enum, confirm:true) are asserted
+ * against `tool.inputSchema` itself: the registry/SDK validates arguments
+ * BEFORE the handler runs, so a direct handler call bypasses zod entirely.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  quizCreate: vi.fn(),
+  quizUpdate: vi.fn(),
+  quizPublish: vi.fn(),
+  quizDelete: vi.fn(),
+  quizFindById: vi.fn(),
+  repositoryFindById: vi.fn(),
+  getProState: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    quiz: {
+      create: (...a: unknown[]) => mocks.quizCreate(...a),
+      update: (...a: unknown[]) => mocks.quizUpdate(...a),
+      publish: (...a: unknown[]) => mocks.quizPublish(...a),
+      delete: (...a: unknown[]) => mocks.quizDelete(...a),
+      findById: (...a: unknown[]) => mocks.quizFindById(...a),
+    },
+    repository: { findById: (...a: unknown[]) => mocks.repositoryFindById(...a) },
+    // Reached through the shared assertProTier helper exported by
+    // resources/content.ts (one Pro-tier definition for reads AND writes).
+    subscription: { getProStateForClassroomId: (...a: unknown[]) => mocks.getProState(...a) },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+  },
+}));
+
+const { quizCreateTool, quizUpdateTool, quizPublishTool, quizDeleteTool } =
+  await import('../quizzes.ts');
+
+/** Context with the quiz surface enabled (Pro + quizzes_enabled). */
+function ctxWithSettings(settings: Record<string, unknown>): ToolContext {
+  return {
+    viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+    classroom: {
+      classroomId: 'class-1',
+      role: 'OWNER',
+      status: 'ACTIVE',
+      membership: { id: 'm-1', role: 'OWNER' },
+      classroom: { settings },
+    },
+  } as unknown as ToolContext;
+}
+
+const CTX = ctxWithSettings({ quizzes_enabled: true });
+
+const QUIZ_ROW = {
+  id: 'quiz-1',
+  classroom_id: 'class-1',
+  name: 'Week 3 concepts',
+  status: 'DRAFT',
+  rubric_prompt: 'Ask about recursion',
+  weight: 10,
+  question_count: 5,
+  max_attempts: 1,
+  grading_strategy: 'HIGHEST',
+  include_code_context: false,
+  attempts: [{ id: 'att-1', user: { id: 'stu-1', name: 'Alice', email: 'a@x.edu' } }],
+};
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+  mocks.getProState.mockResolvedValue({ isPro: true });
+});
+
+describe('quiz_create', () => {
+  const ARGS = {
+    classroom: 'org/w26',
+    name: 'Week 3 concepts',
+    rubric_prompt: 'Ask about recursion',
+    weight: 10,
+    question_count: 5,
+  };
+
+  it('creates a DRAFT under the ctx classroom and audits CREATE', async () => {
+    mocks.quizCreate.mockResolvedValue(QUIZ_ROW);
+
+    const payload = parse(await quizCreateTool.handler(ARGS, CTX));
+    expect(payload.success).toBe(true);
+    expect(payload.quiz.id).toBe('quiz-1');
+
+    const data = mocks.quizCreate.mock.calls[0][0] as Record<string, unknown>;
+    // classroomId comes from ctx, never from args, and status is pinned DRAFT:
+    // publishing must go through quiz_publish so students get notified.
+    expect(data.classroomId).toBe('class-1');
+    expect(data.status).toBe('DRAFT');
+    expect(data.rubricPrompt).toBe('Ask about recursion');
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as { action: string; classroom_id: string };
+    expect(audit.action).toBe('CREATE');
+    expect(audit.classroom_id).toBe('class-1');
+  });
+
+  it('does not accept a status argument at all (always DRAFT)', () => {
+    expect(quizCreateTool.inputSchema).not.toHaveProperty('status');
+  });
+
+  it('never echoes the attempts/user rows the service returns', async () => {
+    mocks.quizCreate.mockResolvedValue(QUIZ_ROW);
+    const payload = parse(await quizCreateTool.handler(ARGS, CTX));
+    expect(payload.quiz).not.toHaveProperty('attempts');
+    expect(JSON.stringify(payload)).not.toContain('a@x.edu');
+  });
+
+  it('links a repository only after verifying it is in this classroom', async () => {
+    mocks.repositoryFindById.mockResolvedValue({ id: 'repo-1', classroom_id: 'class-1' });
+    mocks.quizCreate.mockResolvedValue({ ...QUIZ_ROW, repository_id: 'repo-1' });
+
+    await quizCreateTool.handler({ ...ARGS, repository_id: 'repo-1' }, CTX);
+    expect((mocks.quizCreate.mock.calls[0][0] as { repositoryId: string }).repositoryId).toBe(
+      'repo-1'
+    );
+  });
+
+  it('refuses a repository from another classroom (S1) and never creates', async () => {
+    mocks.repositoryFindById.mockResolvedValue({ id: 'repo-1', classroom_id: 'OTHER-class' });
+
+    await expect(
+      quizCreateTool.handler({ ...ARGS, repository_id: 'repo-1' }, CTX)
+    ).rejects.toMatchObject({ kind: 'not_found' });
+    expect(mocks.quizCreate).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('denies a classroom without a Pro subscription before mutating', async () => {
+    mocks.getProState.mockResolvedValue({ isPro: false });
+    await expect(quizCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({ kind: 'forbidden' });
+    expect(mocks.quizCreate).not.toHaveBeenCalled();
+  });
+
+  it('denies when quizzes are disabled for the classroom (stricter than the web app)', async () => {
+    const disabled = ctxWithSettings({ quizzes_enabled: false });
+    await expect(quizCreateTool.handler(ARGS, disabled)).rejects.toMatchObject({
+      kind: 'forbidden',
+      message: 'Quizzes are disabled for this classroom',
+    });
+    expect(mocks.quizCreate).not.toHaveBeenCalled();
+  });
+
+  it('enforces the service clamps in the schema (question_count, max_attempts, weight)', () => {
+    const schema = z.object(quizCreateTool.inputSchema);
+    const base = { classroom: 'org/w26', name: 'Q', rubric_prompt: 'r' };
+
+    expect(schema.safeParse({ ...base, question_count: 0 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, question_count: 21 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, question_count: 20 }).success).toBe(true);
+    expect(schema.safeParse({ ...base, question_count: 2.5 }).success).toBe(false);
+
+    // 0 is legal for max_attempts — it means unlimited.
+    expect(schema.safeParse({ ...base, max_attempts: 0 }).success).toBe(true);
+    expect(schema.safeParse({ ...base, max_attempts: -1 }).success).toBe(false);
+
+    expect(schema.safeParse({ ...base, weight: 0 }).success).toBe(true);
+    expect(schema.safeParse({ ...base, weight: 101 }).success).toBe(false);
+
+    // rubric_prompt is required and non-empty.
+    expect(schema.safeParse({ classroom: 'org/w26', name: 'Q' }).success).toBe(false);
+    expect(schema.safeParse({ ...base, rubric_prompt: '' }).success).toBe(false);
+  });
+});
+
+describe('quiz_update', () => {
+  const ARGS = { classroom: 'org/w26', quiz_id: 'quiz-1', name: 'Renamed' };
+
+  it('updates a quiz in this classroom and audits the changed fields', async () => {
+    mocks.quizFindById.mockResolvedValue(QUIZ_ROW);
+    mocks.quizUpdate.mockResolvedValue({ ...QUIZ_ROW, name: 'Renamed' });
+
+    const payload = parse(await quizUpdateTool.handler(ARGS, CTX));
+    expect(payload.quiz.name).toBe('Renamed');
+
+    // Mapped explicitly into the service's camelCase vocabulary.
+    expect(mocks.quizUpdate).toHaveBeenCalledWith('quiz-1', { name: 'Renamed' });
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      classroom_id: string;
+      data: { fields: string[] };
+    };
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.data.fields).toEqual(['name']);
+  });
+
+  it('requires at least one field', async () => {
+    await expect(
+      quizUpdateTool.handler({ classroom: 'org/w26', quiz_id: 'quiz-1' }, CTX)
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.quizFindById).not.toHaveBeenCalled();
+    expect(mocks.quizUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a quiz in another classroom (S1) with zero service calls', async () => {
+    mocks.quizFindById.mockResolvedValue({ ...QUIZ_ROW, classroom_id: 'OTHER-class' });
+
+    await expect(quizUpdateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Quiz not found in this classroom',
+    });
+    expect(mocks.quizUpdate).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown quiz id with the identical error (no existence leak)', async () => {
+    mocks.quizFindById.mockResolvedValue(null);
+    await expect(quizUpdateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Quiz not found in this classroom',
+    });
+  });
+
+  it('disconnects the repository on null and verifies a non-null one first', async () => {
+    mocks.quizFindById.mockResolvedValue(QUIZ_ROW);
+    mocks.quizUpdate.mockResolvedValue(QUIZ_ROW);
+
+    await quizUpdateTool.handler(
+      { classroom: 'org/w26', quiz_id: 'quiz-1', repository_id: null },
+      CTX
+    );
+    expect(mocks.quizUpdate).toHaveBeenCalledWith('quiz-1', { repositoryId: null });
+    expect(mocks.repositoryFindById).not.toHaveBeenCalled();
+
+    mocks.repositoryFindById.mockResolvedValue({ id: 'repo-9', classroom_id: 'OTHER-class' });
+    await expect(
+      quizUpdateTool.handler(
+        { classroom: 'org/w26', quiz_id: 'quiz-1', repository_id: 'repo-9' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'not_found' });
+    expect(mocks.quizUpdate).toHaveBeenCalledTimes(1); // only the null-disconnect call
+  });
+
+  it('rejects PUBLISHED and ARCHIVED in the status schema', () => {
+    const status = quizUpdateTool.inputSchema.status;
+    expect(status.safeParse('DRAFT').success).toBe(true);
+    expect(status.safeParse('CLOSED').success).toBe(true);
+    // PUBLISHED would skip the notification path; ARCHIVED is not in the enum.
+    expect(status.safeParse('PUBLISHED').success).toBe(false);
+    expect(status.safeParse('ARCHIVED').success).toBe(false);
+  });
+
+  it('applies the same clamps as create', () => {
+    const schema = z.object(quizUpdateTool.inputSchema);
+    const base = { classroom: 'org/w26', quiz_id: '11111111-1111-4111-8111-111111111111' };
+    expect(schema.safeParse({ ...base, question_count: 21 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, max_attempts: -1 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, weight: 101 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, rubric_prompt: '' }).success).toBe(false);
+  });
+
+  it('denies when the quiz surface is off (Pro / quizzes_enabled) before loading', async () => {
+    mocks.getProState.mockResolvedValue({ isPro: false });
+    await expect(quizUpdateTool.handler(ARGS, CTX)).rejects.toMatchObject({ kind: 'forbidden' });
+    expect(mocks.quizFindById).not.toHaveBeenCalled();
+  });
+});
+
+describe('quiz_publish', () => {
+  const ARGS = { classroom: 'org/w26', quiz_id: 'quiz-1' };
+
+  it('publishes a draft and reports that students were notified', async () => {
+    mocks.quizFindById.mockResolvedValue(QUIZ_ROW); // status DRAFT
+    mocks.quizPublish.mockResolvedValue({ ...QUIZ_ROW, status: 'PUBLISHED' });
+
+    const payload = parse(await quizPublishTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      previous_status: 'DRAFT',
+      students_notified: true,
+    });
+    expect(mocks.quizPublish).toHaveBeenCalledWith('quiz-1');
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      data: { students_notified: boolean };
+    };
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.data.students_notified).toBe(true);
+  });
+
+  it('is idempotent: republishing reports that nobody was notified', async () => {
+    mocks.quizFindById.mockResolvedValue({ ...QUIZ_ROW, status: 'PUBLISHED' });
+    mocks.quizPublish.mockResolvedValue({ ...QUIZ_ROW, status: 'PUBLISHED' });
+
+    const payload = parse(await quizPublishTool.handler(ARGS, CTX));
+    expect(payload.students_notified).toBe(false);
+    expect(payload.previous_status).toBe('PUBLISHED');
+    expect(quizPublishTool.annotations?.idempotent).toBe(true);
+  });
+
+  it('refuses a quiz from another classroom (S1) and never publishes', async () => {
+    mocks.quizFindById.mockResolvedValue({ ...QUIZ_ROW, classroom_id: 'OTHER-class' });
+    await expect(quizPublishTool.handler(ARGS, CTX)).rejects.toMatchObject({ kind: 'not_found' });
+    expect(mocks.quizPublish).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('denies when quizzes are disabled for the classroom', async () => {
+    const disabled = ctxWithSettings({ quizzes_enabled: false });
+    await expect(quizPublishTool.handler(ARGS, disabled)).rejects.toMatchObject({
+      kind: 'forbidden',
+    });
+    expect(mocks.quizPublish).not.toHaveBeenCalled();
+  });
+});
+
+describe('quiz_delete', () => {
+  const ARGS = { classroom: 'org/w26', quiz_id: 'quiz-1', confirm: true as const };
+
+  it('deletes the quiz and records the cascade blast radius', async () => {
+    mocks.quizFindById.mockResolvedValue(QUIZ_ROW);
+    mocks.quizDelete.mockResolvedValue({ id: 'quiz-1' });
+
+    const payload = parse(await quizDeleteTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      deleted_quiz_id: 'quiz-1',
+      attempts_deleted: 1,
+    });
+    expect(mocks.quizDelete).toHaveBeenCalledWith('quiz-1');
+
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      classroom_id: string;
+      data: { attempts_deleted: number };
+    };
+    expect(audit.action).toBe('DELETE');
+    expect(audit.classroom_id).toBe('class-1');
+    // Student attempts cascade-delete with the quiz (schema: QuizAttempt.quiz
+    // onDelete: Cascade) — the count is preserved in the audit trail.
+    expect(audit.data.attempts_deleted).toBe(1);
+  });
+
+  it('requires confirm:true in the schema (destructive gate)', () => {
+    const confirm = quizDeleteTool.inputSchema.confirm;
+    expect(confirm.safeParse(true).success).toBe(true);
+    expect(confirm.safeParse(false).success).toBe(false);
+    expect(confirm.safeParse(undefined).success).toBe(false);
+    expect(quizDeleteTool.annotations?.destructive).toBe(true);
+  });
+
+  it('refuses a quiz from another classroom (S1) and never deletes', async () => {
+    mocks.quizFindById.mockResolvedValue({ ...QUIZ_ROW, classroom_id: 'OTHER-class' });
+    await expect(quizDeleteTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Quiz not found in this classroom',
+    });
+    expect(mocks.quizDelete).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('denies without a Pro subscription before loading the quiz', async () => {
+    mocks.getProState.mockResolvedValue({ isPro: false });
+    await expect(quizDeleteTool.handler(ARGS, CTX)).rejects.toMatchObject({ kind: 'forbidden' });
+    expect(mocks.quizFindById).not.toHaveBeenCalled();
+    expect(mocks.quizDelete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/src/tools/__tests__/quizzes.test.ts
+++ b/apps/mcp/src/tools/__tests__/quizzes.test.ts
@@ -259,6 +259,32 @@ describe('quiz_update', () => {
     expect(mocks.quizUpdate).toHaveBeenCalledTimes(1); // only the null-disconnect call
   });
 
+  it('clears the due date on null and forwards a supplied one', async () => {
+    mocks.quizFindById.mockResolvedValue(QUIZ_ROW);
+    mocks.quizUpdate.mockResolvedValue(QUIZ_ROW);
+
+    // null reaches the service as a clear; the service maps falsy → null.
+    await quizUpdateTool.handler({ classroom: 'org/w26', quiz_id: 'quiz-1', due_date: null }, CTX);
+    expect(mocks.quizUpdate).toHaveBeenCalledWith('quiz-1', { dueDate: null });
+    expect(mocks.auditCreate.mock.calls[0][0].data.fields).toEqual(['due_date']);
+
+    await quizUpdateTool.handler(
+      { classroom: 'org/w26', quiz_id: 'quiz-1', due_date: '2026-07-20T23:59:00-04:00' },
+      CTX
+    );
+    expect(mocks.quizUpdate).toHaveBeenLastCalledWith('quiz-1', {
+      dueDate: '2026-07-20T23:59:00-04:00',
+    });
+  });
+
+  it('accepts null but not a malformed string for due_date', () => {
+    const dueDate = quizUpdateTool.inputSchema.due_date;
+    expect(dueDate.safeParse(null).success).toBe(true);
+    expect(dueDate.safeParse(undefined).success).toBe(true);
+    expect(dueDate.safeParse('2026-07-20T23:59:00-04:00').success).toBe(true);
+    expect(dueDate.safeParse('next friday').success).toBe(false);
+  });
+
   it('rejects PUBLISHED and ARCHIVED in the status schema', () => {
     const status = quizUpdateTool.inputSchema.status;
     expect(status.safeParse('DRAFT').success).toBe(true);

--- a/apps/mcp/src/tools/__tests__/settings.test.ts
+++ b/apps/mcp/src/tools/__tests__/settings.test.ts
@@ -283,22 +283,24 @@ describe('classroom_status_update', () => {
 
 describe('org_repo_settings_update', () => {
   const ORG = { id: 'gorg-1', login: 'myorg', github_installation_id: '123' };
+  // The confirm gate lives in the schema; the handler takes it already parsed.
+  const BASE = { classroom: 'org/w26', confirm: true as const };
 
   beforeEach(() => {
     mocks.classroomFindById.mockResolvedValue({ id: 'class-1', git_organization: ORG });
   });
 
   it('requires at least one field', async () => {
-    await expect(
-      orgRepoSettingsUpdateTool.handler({ classroom: 'org/w26' }, CTX)
-    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    await expect(orgRepoSettingsUpdateTool.handler(BASE, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+    });
     expect(mocks.updateOrganization).not.toHaveBeenCalled();
   });
 
   it('sends an exact object to updateOrganization for the ctx classroom org', async () => {
     const payload = parse(
       await orgRepoSettingsUpdateTool.handler(
-        { classroom: 'org/w26', default_repository_permission: 'read' },
+        { ...BASE, default_repository_permission: 'read' },
         CTX
       )
     );
@@ -318,12 +320,13 @@ describe('org_repo_settings_update', () => {
   it('never forwards extra argument keys to GitHub', async () => {
     await orgRepoSettingsUpdateTool.handler(
       {
-        classroom: 'org/w26',
+        ...BASE,
         members_can_create_repositories: true,
         billing_email: 'nope@x.edu',
       } as unknown as Parameters<typeof orgRepoSettingsUpdateTool.handler>[0],
       CTX
     );
+    // Neither the stray key nor `confirm` reaches the organization payload.
     expect(mocks.updateOrganization.mock.calls[0][1]).toEqual({
       members_can_create_repositories: true,
     });
@@ -338,18 +341,29 @@ describe('org_repo_settings_update', () => {
     expect(permission.safeParse('READ').success).toBe(false);
   });
 
-  it('is annotated openWorld (it writes to GitHub, not our database)', () => {
+  it('is annotated openWorld and destructive (it changes the whole organization)', () => {
     expect(orgRepoSettingsUpdateTool.annotations?.openWorld).toBe(true);
-    expect(orgRepoSettingsUpdateTool.annotations?.destructive).toBe(false);
+    expect(orgRepoSettingsUpdateTool.annotations?.destructive).toBe(true);
+  });
+
+  it('requires confirm:true in the schema', () => {
+    // The registry validates inputSchema before the handler runs, so the gate
+    // lives in the schema: only the literal `true` is accepted.
+    const confirm = orgRepoSettingsUpdateTool.inputSchema.confirm;
+    expect(confirm.safeParse(true).success).toBe(true);
+    expect(confirm.safeParse(false).success).toBe(false);
+    expect(confirm.safeParse(undefined).success).toBe(false);
+  });
+
+  it('says in its description that the change is organization-wide and immediate', () => {
+    expect(orgRepoSettingsUpdateTool.description).toContain('IMMEDIATELY');
+    expect(orgRepoSettingsUpdateTool.description).toContain('ORGANIZATION-WIDE');
   });
 
   it('refuses a classroom with no linked GitHub organization', async () => {
     mocks.classroomFindById.mockResolvedValue({ id: 'class-1', git_organization: null });
     await expect(
-      orgRepoSettingsUpdateTool.handler(
-        { classroom: 'org/w26', members_can_create_repositories: false },
-        CTX
-      )
+      orgRepoSettingsUpdateTool.handler({ ...BASE, members_can_create_repositories: false }, CTX)
     ).rejects.toMatchObject({ kind: 'invalid_params' });
     expect(mocks.updateOrganization).not.toHaveBeenCalled();
   });
@@ -360,10 +374,7 @@ describe('org_repo_settings_update', () => {
       git_organization: { ...ORG, github_installation_id: null },
     });
     await expect(
-      orgRepoSettingsUpdateTool.handler(
-        { classroom: 'org/w26', members_can_create_repositories: false },
-        CTX
-      )
+      orgRepoSettingsUpdateTool.handler({ ...BASE, members_can_create_repositories: false }, CTX)
     ).rejects.toMatchObject({ kind: 'invalid_params' });
     expect(mocks.updateOrganization).not.toHaveBeenCalled();
     expect(mocks.auditCreate).not.toHaveBeenCalled();
@@ -371,7 +382,7 @@ describe('org_repo_settings_update', () => {
 
   it('audits against REPO_SETTINGS after the GitHub write', async () => {
     await orgRepoSettingsUpdateTool.handler(
-      { classroom: 'org/w26', default_repository_permission: 'none' },
+      { ...BASE, default_repository_permission: 'none' },
       CTX
     );
     const audit = mocks.auditCreate.mock.calls[0][0] as {

--- a/apps/mcp/src/tools/__tests__/settings.test.ts
+++ b/apps/mcp/src/tools/__tests__/settings.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for classroom_settings_update / classroom_status_update /
+ * org_repo_settings_update.
+ *
+ * Security focus: `updateSettings` is a bare upsert that writes ANY key it
+ * receives (including anthropic_api_key / openai_api_key), and the web actions
+ * forward whole request bodies into it. These tools must build an EXPLICIT
+ * object instead — so the load-bearing assertions here are that the object
+ * handed to the service contains EXACTLY the expected keys, and that an extra
+ * key riding along on the arguments is not forwarded. The same rule is checked
+ * for classroom.update (name only) and gitProvider.updateOrganization.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  classroomUpdate: vi.fn(),
+  updateSettings: vi.fn(),
+  classroomFindById: vi.fn(),
+  pageFindById: vi.fn(),
+  updateOrganization: vi.fn(),
+  getGitProvider: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroom: {
+      update: (...a: unknown[]) => mocks.classroomUpdate(...a),
+      updateSettings: (...a: unknown[]) => mocks.updateSettings(...a),
+      findById: (...a: unknown[]) => mocks.classroomFindById(...a),
+    },
+    page: { findById: (...a: unknown[]) => mocks.pageFindById(...a) },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+  },
+  getGitProvider: (...a: unknown[]) => mocks.getGitProvider(...a),
+}));
+
+const { classroomSettingsUpdateTool, classroomStatusUpdateTool, orgRepoSettingsUpdateTool } =
+  await import('../settings.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+  mocks.updateSettings.mockResolvedValue({});
+  mocks.classroomUpdate.mockResolvedValue({ status: 'ACTIVE', is_archived: false });
+  mocks.getGitProvider.mockReturnValue({ updateOrganization: mocks.updateOrganization });
+  mocks.updateOrganization.mockResolvedValue(undefined);
+});
+
+describe('classroom_settings_update', () => {
+  it('requires at least one field', async () => {
+    await expect(
+      classroomSettingsUpdateTool.handler({ classroom: 'org/w26' }, CTX)
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+    expect(mocks.classroomUpdate).not.toHaveBeenCalled();
+  });
+
+  it('passes an explicit object with EXACTLY the validated keys', async () => {
+    await classroomSettingsUpdateTool.handler(
+      { classroom: 'org/w26', quizzes_enabled: false, default_tokens_per_hour: 5 },
+      CTX
+    );
+
+    const [classroomId, settings] = mocks.updateSettings.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(classroomId).toBe('class-1'); // from ctx, never from args
+    expect(Object.keys(settings).sort()).toEqual(['default_tokens_per_hour', 'quizzes_enabled']);
+    expect(settings).toEqual({ quizzes_enabled: false, default_tokens_per_hour: 5 });
+  });
+
+  it('never forwards an unknown argument key to the settings upsert', async () => {
+    // updateSettings writes any key it receives — including API-key columns. An
+    // extra key on the arguments must therefore die at the tool boundary, not
+    // reach the service. (The registry's zod validation would already strip it;
+    // this proves the handler does not depend on that.)
+    await classroomSettingsUpdateTool.handler(
+      {
+        classroom: 'org/w26',
+        show_pages: true,
+        anthropic_api_key: 'sk-should-never-be-written',
+        content_repo_name: 'nope',
+      } as unknown as Parameters<typeof classroomSettingsUpdateTool.handler>[0],
+      CTX
+    );
+
+    const settings = mocks.updateSettings.mock.calls[0][1] as Record<string, unknown>;
+    expect(settings).toEqual({ show_pages: true });
+    expect(settings).not.toHaveProperty('anthropic_api_key');
+    expect(settings).not.toHaveProperty('content_repo_name');
+    expect(JSON.stringify(mocks.updateSettings.mock.calls)).not.toContain('sk-should-never');
+  });
+
+  it('sends name to classroom.update (PROFILE_FIELDS) and not to updateSettings', async () => {
+    await classroomSettingsUpdateTool.handler(
+      { classroom: 'org/w26', name: 'CS 52 — Winter', theme: 'sand' },
+      CTX
+    );
+
+    expect(mocks.classroomUpdate).toHaveBeenCalledWith('class-1', { name: 'CS 52 — Winter' });
+    const settings = mocks.updateSettings.mock.calls[0][1] as Record<string, unknown>;
+    expect(settings).toEqual({ theme: 'sand' });
+    expect(settings).not.toHaveProperty('name');
+  });
+
+  it('does not touch the classroom row when only settings change', async () => {
+    await classroomSettingsUpdateTool.handler({ classroom: 'org/w26', show_repos: false }, CTX);
+    expect(mocks.classroomUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not touch settings when only the name changes', async () => {
+    await classroomSettingsUpdateTool.handler({ classroom: 'org/w26', name: 'Renamed' }, CTX);
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+    expect(mocks.classroomUpdate).toHaveBeenCalledWith('class-1', { name: 'Renamed' });
+  });
+
+  it('resolves a page: default_student_page inside this classroom', async () => {
+    mocks.pageFindById.mockResolvedValue({ id: 'page-1', classroom_id: 'class-1' });
+
+    await classroomSettingsUpdateTool.handler(
+      { classroom: 'org/w26', default_student_page: 'page:page-1' },
+      CTX
+    );
+    expect(mocks.updateSettings.mock.calls[0][1]).toEqual({ default_student_page: 'page:page-1' });
+  });
+
+  it('refuses a page from another classroom (S1) and writes nothing', async () => {
+    mocks.pageFindById.mockResolvedValue({ id: 'page-1', classroom_id: 'OTHER-class' });
+
+    await expect(
+      classroomSettingsUpdateTool.handler(
+        { classroom: 'org/w26', default_student_page: 'page:page-1' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'not_found', message: 'Page not found in this classroom' });
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed default_student_page', async () => {
+    await expect(
+      classroomSettingsUpdateTool.handler(
+        { classroom: 'org/w26', default_student_page: 'grades' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+  });
+
+  it('audits the changed field names with the ctx classroom id', async () => {
+    await classroomSettingsUpdateTool.handler(
+      { classroom: 'org/w26', name: 'Renamed', slides_enabled: true },
+      CTX
+    );
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      classroom_id: string;
+      resource_type: string;
+      data: { fields: string[] };
+    };
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.resource_type).toBe('SETTINGS');
+    expect(audit.data.fields.sort()).toEqual(['name', 'slides_enabled']);
+  });
+
+  it('constrains theme to the known keys in the schema', () => {
+    const theme = classroomSettingsUpdateTool.inputSchema.theme;
+    expect(theme.safeParse('stone').success).toBe(true);
+    expect(theme.safeParse('lavender').success).toBe(true);
+    expect(theme.safeParse('neon').success).toBe(false);
+  });
+
+  it('exposes no API-key or llm_* fields in its schema', () => {
+    const keys = Object.keys(classroomSettingsUpdateTool.inputSchema);
+    expect(keys.filter(k => k.includes('api_key') || k.startsWith('llm_'))).toEqual([]);
+    // Dead / legacy columns stay out too.
+    expect(keys).not.toContain('show_grades_to_students');
+    expect(keys).not.toContain('content_repo_name');
+  });
+
+  it('rejects negative numeric settings in the schema', () => {
+    const schema = z.object(classroomSettingsUpdateTool.inputSchema);
+    const base = { classroom: 'org/w26' };
+    expect(schema.safeParse({ ...base, default_tokens_per_hour: -1 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, default_tokens_per_hour: 1.5 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, late_penalty_points_per_hour: -0.5 }).success).toBe(false);
+    expect(schema.safeParse({ ...base, late_penalty_points_per_hour: 2.5 }).success).toBe(true);
+    expect(schema.safeParse({ ...base, name: '   ' }).success).toBe(false);
+  });
+});
+
+describe('classroom_status_update', () => {
+  it('requires status and/or is_archived', async () => {
+    await expect(
+      classroomStatusUpdateTool.handler({ classroom: 'org/w26' }, CTX)
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.classroomUpdate).not.toHaveBeenCalled();
+  });
+
+  it('updates both columns explicitly using the ctx classroom id', async () => {
+    mocks.classroomUpdate.mockResolvedValue({ status: 'LOCKED', is_archived: true });
+
+    const payload = parse(
+      await classroomStatusUpdateTool.handler(
+        { classroom: 'org/w26', status: 'LOCKED', is_archived: true },
+        CTX
+      )
+    );
+    expect(payload).toMatchObject({ status: 'LOCKED', is_archived: true });
+    expect(mocks.classroomUpdate).toHaveBeenCalledWith('class-1', {
+      status: 'LOCKED',
+      is_archived: true,
+    });
+  });
+
+  it('sets only the column provided', async () => {
+    mocks.classroomUpdate.mockResolvedValue({ status: 'ACTIVE', is_archived: true });
+    await classroomStatusUpdateTool.handler({ classroom: 'org/w26', is_archived: true }, CTX);
+    expect(mocks.classroomUpdate.mock.calls[0][1]).toEqual({ is_archived: true });
+  });
+
+  it('accepts only the three lifecycle statuses and is marked idempotent', () => {
+    const status = classroomStatusUpdateTool.inputSchema.status;
+    for (const value of ['ACTIVE', 'LOCKED', 'UNPUBLISHED']) {
+      expect(status.safeParse(value).success).toBe(true);
+    }
+    expect(status.safeParse('ARCHIVED').success).toBe(false);
+    expect(status.safeParse('DELETED').success).toBe(false);
+    expect(classroomStatusUpdateTool.annotations?.idempotent).toBe(true);
+  });
+
+  it('audits against CLASSROOM with the ctx classroom id', async () => {
+    await classroomStatusUpdateTool.handler({ classroom: 'org/w26', status: 'ACTIVE' }, CTX);
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      resource_type: string;
+      classroom_id: string;
+    };
+    expect(audit.resource_type).toBe('CLASSROOM');
+    expect(audit.classroom_id).toBe('class-1');
+  });
+});
+
+describe('org_repo_settings_update', () => {
+  const ORG = { id: 'gorg-1', login: 'myorg', github_installation_id: '123' };
+
+  beforeEach(() => {
+    mocks.classroomFindById.mockResolvedValue({ id: 'class-1', git_organization: ORG });
+  });
+
+  it('requires at least one field', async () => {
+    await expect(
+      orgRepoSettingsUpdateTool.handler({ classroom: 'org/w26' }, CTX)
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.updateOrganization).not.toHaveBeenCalled();
+  });
+
+  it('sends an exact object to updateOrganization for the ctx classroom org', async () => {
+    const payload = parse(
+      await orgRepoSettingsUpdateTool.handler(
+        { classroom: 'org/w26', default_repository_permission: 'read' },
+        CTX
+      )
+    );
+    expect(payload).toMatchObject({ success: true, organization: 'myorg' });
+
+    expect(mocks.classroomFindById).toHaveBeenCalledWith('class-1');
+    expect(mocks.getGitProvider).toHaveBeenCalledWith(ORG);
+    const [login, data] = mocks.updateOrganization.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(login).toBe('myorg');
+    expect(Object.keys(data)).toEqual(['default_repository_permission']);
+    expect(data).toEqual({ default_repository_permission: 'read' });
+  });
+
+  it('never forwards extra argument keys to GitHub', async () => {
+    await orgRepoSettingsUpdateTool.handler(
+      {
+        classroom: 'org/w26',
+        members_can_create_repositories: true,
+        billing_email: 'nope@x.edu',
+      } as unknown as Parameters<typeof orgRepoSettingsUpdateTool.handler>[0],
+      CTX
+    );
+    expect(mocks.updateOrganization.mock.calls[0][1]).toEqual({
+      members_can_create_repositories: true,
+    });
+  });
+
+  it('enforces a strict permission enum', () => {
+    const permission = orgRepoSettingsUpdateTool.inputSchema.default_repository_permission;
+    for (const value of ['none', 'read', 'write']) {
+      expect(permission.safeParse(value).success).toBe(true);
+    }
+    expect(permission.safeParse('admin').success).toBe(false);
+    expect(permission.safeParse('READ').success).toBe(false);
+  });
+
+  it('is annotated openWorld (it writes to GitHub, not our database)', () => {
+    expect(orgRepoSettingsUpdateTool.annotations?.openWorld).toBe(true);
+    expect(orgRepoSettingsUpdateTool.annotations?.destructive).toBe(false);
+  });
+
+  it('refuses a classroom with no linked GitHub organization', async () => {
+    mocks.classroomFindById.mockResolvedValue({ id: 'class-1', git_organization: null });
+    await expect(
+      orgRepoSettingsUpdateTool.handler(
+        { classroom: 'org/w26', members_can_create_repositories: false },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.updateOrganization).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the GitHub App is not installed on the org', async () => {
+    mocks.classroomFindById.mockResolvedValue({
+      id: 'class-1',
+      git_organization: { ...ORG, github_installation_id: null },
+    });
+    await expect(
+      orgRepoSettingsUpdateTool.handler(
+        { classroom: 'org/w26', members_can_create_repositories: false },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.updateOrganization).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('audits against REPO_SETTINGS after the GitHub write', async () => {
+    await orgRepoSettingsUpdateTool.handler(
+      { classroom: 'org/w26', default_repository_permission: 'none' },
+      CTX
+    );
+    const audit = mocks.auditCreate.mock.calls[0][0] as {
+      resource_type: string;
+      classroom_id: string;
+      data: Record<string, unknown>;
+    };
+    expect(audit.resource_type).toBe('REPO_SETTINGS');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.data).toMatchObject({ org: 'myorg', default_repository_permission: 'none' });
+  });
+});

--- a/apps/mcp/src/tools/__tests__/settings.test.ts
+++ b/apps/mcp/src/tools/__tests__/settings.test.ts
@@ -240,6 +240,26 @@ describe('classroom_status_update', () => {
     expect(mocks.classroomUpdate.mock.calls[0][1]).toEqual({ is_archived: true });
   });
 
+  it('never forwards extra argument keys to the classroom row', async () => {
+    // classroom.update takes an arbitrary ClassroomUpdateInput — slug (the key
+    // in every URL and two HMAC credentials) and git_org_id are exactly what
+    // the web route's PROFILE_FIELDS whitelist exists to keep unwritable.
+    await classroomStatusUpdateTool.handler(
+      {
+        classroom: 'org/w26',
+        status: 'LOCKED',
+        slug: 'hijacked',
+        git_org_id: 'other-org',
+      } as unknown as Parameters<typeof classroomStatusUpdateTool.handler>[0],
+      CTX
+    );
+
+    const updates = mocks.classroomUpdate.mock.calls[0][1] as Record<string, unknown>;
+    expect(updates).toEqual({ status: 'LOCKED' });
+    expect(updates).not.toHaveProperty('slug');
+    expect(updates).not.toHaveProperty('git_org_id');
+  });
+
   it('accepts only the three lifecycle statuses and is marked idempotent', () => {
     const status = classroomStatusUpdateTool.inputSchema.status;
     for (const value of ['ACTIVE', 'LOCKED', 'UNPUBLISHED']) {

--- a/apps/mcp/src/tools/__tests__/teams.test.ts
+++ b/apps/mcp/src/tools/__tests__/teams.test.ts
@@ -1,0 +1,745 @@
+/**
+ * Unit tests for the team tools.
+ *
+ * Security focus: the classroomId handed to every service call comes from the
+ * ToolContext, never from args; an unknown or foreign team/tag is the uniform
+ * scopedNotFound with no further service call; team_members_add refuses logins
+ * that are not classroom members BEFORE anything reaches the team service; no
+ * mutation is left un-audited, and every audit row names the team; and no
+ * response echoes a raw service row (team.findByClassroomId carries full
+ * member User records).
+ *
+ * `@classmoji/services` is mocked (factory idiom) INCLUDING TeamServiceError,
+ * so the handlers' `instanceof` mapping runs against the same class the tests
+ * throw — no real GitHub calls.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  createTeam: vi.fn(),
+  deleteTeam: vi.fn(),
+  renameTeam: vi.fn(),
+  addTeamMembers: vi.fn(),
+  removeTeamMember: vi.fn(),
+  addTeamTags: vi.fn(),
+  removeTeamTag: vi.fn(),
+  findTeamsByClassroomId: vi.fn(),
+  findMembershipsByClassroomId: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => {
+  // Same shape as the real service error; the tools branch on `instanceof`, so
+  // the class the handler imports must be the class the test constructs.
+  class TeamServiceError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'TeamServiceError';
+      this.code = code;
+    }
+  }
+  return {
+    TeamServiceError,
+    ClassmojiService: {
+      teamAdmin: {
+        createTeam: (...a: unknown[]) => mocks.createTeam(...a),
+        deleteTeam: (...a: unknown[]) => mocks.deleteTeam(...a),
+        renameTeam: (...a: unknown[]) => mocks.renameTeam(...a),
+        addTeamMembers: (...a: unknown[]) => mocks.addTeamMembers(...a),
+        removeTeamMember: (...a: unknown[]) => mocks.removeTeamMember(...a),
+        addTeamTags: (...a: unknown[]) => mocks.addTeamTags(...a),
+        removeTeamTag: (...a: unknown[]) => mocks.removeTeamTag(...a),
+      },
+      team: { findByClassroomId: (...a: unknown[]) => mocks.findTeamsByClassroomId(...a) },
+      classroomMembership: {
+        findByClassroomId: (...a: unknown[]) => mocks.findMembershipsByClassroomId(...a),
+      },
+      audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+    },
+  };
+});
+
+const { TeamServiceError } = await import('@classmoji/services');
+const {
+  teamCreateTool,
+  teamDeleteTool,
+  teamRenameTool,
+  teamMembersAddTool,
+  teamMemberRemoveTool,
+  teamTagAddTool,
+  teamTagRemoveTool,
+} = await import('../teams.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'owner-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'OWNER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'OWNER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/** The audit row the handler wrote (first call). */
+function auditRow() {
+  return mocks.auditCreate.mock.calls[0][0] as {
+    action: string;
+    classroom_id: string;
+    resource_type: string;
+    resource_id?: string | null;
+    data: Record<string, unknown>;
+  };
+}
+
+/**
+ * A team row shaped like team.findByClassroomId returns it — memberships carry
+ * FULL User records (contact PII), which is exactly what must never be echoed.
+ */
+const TEAM_ROW = {
+  id: 'team-1',
+  name: 'Team Rocket',
+  slug: 'team-rocket',
+  is_visible: false,
+  created_at: new Date('2026-01-01T00:00:00Z'),
+  memberships: [
+    { id: 'tm-1', user: { id: 'u-1', login: 'ada', email: 'ada@x.edu', school_id: 'S1' } },
+  ],
+  tags: [
+    { id: 'tt-1', tag_id: 'tag-1', tag: { id: 'tag-1', name: 'frontend' } },
+    { id: 'tt-2', tag_id: 'tag-2', tag: { id: 'tag-2', name: 'week-3' } },
+  ],
+};
+
+/** No response may carry member PII or raw relation rows from a service row. */
+function expectNoServiceRowLeak(payload: unknown) {
+  const text = JSON.stringify(payload);
+  expect(text).not.toContain('memberships');
+  expect(text).not.toContain('ada@x.edu');
+  expect(text).not.toContain('school_id');
+  expect(text).not.toContain('created_at');
+}
+
+/** Every teamAdmin mutation mock, for "the service was never reached" asserts. */
+const teamAdminMocks = () => [
+  mocks.createTeam,
+  mocks.deleteTeam,
+  mocks.renameTeam,
+  mocks.addTeamMembers,
+  mocks.removeTeamMember,
+  mocks.addTeamTags,
+  mocks.removeTeamTag,
+];
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+  mocks.findTeamsByClassroomId.mockResolvedValue([TEAM_ROW]);
+  mocks.findMembershipsByClassroomId.mockResolvedValue([
+    { role: 'STUDENT', user: { id: 'u-1', login: 'ada', email: 'ada@x.edu' } },
+    { role: 'ASSISTANT', user: { id: 'u-2', login: 'Grace' } },
+    { role: 'STUDENT', user: null },
+  ]);
+});
+
+describe('team_create', () => {
+  const ARGS = { classroom: 'org/w26', name: 'Team Rocket', tag_ids: ['tag-1'] };
+
+  it('creates via the service using ctx classroomId and audits the CREATE', async () => {
+    mocks.createTeam.mockResolvedValue({
+      team: { id: 'team-1', name: 'Team Rocket', slug: 'team-rocket', isVisible: false },
+      tagsAdded: ['tag-1'],
+      tagsFailed: [{ tagId: 'tag-9', error: 'Tag does not belong to this classroom' }],
+    });
+
+    const payload = parse(await teamCreateTool.handler(ARGS, CTX));
+    expect(payload).toEqual({
+      success: true,
+      team: { id: 'team-1', name: 'Team Rocket', slug: 'team-rocket', is_visible: false },
+      tags_added: ['tag-1'],
+      tags_failed: [{ tag_id: 'tag-9', error: 'Tag does not belong to this classroom' }],
+    });
+
+    // classroomId comes from ctx, never from args; is_visible defaults to false.
+    expect(mocks.createTeam).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      name: 'Team Rocket',
+      isVisible: false,
+      tagIds: ['tag-1'],
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('CREATE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.resource_type).toBe('TEAMS');
+    // resource_id names the team; it is part of the audit dedup key, so two
+    // creates inside the dedup window stay two rows.
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_create', team_id: 'team-1' });
+  });
+
+  it('passes is_visible through when set', async () => {
+    mocks.createTeam.mockResolvedValue({
+      team: { id: 'team-1', name: 'Team Rocket', slug: 'team-rocket', isVisible: true },
+      tagsAdded: [],
+      tagsFailed: [],
+    });
+
+    const payload = parse(
+      await teamCreateTool.handler({ ...ARGS, is_visible: true, tag_ids: undefined }, CTX)
+    );
+    expect(payload.team.is_visible).toBe(true);
+    expect(mocks.createTeam).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, tagIds: [] })
+    );
+  });
+
+  it('maps reserved_name to invalid_params and audits nothing', async () => {
+    mocks.createTeam.mockRejectedValue(
+      new TeamServiceError('reserved_name', '[team] "w26-students" is reserved for classroom teams')
+    );
+
+    await expect(teamCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: '"w26-students" is reserved for classroom teams',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('maps name_collision to invalid_params', async () => {
+    mocks.createTeam.mockRejectedValue(
+      new TeamServiceError('name_collision', '[team] a team named "Team Rocket" already exists')
+    );
+
+    await expect(teamCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: 'a team named "Team Rocket" already exists',
+    });
+  });
+
+  it('maps no_org_configured to invalid_params without echoing the internal id', async () => {
+    mocks.createTeam.mockRejectedValue(
+      new TeamServiceError('no_org_configured', '[team] classroom class-1 has no git organization')
+    );
+
+    await expect(teamCreateTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: 'This classroom has no linked GitHub organization — teams cannot be managed',
+    });
+  });
+
+  it('carries a tighter rate-limit bucket than the default (each call creates a GitHub team)', () => {
+    expect(teamCreateTool.rateLimit).toEqual({ capacity: 5, refillPerSecond: 0.05 });
+  });
+
+  it('lets an unexpected service failure through for the generic wrapper', async () => {
+    mocks.createTeam.mockRejectedValue(new Error('boom'));
+    await expect(teamCreateTool.handler(ARGS, CTX)).rejects.toThrow('boom');
+  });
+});
+
+describe('team_delete', () => {
+  const ARGS = { classroom: 'org/w26', team: 'team-rocket', confirm: true as const };
+
+  it('deletes via the service and audits the DELETE', async () => {
+    mocks.deleteTeam.mockResolvedValue({
+      id: 'team-1',
+      name: 'Team Rocket',
+      slug: 'team-rocket',
+      removedFromProvider: true,
+    });
+
+    const payload = parse(await teamDeleteTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      id: 'team-1',
+      slug: 'team-rocket',
+      removed_from_provider: true,
+    });
+
+    expect(mocks.deleteTeam).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      slugOrId: 'team-rocket',
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('DELETE');
+    expect(audit.classroom_id).toBe('class-1');
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_delete', team_id: 'team-1' });
+  });
+
+  it('reports removed_from_provider:false when the GitHub team was already gone', async () => {
+    mocks.deleteTeam.mockResolvedValue({
+      id: 'team-1',
+      name: 'Team Rocket',
+      slug: 'team-rocket',
+      removedFromProvider: false,
+    });
+
+    const payload = parse(await teamDeleteTool.handler(ARGS, CTX));
+    expect(payload.removed_from_provider).toBe(false);
+  });
+
+  it('refuses an unknown / cross-classroom team and audits nothing', async () => {
+    mocks.deleteTeam.mockRejectedValue(
+      new TeamServiceError('team_not_found', '[team] no team "nope" in classroom class-1')
+    );
+
+    await expect(teamDeleteTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Team not found in this classroom',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('requires confirm:true in the schema (destructive gate)', () => {
+    // The registry validates inputSchema before the handler runs, so the gate
+    // lives in the schema: only the literal `true` is accepted.
+    const confirm = teamDeleteTool.inputSchema.confirm;
+    expect(confirm.safeParse(true).success).toBe(true);
+    expect(confirm.safeParse(false).success).toBe(false);
+    expect(confirm.safeParse(undefined).success).toBe(false);
+  });
+});
+
+describe('team_rename', () => {
+  const ARGS = { classroom: 'org/w26', team: 'team-rocket', new_name: 'Team Magma' };
+
+  it('renames via the service and audits the UPDATE', async () => {
+    mocks.renameTeam.mockResolvedValue({
+      teamId: 'team-1',
+      newName: 'Team Magma',
+      newSlug: 'team-magma',
+      renamedRepos: ['hw1-team-magma'],
+      failed: [],
+    });
+
+    const payload = parse(await teamRenameTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      team_id: 'team-1',
+      new_name: 'Team Magma',
+      new_slug: 'team-magma',
+      renamed_repos: ['hw1-team-magma'],
+      failed: [],
+      failed_count: 0,
+    });
+    expect(payload.warning).toBeUndefined();
+
+    expect(mocks.renameTeam).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      slugOrId: 'team-rocket',
+      newName: 'Team Magma',
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_rename', new_slug: 'team-magma' });
+  });
+
+  it('surfaces failed repository renames prominently (they cannot be retried)', async () => {
+    mocks.renameTeam.mockResolvedValue({
+      teamId: 'team-1',
+      newName: 'Team Magma',
+      newSlug: 'team-magma',
+      renamedRepos: ['hw1-team-magma'],
+      failed: [{ name: 'hw2-team-rocket', error: 'Not Found' }],
+    });
+
+    const payload = parse(await teamRenameTool.handler(ARGS, CTX));
+    expect(payload.failed).toEqual([{ name: 'hw2-team-rocket', error: 'Not Found' }]);
+    expect(payload.failed_count).toBe(1);
+    // Top-level, not buried: the client must not miss a partial rename.
+    expect(payload.warning).toContain('hw2-team-rocket');
+    expect(payload.warning).toContain('by hand');
+    expect(payload.message).toContain('old name');
+    // The failure is on the audit row too.
+    expect(auditRow().data).toMatchObject({ failed_repos: ['hw2-team-rocket'] });
+  });
+
+  it('refuses an unknown / cross-classroom team and audits nothing', async () => {
+    mocks.renameTeam.mockRejectedValue(
+      new TeamServiceError('team_not_found', '[team] no team "nope" in classroom class-1')
+    );
+
+    await expect(teamRenameTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Team not found in this classroom',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('maps provider_unsupported to invalid_params', async () => {
+    mocks.renameTeam.mockRejectedValue(
+      new TeamServiceError(
+        'provider_unsupported',
+        '[team] renaming a team is only supported for GitHub organizations'
+      )
+    );
+
+    await expect(teamRenameTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'invalid_params',
+      message: 'renaming a team is only supported for GitHub organizations',
+    });
+  });
+});
+
+describe('team_members_add', () => {
+  const ARGS = { classroom: 'org/w26', team: 'team-rocket', logins: ['ada', 'Grace'] };
+
+  it('adds classroom members via the service and audits the UPDATE', async () => {
+    mocks.addTeamMembers.mockResolvedValue({
+      succeeded: [{ login: 'ada' }],
+      failed: [{ login: 'Grace', error: 'Not Found' }],
+    });
+
+    const payload = parse(await teamMembersAddTool.handler(ARGS, CTX));
+    expect(payload).toEqual({
+      success: true,
+      team_id: 'team-1',
+      team_slug: 'team-rocket',
+      succeeded: ['ada'],
+      succeeded_count: 1,
+      failed: [{ login: 'Grace', error: 'Not Found' }],
+      failed_count: 1,
+    });
+    expectNoServiceRowLeak(payload);
+
+    expect(mocks.addTeamMembers).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      slugOrId: 'team-rocket',
+      logins: ['ada', 'Grace'],
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.classroom_id).toBe('class-1');
+    // addTeamMembers returns no team id, so the team is resolved first purely
+    // to keep the audit row (and its dedup key) team-specific.
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_members_add', succeeded: ['ada'] });
+  });
+
+  it('rejects logins that are not classroom members BEFORE any service call', async () => {
+    await expect(
+      teamMembersAddTool.handler({ ...ARGS, logins: ['ada', 'mallory'] }, CTX)
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      data: { logins: ['mallory'] },
+    });
+
+    // Nothing was attempted: no GitHub call, no membership write, no audit row.
+    for (const mock of teamAdminMocks()) expect(mock).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('matches classroom membership case-insensitively and dedupes repeats', async () => {
+    mocks.addTeamMembers.mockResolvedValue({ succeeded: [{ login: 'ada' }], failed: [] });
+
+    // 'Ada', '@ada' and 'ada' are one person; 'grace' matches the stored 'Grace'.
+    await teamMembersAddTool.handler({ ...ARGS, logins: ['Ada', '@ada', 'grace'] }, CTX);
+
+    expect(mocks.addTeamMembers).toHaveBeenCalledWith(
+      expect.objectContaining({ logins: ['Ada', 'grace'] })
+    );
+  });
+
+  it('refuses an unknown / cross-classroom team before the membership check', async () => {
+    mocks.findTeamsByClassroomId.mockResolvedValue([TEAM_ROW]);
+
+    await expect(
+      teamMembersAddTool.handler({ ...ARGS, team: 'not-a-team' }, CTX)
+    ).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Team not found in this classroom',
+    });
+
+    // The team lookup is classroom-scoped, and nothing else ran.
+    expect(mocks.findTeamsByClassroomId).toHaveBeenCalledWith('class-1');
+    for (const mock of teamAdminMocks()) expect(mock).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('team_member_remove', () => {
+  const ARGS = { classroom: 'org/w26', team: 'team-rocket', login: 'ada' };
+
+  it('removes via the service and audits the UPDATE', async () => {
+    mocks.removeTeamMember.mockResolvedValue({ teamId: 'team-1', login: 'ada', removed: true });
+
+    const payload = parse(await teamMemberRemoveTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({
+      success: true,
+      team_id: 'team-1',
+      login: 'ada',
+      removed: true,
+    });
+
+    expect(mocks.removeTeamMember).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      slugOrId: 'team-rocket',
+      login: 'ada',
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_member_remove', removed: true });
+  });
+
+  it('is idempotent: a non-member still succeeds and reports removed:false', async () => {
+    mocks.removeTeamMember.mockResolvedValue({ teamId: 'team-1', login: 'ada', removed: false });
+
+    const payload = parse(await teamMemberRemoveTool.handler(ARGS, CTX));
+    expect(payload).toMatchObject({ success: true, removed: false });
+    expect(payload.message).toContain('no membership row');
+    expect(teamMemberRemoveTool.annotations).toMatchObject({ idempotent: true });
+  });
+
+  it('maps user_not_found to a plain not_found', async () => {
+    mocks.removeTeamMember.mockRejectedValue(
+      new TeamServiceError('user_not_found', '[team] no user with login nope')
+    );
+
+    await expect(teamMemberRemoveTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'No Classmoji user with that login',
+    });
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown / cross-classroom team', async () => {
+    mocks.removeTeamMember.mockRejectedValue(
+      new TeamServiceError('team_not_found', '[team] no team "nope" in classroom class-1')
+    );
+
+    await expect(teamMemberRemoveTool.handler(ARGS, CTX)).rejects.toMatchObject({
+      kind: 'not_found',
+      message: 'Team not found in this classroom',
+    });
+  });
+});
+
+describe('team_tag_add', () => {
+  const ARGS = { classroom: 'org/w26', team: 'team-rocket', tag_ids: ['tag-1', 'tag-9'] };
+
+  it('attaches tags via the service and audits the UPDATE', async () => {
+    mocks.addTeamTags.mockResolvedValue({
+      added: ['tag-1'],
+      failed: [{ tagId: 'tag-9', error: 'Tag does not belong to this classroom' }],
+    });
+
+    const payload = parse(await teamTagAddTool.handler(ARGS, CTX));
+    expect(payload).toEqual({
+      success: true,
+      team_id: 'team-1',
+      team_slug: 'team-rocket',
+      added: ['tag-1'],
+      added_count: 1,
+      failed: [{ tag_id: 'tag-9', error: 'Tag does not belong to this classroom' }],
+      failed_count: 1,
+    });
+    expectNoServiceRowLeak(payload);
+
+    expect(mocks.addTeamTags).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      slugOrId: 'team-rocket',
+      tagIds: ['tag-1', 'tag-9'],
+    });
+
+    const audit = auditRow();
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_tag_add', added: ['tag-1'] });
+  });
+
+  it('refuses an unknown / cross-classroom team with zero service calls', async () => {
+    await expect(
+      teamTagAddTool.handler({ ...ARGS, team: 'other-class-team' }, CTX)
+    ).rejects.toMatchObject({ kind: 'not_found', message: 'Team not found in this classroom' });
+    for (const mock of teamAdminMocks()) expect(mock).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('team_tag_remove', () => {
+  const REMOVED = { teamTagId: 'tt-1', teamId: 'team-1', tagId: 'tag-1' };
+
+  it('resolves the TeamTag row from a tag name and detaches it via the service', async () => {
+    mocks.removeTeamTag.mockResolvedValue(REMOVED);
+
+    const payload = parse(
+      await teamTagRemoveTool.handler(
+        { classroom: 'org/w26', team: 'team-rocket', tag_name: 'frontend' },
+        CTX
+      )
+    );
+    expect(payload).toEqual({
+      success: true,
+      team_id: 'team-1',
+      team_slug: 'team-rocket',
+      tag_id: 'tag-1',
+      tag_name: 'frontend',
+      team_tag_id: 'tt-1',
+    });
+    expectNoServiceRowLeak(payload);
+
+    // The row id is resolved in-handler (list_teams exposes tag names only) and
+    // the service stays the single mutation path.
+    expect(mocks.removeTeamTag).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      teamTagId: 'tt-1',
+    });
+
+    const audit = auditRow();
+    expect(audit.action).toBe('UPDATE');
+    expect(audit.resource_id).toBe('team-1');
+    expect(audit.data).toMatchObject({ tool: 'team_tag_remove', tag_id: 'tag-1' });
+  });
+
+  it('accepts a tag id as well', async () => {
+    mocks.removeTeamTag.mockResolvedValue({ ...REMOVED, teamTagId: 'tt-2', tagId: 'tag-2' });
+
+    const payload = parse(
+      await teamTagRemoveTool.handler(
+        { classroom: 'org/w26', team: 'team-1', tag_id: 'tag-2' },
+        CTX
+      )
+    );
+    expect(payload).toMatchObject({ tag_id: 'tag-2', team_tag_id: 'tt-2' });
+    expect(mocks.removeTeamTag).toHaveBeenCalledWith({
+      classroomId: 'class-1',
+      teamTagId: 'tt-2',
+    });
+  });
+
+  it('falls back to a case-insensitive name match', async () => {
+    mocks.removeTeamTag.mockResolvedValue(REMOVED);
+
+    await teamTagRemoveTool.handler(
+      { classroom: 'org/w26', team: 'team-rocket', tag_name: 'FrontEnd' },
+      CTX
+    );
+    expect(mocks.removeTeamTag).toHaveBeenCalledWith({ classroomId: 'class-1', teamTagId: 'tt-1' });
+  });
+
+  it('refuses an ambiguous case-insensitive name instead of guessing', async () => {
+    mocks.findTeamsByClassroomId.mockResolvedValue([
+      {
+        ...TEAM_ROW,
+        tags: [
+          { id: 'tt-1', tag_id: 'tag-1', tag: { id: 'tag-1', name: 'frontend' } },
+          { id: 'tt-3', tag_id: 'tag-3', tag: { id: 'tag-3', name: 'Frontend' } },
+        ],
+      },
+    ]);
+
+    await expect(
+      teamTagRemoveTool.handler(
+        { classroom: 'org/w26', team: 'team-rocket', tag_name: 'FRONTEND' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'invalid_params' });
+    expect(mocks.removeTeamTag).not.toHaveBeenCalled();
+  });
+
+  it('prefers the exact name when a case-variant also exists', async () => {
+    mocks.findTeamsByClassroomId.mockResolvedValue([
+      {
+        ...TEAM_ROW,
+        tags: [
+          { id: 'tt-1', tag_id: 'tag-1', tag: { id: 'tag-1', name: 'frontend' } },
+          { id: 'tt-3', tag_id: 'tag-3', tag: { id: 'tag-3', name: 'Frontend' } },
+        ],
+      },
+    ]);
+    mocks.removeTeamTag.mockResolvedValue({ ...REMOVED, teamTagId: 'tt-3', tagId: 'tag-3' });
+
+    await teamTagRemoveTool.handler(
+      { classroom: 'org/w26', team: 'team-rocket', tag_name: 'Frontend' },
+      CTX
+    );
+    expect(mocks.removeTeamTag).toHaveBeenCalledWith({ classroomId: 'class-1', teamTagId: 'tt-3' });
+  });
+
+  it('refuses a tag that is not on this team (uniform scopedNotFound)', async () => {
+    await expect(
+      teamTagRemoveTool.handler(
+        { classroom: 'org/w26', team: 'team-rocket', tag_name: 'backend' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'not_found', message: 'Tag not found in this classroom' });
+    expect(mocks.removeTeamTag).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown / cross-classroom team with zero service calls', async () => {
+    await expect(
+      teamTagRemoveTool.handler(
+        { classroom: 'org/w26', team: 'other-class-team', tag_name: 'frontend' },
+        CTX
+      )
+    ).rejects.toMatchObject({ kind: 'not_found', message: 'Team not found in this classroom' });
+    expect(mocks.findTeamsByClassroomId).toHaveBeenCalledWith('class-1');
+    for (const mock of teamAdminMocks()) expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('requires one of tag_name / tag_id', async () => {
+    await expect(
+      teamTagRemoveTool.handler({ classroom: 'org/w26', team: 'team-rocket' }, CTX)
+    ).rejects.toMatchObject({ kind: 'invalid_params', message: 'Provide tag_name or tag_id' });
+    expect(mocks.findTeamsByClassroomId).not.toHaveBeenCalled();
+  });
+});
+
+describe('tool declarations', () => {
+  const TOOLS = [
+    teamCreateTool,
+    teamDeleteTool,
+    teamRenameTool,
+    teamMembersAddTool,
+    teamMemberRemoveTool,
+    teamTagAddTool,
+    teamTagRemoveTool,
+  ];
+
+  it('are all OWNER-only write tools taking a classroom argument', () => {
+    for (const tool of TOOLS) {
+      expect(tool.scope).toBe('write');
+      expect(tool.roles).toEqual(['OWNER']);
+      expect(tool.inputSchema.classroom).toBeDefined();
+    }
+  });
+
+  it('declare the GitHub-touching tools as openWorld and the tag tools as local', () => {
+    for (const tool of [
+      teamCreateTool,
+      teamDeleteTool,
+      teamRenameTool,
+      teamMembersAddTool,
+      teamMemberRemoveTool,
+    ]) {
+      expect(tool.annotations?.openWorld).toBe(true);
+    }
+    expect(teamTagAddTool.annotations?.openWorld).toBe(false);
+    expect(teamTagRemoveTool.annotations?.openWorld).toBe(false);
+  });
+
+  it('flag the removals as destructive and the additions as not', () => {
+    expect(teamDeleteTool.annotations?.destructive).toBe(true);
+    expect(teamMemberRemoveTool.annotations?.destructive).toBe(true);
+    expect(teamTagRemoveTool.annotations?.destructive).toBe(true);
+    expect(teamCreateTool.annotations?.destructive).toBe(false);
+    expect(teamRenameTool.annotations?.destructive).toBe(false);
+    expect(teamMembersAddTool.annotations?.destructive).toBe(false);
+    expect(teamTagAddTool.annotations?.destructive).toBe(false);
+  });
+});

--- a/apps/mcp/src/tools/__tests__/teams.test.ts
+++ b/apps/mcp/src/tools/__tests__/teams.test.ts
@@ -43,6 +43,10 @@ vi.mock('@classmoji/services', () => {
   }
   return {
     TeamServiceError,
+    // The reason→phrase mapper is pure; the tools only need it to produce a
+    // non-empty phrase per code, so the fake keeps the test independent of the
+    // exact wording.
+    describeTeamFailureReason: (reason: string) => `reason:${reason}`,
     ClassmojiService: {
       teamAdmin: {
         createTeam: (...a: unknown[]) => mocks.createTeam(...a),
@@ -156,7 +160,7 @@ describe('team_create', () => {
     mocks.createTeam.mockResolvedValue({
       team: { id: 'team-1', name: 'Team Rocket', slug: 'team-rocket', isVisible: false },
       tagsAdded: ['tag-1'],
-      tagsFailed: [{ tagId: 'tag-9', error: 'Tag does not belong to this classroom' }],
+      tagsFailed: [{ tagId: 'tag-9', error: 'invalid' }],
     });
 
     const payload = parse(await teamCreateTool.handler(ARGS, CTX));
@@ -164,7 +168,8 @@ describe('team_create', () => {
       success: true,
       team: { id: 'team-1', name: 'Team Rocket', slug: 'team-rocket', is_visible: false },
       tags_added: ['tag-1'],
-      tags_failed: [{ tag_id: 'tag-9', error: 'Tag does not belong to this classroom' }],
+      // The service's closed reason vocabulary, plus its phrase.
+      tags_failed: [{ tag_id: 'tag-9', error: 'invalid', error_description: expect.any(String) }],
     });
 
     // classroomId comes from ctx, never from args; is_visible defaults to false.
@@ -254,6 +259,8 @@ describe('team_delete', () => {
       name: 'Team Rocket',
       slug: 'team-rocket',
       removedFromProvider: true,
+      reposDeleted: 0,
+      deletedRepoNames: [],
     });
 
     const payload = parse(await teamDeleteTool.handler(ARGS, CTX));
@@ -262,6 +269,7 @@ describe('team_delete', () => {
       id: 'team-1',
       slug: 'team-rocket',
       removed_from_provider: true,
+      repos_deleted: 0,
     });
 
     expect(mocks.deleteTeam).toHaveBeenCalledWith({
@@ -282,10 +290,39 @@ describe('team_delete', () => {
       name: 'Team Rocket',
       slug: 'team-rocket',
       removedFromProvider: false,
+      reposDeleted: 0,
+      deletedRepoNames: [],
     });
 
     const payload = parse(await teamDeleteTool.handler(ARGS, CTX));
     expect(payload.removed_from_provider).toBe(false);
+  });
+
+  it('carries the blast radius into the response, the message and the audit row', async () => {
+    mocks.deleteTeam.mockResolvedValue({
+      id: 'team-1',
+      name: 'Team Rocket',
+      slug: 'team-rocket',
+      removedFromProvider: true,
+      reposDeleted: 3,
+      deletedRepoNames: ['hw1-team-rocket', 'hw2-team-rocket', 'hw3-team-rocket'],
+    });
+
+    const payload = parse(await teamDeleteTool.handler(ARGS, CTX));
+    expect(payload.repos_deleted).toBe(3);
+    expect(payload.deleted_repo_names).toEqual([
+      'hw1-team-rocket',
+      'hw2-team-rocket',
+      'hw3-team-rocket',
+    ]);
+    expect(payload.message).toContain('3 linked repository record(s)');
+
+    // The repo records are gone, so the audit trail is the only remaining
+    // record of what the delete took with it.
+    expect(auditRow().data).toMatchObject({
+      repos_deleted: 3,
+      deleted_repo_names: ['hw1-team-rocket', 'hw2-team-rocket', 'hw3-team-rocket'],
+    });
   });
 
   it('refuses an unknown / cross-classroom team and audits nothing', async () => {
@@ -352,11 +389,19 @@ describe('team_rename', () => {
       newName: 'Team Magma',
       newSlug: 'team-magma',
       renamedRepos: ['hw1-team-magma'],
-      failed: [{ name: 'hw2-team-rocket', error: 'Not Found' }],
+      failed: [{ name: 'hw2-team-rocket', error: 'provider_error' }],
     });
 
     const payload = parse(await teamRenameTool.handler(ARGS, CTX));
-    expect(payload.failed).toEqual([{ name: 'hw2-team-rocket', error: 'Not Found' }]);
+    // The service's closed reason vocabulary, plus its phrase — never a raw
+    // provider message.
+    expect(payload.failed).toEqual([
+      {
+        name: 'hw2-team-rocket',
+        error: 'provider_error',
+        error_description: expect.any(String),
+      },
+    ]);
     expect(payload.failed_count).toBe(1);
     // Top-level, not buried: the client must not miss a partial rename.
     expect(payload.warning).toContain('hw2-team-rocket');
@@ -399,7 +444,7 @@ describe('team_members_add', () => {
   it('adds classroom members via the service and audits the UPDATE', async () => {
     mocks.addTeamMembers.mockResolvedValue({
       succeeded: [{ login: 'ada' }],
-      failed: [{ login: 'Grace', error: 'Not Found' }],
+      failed: [{ login: 'Grace', error: 'provider_error' }],
     });
 
     const payload = parse(await teamMembersAddTool.handler(ARGS, CTX));
@@ -409,7 +454,7 @@ describe('team_members_add', () => {
       team_slug: 'team-rocket',
       succeeded: ['ada'],
       succeeded_count: 1,
-      failed: [{ login: 'Grace', error: 'Not Found' }],
+      failed: [{ login: 'Grace', error: 'provider_error', error_description: expect.any(String) }],
       failed_count: 1,
     });
     expectNoServiceRowLeak(payload);
@@ -463,8 +508,10 @@ describe('team_members_add', () => {
       message: 'Team not found in this classroom',
     });
 
-    // The team lookup is classroom-scoped, and nothing else ran.
+    // The team lookup is classroom-scoped, and nothing else ran — not even the
+    // membership check, which is what "before" means here.
     expect(mocks.findTeamsByClassroomId).toHaveBeenCalledWith('class-1');
+    expect(mocks.findMembershipsByClassroomId).not.toHaveBeenCalled();
     for (const mock of teamAdminMocks()) expect(mock).not.toHaveBeenCalled();
     expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
@@ -505,7 +552,9 @@ describe('team_member_remove', () => {
     expect(teamMemberRemoveTool.annotations).toMatchObject({ idempotent: true });
   });
 
-  it('maps user_not_found to a plain not_found', async () => {
+  it('keeps mapping the service user_not_found as a backstop', async () => {
+    // The pre-check makes this branch unreachable through the tool, but the
+    // mapping stays: the service is the shared path, not a private one.
     mocks.removeTeamMember.mockRejectedValue(
       new TeamServiceError('user_not_found', '[team] no user with login nope')
     );
@@ -515,6 +564,47 @@ describe('team_member_remove', () => {
       message: 'No Classmoji user with that login',
     });
     expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a login that is not a classroom member BEFORE any service call', async () => {
+    await expect(
+      teamMemberRemoveTool.handler({ ...ARGS, login: 'mallory' }, CTX)
+    ).rejects.toMatchObject({
+      kind: 'invalid_params',
+      data: { logins: ['mallory'] },
+    });
+
+    for (const mock of teamAdminMocks()) expect(mock).not.toHaveBeenCalled();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('answers a login with no Classmoji user exactly as it answers a non-member', async () => {
+    // Both refusals must look identical, so the tool never reports whether an
+    // account exists on the platform.
+    const nonMember = await teamMemberRemoveTool
+      .handler({ ...ARGS, login: 'grace-from-another-class' }, CTX)
+      .catch((e: unknown) => e);
+    const unknownUser = await teamMemberRemoveTool
+      .handler({ ...ARGS, login: 'nobody-at-all' }, CTX)
+      .catch((e: unknown) => e);
+
+    const shape = (e: unknown) => ({
+      kind: (e as { kind: string }).kind,
+      message: (e as { message: string }).message.replace(/: .*$/, ''),
+    });
+    expect(shape(nonMember)).toEqual(shape(unknownUser));
+    expect(shape(nonMember).kind).toBe('invalid_params');
+  });
+
+  it('matches classroom membership case-insensitively', async () => {
+    mocks.removeTeamMember.mockResolvedValue({ teamId: 'team-1', login: 'Grace', removed: true });
+
+    // The roster stores 'Grace'; '@grace' is the same person.
+    await teamMemberRemoveTool.handler({ ...ARGS, login: '@grace' }, CTX);
+
+    expect(mocks.removeTeamMember).toHaveBeenCalledWith(
+      expect.objectContaining({ login: '@grace' })
+    );
   });
 
   it('refuses an unknown / cross-classroom team', async () => {
@@ -535,7 +625,7 @@ describe('team_tag_add', () => {
   it('attaches tags via the service and audits the UPDATE', async () => {
     mocks.addTeamTags.mockResolvedValue({
       added: ['tag-1'],
-      failed: [{ tagId: 'tag-9', error: 'Tag does not belong to this classroom' }],
+      failed: [{ tagId: 'tag-9', error: 'invalid' }],
     });
 
     const payload = parse(await teamTagAddTool.handler(ARGS, CTX));
@@ -545,7 +635,7 @@ describe('team_tag_add', () => {
       team_slug: 'team-rocket',
       added: ['tag-1'],
       added_count: 1,
-      failed: [{ tag_id: 'tag-9', error: 'Tag does not belong to this classroom' }],
+      failed: [{ tag_id: 'tag-9', error: 'invalid', error_description: expect.any(String) }],
       failed_count: 1,
     });
     expectNoServiceRowLeak(payload);

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -50,6 +50,12 @@ import { extensionPurchaseTool } from './extensions.ts';
 import { repoCreateTool, repoPublishTool, repoUnpublishTool } from './repos.ts';
 import { rosterAddStudentTool, rosterRemoveStudentTool } from './roster.ts';
 import { assistantAddTool, assistantUpdateTool, assistantRemoveTool } from './assistants.ts';
+import { quizCreateTool, quizUpdateTool, quizPublishTool, quizDeleteTool } from './quizzes.ts';
+import {
+  classroomSettingsUpdateTool,
+  classroomStatusUpdateTool,
+  orgRepoSettingsUpdateTool,
+} from './settings.ts';
 
 export function registerAllTools(): void {
   // Identity / bootstrap
@@ -123,6 +129,13 @@ export function registerAllTools(): void {
   registerToolDefinition(deckPreviewAcceptTool);
   registerToolDefinition(deckPreviewDiscardTool);
 
+  // Quizzes (OWNER+ASSISTANT — the quiz surface excludes TEACHER; each tool
+  // also re-checks Pro tier + quizzes_enabled in-handler)
+  registerToolDefinition(quizCreateTool);
+  registerToolDefinition(quizUpdateTool);
+  registerToolDefinition(quizPublishTool);
+  registerToolDefinition(quizDeleteTool);
+
   // Tokens (OWNER)
   registerToolDefinition(tokenGrantTool);
 
@@ -143,4 +156,11 @@ export function registerAllTools(): void {
   registerToolDefinition(repoCreateTool);
   registerToolDefinition(repoPublishTool);
   registerToolDefinition(repoUnpublishTool);
+
+  // Classroom settings + lifecycle status (OWNER). The org tool writes
+  // ORGANIZATION-WIDE GitHub settings, so it sits beside the repo tools it
+  // affects and carries a tighter rate limit.
+  registerToolDefinition(classroomSettingsUpdateTool);
+  registerToolDefinition(classroomStatusUpdateTool);
+  registerToolDefinition(orgRepoSettingsUpdateTool);
 }

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -56,6 +56,15 @@ import {
   classroomStatusUpdateTool,
   orgRepoSettingsUpdateTool,
 } from './settings.ts';
+import {
+  teamCreateTool,
+  teamDeleteTool,
+  teamRenameTool,
+  teamMembersAddTool,
+  teamMemberRemoveTool,
+  teamTagAddTool,
+  teamTagRemoveTool,
+} from './teams.ts';
 
 export function registerAllTools(): void {
   // Identity / bootstrap
@@ -163,4 +172,15 @@ export function registerAllTools(): void {
   registerToolDefinition(classroomSettingsUpdateTool);
   registerToolDefinition(classroomStatusUpdateTool);
   registerToolDefinition(orgRepoSettingsUpdateTool);
+
+  // Teams (OWNER — the write surface behind list_teams). create/rename/members
+  // touch real GitHub teams; delete is destructive and confirm-gated; the tag
+  // tools are Classmoji-only links.
+  registerToolDefinition(teamCreateTool);
+  registerToolDefinition(teamDeleteTool);
+  registerToolDefinition(teamRenameTool);
+  registerToolDefinition(teamMembersAddTool);
+  registerToolDefinition(teamMemberRemoveTool);
+  registerToolDefinition(teamTagAddTool);
+  registerToolDefinition(teamTagRemoveTool);
 }

--- a/apps/mcp/src/tools/quizzes.ts
+++ b/apps/mcp/src/tools/quizzes.ts
@@ -253,7 +253,8 @@ interface QuizServiceUpdate {
   rubricPrompt?: string;
   subject?: string;
   difficultyLevel?: string;
-  dueDate?: string;
+  /** null clears the due date; the service maps a falsy value to null. */
+  dueDate?: string | null;
   status?: 'DRAFT' | 'CLOSED';
   weight?: number;
   questionCount?: number;
@@ -269,7 +270,7 @@ interface QuizUpdateArgs {
   rubric_prompt?: string;
   system_prompt?: string;
   repository_id?: string | null;
-  due_date?: string;
+  due_date?: string | null;
   status?: 'DRAFT' | 'CLOSED';
   weight?: number;
   question_count?: number;
@@ -289,7 +290,8 @@ export const quizUpdateTool: ToolDefinition<QuizUpdateArgs> = {
     'and quizzes enabled. Provide at least one field. status accepts only DRAFT (unpublish, ' +
     'hiding it from students again) or CLOSED (stop new attempts); publishing must go through ' +
     'quiz_publish, because only that path notifies students. Set repository_id to null to unlink ' +
-    'the repo. Editing prompts does not re-grade attempts already taken.',
+    'the repo, or due_date to null to clear the deadline. Editing prompts does not re-grade ' +
+    'attempts already taken.',
   scope: 'write',
   roles: OWNER_ASSISTANT,
   inputSchema: {
@@ -313,7 +315,9 @@ export const quizUpdateTool: ToolDefinition<QuizUpdateArgs> = {
       .nullable()
       .optional()
       .describe('Repo (assignment container) this quiz is about; null unlinks it'),
-    due_date: dueDateSchema.optional(),
+    // Nullable here but not on quiz_create: an update has an existing value to
+    // clear, and `set()` forwards null while it skips undefined.
+    due_date: dueDateSchema.nullable().optional().describe('Due date (ISO 8601); null clears it'),
     status: z
       .enum(['DRAFT', 'CLOSED'])
       .optional()
@@ -400,10 +404,10 @@ export const quizPublishTool: ToolDefinition<QuizPublishArgs> = {
   title: 'Publish a quiz',
   description:
     'Publishes a quiz so students can take it. Owner/assistant only; requires a Pro subscription ' +
-    'and quizzes enabled. This is the ONLY path that notifies students — every student in the ' +
-    'classroom gets a "Quiz published" notification, but only on the transition INTO published, ' +
-    'so republishing an already-published quiz notifies nobody. The response reports whether ' +
-    'students were notified. Use quiz_update with status DRAFT to unpublish.',
+    'and quizzes enabled. This is the ONLY path that notifies students — they get a "Quiz ' +
+    'published" notification, but only on the transition INTO published, so republishing an ' +
+    'already-published quiz notifies nobody. The response reports whether students were ' +
+    'notified. Use quiz_update with status DRAFT to unpublish.',
   scope: 'write',
   roles: OWNER_ASSISTANT,
   inputSchema: {
@@ -438,7 +442,7 @@ export const quizPublishTool: ToolDefinition<QuizPublishArgs> = {
       previous_status: quiz.status,
       students_notified: notified,
       message: notified
-        ? 'Quiz published — every student in the classroom has been notified.'
+        ? 'Quiz published — students have been notified.'
         : 'Quiz was already published — nothing changed and no notifications were sent.',
     });
   },

--- a/apps/mcp/src/tools/quizzes.ts
+++ b/apps/mcp/src/tools/quizzes.ts
@@ -1,0 +1,495 @@
+/**
+ * Quiz tools — quiz_create / quiz_update / quiz_publish / quiz_delete.
+ *
+ * ROUTE-DERIVED TIER: the web actions live in
+ * apps/webapp/app/routes/admin.$class.quizzes/route.tsx, gated by
+ * assertClassroomAccess with allowedRoles ['OWNER','ASSISTANT'] — TEACHER is
+ * genuinely excluded from the quiz surface (S4 role parity), so these tools use
+ * OWNER_ASSISTANT, not TEACHING_TEAM.
+ *
+ * TWO EXTRA GATES run in-handler, because the registry pipeline (scope → rate
+ * limit → role → mutation gate) does not know about them:
+ *   1. Pro tier — the web action calls assertProTier before dispatching any
+ *      quiz mutation. We call the SAME helper the quizzes read resource uses
+ *      (resources/content.ts), so read and write cannot drift apart.
+ *   2. quizzes_enabled — read from the request's already-resolved, sanitized
+ *      classroom settings. The web app checks this in the LOADER only, not in
+ *      the action; MCP is deliberately stricter, so a classroom that has turned
+ *      quizzes off cannot be mutated through this surface either.
+ *
+ * Backbone: ClassmojiService.quiz.* — the same functions the web action calls.
+ * quiz.publish is the ONLY path that notifies students (it reads the previous
+ * status and fires QUIZ_PUBLISHED on a transition INTO published), which is why
+ * quiz_update refuses to set PUBLISHED: a status flip through quiz.update would
+ * publish the quiz silently.
+ *
+ * S1: every tool resolves its target through loadQuizInClassroom, comparing
+ * quiz.classroom_id against ctx.classroom.classroomId; a missing quiz and
+ * another classroom's quiz produce the identical scopedNotFound('Quiz').
+ *
+ * RESPONSES ARE ALLOW-LISTED: quiz.create/update return the row WITH
+ * `attempts: { include: { user: true } }` — full student User rows. Never echo
+ * a service return; every response here is built field-by-field by quizSummary.
+ */
+
+import { ClassmojiService } from '@classmoji/services';
+import { z } from 'zod';
+import { ToolError } from '../mcp/errors.ts';
+import type { ToolContext, ToolDefinition } from '../mcp/registry.ts';
+import { assertProTier } from '../resources/content.ts';
+import { sanitizedSettings } from '../resources/shape.ts';
+import {
+  loadQuizInClassroom,
+  loadRepositoryInClassroom,
+  ok,
+  OWNER_ASSISTANT,
+  requireClassroomCtx,
+  writeAudit,
+} from './shared.ts';
+
+/**
+ * The two quiz-surface gates the registry cannot apply, in the web's order:
+ * Pro subscription, then the classroom's quizzes_enabled flag. Settings come
+ * from the context the registry already resolved (getClassroomForUI's
+ * SAFE_SETTINGS_FIELDS whitelist, which includes quizzes_enabled) — the same
+ * values the quizzes read resource gates on, with no extra query.
+ */
+async function assertQuizSurfaceEnabled(ctx: ToolContext): Promise<void> {
+  await assertProTier(requireClassroomCtx(ctx).classroomId);
+  if (sanitizedSettings(ctx).quizzes_enabled === false) {
+    throw new ToolError('forbidden', 'Quizzes are disabled for this classroom');
+  }
+}
+
+/** Row shape the quiz service returns (only the fields we echo are named). */
+interface QuizRow {
+  id: string;
+  name: string;
+  status: string;
+  classroom_id: string;
+  repository_id?: string | null;
+  system_prompt?: string | null;
+  rubric_prompt?: string | null;
+  subject?: string | null;
+  difficulty_level?: string | null;
+  due_date?: Date | string | null;
+  weight?: number;
+  question_count?: number;
+  max_attempts?: number;
+  grading_strategy?: string;
+  include_code_context?: boolean;
+}
+
+/**
+ * Explicit response allowlist — mirrors the staff shape of the quizzes read
+ * resource. Never spread the service row: it carries every attempt with the
+ * student User record attached.
+ */
+function quizSummary(quiz: QuizRow) {
+  const dueDate = quiz.due_date;
+  return {
+    id: quiz.id,
+    name: quiz.name,
+    status: quiz.status,
+    repository_id: quiz.repository_id ?? null,
+    due_date: dueDate instanceof Date ? dueDate.toISOString() : (dueDate ?? null),
+    weight: quiz.weight ?? 0,
+    question_count: quiz.question_count ?? null,
+    max_attempts: quiz.max_attempts ?? null,
+    grading_strategy: quiz.grading_strategy ?? null,
+    include_code_context: quiz.include_code_context ?? false,
+    subject: quiz.subject ?? null,
+    difficulty_level: quiz.difficulty_level ?? null,
+    system_prompt: quiz.system_prompt ?? null,
+    rubric_prompt: quiz.rubric_prompt ?? null,
+  };
+}
+
+// ─── Shared field schemas (clamps mirror the service's own clamping) ────────
+
+const questionCountSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(20)
+  .describe('How many questions the AI asks in a session (1–20, default 5)');
+
+const maxAttemptsSchema = z
+  .number()
+  .int()
+  .min(0)
+  .describe('Maximum attempts per student; 0 = unlimited (default 1)');
+
+const weightSchema = z.number().int().min(0).max(100).describe('Grading weight (default 0)');
+
+const gradingStrategySchema = z
+  .enum(['HIGHEST', 'MOST_RECENT', 'FIRST'])
+  .describe('Which attempt counts toward the grade (default HIGHEST)');
+
+const dueDateSchema = z
+  .string()
+  .datetime({ offset: true })
+  .describe('Due date (ISO 8601, e.g. 2026-07-20T23:59:00-04:00)');
+
+interface QuizCreateArgs {
+  classroom: string;
+  name: string;
+  rubric_prompt: string;
+  repository_id?: string;
+  system_prompt?: string;
+  due_date?: string;
+  weight?: number;
+  question_count?: number;
+  difficulty_level?: string;
+  subject?: string;
+  include_code_context?: boolean;
+  grading_strategy?: 'HIGHEST' | 'MOST_RECENT' | 'FIRST';
+  max_attempts?: number;
+}
+
+export const quizCreateTool: ToolDefinition<QuizCreateArgs> = {
+  name: 'quiz_create',
+  // Creates one row; nothing is removed and no external system is touched.
+  annotations: { destructive: false, openWorld: false },
+  title: 'Create a quiz',
+  description:
+    'Creates an AI-conversation quiz. There is NO stored question bank: the AI generates and ' +
+    'asks questions live from rubric_prompt (required) and system_prompt, and question_count ' +
+    'just tells it how many to ask. Set include_code_context to have it explore the student’s ' +
+    'repository for the linked repo while questioning them. Owner/assistant only; requires a Pro ' +
+    'subscription and quizzes enabled. ALWAYS created as a DRAFT (students see nothing) — use ' +
+    'quiz_publish to go live and notify students.',
+  scope: 'write',
+  roles: OWNER_ASSISTANT,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    name: z.string().min(1).max(200).describe('Quiz name'),
+    rubric_prompt: z
+      .string()
+      .min(1)
+      .max(20000)
+      .describe('Required. What the AI should ask about and how it should grade the answers'),
+    system_prompt: z
+      .string()
+      .max(20000)
+      .optional()
+      .describe('Extra instructions steering the AI’s persona/behavior during the quiz'),
+    repository_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('Repo (assignment container) this quiz is about — required for code context'),
+    due_date: dueDateSchema.optional(),
+    weight: weightSchema.optional(),
+    question_count: questionCountSchema.optional(),
+    difficulty_level: z
+      .string()
+      .max(100)
+      .optional()
+      .describe("Free-text difficulty label (e.g. 'Beginner')"),
+    subject: z.string().max(200).optional().describe('Free-text subject label'),
+    include_code_context: z
+      .boolean()
+      .optional()
+      .describe('Let the AI read the student’s repo for the linked repository (default false)'),
+    grading_strategy: gradingStrategySchema.optional(),
+    max_attempts: maxAttemptsSchema.optional(),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+    await assertQuizSurfaceEnabled(ctx);
+
+    // S1: the quiz row does not exist yet, so a supplied repository is verified
+    // against the authorized classroom before it can be linked.
+    let repositoryId: string | undefined;
+    if (args.repository_id !== undefined) {
+      repositoryId = (await loadRepositoryInClassroom(args.repository_id, ctx)).id;
+    }
+
+    // classroomId is ALWAYS the authorized classroom, never request input, and
+    // status is pinned to DRAFT — publishing is quiz_publish's job because only
+    // that path notifies students.
+    const created = (await ClassmojiService.quiz.create({
+      classroomId: classroom.classroomId,
+      name: args.name,
+      rubricPrompt: args.rubric_prompt,
+      status: 'DRAFT',
+      ...(repositoryId !== undefined ? { repositoryId } : {}),
+      ...(args.system_prompt !== undefined ? { systemPrompt: args.system_prompt } : {}),
+      ...(args.due_date !== undefined ? { dueDate: args.due_date } : {}),
+      ...(args.weight !== undefined ? { weight: args.weight } : {}),
+      ...(args.question_count !== undefined ? { questionCount: args.question_count } : {}),
+      ...(args.difficulty_level !== undefined ? { difficultyLevel: args.difficulty_level } : {}),
+      ...(args.subject !== undefined ? { subject: args.subject } : {}),
+      ...(args.include_code_context !== undefined
+        ? { includeCodeContext: args.include_code_context }
+        : {}),
+      ...(args.grading_strategy !== undefined ? { gradingStrategy: args.grading_strategy } : {}),
+      ...(args.max_attempts !== undefined ? { maxAttempts: args.max_attempts } : {}),
+    })) as QuizRow;
+
+    await writeAudit(ctx, {
+      resource_type: 'QUIZ',
+      resource_id: created.id,
+      action: 'CREATE',
+      data: { tool: 'quiz_create', name: created.name, repository_id: repositoryId ?? null },
+    });
+
+    return ok({ success: true, quiz: quizSummary(created) });
+  },
+};
+
+/**
+ * The subset of the quiz service's update input these tools may write, in the
+ * service's own camelCase vocabulary. Declaring it explicitly is what makes
+ * "never forward caller args" checkable: an argument reaches the service only
+ * by being copied into one of these named keys. `status` is narrowed to the two
+ * values quiz_update accepts — PUBLISHED is reachable only via quiz.publish.
+ */
+interface QuizServiceUpdate {
+  name?: string;
+  repositoryId?: string | null;
+  systemPrompt?: string;
+  rubricPrompt?: string;
+  subject?: string;
+  difficultyLevel?: string;
+  dueDate?: string;
+  status?: 'DRAFT' | 'CLOSED';
+  weight?: number;
+  questionCount?: number;
+  includeCodeContext?: boolean;
+  maxAttempts?: number;
+  gradingStrategy?: 'HIGHEST' | 'MOST_RECENT' | 'FIRST';
+}
+
+interface QuizUpdateArgs {
+  classroom: string;
+  quiz_id: string;
+  name?: string;
+  rubric_prompt?: string;
+  system_prompt?: string;
+  repository_id?: string | null;
+  due_date?: string;
+  status?: 'DRAFT' | 'CLOSED';
+  weight?: number;
+  question_count?: number;
+  difficulty_level?: string;
+  subject?: string;
+  include_code_context?: boolean;
+  grading_strategy?: 'HIGHEST' | 'MOST_RECENT' | 'FIRST';
+  max_attempts?: number;
+}
+
+export const quizUpdateTool: ToolDefinition<QuizUpdateArgs> = {
+  name: 'quiz_update',
+  annotations: { destructive: false, openWorld: false },
+  title: 'Update a quiz',
+  description:
+    'Updates a quiz’s settings and prompts. Owner/assistant only; requires a Pro subscription ' +
+    'and quizzes enabled. Provide at least one field. status accepts only DRAFT (unpublish, ' +
+    'hiding it from students again) or CLOSED (stop new attempts); publishing must go through ' +
+    'quiz_publish, because only that path notifies students. Set repository_id to null to unlink ' +
+    'the repo. Editing prompts does not re-grade attempts already taken.',
+  scope: 'write',
+  roles: OWNER_ASSISTANT,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    quiz_id: z.string().uuid().describe('Quiz id'),
+    name: z.string().min(1).max(200).optional().describe('Quiz name'),
+    rubric_prompt: z
+      .string()
+      .min(1)
+      .max(20000)
+      .optional()
+      .describe('What the AI should ask about and how it should grade the answers'),
+    system_prompt: z
+      .string()
+      .max(20000)
+      .optional()
+      .describe('Extra instructions steering the AI’s persona/behavior during the quiz'),
+    repository_id: z
+      .string()
+      .uuid()
+      .nullable()
+      .optional()
+      .describe('Repo (assignment container) this quiz is about; null unlinks it'),
+    due_date: dueDateSchema.optional(),
+    status: z
+      .enum(['DRAFT', 'CLOSED'])
+      .optional()
+      .describe('DRAFT unpublishes, CLOSED stops new attempts. To PUBLISH, use quiz_publish'),
+    weight: weightSchema.optional(),
+    question_count: questionCountSchema.optional(),
+    difficulty_level: z.string().max(100).optional().describe('Free-text difficulty label'),
+    subject: z.string().max(200).optional().describe('Free-text subject label'),
+    include_code_context: z
+      .boolean()
+      .optional()
+      .describe('Let the AI read the student’s repo for the linked repository'),
+    grading_strategy: gradingStrategySchema.optional(),
+    max_attempts: maxAttemptsSchema.optional(),
+  },
+  handler: async (args, ctx) => {
+    await assertQuizSurfaceEnabled(ctx);
+
+    // Explicit field-by-field mapping (snake_case tool args → the service's
+    // camelCase input): nothing the caller sends is forwarded wholesale.
+    const updates: QuizServiceUpdate = {};
+    const fields: string[] = [];
+    const set = <K extends keyof QuizServiceUpdate>(
+      field: string,
+      key: K,
+      value: QuizServiceUpdate[K] | undefined
+    ) => {
+      if (value === undefined) return;
+      updates[key] = value;
+      fields.push(field);
+    };
+    set('name', 'name', args.name);
+    set('rubric_prompt', 'rubricPrompt', args.rubric_prompt);
+    set('system_prompt', 'systemPrompt', args.system_prompt);
+    set('due_date', 'dueDate', args.due_date);
+    set('status', 'status', args.status);
+    set('weight', 'weight', args.weight);
+    set('question_count', 'questionCount', args.question_count);
+    set('difficulty_level', 'difficultyLevel', args.difficulty_level);
+    set('subject', 'subject', args.subject);
+    set('include_code_context', 'includeCodeContext', args.include_code_context);
+    set('grading_strategy', 'gradingStrategy', args.grading_strategy);
+    set('max_attempts', 'maxAttempts', args.max_attempts);
+    if (args.repository_id !== undefined) fields.push('repository_id');
+
+    if (fields.length === 0) {
+      throw new ToolError('invalid_params', 'Provide at least one field to update');
+    }
+
+    // S1 before any write: the quiz must belong to the authorized classroom.
+    const quiz = await loadQuizInClassroom(args.quiz_id, ctx);
+
+    if (args.repository_id !== undefined) {
+      // null disconnects; a value must first prove it lives in this classroom.
+      updates.repositoryId =
+        args.repository_id === null
+          ? null
+          : (await loadRepositoryInClassroom(args.repository_id, ctx)).id;
+    }
+
+    const updated = (await ClassmojiService.quiz.update(quiz.id, updates)) as QuizRow;
+
+    await writeAudit(ctx, {
+      resource_type: 'QUIZ',
+      resource_id: quiz.id,
+      action: 'UPDATE',
+      data: { tool: 'quiz_update', fields },
+    });
+
+    return ok({ success: true, quiz: quizSummary(updated) });
+  },
+};
+
+interface QuizPublishArgs {
+  classroom: string;
+  quiz_id: string;
+}
+
+export const quizPublishTool: ToolDefinition<QuizPublishArgs> = {
+  name: 'quiz_publish',
+  // Sets one status; republishing an already-published quiz changes nothing
+  // (and notifies nobody a second time) → idempotent.
+  annotations: { destructive: false, idempotent: true, openWorld: false },
+  title: 'Publish a quiz',
+  description:
+    'Publishes a quiz so students can take it. Owner/assistant only; requires a Pro subscription ' +
+    'and quizzes enabled. This is the ONLY path that notifies students — every student in the ' +
+    'classroom gets a "Quiz published" notification, but only on the transition INTO published, ' +
+    'so republishing an already-published quiz notifies nobody. The response reports whether ' +
+    'students were notified. Use quiz_update with status DRAFT to unpublish.',
+  scope: 'write',
+  roles: OWNER_ASSISTANT,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    quiz_id: z.string().uuid().describe('Quiz id'),
+  },
+  handler: async (args, ctx) => {
+    await assertQuizSurfaceEnabled(ctx);
+    const quiz = await loadQuizInClassroom(args.quiz_id, ctx);
+
+    // Read the pre-publish status from the record we already loaded: the
+    // service notifies only on a transition INTO published, and after the call
+    // the row says PUBLISHED either way.
+    const notified = quiz.status !== 'PUBLISHED';
+
+    const published = (await ClassmojiService.quiz.publish(quiz.id)) as QuizRow;
+
+    await writeAudit(ctx, {
+      resource_type: 'QUIZ',
+      resource_id: quiz.id,
+      action: 'UPDATE',
+      data: {
+        tool: 'quiz_publish',
+        previous_status: quiz.status,
+        students_notified: notified,
+      },
+    });
+
+    return ok({
+      success: true,
+      quiz: quizSummary(published),
+      previous_status: quiz.status,
+      students_notified: notified,
+      message: notified
+        ? 'Quiz published — every student in the classroom has been notified.'
+        : 'Quiz was already published — nothing changed and no notifications were sent.',
+    });
+  },
+};
+
+interface QuizDeleteArgs {
+  classroom: string;
+  quiz_id: string;
+  confirm: true;
+}
+
+export const quizDeleteTool: ToolDefinition<QuizDeleteArgs> = {
+  name: 'quiz_delete',
+  // Cascade-deletes every attempt → destructive, confirm-gated by the schema.
+  annotations: { destructive: true, openWorld: false },
+  title: 'Delete a quiz',
+  description:
+    'Permanently deletes a quiz. Owner/assistant only, destructive, requires confirm:true; ' +
+    'requires a Pro subscription and quizzes enabled. THIS CANNOT BE UNDONE and cascades: every ' +
+    'student attempt at this quiz — transcripts, scores, and focus metrics — is permanently ' +
+    'deleted with it, and the quiz is removed from any curriculum module that lists it. To take ' +
+    'a quiz out of circulation without losing student work, use quiz_update with status CLOSED.',
+  scope: 'write',
+  roles: OWNER_ASSISTANT,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    quiz_id: z.string().uuid().describe('Quiz id'),
+    confirm: z
+      .literal(true)
+      .describe('Must be true — acknowledges that all student attempts are deleted with the quiz'),
+  },
+  handler: async (args, ctx) => {
+    await assertQuizSurfaceEnabled(ctx);
+    const quiz = await loadQuizInClassroom(args.quiz_id, ctx);
+    // Blast-radius count for the audit trail (findById includes the attempts).
+    const attemptsDeleted = (quiz as { attempts?: unknown[] }).attempts?.length ?? 0;
+
+    await ClassmojiService.quiz.delete(quiz.id);
+
+    await writeAudit(ctx, {
+      resource_type: 'QUIZ',
+      resource_id: quiz.id,
+      action: 'DELETE',
+      data: { tool: 'quiz_delete', name: quiz.name, attempts_deleted: attemptsDeleted },
+    });
+
+    return ok({
+      success: true,
+      deleted_quiz_id: quiz.id,
+      name: quiz.name,
+      attempts_deleted: attemptsDeleted,
+    });
+  },
+};

--- a/apps/mcp/src/tools/settings.ts
+++ b/apps/mcp/src/tools/settings.ts
@@ -1,0 +1,351 @@
+/**
+ * Classroom settings tools — classroom_settings_update /
+ * classroom_status_update / org_repo_settings_update.
+ *
+ * ROUTE-DERIVED TIER: OWNER only for all three.
+ *   - admin.$class.settings.general / .content / .grades / .quizzes →
+ *     assertClassroomAccess allowedRoles ['OWNER']
+ *   - api.classrooms.$id.status / api.classrooms.$id.archive → ['OWNER']
+ *   - admin.$class.settings.repos → ['OWNER']
+ *
+ * THE CENTRAL SAFETY PROPERTY: `ClassmojiService.classroom.updateSettings` is a
+ * bare upsert — it writes ANY key it is handed, including `anthropic_api_key`,
+ * `openai_api_key` and the llm_* columns. The web actions forward the whole
+ * request body into it; this tool must not. Every handler here builds an
+ * EXPLICIT object field-by-field from validated arguments and passes THAT, so
+ * an unknown or secret key simply has no path to the database. The same rule
+ * covers `classroom.update` (whitelisted to `name`, mirroring the web route's
+ * PROFILE_FIELDS, which exists to keep `slug` and `git_org_id` unwritable) and
+ * `gitProvider.updateOrganization`.
+ *
+ * Responses echo only the fields the tool itself set — never the service
+ * return, which carries the raw settings row (API keys included).
+ */
+
+import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { z } from 'zod';
+import { ToolError } from '../mcp/errors.ts';
+import type { ToolDefinition } from '../mcp/registry.ts';
+import { loadPageInClassroom, ok, OWNER_ONLY, requireClassroomCtx, writeAudit } from './shared.ts';
+
+/**
+ * Classroom theme keys. Source of truth is the webapp's
+ * apps/webapp/app/constants/themes.ts (CLASSROOM_THEMES); duplicated as a
+ * literal here rather than imported, because apps/mcp does not depend on
+ * apps/webapp. Adding a theme there means adding it here.
+ */
+const THEME_KEYS = ['classic', 'stone', 'lavender', 'sand', 'peach'] as const;
+
+/** The settings columns this tool may write, in database vocabulary. */
+interface SafeSettingsUpdate {
+  show_modules?: boolean;
+  show_pages?: boolean;
+  show_repos?: boolean;
+  slides_enabled?: boolean;
+  syllabus_bot_enabled?: boolean;
+  quizzes_enabled?: boolean;
+  recent_viewers_enabled?: boolean;
+  default_tokens_per_hour?: number;
+  late_penalty_points_per_hour?: number;
+  default_student_page?: string;
+  theme?: string;
+}
+
+interface ClassroomSettingsUpdateArgs {
+  classroom: string;
+  name?: string;
+  show_modules?: boolean;
+  show_pages?: boolean;
+  show_repos?: boolean;
+  slides_enabled?: boolean;
+  syllabus_bot_enabled?: boolean;
+  quizzes_enabled?: boolean;
+  recent_viewers_enabled?: boolean;
+  default_tokens_per_hour?: number;
+  late_penalty_points_per_hour?: number;
+  default_student_page?: string;
+  theme?: (typeof THEME_KEYS)[number];
+}
+
+export const classroomSettingsUpdateTool: ToolDefinition<ClassroomSettingsUpdateArgs> = {
+  name: 'classroom_settings_update',
+  annotations: { destructive: false, openWorld: false },
+  title: 'Update classroom settings',
+  description:
+    'Updates classroom settings: the display name, navigation/feature toggles (modules, pages, ' +
+    'repos, slides, syllabus bot, quizzes, recent viewers), token and late-penalty defaults, the ' +
+    'student landing page, and the theme. Owner only. Provide at least one field; omitted fields ' +
+    'are left alone. Turning a feature off hides it from students but deletes nothing. ' +
+    'default_student_page takes "dashboard", "repositories", or "page:{pageId}" for a specific ' +
+    'page (it must be a page in this classroom, published and shown in the student menu, or ' +
+    'students fall back to the dashboard). AI provider keys and model settings are not editable ' +
+    'here — those are managed in the web app.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    name: z.string().trim().min(1).max(200).optional().describe('Classroom display name'),
+    show_modules: z.boolean().optional().describe('Show the modules section to students'),
+    show_pages: z.boolean().optional().describe('Show course pages to students'),
+    show_repos: z.boolean().optional().describe('Show repositories to students'),
+    slides_enabled: z.boolean().optional().describe('Enable the slides feature'),
+    syllabus_bot_enabled: z.boolean().optional().describe('Enable the AI syllabus bot'),
+    quizzes_enabled: z.boolean().optional().describe('Enable AI quizzes'),
+    recent_viewers_enabled: z
+      .boolean()
+      .optional()
+      .describe('Show who recently viewed each page in the navbar'),
+    default_tokens_per_hour: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Default extension-token cost per late hour for new assignments'),
+    late_penalty_points_per_hour: z
+      .number()
+      .min(0)
+      .optional()
+      .describe('Grade points deducted per late hour'),
+    default_student_page: z
+      .string()
+      .optional()
+      .describe("Student landing page: 'dashboard', 'repositories', or 'page:{pageId}'"),
+    theme: z.enum(THEME_KEYS).optional().describe('Classroom color theme'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // Build the settings payload EXPLICITLY, key by key. Nothing that is not
+    // named here can reach classroom_settings — including the API-key columns
+    // updateSettings would happily write.
+    const settings: SafeSettingsUpdate = {};
+    const set = <K extends keyof SafeSettingsUpdate>(
+      key: K,
+      value: SafeSettingsUpdate[K] | undefined
+    ) => {
+      if (value !== undefined) settings[key] = value;
+    };
+    set('show_modules', args.show_modules);
+    set('show_pages', args.show_pages);
+    set('show_repos', args.show_repos);
+    set('slides_enabled', args.slides_enabled);
+    set('syllabus_bot_enabled', args.syllabus_bot_enabled);
+    set('quizzes_enabled', args.quizzes_enabled);
+    set('recent_viewers_enabled', args.recent_viewers_enabled);
+    set('default_tokens_per_hour', args.default_tokens_per_hour);
+    set('late_penalty_points_per_hour', args.late_penalty_points_per_hour);
+    set('theme', args.theme);
+
+    if (args.default_student_page !== undefined) {
+      const target = args.default_student_page;
+      if (target === 'dashboard' || target === 'repositories') {
+        settings.default_student_page = target;
+      } else if (target.startsWith('page:')) {
+        // S1: the referenced page must live in the authorized classroom, so a
+        // landing page cannot be pointed at another classroom's content.
+        const page = await loadPageInClassroom(target.slice('page:'.length), ctx);
+        settings.default_student_page = `page:${page.id}`;
+      } else {
+        throw new ToolError(
+          'invalid_params',
+          "default_student_page must be 'dashboard', 'repositories', or 'page:{pageId}'"
+        );
+      }
+    }
+
+    const changed = Object.keys(settings);
+    if (args.name !== undefined) changed.push('name');
+    if (changed.length === 0) {
+      throw new ToolError('invalid_params', 'Provide at least one setting to update');
+    }
+
+    // The Classroom row itself: `name` ONLY, mirroring the web route's
+    // PROFILE_FIELDS whitelist (slug is the key in every URL and two HMAC
+    // credentials; git_org_id would move the classroom to another org).
+    if (args.name !== undefined) {
+      await ClassmojiService.classroom.update(classroom.classroomId, { name: args.name });
+    }
+    if (Object.keys(settings).length > 0) {
+      await ClassmojiService.classroom.updateSettings(classroom.classroomId, settings);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'SETTINGS',
+      resource_id: classroom.classroomId,
+      action: 'UPDATE',
+      data: { tool: 'classroom_settings_update', fields: changed },
+    });
+
+    // Echo the validated values we just wrote — never the service return, which
+    // carries the raw settings row (API keys included).
+    return ok({
+      success: true,
+      updated_fields: changed,
+      settings: { ...settings, ...(args.name !== undefined ? { name: args.name } : {}) },
+    });
+  },
+};
+
+interface ClassroomStatusUpdateArgs {
+  classroom: string;
+  status?: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED';
+  is_archived?: boolean;
+}
+
+export const classroomStatusUpdateTool: ToolDefinition<ClassroomStatusUpdateArgs> = {
+  name: 'classroom_status_update',
+  // Sets one or two columns; setting the same value twice is a no-op.
+  annotations: { destructive: false, idempotent: true, openWorld: false },
+  title: 'Update classroom status or archive flag',
+  description:
+    'Sets the classroom lifecycle status and/or its archive flag. Owner only. Provide at least ' +
+    'one. status: ACTIVE = normal; LOCKED = read-only for everyone except the owner (members ' +
+    'can still browse the class, they just cannot change anything); UNPUBLISHED = hidden from ' +
+    'everyone except the owner. is_archived only groups the class separately on the owner ' +
+    'dashboard — it is cosmetic and changes nobody’s access. Nothing here deletes data, and each ' +
+    'change is reversible with another call.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    status: z
+      .enum(['ACTIVE', 'LOCKED', 'UNPUBLISHED'])
+      .optional()
+      .describe('Lifecycle status: ACTIVE, LOCKED (read-only), or UNPUBLISHED (hidden)'),
+    is_archived: z
+      .boolean()
+      .optional()
+      .describe('Archive flag — dashboard grouping only, no access change'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // Explicit two-column payload; the whole args object never reaches Prisma.
+    const updates: { status?: 'ACTIVE' | 'LOCKED' | 'UNPUBLISHED'; is_archived?: boolean } = {};
+    if (args.status !== undefined) updates.status = args.status;
+    if (args.is_archived !== undefined) updates.is_archived = args.is_archived;
+
+    const fields = Object.keys(updates);
+    if (fields.length === 0) {
+      throw new ToolError('invalid_params', 'Provide status and/or is_archived');
+    }
+
+    // The owner is exempt from the registry's mutation gate, so the owner of a
+    // LOCKED classroom can still call this to unlock it — the same semantics
+    // the web status route has.
+    const updated = await ClassmojiService.classroom.update(classroom.classroomId, updates);
+
+    await writeAudit(ctx, {
+      resource_type: 'CLASSROOM',
+      resource_id: classroom.classroomId,
+      action: 'UPDATE',
+      data: { tool: 'classroom_status_update', ...updates },
+    });
+
+    return ok({
+      success: true,
+      updated_fields: fields,
+      status: updated.status,
+      is_archived: updated.is_archived,
+    });
+  },
+};
+
+interface OrgRepoSettingsUpdateArgs {
+  classroom: string;
+  default_repository_permission?: 'none' | 'read' | 'write';
+  members_can_create_repositories?: boolean;
+}
+
+export const orgRepoSettingsUpdateTool: ToolDefinition<OrgRepoSettingsUpdateArgs> = {
+  name: 'org_repo_settings_update',
+  // Writes to GitHub, not our database → openWorld. Changes settings only.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Update GitHub organization repository settings',
+  description:
+    'Updates repository defaults on the GitHub ORGANIZATION this classroom belongs to. Owner ' +
+    'only. WARNING: these are ORGANIZATION-WIDE GitHub settings, not classroom settings — they ' +
+    'affect every classroom, every member and every repository in that organization, including ' +
+    'other courses hosted there, not just this class. default_repository_permission is the base ' +
+    'permission members get on org repos: none (students see only their own or their team’s ' +
+    'repos), read (students can read other students’ repos), or write (students can also write ' +
+    'to them). members_can_create_repositories lets students create repositories in the org. ' +
+    'Provide at least one.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  // Tighter than the default bucket: every call is a live GitHub org-settings
+  // write — a burst of 5, roughly 3 per minute sustained.
+  rateLimit: { capacity: 5, refillPerSecond: 0.05 },
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    default_repository_permission: z
+      .enum(['none', 'read', 'write'])
+      .optional()
+      .describe('Base permission org members get on organization repositories'),
+    members_can_create_repositories: z
+      .boolean()
+      .optional()
+      .describe('Whether org members may create repositories'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // Strict, closed payload — built from validated values only. The web route
+    // forwards the request body straight to GitHub; this one cannot.
+    const updates: {
+      default_repository_permission?: 'none' | 'read' | 'write';
+      members_can_create_repositories?: boolean;
+    } = {};
+    if (args.default_repository_permission !== undefined) {
+      updates.default_repository_permission = args.default_repository_permission;
+    }
+    if (args.members_can_create_repositories !== undefined) {
+      updates.members_can_create_repositories = args.members_can_create_repositories;
+    }
+
+    const fields = Object.keys(updates);
+    if (fields.length === 0) {
+      throw new ToolError(
+        'invalid_params',
+        'Provide default_repository_permission and/or members_can_create_repositories'
+      );
+    }
+
+    // Resolve the git organization from the authorized classroom (never from
+    // request input), and refuse the same two ways the web route does.
+    const record = await ClassmojiService.classroom.findById(classroom.classroomId);
+    const gitOrganization = record?.git_organization;
+    if (!gitOrganization?.login) {
+      throw new ToolError(
+        'invalid_params',
+        'This classroom is not connected to a GitHub organization'
+      );
+    }
+    if (!gitOrganization.github_installation_id) {
+      throw new ToolError(
+        'invalid_params',
+        `The Classmoji GitHub App is not installed on '${gitOrganization.login}' — install it to manage repository settings`
+      );
+    }
+
+    const gitProvider = getGitProvider(gitOrganization) as unknown as {
+      updateOrganization: (login: string, data: Record<string, unknown>) => Promise<unknown>;
+    };
+    await gitProvider.updateOrganization(gitOrganization.login, updates);
+
+    await writeAudit(ctx, {
+      resource_type: 'REPO_SETTINGS',
+      resource_id: classroom.classroomId,
+      action: 'UPDATE',
+      data: { tool: 'org_repo_settings_update', org: gitOrganization.login, ...updates },
+    });
+
+    return ok({
+      success: true,
+      organization: gitOrganization.login,
+      updated_fields: fields,
+      settings: updates,
+      message: `Updated organization-wide GitHub settings for '${gitOrganization.login}' — this affects every classroom and repository in that organization.`,
+    });
+  },
+};

--- a/apps/mcp/src/tools/settings.ts
+++ b/apps/mcp/src/tools/settings.ts
@@ -255,22 +255,28 @@ interface OrgRepoSettingsUpdateArgs {
   classroom: string;
   default_repository_permission?: 'none' | 'read' | 'write';
   members_can_create_repositories?: boolean;
+  confirm: true;
 }
 
 export const orgRepoSettingsUpdateTool: ToolDefinition<OrgRepoSettingsUpdateArgs> = {
   name: 'org_repo_settings_update',
-  // Writes to GitHub, not our database → openWorld. Changes settings only.
-  annotations: { destructive: false, openWorld: true },
+  // Writes to GitHub, not our database → openWorld. It reaches far outside the
+  // classroom the caller was authorized for (every repository in the org, and
+  // widening default_repository_permission exposes existing student work), so
+  // it is declared destructive and gated on confirm:true.
+  annotations: { destructive: true, openWorld: true },
   title: 'Update GitHub organization repository settings',
   description:
     'Updates repository defaults on the GitHub ORGANIZATION this classroom belongs to. Owner ' +
-    'only. WARNING: these are ORGANIZATION-WIDE GitHub settings, not classroom settings — they ' +
-    'affect every classroom, every member and every repository in that organization, including ' +
-    'other courses hosted there, not just this class. default_repository_permission is the base ' +
-    'permission members get on org repos: none (students see only their own or their team’s ' +
-    'repos), read (students can read other students’ repos), or write (students can also write ' +
-    'to them). members_can_create_repositories lets students create repositories in the org. ' +
-    'Provide at least one.',
+    'only, destructive, requires confirm:true. WARNING: these are ORGANIZATION-WIDE GitHub ' +
+    'settings, not classroom settings — they take effect IMMEDIATELY and affect every classroom, ' +
+    'every member and every repository in that organization, including other courses hosted ' +
+    'there, not just this class. default_repository_permission is the base permission members get ' +
+    'on org repos: none (students see only their own or their team’s repos), read (students can ' +
+    'read other students’ repos, including existing ones), or write (students can also write to ' +
+    'them). members_can_create_repositories lets students create repositories in the org. ' +
+    'Confirm with the user which organization is affected before calling. Provide at least one ' +
+    'setting.',
   scope: 'write',
   roles: OWNER_ONLY,
   // Tighter than the default bucket: every call is a live GitHub org-settings
@@ -286,6 +292,12 @@ export const orgRepoSettingsUpdateTool: ToolDefinition<OrgRepoSettingsUpdateArgs
       .boolean()
       .optional()
       .describe('Whether org members may create repositories'),
+    confirm: z
+      .literal(true)
+      .describe(
+        'Must be true — acknowledges the change applies immediately to the whole GitHub ' +
+          'organization, not just this classroom'
+      ),
   },
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);

--- a/apps/mcp/src/tools/shared.ts
+++ b/apps/mcp/src/tools/shared.ts
@@ -35,6 +35,13 @@ export const TEACHING_TEAM = ['OWNER', 'TEACHER', 'ASSISTANT'] as const;
 export const OWNER_TEACHER = ['OWNER', 'TEACHER'] as const;
 /** requireClassroomAdmin routes (modules, tokens, settings, grader assignment). */
 export const OWNER_ONLY = ['OWNER'] as const;
+/**
+ * Quiz admin surface (admin.$class.quizzes loader + action, and the assistant
+ * route that re-exports it): allowedRoles ['OWNER','ASSISTANT']. TEACHER is
+ * genuinely excluded there, so it is excluded here (S4 role parity). Mirrors
+ * QUIZ_ROLES in resources/shape.ts minus STUDENT, which has no write surface.
+ */
+export const OWNER_ASSISTANT = ['OWNER', 'ASSISTANT'] as const;
 
 // ─── Results & errors ────────────────────────────────────────────────────────
 
@@ -326,6 +333,22 @@ export async function loadRepositoryInClassroom(
   const record = await ClassmojiService.repository.findById(id);
   if (!record || record.classroom_id !== requireClassroomCtx(ctx).classroomId) {
     throw scopedNotFound('Repo');
+  }
+  return record;
+}
+
+type QuizRecord = NonNullable<Awaited<ReturnType<typeof ClassmojiService.quiz.findById>>>;
+
+/**
+ * Load a Quiz and verify its classroom_id (S1). Quiz carries classroom_id
+ * directly, so the comparison is a single hop — same uniform rejection as every
+ * other loader, so an unknown id and another classroom's quiz are
+ * indistinguishable to the caller.
+ */
+export async function loadQuizInClassroom(id: string, ctx: ToolContext): Promise<QuizRecord> {
+  const record = await ClassmojiService.quiz.findById(id);
+  if (!record || record.classroom_id !== requireClassroomCtx(ctx).classroomId) {
+    throw scopedNotFound('Quiz');
   }
   return record;
 }

--- a/apps/mcp/src/tools/teams.ts
+++ b/apps/mcp/src/tools/teams.ts
@@ -30,7 +30,12 @@
  * spread into a response — every payload below is built field by field.
  */
 
-import { ClassmojiService, TeamServiceError } from '@classmoji/services';
+import {
+  ClassmojiService,
+  TeamServiceError,
+  describeTeamFailureReason,
+  type TeamFailureReason,
+} from '@classmoji/services';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolContext, ToolDefinition } from '../mcp/registry.ts';
@@ -108,15 +113,47 @@ async function resolveTeamInClassroom(ref: string, ctx: ToolContext): Promise<Te
   return team;
 }
 
+/**
+ * Per-item failures carry the service's CLOSED reason vocabulary, never the
+ * raw provider/database message (which the service logs instead). Both the
+ * code and its phrase are surfaced: the code is what a caller can branch on,
+ * the phrase is what it can repeat to a user.
+ */
+const describeFailure = (reason: TeamFailureReason) => ({
+  error: reason,
+  error_description: describeTeamFailureReason(reason),
+});
+
 /** Per-tag failure in platform vocabulary (the service uses camelCase). */
-const tagFailures = (failed: Array<{ tagId: string; error: string }>) =>
-  failed.map(f => ({ tag_id: f.tagId, error: f.error }));
+const tagFailures = (failed: Array<{ tagId: string; error: TeamFailureReason }>) =>
+  failed.map(f => ({ tag_id: f.tagId, ...describeFailure(f.error) }));
 
 /**
  * Normalize a login the way teamAdmin.service does before its case-insensitive
  * lookup, so the membership pre-check accepts exactly what the service accepts.
  */
 const normalizeLogin = (login: string) => login.replace('@', '').trim().toLowerCase();
+
+/**
+ * The normalized logins of everyone who belongs to the authorized classroom in
+ * any role.
+ *
+ * DELIBERATELY STRICTER THAN THE WEB FORMS, which forward whatever logins they
+ * are given: on this surface every login named by a team tool must belong to
+ * THIS classroom, so an arbitrary GitHub account can neither be pulled into an
+ * organization team nor probed against one.
+ */
+async function classroomMemberLogins(classroomId: string): Promise<Set<string>> {
+  const memberships = (await ClassmojiService.classroomMembership.findByClassroomId(
+    classroomId
+  )) as Array<{ user?: { login?: string | null } | null }>;
+  return new Set(
+    memberships
+      .map(m => m.user?.login)
+      .filter((login): login is string => Boolean(login))
+      .map(normalizeLogin)
+  );
+}
 
 const teamRefSchema = z.string().min(1).describe("The team's slug or id (from list_teams)");
 
@@ -229,13 +266,14 @@ export const teamDeleteTool: ToolDefinition<TeamDeleteArgs> = {
   title: 'Delete a team',
   description:
     'Deletes a team: the team in the classroom GitHub organization and its Classmoji record. ' +
-    'Owner only, destructive, requires confirm:true. The GitHub REPOSITORIES themselves are not ' +
-    "deleted — they stay in the organization. Classmoji's records of them are not kept, though: " +
-    "the team's linked repo records are removed along with the team, and that takes their " +
-    'submissions, grades, grader assignments, regrade requests, token transactions and analytics ' +
-    'with them. That history cannot be restored from this surface, so prefer team_rename, or ' +
-    'removing members, when the team has graded work. Team memberships and tag links go too. If ' +
-    'the team is already gone on GitHub the local record is still removed and ' +
+    'Owner only, destructive, requires confirm:true. The GitHub REPOSITORIES themselves survive — ' +
+    "they stay in the organization. Classmoji's RECORDS of them do not: every linked repo record " +
+    'is permanently deleted along with the team, and that takes its submissions, grades, grader ' +
+    'assignments, regrade requests, token transactions and analytics with it. That history cannot ' +
+    'be restored from this surface or any other, so when the team has graded work use team_rename ' +
+    '(or remove its members) instead. Team memberships and tag links go too. The response reports ' +
+    'repos_deleted — check it against list_repos BEFORE confirming if you are unsure what the ' +
+    'team owns. If the team is already gone on GitHub the local record is still removed and ' +
     'removed_from_provider comes back false.',
   scope: 'write',
   roles: OWNER_ONLY,
@@ -246,7 +284,7 @@ export const teamDeleteTool: ToolDefinition<TeamDeleteArgs> = {
       .literal(true)
       .describe(
         'Must be true — acknowledges the GitHub team and the linked repo records (with their ' +
-          'grading history) are deleted'
+          'grading history) are permanently deleted'
       ),
   },
   handler: async (args, ctx) => {
@@ -271,8 +309,19 @@ export const teamDeleteTool: ToolDefinition<TeamDeleteArgs> = {
         team_id: result.id,
         slug: result.slug,
         removed_from_provider: result.removedFromProvider,
+        // Blast radius on the audit row: the repo records (and their grading
+        // history) are gone, so the trail is the only place left that says
+        // what the delete cost.
+        repos_deleted: result.reposDeleted,
+        deleted_repo_names: result.deletedRepoNames,
       },
     });
+
+    const repoNote =
+      result.reposDeleted > 0
+        ? ` ${result.reposDeleted} linked repository record(s) were deleted with it, along with ` +
+          'their submissions, grades and analytics; the GitHub repositories themselves remain.'
+        : '';
 
     return ok({
       success: true,
@@ -280,9 +329,13 @@ export const teamDeleteTool: ToolDefinition<TeamDeleteArgs> = {
       name: result.name,
       slug: result.slug,
       removed_from_provider: result.removedFromProvider,
-      message: result.removedFromProvider
-        ? `Team '${result.slug}' was deleted on GitHub and removed from Classmoji.`
-        : `Team '${result.slug}' was already gone on GitHub; the Classmoji record was removed.`,
+      repos_deleted: result.reposDeleted,
+      deleted_repo_names: result.deletedRepoNames,
+      message:
+        (result.removedFromProvider
+          ? `Team '${result.slug}' was deleted on GitHub and removed from Classmoji.`
+          : `Team '${result.slug}' was already gone on GitHub; the Classmoji record was removed.`) +
+        repoNote,
     });
   },
 };
@@ -342,7 +395,7 @@ export const teamRenameTool: ToolDefinition<TeamRenameArgs> = {
       },
     });
 
-    const failed = result.failed.map(f => ({ name: f.name, error: f.error }));
+    const failed = result.failed.map(f => ({ name: f.name, ...describeFailure(f.error) }));
     return ok({
       success: true,
       team_id: result.teamId,
@@ -408,20 +461,9 @@ export const teamMembersAddTool: ToolDefinition<TeamMembersAddArgs> = {
     // the audit row can name the team (addTeamMembers returns no team id).
     const team = await resolveTeamInClassroom(args.team, ctx);
 
-    // DELIBERATELY STRICTER THAN THE WEB FORM: the web action forwards whatever
-    // logins it is given, which lets any GitHub account be pulled into an org
-    // team. Here every login must resolve to a member of THIS classroom (any
-    // role) or the whole call is refused — an MCP tool must not be a path for
-    // adding arbitrary GitHub accounts to the organization.
-    const memberships = (await ClassmojiService.classroomMembership.findByClassroomId(
-      classroom.classroomId
-    )) as Array<{ user?: { login?: string | null } | null }>;
-    const classroomLogins = new Set(
-      memberships
-        .map(m => m.user?.login)
-        .filter((login): login is string => Boolean(login))
-        .map(normalizeLogin)
-    );
+    // Every login must resolve to a member of THIS classroom (any role) or the
+    // whole call is refused — see classroomMemberLogins.
+    const classroomLogins = await classroomMemberLogins(classroom.classroomId);
 
     // Dedupe on the same normalized key the service matches on, so 'Ada' and
     // '@ada' do not cost two throttled provider calls.
@@ -473,7 +515,7 @@ export const teamMembersAddTool: ToolDefinition<TeamMembersAddArgs> = {
       team_slug: team.slug,
       succeeded: result.succeeded.map(s => s.login),
       succeeded_count: result.succeeded.length,
-      failed: result.failed.map(f => ({ login: f.login, error: f.error })),
+      failed: result.failed.map(f => ({ login: f.login, ...describeFailure(f.error) })),
       failed_count: result.failed.length,
     });
   },
@@ -494,19 +536,44 @@ export const teamMemberRemoveTool: ToolDefinition<TeamMemberRemoveArgs> = {
   annotations: { destructive: true, idempotent: true, openWorld: true },
   title: 'Remove a member from a team',
   description:
-    'Removes one person from a team, on GitHub and in Classmoji. Owner only. This only drops the ' +
-    'team membership — it does not remove them from the classroom or the GitHub organization, ' +
-    'and no repository is deleted; they simply lose the access the team granted. Idempotent: if ' +
-    'they were not a member, the call still succeeds and reports removed:false.',
+    'Removes one person from a team, on GitHub and in Classmoji. Owner only. The login must be a ' +
+    'member of THIS classroom in some role (get_roster and list_teaching_team show who is); any ' +
+    'other login is refused. This only drops the team membership — it does not remove them from ' +
+    'the classroom or the GitHub organization, and no repository is deleted; they simply lose the ' +
+    'access the team granted. Idempotent: if they were not a member of the team, the call still ' +
+    'succeeds and reports removed:false.',
   scope: 'write',
   roles: OWNER_ONLY,
   inputSchema: {
     classroom: z.string().describe("Classroom reference as 'org/slug'"),
     team: teamRefSchema,
-    login: z.string().min(1).max(100).describe('The member GitHub username'),
+    login: z
+      .string()
+      .min(1)
+      .max(100)
+      .describe('The member GitHub username; must be a member of this classroom'),
   },
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
+
+    // Same order as team_members_add: the team is resolved inside the
+    // authorized classroom first (S1), then the login is checked against
+    // classroom membership.
+    await resolveTeamInClassroom(args.team, ctx);
+
+    // ONE uniform refusal for both "no such Classmoji user" and "not in this
+    // classroom": without it the tool's two error shapes would differ, and the
+    // service's own user_not_found would answer a question about who exists on
+    // the platform. That branch of mapTeamError stays as a backstop.
+    const classroomLogins = await classroomMemberLogins(classroom.classroomId);
+    if (!classroomLogins.has(normalizeLogin(args.login))) {
+      throw new ToolError(
+        'invalid_params',
+        `Not a member of this classroom: ${args.login} — nobody was removed from the team.`,
+        undefined,
+        { logins: [args.login] }
+      );
+    }
 
     let result;
     try {

--- a/apps/mcp/src/tools/teams.ts
+++ b/apps/mcp/src/tools/teams.ts
@@ -1,0 +1,711 @@
+/**
+ * Team tools — team_create / team_delete / team_rename, team_members_add /
+ * team_member_remove, team_tag_add / team_tag_remove.
+ *
+ * ROUTE-DERIVED TIER: the web actions live in
+ * apps/webapp/app/routes/admin.$class.teams*, all gated by assertClassroomAccess
+ * with allowedRoles ['OWNER'] — OWNER only for all seven.
+ *
+ * Backbone: ClassmojiService.teamAdmin.* (extracted so the web routes and these
+ * tools take ONE code path — same precedent as roster.service.ts and
+ * assistant.service.ts). Two properties of that service matter here:
+ *
+ *   1. RESOLVE FIRST. Every function looks the team up by (classroom_id,
+ *      slug|id) BEFORE anything reaches GitHub, so `team_not_found` always beats
+ *      a provider call, and the classroom's own `{slug}-students` /
+ *      `-assistants` GitHub teams — which have no local Team row — are
+ *      unreachable from this surface.
+ *   2. PARTIAL WORK IS REPORTED, NOT SWALLOWED. The bulk operations hand back
+ *      per-item `failed` lists; these tools surface every one of them.
+ *
+ * S1: classroomId is ALWAYS ctx.classroom.classroomId, never request input, so
+ * every lookup inside the service is classroom-scoped already. A team ref that
+ * names nothing and one that names another classroom's team both come back as
+ * the same scopedNotFound('Team'), so a cross-classroom probe cannot enumerate
+ * foreign teams. The same holds for tags (Tag is classroom-scoped) and for the
+ * TeamTag rows team_tag_remove resolves.
+ *
+ * RESPONSES ARE ALLOW-LISTED: team.findByClassroomId returns memberships with
+ * full User rows attached (contact PII included), so no service row is ever
+ * spread into a response — every payload below is built field by field.
+ */
+
+import { ClassmojiService, TeamServiceError } from '@classmoji/services';
+import { z } from 'zod';
+import { ToolError } from '../mcp/errors.ts';
+import type { ToolContext, ToolDefinition } from '../mcp/registry.ts';
+import { ok, OWNER_ONLY, requireClassroomCtx, scopedNotFound, writeAudit } from './shared.ts';
+
+/**
+ * Map the service's caller-fixable failures onto tool errors.
+ *
+ * - `team_not_found` / `tag_not_found` → the uniform scopedNotFound: an unknown
+ *   ref and another classroom's record are indistinguishable to the caller.
+ * - `user_not_found` → a PLAIN not_found: the miss is on a global user lookup,
+ *   not on a classroom-scoped record, so there is nothing to leak.
+ * - `no_org_configured` → invalid_params with a neutral message of our own; the
+ *   service's message embeds the internal classroom id.
+ * - `invalid_name` / `reserved_name` / `name_collision` / `provider_unsupported`
+ *   → invalid_params carrying the service's own message (minus its log prefix):
+ *   it names the offending team/organization, which is what the caller needs to
+ *   fix the call, and every one of those checks already ran classroom-scoped.
+ * - `classroom_not_found` is unreachable (the id comes from a resolved ctx) and
+ *   anything else is returned unchanged for the registry's generic wrapper.
+ */
+function mapTeamError(error: unknown): unknown {
+  if (!(error instanceof TeamServiceError)) return error;
+  switch (error.code) {
+    case 'team_not_found':
+      return scopedNotFound('Team');
+    case 'tag_not_found':
+      return scopedNotFound('Tag');
+    case 'user_not_found':
+      return new ToolError('not_found', 'No Classmoji user with that login');
+    case 'no_org_configured':
+      return new ToolError(
+        'invalid_params',
+        'This classroom has no linked GitHub organization — teams cannot be managed'
+      );
+    case 'invalid_name':
+    case 'reserved_name':
+    case 'name_collision':
+    case 'provider_unsupported':
+      return new ToolError('invalid_params', error.message.replace(/^\[team\]\s*/, ''));
+    default:
+      return error;
+  }
+}
+
+// ─── Shared shapes + helpers ────────────────────────────────────────────────
+
+/** The subset of team.findByClassroomId we read (never the memberships). */
+interface TeamRecord {
+  id: string;
+  name: string;
+  slug: string;
+  is_visible: boolean;
+  tags?: Array<{ id: string; tag_id: string; tag?: { id: string; name: string } | null }>;
+}
+
+/**
+ * Resolve a team by slug OR id inside the authorized classroom (S1), the same
+ * way the service does, and hand back its tag rows.
+ *
+ * Two tools need the team id for their audit row before the service call
+ * (addTeamMembers/addTeamTags return only per-item results), and team_tag_remove
+ * needs the TeamTag row id, which list_teams does not expose. The service still
+ * re-resolves the team itself, so this stays a lookup — the mutation path is
+ * unchanged. A team deleted between this lookup and the service call simply
+ * surfaces as the mapped `team_not_found`.
+ */
+async function resolveTeamInClassroom(ref: string, ctx: ToolContext): Promise<TeamRecord> {
+  const classroom = requireClassroomCtx(ctx);
+  const teams = (await ClassmojiService.team.findByClassroomId(
+    classroom.classroomId
+  )) as TeamRecord[];
+  const team = teams.find(t => t.slug === ref || t.id === ref);
+  if (!team) throw scopedNotFound('Team');
+  return team;
+}
+
+/** Per-tag failure in platform vocabulary (the service uses camelCase). */
+const tagFailures = (failed: Array<{ tagId: string; error: string }>) =>
+  failed.map(f => ({ tag_id: f.tagId, error: f.error }));
+
+/**
+ * Normalize a login the way teamAdmin.service does before its case-insensitive
+ * lookup, so the membership pre-check accepts exactly what the service accepts.
+ */
+const normalizeLogin = (login: string) => login.replace('@', '').trim().toLowerCase();
+
+const teamRefSchema = z.string().min(1).describe("The team's slug or id (from list_teams)");
+
+const tagIdsSchema = z
+  .array(z.string().min(1))
+  .max(20)
+  .describe('Tag ids to attach (tags must belong to this classroom)');
+
+// ─── team_create ────────────────────────────────────────────────────────────
+
+interface TeamCreateArgs {
+  classroom: string;
+  name: string;
+  is_visible?: boolean;
+  tag_ids?: string[];
+}
+
+export const teamCreateTool: ToolDefinition<TeamCreateArgs> = {
+  name: 'team_create',
+  // Creates a REAL GitHub team (openWorld). Adds records only — nothing removed.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Create a team',
+  description:
+    'Creates a team in the classroom: a real team in the classroom GitHub organization plus its ' +
+    'Classmoji record. Owner only. GitHub derives the slug from the name. Names that would ' +
+    "collide with an existing org team, or that end in '-students' / '-assistants' (reserved for " +
+    "the classroom's own membership teams), are refused before anything is created. is_visible " +
+    'controls student visibility: false (the default) means only its own members see the team in ' +
+    'list_teams — other students do not. tag_ids attach classroom tags at creation time; a tag id ' +
+    'from another classroom is reported in tags_failed and the team is still created. Add members ' +
+    'afterwards with team_members_add.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  // Tighter than the default bucket: every call creates a real GitHub team —
+  // a burst of 5, roughly 3 per minute sustained.
+  rateLimit: { capacity: 5, refillPerSecond: 0.05 },
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    name: z.string().trim().min(1).max(200).describe('Team name'),
+    is_visible: z
+      .boolean()
+      .optional()
+      .describe(
+        'Whether students who are not members can see this team (default false — invisible ' +
+          'teams are hidden from non-member students in list_teams)'
+      ),
+    tag_ids: tagIdsSchema.optional(),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let result;
+    try {
+      // classroomId is ALWAYS the authorized classroom, never request input.
+      result = await ClassmojiService.teamAdmin.createTeam({
+        classroomId: classroom.classroomId,
+        name: args.name,
+        isVisible: args.is_visible ?? false,
+        tagIds: args.tag_ids ?? [],
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    // Audit right after the service call: the GitHub team and the local row are
+    // already committed, so nothing downstream may leave the mutation
+    // un-audited. resource_id names the team — it is also part of the audit
+    // dedup key, so two creates in the same window stay two rows.
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: result.team.id,
+      action: 'CREATE',
+      data: {
+        tool: 'team_create',
+        team_id: result.team.id,
+        slug: result.team.slug,
+        is_visible: result.team.isVisible,
+        tags_added: result.tagsAdded.length,
+        tags_failed: result.tagsFailed.length,
+      },
+    });
+
+    return ok({
+      success: true,
+      team: {
+        id: result.team.id,
+        name: result.team.name,
+        slug: result.team.slug,
+        is_visible: result.team.isVisible,
+      },
+      tags_added: result.tagsAdded,
+      tags_failed: tagFailures(result.tagsFailed),
+    });
+  },
+};
+
+// ─── team_delete ────────────────────────────────────────────────────────────
+
+interface TeamDeleteArgs {
+  classroom: string;
+  team: string;
+  confirm: true;
+}
+
+export const teamDeleteTool: ToolDefinition<TeamDeleteArgs> = {
+  name: 'team_delete',
+  // Deletes the GitHub team AND local records that cascade from it → destructive
+  // + openWorld. Requires confirm:true (enforced by the schema).
+  annotations: { destructive: true, openWorld: true },
+  title: 'Delete a team',
+  description:
+    'Deletes a team: the team in the classroom GitHub organization and its Classmoji record. ' +
+    'Owner only, destructive, requires confirm:true. The GitHub REPOSITORIES themselves are not ' +
+    "deleted — they stay in the organization. Classmoji's records of them are not kept, though: " +
+    "the team's linked repo records are removed along with the team, and that takes their " +
+    'submissions, grades, grader assignments, regrade requests, token transactions and analytics ' +
+    'with them. That history cannot be restored from this surface, so prefer team_rename, or ' +
+    'removing members, when the team has graded work. Team memberships and tag links go too. If ' +
+    'the team is already gone on GitHub the local record is still removed and ' +
+    'removed_from_provider comes back false.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    team: teamRefSchema,
+    confirm: z
+      .literal(true)
+      .describe(
+        'Must be true — acknowledges the GitHub team and the linked repo records (with their ' +
+          'grading history) are deleted'
+      ),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let result;
+    try {
+      result = await ClassmojiService.teamAdmin.deleteTeam({
+        classroomId: classroom.classroomId,
+        slugOrId: args.team,
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: result.id,
+      action: 'DELETE',
+      data: {
+        tool: 'team_delete',
+        team_id: result.id,
+        slug: result.slug,
+        removed_from_provider: result.removedFromProvider,
+      },
+    });
+
+    return ok({
+      success: true,
+      id: result.id,
+      name: result.name,
+      slug: result.slug,
+      removed_from_provider: result.removedFromProvider,
+      message: result.removedFromProvider
+        ? `Team '${result.slug}' was deleted on GitHub and removed from Classmoji.`
+        : `Team '${result.slug}' was already gone on GitHub; the Classmoji record was removed.`,
+    });
+  },
+};
+
+// ─── team_rename ────────────────────────────────────────────────────────────
+
+interface TeamRenameArgs {
+  classroom: string;
+  team: string;
+  new_name: string;
+}
+
+export const teamRenameTool: ToolDefinition<TeamRenameArgs> = {
+  name: 'team_rename',
+  // Renames the GitHub team and its repos — an update, nothing is deleted.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Rename a team',
+  description:
+    'Renames a team on GitHub and in Classmoji, then renames every linked repository so it ' +
+    'carries the new team slug. Owner only, GitHub organizations only. A name already used by ' +
+    "another team in this classroom, or one ending in '-students' / '-assistants', is refused " +
+    'before the rename runs. IMPORTANT: repositories are renamed one at a time and any that fail ' +
+    'come back in `failed`. Those CANNOT be fixed by running team_rename again — the team already ' +
+    'carries the new slug, so a second pass no longer matches the old repository names, and each ' +
+    'listed repository has to be renamed by hand on GitHub. Always report `failed` to the user.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    team: teamRefSchema,
+    new_name: z.string().trim().min(1).max(200).describe('The new team name'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let result;
+    try {
+      result = await ClassmojiService.teamAdmin.renameTeam({
+        classroomId: classroom.classroomId,
+        slugOrId: args.team,
+        newName: args.new_name,
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: result.teamId,
+      action: 'UPDATE',
+      data: {
+        tool: 'team_rename',
+        team_id: result.teamId,
+        new_slug: result.newSlug,
+        renamed_repos: result.renamedRepos.length,
+        failed_repos: result.failed.map(f => f.name),
+      },
+    });
+
+    const failed = result.failed.map(f => ({ name: f.name, error: f.error }));
+    return ok({
+      success: true,
+      team_id: result.teamId,
+      new_name: result.newName,
+      new_slug: result.newSlug,
+      renamed_repos: result.renamedRepos,
+      renamed_repo_count: result.renamedRepos.length,
+      failed,
+      failed_count: failed.length,
+      // Surfaced at the top level so a partial rename is not lost in the payload.
+      ...(failed.length > 0
+        ? {
+            warning:
+              `${failed.length} repository rename(s) FAILED and cannot be recovered by running ` +
+              'team_rename again — rename them by hand on GitHub: ' +
+              failed.map(f => f.name).join(', '),
+          }
+        : {}),
+      message:
+        failed.length > 0
+          ? `Team renamed to '${result.newSlug}', but some repositories still carry the old name.`
+          : `Team renamed to '${result.newSlug}'.`,
+    });
+  },
+};
+
+// ─── team_members_add ───────────────────────────────────────────────────────
+
+interface TeamMembersAddArgs {
+  classroom: string;
+  team: string;
+  logins: string[];
+}
+
+export const teamMembersAddTool: ToolDefinition<TeamMembersAddArgs> = {
+  name: 'team_members_add',
+  // Adds people to a real GitHub team (openWorld); nothing is removed.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Add members to a team',
+  description:
+    'Adds people to a team by GitHub username, on GitHub and in Classmoji. Owner only. Every ' +
+    'login must already be a member of THIS classroom in some role — the whole call is refused, ' +
+    'with the offending logins named, if any is not (get_roster and list_teaching_team show who ' +
+    'is). Members are added one at a time and throttled, so a large list takes a while; each ' +
+    'login is reported in succeeded or failed and one failure does not stop the rest. Re-adding ' +
+    'an existing member is a no-op.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    team: teamRefSchema,
+    logins: z
+      .array(z.string().min(1).max(100))
+      .min(1)
+      .max(100)
+      .describe('GitHub usernames to add (1–100); each must be a member of this classroom'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // S1 + audit: resolve the team inside the authorized classroom first, so an
+    // unknown/foreign ref is the uniform not_found before anything else runs and
+    // the audit row can name the team (addTeamMembers returns no team id).
+    const team = await resolveTeamInClassroom(args.team, ctx);
+
+    // DELIBERATELY STRICTER THAN THE WEB FORM: the web action forwards whatever
+    // logins it is given, which lets any GitHub account be pulled into an org
+    // team. Here every login must resolve to a member of THIS classroom (any
+    // role) or the whole call is refused — an MCP tool must not be a path for
+    // adding arbitrary GitHub accounts to the organization.
+    const memberships = (await ClassmojiService.classroomMembership.findByClassroomId(
+      classroom.classroomId
+    )) as Array<{ user?: { login?: string | null } | null }>;
+    const classroomLogins = new Set(
+      memberships
+        .map(m => m.user?.login)
+        .filter((login): login is string => Boolean(login))
+        .map(normalizeLogin)
+    );
+
+    // Dedupe on the same normalized key the service matches on, so 'Ada' and
+    // '@ada' do not cost two throttled provider calls.
+    const requested = new Map<string, string>();
+    for (const login of args.logins) {
+      const key = normalizeLogin(login);
+      if (key && !requested.has(key)) requested.set(key, login);
+    }
+
+    const notMembers = [...requested].filter(([key]) => !classroomLogins.has(key));
+    if (notMembers.length > 0) {
+      const logins = notMembers.map(([, original]) => original);
+      throw new ToolError(
+        'invalid_params',
+        `Not a member of this classroom: ${logins.join(', ')} — add them to the classroom first ` +
+          '(roster_add_student or assistant_add). No one was added to the team.',
+        undefined,
+        { logins }
+      );
+    }
+
+    let result;
+    try {
+      result = await ClassmojiService.teamAdmin.addTeamMembers({
+        classroomId: classroom.classroomId,
+        slugOrId: args.team,
+        logins: [...requested.values()],
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: team.id,
+      action: 'UPDATE',
+      data: {
+        tool: 'team_members_add',
+        team_id: team.id,
+        slug: team.slug,
+        succeeded: result.succeeded.map(s => s.login),
+        failed: result.failed.map(f => f.login),
+      },
+    });
+
+    return ok({
+      success: true,
+      team_id: team.id,
+      team_slug: team.slug,
+      succeeded: result.succeeded.map(s => s.login),
+      succeeded_count: result.succeeded.length,
+      failed: result.failed.map(f => ({ login: f.login, error: f.error })),
+      failed_count: result.failed.length,
+    });
+  },
+};
+
+// ─── team_member_remove ─────────────────────────────────────────────────────
+
+interface TeamMemberRemoveArgs {
+  classroom: string;
+  team: string;
+  login: string;
+}
+
+export const teamMemberRemoveTool: ToolDefinition<TeamMemberRemoveArgs> = {
+  name: 'team_member_remove',
+  // Removes a membership on GitHub and locally → destructive + openWorld, but
+  // repeating the call changes nothing further → idempotent.
+  annotations: { destructive: true, idempotent: true, openWorld: true },
+  title: 'Remove a member from a team',
+  description:
+    'Removes one person from a team, on GitHub and in Classmoji. Owner only. This only drops the ' +
+    'team membership — it does not remove them from the classroom or the GitHub organization, ' +
+    'and no repository is deleted; they simply lose the access the team granted. Idempotent: if ' +
+    'they were not a member, the call still succeeds and reports removed:false.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    team: teamRefSchema,
+    login: z.string().min(1).max(100).describe('The member GitHub username'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let result;
+    try {
+      result = await ClassmojiService.teamAdmin.removeTeamMember({
+        classroomId: classroom.classroomId,
+        slugOrId: args.team,
+        login: args.login,
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: result.teamId,
+      action: 'UPDATE',
+      data: {
+        tool: 'team_member_remove',
+        team_id: result.teamId,
+        login: result.login,
+        removed: result.removed,
+      },
+    });
+
+    return ok({
+      success: true,
+      team_id: result.teamId,
+      login: result.login,
+      removed: result.removed,
+      message: result.removed
+        ? `${result.login} was removed from the team.`
+        : `${result.login} held no membership row on this team — the GitHub team membership was cleared anyway.`,
+    });
+  },
+};
+
+// ─── team_tag_add ───────────────────────────────────────────────────────────
+
+interface TeamTagAddArgs {
+  classroom: string;
+  team: string;
+  tag_ids: string[];
+}
+
+export const teamTagAddTool: ToolDefinition<TeamTagAddArgs> = {
+  name: 'team_tag_add',
+  // Database-only link rows: no provider call, and re-attaching an already
+  // attached tag is a no-op that still reports it as added → idempotent.
+  annotations: { destructive: false, idempotent: true, openWorld: false },
+  title: 'Attach tags to a team',
+  description:
+    'Attaches classroom tags to a team (Classmoji only — nothing is written to GitHub). Owner ' +
+    'only. Tags group teams for assignment distribution. Tag ids must belong to this classroom; ' +
+    'ones that do not are reported in failed while the rest are still attached. Attaching a tag ' +
+    'the team already has is a no-op and counts as added.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    team: teamRefSchema,
+    tag_ids: tagIdsSchema.min(1),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    // S1 + audit: same reason as team_members_add — addTeamTags returns per-tag
+    // results only, with no team id for the audit row.
+    const team = await resolveTeamInClassroom(args.team, ctx);
+
+    let result;
+    try {
+      result = await ClassmojiService.teamAdmin.addTeamTags({
+        classroomId: classroom.classroomId,
+        slugOrId: args.team,
+        tagIds: args.tag_ids,
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: team.id,
+      action: 'UPDATE',
+      data: {
+        tool: 'team_tag_add',
+        team_id: team.id,
+        added: result.added,
+        failed: result.failed.map(f => f.tagId),
+      },
+    });
+
+    return ok({
+      success: true,
+      team_id: team.id,
+      team_slug: team.slug,
+      added: result.added,
+      added_count: result.added.length,
+      failed: tagFailures(result.failed),
+      failed_count: result.failed.length,
+    });
+  },
+};
+
+// ─── team_tag_remove ────────────────────────────────────────────────────────
+
+interface TeamTagRemoveArgs {
+  classroom: string;
+  team: string;
+  tag_name?: string;
+  tag_id?: string;
+}
+
+export const teamTagRemoveTool: ToolDefinition<TeamTagRemoveArgs> = {
+  name: 'team_tag_remove',
+  // Deletes the link row (a removal), database only, and a second call errors
+  // rather than repeating cleanly → not idempotent.
+  annotations: { destructive: true, openWorld: false },
+  title: 'Detach a tag from a team',
+  description:
+    'Detaches a tag from a team (Classmoji only — nothing is written to GitHub). Owner only. ' +
+    'Identify the tag by tag_name (as shown in list_teams) or tag_id; the tag itself is not ' +
+    'deleted, only its link to this team. A tag that is not on this team is reported as not ' +
+    'found.',
+  scope: 'write',
+  roles: OWNER_ONLY,
+  inputSchema: {
+    classroom: z.string().describe("Classroom reference as 'org/slug'"),
+    team: teamRefSchema,
+    tag_name: z.string().min(1).optional().describe('Tag name as shown in list_teams'),
+    tag_id: z.string().min(1).optional().describe('Tag id (alternative to tag_name)'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    if (!args.tag_name && !args.tag_id) {
+      throw new ToolError('invalid_params', 'Provide tag_name or tag_id');
+    }
+
+    // list_teams exposes tag NAMES only — no TeamTag row ids — so the row the
+    // service deletes is resolved here, inside the authorized classroom (S1),
+    // from the team's own tag list. The service remains the single mutation
+    // path and re-checks the row against the classroom itself.
+    const team = await resolveTeamInClassroom(args.team, ctx);
+    const tags = team.tags ?? [];
+
+    let matches;
+    if (args.tag_id) {
+      matches = tags.filter(tt => tt.tag_id === args.tag_id);
+    } else {
+      const wanted = (args.tag_name ?? '').trim();
+      // Tag is unique on (classroom_id, name) CASE-SENSITIVELY, so 'Frontend'
+      // and 'frontend' can both exist: match exactly first, and only fall back
+      // to a case-insensitive match when it is unambiguous.
+      matches = tags.filter(tt => tt.tag?.name === wanted);
+      if (matches.length === 0) {
+        matches = tags.filter(tt => tt.tag?.name?.toLowerCase() === wanted.toLowerCase());
+      }
+    }
+
+    if (matches.length === 0) throw scopedNotFound('Tag');
+    if (matches.length > 1) {
+      throw new ToolError(
+        'invalid_params',
+        `Several tags on this team match that name (${matches
+          .map(m => m.tag?.name)
+          .join(', ')}) — pass tag_id instead`
+      );
+    }
+
+    let result;
+    try {
+      result = await ClassmojiService.teamAdmin.removeTeamTag({
+        classroomId: classroom.classroomId,
+        teamTagId: matches[0].id,
+      });
+    } catch (error) {
+      throw mapTeamError(error);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: 'TEAMS',
+      resource_id: result.teamId,
+      action: 'UPDATE',
+      data: {
+        tool: 'team_tag_remove',
+        team_id: result.teamId,
+        tag_id: result.tagId,
+        team_tag_id: result.teamTagId,
+      },
+    });
+
+    return ok({
+      success: true,
+      team_id: result.teamId,
+      team_slug: team.slug,
+      tag_id: result.tagId,
+      tag_name: matches[0].tag?.name ?? null,
+      team_tag_id: result.teamTagId,
+    });
+  },
+};

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
@@ -1,17 +1,38 @@
-import async from 'async';
 import { namedAction } from 'remix-utils/named-action';
 import invariant from 'tiny-invariant';
-import { sleep } from '~/utils/helpers';
-import getPrisma from '@classmoji/database';
-import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { ClassmojiService, TeamServiceError } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
 
-interface RepoRename {
-  id: string;
-  name: string;
-}
+/**
+ * Every mutation here delegates to ClassmojiService.teamAdmin, which resolves
+ * the team through the classroom before it touches GitHub. The route keeps the
+ * auth gates and the callout payload shapes; the service owns validation,
+ * ordering and per-item failure reporting.
+ */
+const errorMessage = (error: TeamServiceError, slug: string) => {
+  switch (error.code) {
+    case 'invalid_name':
+      return 'New team name is required';
+    case 'no_org_configured':
+      return 'Git organization not configured';
+    case 'provider_unsupported':
+      return 'Team rename is only supported for GitHub organizations';
+    case 'team_not_found':
+      return `Team @${slug} was not found in this classroom.`;
+    case 'reserved_name':
+      return 'That name is reserved for classroom teams. Please choose a different name.';
+    case 'name_collision':
+      return 'A team with that name already exists in this classroom.';
+    case 'user_not_found':
+      return 'No user with that login.';
+    case 'tag_not_found':
+      return 'That tag is not on this team.';
+    default:
+      return 'Could not complete this action.';
+  }
+};
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
@@ -27,49 +48,66 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   const data = await request.json();
 
+  // Map the typed service failures onto the `{ error, action }` payload the
+  // global fetcher turns into a toast; anything else keeps bubbling.
+  const run = async <T>(actionType: string, work: () => Promise<T>) => {
+    try {
+      return { ok: true as const, value: await work() };
+    } catch (error: unknown) {
+      if (error instanceof TeamServiceError) {
+        return {
+          ok: false as const,
+          payload: { error: errorMessage(error, slug), action: actionType },
+        };
+      }
+      throw error;
+    }
+  };
+
   return namedAction(request, {
     async addMembersToTeam() {
-      const { members } = data;
+      const { members } = data as { members?: string[] };
 
-      const gitOrgLogin = classroom.git_organization?.login;
-      if (!gitOrgLogin) {
-        throw new Response('Git organization not configured', { status: 400 });
+      const result = await run(ActionTypes.ADD_TEAM_MEMBER, () =>
+        ClassmojiService.teamAdmin.addTeamMembers({
+          classroomId: classroom.id,
+          slugOrId: slug,
+          logins: members ?? [],
+        })
+      );
+      if (!result.ok) return result.payload;
+
+      const { succeeded, failed } = result.value;
+      if (succeeded.length === 0 && failed.length > 0) {
+        return {
+          error: `Could not add ${failed.length} student(s) to @${slug}.`,
+          action: ActionTypes.ADD_TEAM_MEMBER,
+          failed,
+        };
       }
-      const team = await ClassmojiService.team.findBySlugAndClassroomId(slug, classroom.id);
-      const gitProvider = getGitProvider(classroom.git_organization);
-
-      const membersQueue = async.queue(async (login: string) => {
-        const user = await ClassmojiService.user.findByLogin(login);
-
-        await gitProvider.addTeamMember(gitOrgLogin, slug, login);
-        await ClassmojiService.teamMembership.addMemberToTeam(team!.id, user!.id);
-        await sleep(250);
-      }, 1);
-
-      membersQueue.push(members);
-      await membersQueue.drain();
 
       return {
-        success: `Added student(s) to @${slug}.`,
+        success:
+          failed.length === 0
+            ? `Added student(s) to @${slug}.`
+            : `Added ${succeeded.length} student(s) to @${slug}. ${failed.length} failed.`,
         action: ActionTypes.ADD_TEAM_MEMBER,
+        failed,
       };
     },
 
     async removeMemberFromTeam() {
-      const { login } = data;
+      const { login } = data as { login: string };
 
-      const user = await getPrisma().user.findUnique({
-        where: { login },
-      });
-      const gitOrgLogin = classroom.git_organization?.login;
-      if (!gitOrgLogin) {
-        throw new Response('Git organization not configured', { status: 400 });
-      }
-      const team = await ClassmojiService.team.findBySlugAndClassroomId(slug, classroom.id);
-      const gitProvider = getGitProvider(classroom.git_organization);
+      const result = await run(ActionTypes.REMOVE_TEAM_MEMBER, () =>
+        ClassmojiService.teamAdmin.removeTeamMember({
+          classroomId: classroom.id,
+          slugOrId: slug,
+          login,
+        })
+      );
+      if (!result.ok) return result.payload;
 
-      await gitProvider.removeTeamMember(gitOrgLogin, slug, login);
-      await ClassmojiService.teamMembership.removeMemberFromTeam(team!.id, user!.id);
       return {
         success: `Removed ${login} from @${slug}.`,
         action: ActionTypes.REMOVE_TEAM_MEMBER,
@@ -77,19 +115,41 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     },
 
     async addTeamTags() {
-      const { teamId, tags } = data;
+      // The team comes from the URL, never from the request body — the client
+      // used to send the teamId it wanted tagged.
+      const { tags } = data as { tags?: string[] };
 
-      await Promise.all(tags.map((tag: string) => ClassmojiService.teamTag.create(teamId, tag)));
+      const result = await run(ActionTypes.ADD_TEAM_TAG, () =>
+        ClassmojiService.teamAdmin.addTeamTags({
+          classroomId: classroom.id,
+          slugOrId: slug,
+          tagIds: tags ?? [],
+        })
+      );
+      if (!result.ok) return result.payload;
+
+      const { added, failed } = result.value;
+      if (added.length === 0 && failed.length > 0) {
+        return { error: 'Tag could not be added', action: ActionTypes.ADD_TEAM_TAG };
+      }
 
       return {
-        success: 'Tag added successfully',
+        success:
+          failed.length === 0
+            ? 'Tag added successfully'
+            : `Added ${added.length} tag(s). ${failed.length} failed.`,
         action: ActionTypes.ADD_TEAM_TAG,
       };
     },
 
     async removeTeamTag() {
-      const { id } = data;
-      await ClassmojiService.teamTag.delete(id);
+      const { id } = data as { id: string };
+
+      const result = await run(ActionTypes.REMOVE_TEAM_TAG, () =>
+        ClassmojiService.teamAdmin.removeTeamTag({ classroomId: classroom.id, teamTagId: id })
+      );
+      if (!result.ok) return result.payload;
+
       return {
         success: 'Tag removed successfully',
         action: ActionTypes.REMOVE_TEAM_TAG,
@@ -98,80 +158,17 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
     async renameTeam() {
       const { newName } = data as { newName?: string };
-      const trimmed = typeof newName === 'string' ? newName.trim() : '';
-      if (!trimmed) {
-        throw new Response('New team name is required', { status: 400 });
-      }
 
-      const gitOrgLogin = classroom.git_organization?.login;
-      if (!gitOrgLogin) {
-        throw new Response('Git organization not configured', { status: 400 });
-      }
-      if (classroom.git_organization?.provider !== 'GITHUB') {
-        throw new Response('Team rename is only supported for GitHub organizations', {
-          status: 400,
-        });
-      }
+      const result = await run(ActionTypes.RENAME_TEAM, () =>
+        ClassmojiService.teamAdmin.renameTeam({
+          classroomId: classroom.id,
+          slugOrId: slug,
+          newName: newName ?? '',
+        })
+      );
+      if (!result.ok) return result.payload;
 
-      const team = await ClassmojiService.team.findBySlugAndClassroomId(slug, classroom.id);
-      if (!team) {
-        throw new Response('Team not found', { status: 404 });
-      }
-
-      const teamWithRepos = await ClassmojiService.team.findByIdWithRepositories(team.id);
-      const repositories = teamWithRepos?.git_repos ?? [];
-
-      const gitProvider = getGitProvider(classroom.git_organization);
-
-      // Rename GitHub team first — it is authoritative for the new slug.
-      const updated = await gitProvider.updateTeam(gitOrgLogin, slug, { name: trimmed });
-      const newSlug = updated.slug;
-
-      // Collision guard: ensure another local team doesn't already occupy the new slug.
-      if (newSlug !== slug) {
-        const existing = await ClassmojiService.team.findBySlugAndClassroomId(
-          newSlug,
-          classroom.id
-        );
-        if (existing && existing.id !== team.id) {
-          throw new Response(`A team with slug "${newSlug}" already exists in this classroom`, {
-            status: 409,
-          });
-        }
-      }
-
-      const oldSuffix = `-${slug}`;
-      const failed: { name: string; error: string }[] = [];
-      const succeeded: RepoRename[] = [];
-
-      const renameQueue = async.queue<(typeof repositories)[number]>(async repo => {
-        if (!repo.name.includes(oldSuffix)) {
-          return;
-        }
-        const newRepoName = repo.name.split(oldSuffix).join(`-${newSlug}`);
-        try {
-          await gitProvider.updateRepo(gitOrgLogin, repo.name, { name: newRepoName });
-          succeeded.push({ id: repo.id, name: newRepoName });
-        } catch (error: unknown) {
-          failed.push({
-            name: repo.name,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-        await sleep(250);
-      }, 1);
-
-      if (repositories.length > 0) {
-        renameQueue.push(repositories);
-        await renameQueue.drain();
-      }
-
-      await ClassmojiService.team.renameAndRepos({
-        teamId: team.id,
-        newName: updated.name,
-        newSlug,
-        repoRenames: succeeded,
-      });
+      const { newSlug, failed } = result.value;
 
       return {
         success:

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/action.ts
@@ -1,6 +1,11 @@
 import { namedAction } from 'remix-utils/named-action';
 import invariant from 'tiny-invariant';
-import { ClassmojiService, TeamServiceError } from '@classmoji/services';
+import {
+  ClassmojiService,
+  TeamServiceError,
+  describeTeamFailureReason,
+  type TeamFailureReason,
+} from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
@@ -33,6 +38,15 @@ const errorMessage = (error: TeamServiceError, slug: string) => {
       return 'Could not complete this action.';
   }
 };
+
+/**
+ * The service reports per-item failures as reason CODES, not raw provider or
+ * database messages. The UI renders whatever it is handed, so the code is
+ * turned into its phrase here, at the boundary — the client never sees the
+ * vocabulary and the failure cards need no mapping of their own.
+ */
+const toDisplayFailures = <T extends { error: TeamFailureReason }>(failed: T[]) =>
+  failed.map(f => ({ ...f, error: describeTeamFailureReason(f.error) }));
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
@@ -78,11 +92,12 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       if (!result.ok) return result.payload;
 
       const { succeeded, failed } = result.value;
+      const displayFailed = toDisplayFailures(failed);
       if (succeeded.length === 0 && failed.length > 0) {
         return {
           error: `Could not add ${failed.length} student(s) to @${slug}.`,
           action: ActionTypes.ADD_TEAM_MEMBER,
-          failed,
+          failed: displayFailed,
         };
       }
 
@@ -92,7 +107,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
             ? `Added student(s) to @${slug}.`
             : `Added ${succeeded.length} student(s) to @${slug}. ${failed.length} failed.`,
         action: ActionTypes.ADD_TEAM_MEMBER,
-        failed,
+        failed: displayFailed,
       };
     },
 
@@ -177,7 +192,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
             : `Renamed team to @${newSlug}. ${failed.length} repo(s) failed to rename.`,
         action: ActionTypes.RENAME_TEAM,
         newSlug,
-        failed,
+        failed: toDisplayFailures(failed),
       };
     },
   });

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/route.tsx
@@ -28,9 +28,13 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const studentsObjects = _.keyBy(students, 'login');
 
   const team = await ClassmojiService.team.findBySlugAndClassroomId(slug, classroom.id);
-  const teamMembers = team!.memberships.map(({ user }) => user);
+  // The lookup is classroom-scoped, so a slug that resolves to nothing is a
+  // 404, not a crash on a non-null assertion.
+  if (!team) throw new Response(null, { status: 404 });
+
+  const teamMembers = team.memberships.map(({ user }) => user);
   const tags = await ClassmojiService.organizationTag.findByClassroomId(classroom.id);
-  const teamWithRepos = await ClassmojiService.team.findByIdWithRepositories(team!.id);
+  const teamWithRepos = await ClassmojiService.team.findByIdWithRepositories(team.id);
   const repositoryCount = teamWithRepos?.git_repos.length ?? 0;
   const canRenameTeam = classroom.git_organization?.provider === 'GITHUB';
 
@@ -41,7 +45,7 @@ const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
   const { students, teamMembers, tags, team, repositoryCount, canRenameTeam } = loaderData;
   const [membersToAdd, setMembersToAdd] = useState<string[]>([]);
   const [tagsToAdd, setTagsToAdd] = useState<string[]>([]);
-  const [renameValue, setRenameValue] = useState(team!.name);
+  const [renameValue, setRenameValue] = useState(team.name);
   const [renameConfirmOpen, setRenameConfirmOpen] = useState(false);
   const [renameFailures, setRenameFailures] = useState<{ name: string; error: string }[]>([]);
   const renameSubmitted = useRef(false);
@@ -67,7 +71,7 @@ const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
   }, [fetcher?.data, classSlug, navigate]);
 
   const trimmedRenameValue = renameValue.trim();
-  const renameDisabled = !trimmedRenameValue || trimmedRenameValue === team!.name;
+  const renameDisabled = !trimmedRenameValue || trimmedRenameValue === team.name;
 
   const onRenameSubmit = () => {
     if (renameDisabled) return;
@@ -261,7 +265,7 @@ const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
             onChange={setTagsToAdd}
             options={tags
               .filter(tag => {
-                return !team!.tags.map(t => t.tag_id).includes(tag.id);
+                return !team.tags.map(t => t.tag_id).includes(tag.id);
               })
               .map(tag => {
                 return { label: tag.name, value: tag.id };
@@ -273,7 +277,7 @@ const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
 
         <Table
           columns={tagColumns}
-          dataSource={team!.tags}
+          dataSource={team.tags}
           rowHoverable={false}
           size="small"
           className="mt-4"

--- a/apps/webapp/app/routes/admin.$class.teams.$slug.edit/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.$slug.edit/route.tsx
@@ -118,8 +118,10 @@ const AdminSingleTeamView = ({ loaderData }: Route.ComponentProps) => {
   const onAddTags = () => {
     notify(ActionTypes.ADD_TEAM_TAG, 'Adding tag(s) to team...');
 
+    // The team is identified by the URL slug the action already reads; sending
+    // a teamId from the client would just be a second, untrusted source.
     fetcher!.submit(
-      { teamId: team!.id, tags: tagsToAdd },
+      { tags: tagsToAdd },
       { method: 'post', encType: 'application/json', action: '?/addTeamTags' }
     );
 

--- a/apps/webapp/app/routes/admin.$class.teams.new/queries.ts
+++ b/apps/webapp/app/routes/admin.$class.teams.new/queries.ts
@@ -1,7 +1,0 @@
-export const GetTeamAvatarQuery = ` query ($org: String!, $slug: String!){
-    organization(login: $org) {
-      team(slug: $slug) {
-        avatarUrl
-      }
-    }
-  }`;

--- a/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
@@ -32,7 +32,10 @@ const AdminNewTeam = ({ loaderData }: Route.ComponentProps) => {
   const [name, setName] = useState('');
   const [tagsList, setTagsList] = useState([]);
 
-  const [visibility, setVisibility] = useState('secret');
+  // 'closed' (Visible) is the default: the choice used to be ignored and every
+  // team ended up visible, so this keeps the effective default unchanged now
+  // that the radio actually reaches the database.
+  const [visibility, setVisibility] = useState('closed');
   const [nameError, setNameError] = useState(false);
 
   const { show, close, visible } = useDisclosure();

--- a/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
@@ -5,8 +5,7 @@ import { Input, Modal, Form, Radio, Select } from 'antd';
 import type { ButtonProps } from 'antd';
 
 import { useGlobalFetcher, useDisclosure } from '~/hooks';
-import { ClassmojiService, getGitProvider, GitHubProvider } from '@classmoji/services';
-import { GetTeamAvatarQuery } from './queries';
+import { ClassmojiService, TeamServiceError } from '@classmoji/services';
 import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
 import type { Route } from './+types/route';
@@ -129,74 +128,54 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
   const data = await request.json();
-  const { name, visibility: _visibility, tags } = data;
-
-  const gitOrgLogin = classroom.git_organization?.login;
-  if (!gitOrgLogin) {
-    throw new Response('Git organization not configured', { status: 400 });
-  }
+  const { name, visibility, tags } = data as {
+    name: string;
+    visibility?: string;
+    tags?: string[];
+  };
 
   return namedAction(request, {
     async createTeam() {
-      const gitProvider = getGitProvider(classroom.git_organization);
-
-      // GitHub converts team names to slugs: lowercase, spaces become hyphens
-      const expectedSlug = name.toLowerCase().replace(/\s+/g, '-');
-
-      // Check if this would collide with classroom teams (e.g., "cs101-25w-students")
-      if (expectedSlug.endsWith('-students') || expectedSlug.endsWith('-assistants')) {
-        return {
-          error: `Team name "${name}" is reserved for classroom teams. Please choose a different name.`,
-          action: ActionTypes.SAVE_TEAM,
-        };
-      }
-
-      // Check if team already exists in GitHub (prevent cross-classroom collisions)
       try {
-        await gitProvider.getTeam(gitOrgLogin, expectedSlug);
-        // If we get here, team exists - reject the creation
+        const { tagsFailed } = await ClassmojiService.teamAdmin.createTeam({
+          classroomId: classroom.id,
+          name,
+          // The form's "Secret" option finally has an effect: only "closed"
+          // (Visible) stores the team as visible to non-members.
+          isVisible: visibility === 'closed',
+          tagIds: tags ?? [],
+        });
+
         return {
-          error: `A team named "${name}" already exists in this GitHub organization. Please choose a different name.`,
+          success:
+            tagsFailed.length === 0
+              ? 'Team created successfully'
+              : `Team created, but ${tagsFailed.length} tag(s) could not be attached.`,
           action: ActionTypes.SAVE_TEAM,
         };
       } catch (error: unknown) {
-        // 404 means team doesn't exist - this is what we want
-        if ((error as Record<string, unknown>)?.status !== 404) {
-          throw error;
+        if (error instanceof TeamServiceError) {
+          return { error: createErrorMessage(error, name), action: ActionTypes.SAVE_TEAM };
         }
+        throw error;
       }
-
-      const githubTeam = await gitProvider.createTeam(gitOrgLogin, name);
-
-      // Need to refetch with graphql because the GitHub API doesn't have avatarUrl
-      // for team in the return response for some reason
-      const octokit = await (gitProvider as GitHubProvider).getOctokit();
-      const teamQuery = await octokit.graphql<{ organization: { team: { avatarUrl: string } } }>(
-        GetTeamAvatarQuery,
-        {
-          org: gitOrgLogin,
-          slug: githubTeam.slug,
-        }
-      );
-
-      const team = await ClassmojiService.team.create({
-        providerId: githubTeam.id,
-        provider: 'GITHUB',
-        name: githubTeam.name,
-        slug: githubTeam.slug,
-        avatarUrl: teamQuery.organization.team.avatarUrl,
-        privacy: 'closed',
-        classroomId: classroom.id,
-      });
-
-      await Promise.all(tags.map((tag: string) => ClassmojiService.teamTag.create(team.id, tag)));
-
-      return {
-        success: 'Team created successfully',
-        action: ActionTypes.SAVE_TEAM,
-      };
     },
   });
+};
+
+const createErrorMessage = (error: TeamServiceError, name: string) => {
+  switch (error.code) {
+    case 'invalid_name':
+      return 'Team name is required';
+    case 'reserved_name':
+      return `Team name "${name}" is reserved for classroom teams. Please choose a different name.`;
+    case 'name_collision':
+      return `A team named "${name}" already exists in this GitHub organization. Please choose a different name.`;
+    case 'no_org_configured':
+      return 'Git organization not configured';
+    default:
+      return 'Could not create this team.';
+  }
 };
 
 export default AdminNewTeam;

--- a/apps/webapp/app/routes/admin.$class.teams/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams/route.tsx
@@ -9,7 +9,7 @@ import {
   SearchInput,
   TableActionButtons,
 } from '~/components';
-import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { ClassmojiService, TeamServiceError } from '@classmoji/services';
 import { useGlobalFetcher } from '~/hooks';
 import { ActionTypes } from '~/constants';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
@@ -176,6 +176,11 @@ const AdminTeams = ({ loaderData }: Route.ComponentProps) => {
   );
 };
 
+const DELETE_ERRORS: Partial<Record<TeamServiceError['code'], string>> = {
+  team_not_found: 'That team no longer exists in this classroom.',
+  no_org_configured: 'Git organization not configured',
+};
+
 export const action = async ({ params, request }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
@@ -188,10 +193,20 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
   const data = await request.json();
   const { team } = data;
 
-  const gitProvider = getGitProvider(classroom.git_organization);
-
-  await gitProvider.deleteTeam(classroom.git_organization.login, team.slug);
-  await ClassmojiService.team.deleteBySlug(classroom.id, team.slug);
+  try {
+    await ClassmojiService.teamAdmin.deleteTeam({
+      classroomId: classroom.id,
+      slugOrId: team.slug,
+    });
+  } catch (error: unknown) {
+    if (error instanceof TeamServiceError) {
+      return {
+        error: DELETE_ERRORS[error.code] ?? 'Could not delete this team.',
+        action: ActionTypes.DELETE_TEAM,
+      };
+    }
+    throw error;
+  }
 
   return {
     success: 'Team deleted successfully',

--- a/apps/webapp/app/routes/student.$class.repos_.$repo.team/route.tsx
+++ b/apps/webapp/app/routes/student.$class.repos_.$repo.team/route.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useFetcher, Link } from 'react-router';
 import { namedAction } from 'remix-utils/named-action';
 import type { Route } from './+types/route';
-import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import { ClassmojiService, getGitProvider, isReservedSlug } from '@classmoji/services';
 import { useCallout } from '@classmoji/ui-components';
 import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { titleToIdentifier } from '@classmoji/utils';
@@ -125,6 +125,17 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
       const teamSlug = titleToIdentifier(teamName);
 
+      // `{classroom-slug}-students` / `-assistants` name the classroom's own
+      // GitHub membership teams, which have no local Team row and must not be
+      // reachable from this form. The check runs on the slug BEFORE the
+      // provider call, because gitProvider.createTeam adopts an existing team
+      // on a 422 rather than failing — so a request landing on one of those
+      // slugs would come back holding the classroom's membership team. A name
+      // that slugifies to nothing is refused here too.
+      if (!teamSlug || isReservedSlug(teamSlug)) {
+        return { error: 'That team name is not available.' };
+      }
+
       // Check if team name already exists
       const existingTeam = await ClassmojiService.team.findBySlugAndClassroomId(
         teamSlug,
@@ -155,6 +166,18 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         return {
           error: 'Failed to create team on GitHub. Please try again or contact your instructor.',
         };
+      }
+
+      // GitHub is authoritative for the slug, so the same check runs again on
+      // what it returned. Deliberately NO rollback here: createTeam adopts an
+      // existing team on a 422, so the team in hand may be one that already
+      // existed — deleting it could remove the classroom's own membership
+      // team. Nothing local has been written yet, so refusing is enough.
+      if (isReservedSlug(githubTeam.slug)) {
+        console.error(
+          `[team] refusing to record a team on the reserved slug ${githubTeam.slug} in ${orgLogin}`
+        );
+        return { error: 'That team name is not available.' };
       }
 
       // Create team in database with membership and tag
@@ -205,10 +228,12 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         return { error: 'You are already on a team. Leave your current team first.' };
       }
 
-      // Get the team
+      // Get the team. teamId comes from the request body, so the row is scoped
+      // to THIS classroom before it is used — an id naming a team in another
+      // classroom resolves to nothing, exactly like an id naming nothing.
       const team = await ClassmojiService.team.findById(teamId);
 
-      if (!team) {
+      if (!team || team.classroom_id !== classroom.id) {
         return { error: 'Team not found' };
       }
 
@@ -222,8 +247,8 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         return { error: 'This team is full' };
       }
 
-      // Add user to team
-      await ClassmojiService.teamMembership.addMemberToTeam(teamId, userId);
+      // Add user to team — the RESOLVED row's id, not the raw body value.
+      await ClassmojiService.teamMembership.addMemberToTeam(team.id, userId);
 
       // Add user to GitHub team
       try {

--- a/packages/services/src/classmoji/__tests__/team.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/team.service.test.ts
@@ -99,6 +99,9 @@ const notFound = (message = 'Not Found') => Object.assign(new Error(message), { 
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The service logs the raw provider/DB error behind every reported failure;
+  // the tests assert the reason code, so the log itself is silenced.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
   classroomFindById.mockResolvedValue(CLASSROOM);
   teamFindFirst.mockResolvedValue(TEAM);
   teamFindBySlug.mockResolvedValue(null);
@@ -112,6 +115,10 @@ beforeEach(() => {
 
 describe('teamAdmin.createTeam', () => {
   it('creates on the provider then locally, wiring is_visible through honestly', async () => {
+    // The stored row is what the result echoes, so the mock has to agree with
+    // the flag that was asked for — otherwise the assertion proves nothing.
+    teamCreate.mockResolvedValue({ ...TEAM, is_visible: true });
+
     const result = await teamAdmin.createTeam({
       classroomId: 'class-1',
       name: '  Blue Team  ',
@@ -131,7 +138,7 @@ describe('teamAdmin.createTeam', () => {
       id: 'team-1',
       name: 'Blue Team',
       slug: 'blue-team',
-      isVisible: false,
+      isVisible: true,
     });
   });
 
@@ -193,9 +200,7 @@ describe('teamAdmin.createTeam', () => {
     expect(teamTagCreate).toHaveBeenCalledTimes(1);
     expect(teamTagCreate).toHaveBeenCalledWith('team-1', 'tag-ok');
     expect(result.tagsAdded).toEqual(['tag-ok']);
-    expect(result.tagsFailed).toEqual([
-      { tagId: 'tag-elsewhere', error: 'Tag does not belong to this classroom' },
-    ]);
+    expect(result.tagsFailed).toEqual([{ tagId: 'tag-elsewhere', error: 'invalid' }]);
   });
 
   it('reports a failing tag without losing the tags after it', async () => {
@@ -209,7 +214,9 @@ describe('teamAdmin.createTeam', () => {
     });
 
     expect(result.tagsAdded).toEqual(['tag-b']);
-    expect(result.tagsFailed).toEqual([{ tagId: 'tag-a', error: 'boom' }]);
+    // The reason is reported; the raw message stays in the server log.
+    expect(result.tagsFailed).toEqual([{ tagId: 'tag-a', error: 'db_error' }]);
+    expect(JSON.stringify(result.tagsFailed)).not.toContain('boom');
   });
 
   it('throws no_org_configured when the classroom has no git organization', async () => {
@@ -218,6 +225,46 @@ describe('teamAdmin.createTeam', () => {
     await expect(
       teamAdmin.createTeam({ classroomId: 'class-1', name: 'Blue Team' })
     ).rejects.toMatchObject({ code: 'no_org_configured' });
+  });
+
+  // The prediction collapses whitespace only; GitHub also folds punctuation, so
+  // a name whose PREDICTED slug passes the pre-flight checks can still land on
+  // an authoritative slug that fails them. Both checks therefore run again on
+  // the slug the provider returns.
+  it('refuses a reserved authoritative slug and deletes the team it just created', async () => {
+    // Predicted: 'cs1-25f-students!' — not reserved. GitHub: 'cs1-25f-students'.
+    createTeam.mockResolvedValue({ id: 9, slug: 'cs1-25f-students', name: 'CS1-25F Students!' });
+
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: 'CS1-25F Students!' })
+    ).rejects.toMatchObject({ code: 'reserved_name' });
+
+    expect(deleteTeam).toHaveBeenCalledWith('cs1-org', 'cs1-25f-students');
+    expect(teamCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an authoritative slug already used locally and rolls the team back', async () => {
+    createTeam.mockResolvedValue({ id: 9, slug: 'blue-team', name: 'Blue Team!' });
+    teamFindBySlug.mockResolvedValue({ id: 'other-team', slug: 'blue-team' });
+
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: 'Blue Team!' })
+    ).rejects.toMatchObject({ code: 'name_collision' });
+
+    expect(teamFindBySlug).toHaveBeenCalledWith('blue-team', 'class-1');
+    expect(deleteTeam).toHaveBeenCalledWith('cs1-org', 'blue-team');
+    expect(teamCreate).not.toHaveBeenCalled();
+  });
+
+  it('still refuses when the rollback itself fails', async () => {
+    // Predicted: 'cs1-25f.assistants' — not reserved. GitHub: 'cs1-25f-assistants'.
+    createTeam.mockResolvedValue({ id: 9, slug: 'cs1-25f-assistants', name: 'CS1 25F.Assistants' });
+    deleteTeam.mockRejectedValueOnce(new Error('rollback failed'));
+
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: 'CS1 25F.Assistants' })
+    ).rejects.toMatchObject({ code: 'reserved_name' });
+    expect(teamCreate).not.toHaveBeenCalled();
   });
 });
 
@@ -232,7 +279,34 @@ describe('teamAdmin.deleteTeam', () => {
       name: 'Blue Team',
       slug: 'blue-team',
       removedFromProvider: true,
+      reposDeleted: 0,
+      deletedRepoNames: [],
     });
+  });
+
+  it('counts the linked repo records that go with the team, before the delete', async () => {
+    teamFindByIdWithRepositories.mockResolvedValue({
+      git_repos: [
+        { id: 'r1', name: 'hw1-blue-team' },
+        { id: 'r2', name: 'hw2-blue-team' },
+      ],
+    });
+
+    const result = await teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'blue-team' });
+
+    expect(result.reposDeleted).toBe(2);
+    expect(result.deletedRepoNames).toEqual(['hw1-blue-team', 'hw2-blue-team']);
+  });
+
+  it('caps the reported repo names at 20 while still counting them all', async () => {
+    teamFindByIdWithRepositories.mockResolvedValue({
+      git_repos: Array.from({ length: 25 }, (_, i) => ({ id: `r${i}`, name: `hw${i}-blue-team` })),
+    });
+
+    const result = await teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'blue-team' });
+
+    expect(result.reposDeleted).toBe(25);
+    expect(result.deletedRepoNames).toHaveLength(20);
   });
 
   it('resolves first: an unknown slug is rejected with ZERO provider calls', async () => {
@@ -353,7 +427,28 @@ describe('teamAdmin.renameTeam', () => {
       repoRenames: [{ id: 'r1', name: 'hw1-green-team' }],
     });
     expect(result.renamedRepos).toEqual(['hw1-green-team']);
-    expect(result.failed).toEqual([{ name: 'hw2-blue-team', error: 'repo is archived' }]);
+    // The reason is reported; the provider's own message stays in the log.
+    expect(result.failed).toEqual([{ name: 'hw2-blue-team', error: 'provider_error' }]);
+  });
+
+  it('refuses a reserved authoritative slug and puts the provider name back', async () => {
+    // Predicted: 'cs1-25f-students!' — not reserved. GitHub: 'cs1-25f-students'.
+    updateTeam.mockResolvedValue({ id: 7, slug: 'cs1-25f-students', name: 'CS1-25F Students!' });
+
+    await expect(
+      teamAdmin.renameTeam({
+        classroomId: 'class-1',
+        slugOrId: 'blue-team',
+        newName: 'CS1-25F Students!',
+      })
+    ).rejects.toMatchObject({ code: 'reserved_name' });
+
+    // Best-effort revert on the provider; nothing local was written.
+    expect(updateTeam).toHaveBeenLastCalledWith('cs1-org', 'cs1-25f-students', {
+      name: 'Blue Team',
+    });
+    expect(updateRepo).not.toHaveBeenCalled();
+    expect(teamRenameAndRepos).not.toHaveBeenCalled();
   });
 
   it('rejects renaming onto a reserved classroom-team name', async () => {
@@ -404,9 +499,10 @@ describe('teamAdmin.addTeamMembers', () => {
 
     expect(result.succeeded).toEqual([{ login: 'ada' }]);
     expect(result.failed).toEqual([
-      { login: 'ghost', error: 'No user with that login' },
-      { login: 'grace', error: 'not in org' },
+      { login: 'ghost', error: 'not_found' },
+      { login: 'grace', error: 'provider_error' },
     ]);
+    expect(JSON.stringify(result.failed)).not.toContain('not in org');
     // The membership row is only written when the provider call succeeded.
     expect(addMemberToTeam).toHaveBeenCalledTimes(1);
   });
@@ -486,9 +582,7 @@ describe('teamAdmin.addTeamTags', () => {
 
     expect(teamTagCreate).toHaveBeenCalledTimes(1);
     expect(result.added).toEqual(['tag-ok']);
-    expect(result.failed).toEqual([
-      { tagId: 'tag-elsewhere', error: 'Tag does not belong to this classroom' },
-    ]);
+    expect(result.failed).toEqual([{ tagId: 'tag-elsewhere', error: 'invalid' }]);
   });
 
   it('treats an already-attached tag as added', async () => {
@@ -544,5 +638,22 @@ describe('TeamServiceError', () => {
     expect(error).toBeInstanceOf(Error);
     expect(error.name).toBe('TeamServiceError');
     expect(error.code).toBe('team_not_found');
+  });
+});
+
+describe('describeTeamFailureReason', () => {
+  it('gives every reason in the closed vocabulary a phrase', () => {
+    for (const reason of ['provider_error', 'not_found', 'db_error', 'invalid'] as const) {
+      expect(teamAdmin.describeTeamFailureReason(reason)).toBeTruthy();
+    }
+  });
+});
+
+describe('isReservedSlug', () => {
+  it('matches the classroom membership-team suffixes only', () => {
+    expect(teamAdmin.isReservedSlug('cs1-25f-students')).toBe(true);
+    expect(teamAdmin.isReservedSlug('cs1-25f-assistants')).toBe(true);
+    expect(teamAdmin.isReservedSlug('blue-team')).toBe(false);
+    expect(teamAdmin.isReservedSlug('cs1-25f-students-2')).toBe(false);
   });
 });

--- a/packages/services/src/classmoji/__tests__/team.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/team.service.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Unit tests for teamAdmin — the team management logic extracted from the web
+ * admin.$class.teams* actions so the MCP team tools can share it.
+ *
+ * Prisma, the git provider, the sibling services and the throttle are mocked.
+ * The tests pin the two invariants the extraction exists to establish: every
+ * mutation resolves its team through the classroom BEFORE anything reaches the
+ * provider, and every bulk operation reports its per-item failures instead of
+ * swallowing them.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const teamFindFirst = vi.fn();
+const tagFindMany = vi.fn();
+const teamTagFindFirst = vi.fn();
+const userFindFirst = vi.fn();
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    team: { findFirst: (...a: unknown[]) => teamFindFirst(...a) },
+    tag: { findMany: (...a: unknown[]) => tagFindMany(...a) },
+    teamTag: { findFirst: (...a: unknown[]) => teamTagFindFirst(...a) },
+    user: { findFirst: (...a: unknown[]) => userFindFirst(...a) },
+  }),
+}));
+
+const getTeam = vi.fn();
+const createTeam = vi.fn();
+const deleteTeam = vi.fn();
+const updateTeam = vi.fn();
+const updateRepo = vi.fn();
+const addTeamMember = vi.fn();
+const removeTeamMember = vi.fn();
+vi.mock('../../git/index.ts', () => ({
+  getGitProvider: () => ({
+    getTeam: (...a: unknown[]) => getTeam(...a),
+    createTeam: (...a: unknown[]) => createTeam(...a),
+    deleteTeam: (...a: unknown[]) => deleteTeam(...a),
+    updateTeam: (...a: unknown[]) => updateTeam(...a),
+    updateRepo: (...a: unknown[]) => updateRepo(...a),
+    addTeamMember: (...a: unknown[]) => addTeamMember(...a),
+    removeTeamMember: (...a: unknown[]) => removeTeamMember(...a),
+  }),
+}));
+
+// Real timers would make every queued test wait 250ms per item.
+vi.mock('../sleep.ts', () => ({ sleep: vi.fn(async () => {}) }));
+
+const classroomFindById = vi.fn();
+vi.mock('../classroom.service.ts', () => ({
+  findById: (...a: unknown[]) => classroomFindById(...a),
+}));
+
+const teamCreate = vi.fn();
+const teamDeleteBySlug = vi.fn();
+const teamFindBySlug = vi.fn();
+const teamFindByIdWithRepositories = vi.fn();
+const teamRenameAndRepos = vi.fn();
+vi.mock('../team.service.ts', () => ({
+  create: (...a: unknown[]) => teamCreate(...a),
+  deleteBySlug: (...a: unknown[]) => teamDeleteBySlug(...a),
+  findBySlugAndClassroomId: (...a: unknown[]) => teamFindBySlug(...a),
+  findByIdWithRepositories: (...a: unknown[]) => teamFindByIdWithRepositories(...a),
+  renameAndRepos: (...a: unknown[]) => teamRenameAndRepos(...a),
+}));
+
+const addMemberToTeam = vi.fn();
+const removeMemberFromTeam = vi.fn();
+vi.mock('../teamMembership.service.ts', () => ({
+  addMemberToTeam: (...a: unknown[]) => addMemberToTeam(...a),
+  removeMemberFromTeam: (...a: unknown[]) => removeMemberFromTeam(...a),
+}));
+
+const teamTagCreate = vi.fn();
+const teamTagDelete = vi.fn();
+vi.mock('../teamTag.service.ts', () => ({
+  create: (...a: unknown[]) => teamTagCreate(...a),
+  delete: (...a: unknown[]) => teamTagDelete(...a),
+}));
+
+const teamAdmin = await import('../teamAdmin.service.ts');
+const { TeamServiceError } = teamAdmin;
+
+const CLASSROOM = {
+  id: 'class-1',
+  slug: 'cs1-25f',
+  git_organization: { id: 'org-1', login: 'cs1-org', provider: 'GITHUB' },
+};
+
+const TEAM = {
+  id: 'team-1',
+  name: 'Blue Team',
+  slug: 'blue-team',
+  is_visible: false,
+  classroom_id: 'class-1',
+};
+
+const notFound = (message = 'Not Found') => Object.assign(new Error(message), { status: 404 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  classroomFindById.mockResolvedValue(CLASSROOM);
+  teamFindFirst.mockResolvedValue(TEAM);
+  teamFindBySlug.mockResolvedValue(null);
+  teamFindByIdWithRepositories.mockResolvedValue({ git_repos: [] });
+  tagFindMany.mockResolvedValue([]);
+  getTeam.mockRejectedValue(notFound());
+  createTeam.mockResolvedValue({ id: 7, slug: 'blue-team', name: 'Blue Team' });
+  teamCreate.mockResolvedValue(TEAM);
+  removeMemberFromTeam.mockResolvedValue({ count: 1 });
+});
+
+describe('teamAdmin.createTeam', () => {
+  it('creates on the provider then locally, wiring is_visible through honestly', async () => {
+    const result = await teamAdmin.createTeam({
+      classroomId: 'class-1',
+      name: '  Blue Team  ',
+      isVisible: true,
+    });
+
+    expect(createTeam).toHaveBeenCalledWith('cs1-org', 'Blue Team');
+    expect(teamCreate).toHaveBeenCalledWith({
+      providerId: 7,
+      provider: 'GITHUB',
+      name: 'Blue Team',
+      slug: 'blue-team',
+      classroomId: 'class-1',
+      isVisible: true,
+    });
+    expect(result.team).toEqual({
+      id: 'team-1',
+      name: 'Blue Team',
+      slug: 'blue-team',
+      isVisible: false,
+    });
+  });
+
+  it('defaults is_visible to false rather than always storing a visible team', async () => {
+    await teamAdmin.createTeam({ classroomId: 'class-1', name: 'Blue Team' });
+
+    expect(teamCreate.mock.calls[0][0]).toMatchObject({ isVisible: false });
+  });
+
+  it('refuses a name whose slug would collide with the classroom teams', async () => {
+    for (const name of ['cs1 25f students', 'CS1-25F-Assistants']) {
+      await expect(teamAdmin.createTeam({ classroomId: 'class-1', name })).rejects.toMatchObject({
+        code: 'reserved_name',
+      });
+    }
+    expect(getTeam).not.toHaveBeenCalled();
+    expect(createTeam).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty name before anything else runs', async () => {
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: '   ' })
+    ).rejects.toMatchObject({ code: 'invalid_name' });
+    expect(classroomFindById).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the provider already has a team on the predicted slug', async () => {
+    getTeam.mockResolvedValue({ id: 3, slug: 'blue-team', name: 'Blue Team' });
+
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: 'Blue Team' })
+    ).rejects.toMatchObject({ code: 'name_collision' });
+    expect(createTeam).not.toHaveBeenCalled();
+  });
+
+  it('propagates a non-404 collision-check failure instead of reading it as "name taken"', async () => {
+    getTeam.mockRejectedValue(Object.assign(new Error('rate limited'), { status: 403 }));
+
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: 'Blue Team' })
+    ).rejects.toThrow('rate limited');
+    expect(createTeam).not.toHaveBeenCalled();
+  });
+
+  it('validates tag ids against the classroom before the provider write and reports the rest', async () => {
+    tagFindMany.mockResolvedValue([{ id: 'tag-ok' }]);
+
+    const result = await teamAdmin.createTeam({
+      classroomId: 'class-1',
+      name: 'Blue Team',
+      tagIds: ['tag-ok', 'tag-elsewhere'],
+    });
+
+    expect(tagFindMany.mock.calls[0][0].where).toEqual({
+      id: { in: ['tag-ok', 'tag-elsewhere'] },
+      classroom_id: 'class-1',
+    });
+    // The out-of-classroom id never reaches a write.
+    expect(teamTagCreate).toHaveBeenCalledTimes(1);
+    expect(teamTagCreate).toHaveBeenCalledWith('team-1', 'tag-ok');
+    expect(result.tagsAdded).toEqual(['tag-ok']);
+    expect(result.tagsFailed).toEqual([
+      { tagId: 'tag-elsewhere', error: 'Tag does not belong to this classroom' },
+    ]);
+  });
+
+  it('reports a failing tag without losing the tags after it', async () => {
+    tagFindMany.mockResolvedValue([{ id: 'tag-a' }, { id: 'tag-b' }]);
+    teamTagCreate.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({ id: 'tt-2' });
+
+    const result = await teamAdmin.createTeam({
+      classroomId: 'class-1',
+      name: 'Blue Team',
+      tagIds: ['tag-a', 'tag-b'],
+    });
+
+    expect(result.tagsAdded).toEqual(['tag-b']);
+    expect(result.tagsFailed).toEqual([{ tagId: 'tag-a', error: 'boom' }]);
+  });
+
+  it('throws no_org_configured when the classroom has no git organization', async () => {
+    classroomFindById.mockResolvedValue({ ...CLASSROOM, git_organization: null });
+
+    await expect(
+      teamAdmin.createTeam({ classroomId: 'class-1', name: 'Blue Team' })
+    ).rejects.toMatchObject({ code: 'no_org_configured' });
+  });
+});
+
+describe('teamAdmin.deleteTeam', () => {
+  it('deletes on the provider and locally once the local row resolves', async () => {
+    const result = await teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'blue-team' });
+
+    expect(deleteTeam).toHaveBeenCalledWith('cs1-org', 'blue-team');
+    expect(teamDeleteBySlug).toHaveBeenCalledWith('class-1', 'blue-team');
+    expect(result).toEqual({
+      id: 'team-1',
+      name: 'Blue Team',
+      slug: 'blue-team',
+      removedFromProvider: true,
+    });
+  });
+
+  it('resolves first: an unknown slug is rejected with ZERO provider calls', async () => {
+    teamFindFirst.mockResolvedValue(null);
+
+    await expect(
+      teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'cs1-25f-students' })
+    ).rejects.toMatchObject({ code: 'team_not_found' });
+
+    expect(deleteTeam).not.toHaveBeenCalled();
+    expect(teamDeleteBySlug).not.toHaveBeenCalled();
+  });
+
+  it('scopes the lookup to the classroom, by slug or id', async () => {
+    await teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'blue-team' });
+
+    expect(teamFindFirst.mock.calls[0][0].where).toEqual({
+      classroom_id: 'class-1',
+      OR: [{ slug: 'blue-team' }, { id: 'blue-team' }],
+    });
+  });
+
+  it('tolerates a provider 404 and still removes the local row', async () => {
+    deleteTeam.mockRejectedValue(notFound());
+
+    const result = await teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'blue-team' });
+
+    expect(teamDeleteBySlug).toHaveBeenCalledWith('class-1', 'blue-team');
+    expect(result.removedFromProvider).toBe(false);
+  });
+
+  it('propagates a non-404 provider failure and leaves the local row alone', async () => {
+    deleteTeam.mockRejectedValue(Object.assign(new Error('forbidden'), { status: 403 }));
+
+    await expect(
+      teamAdmin.deleteTeam({ classroomId: 'class-1', slugOrId: 'blue-team' })
+    ).rejects.toThrow('forbidden');
+    expect(teamDeleteBySlug).not.toHaveBeenCalled();
+  });
+});
+
+describe('teamAdmin.renameTeam', () => {
+  beforeEach(() => {
+    updateTeam.mockResolvedValue({ id: 7, slug: 'green-team', name: 'Green Team' });
+  });
+
+  it('runs the local collision check BEFORE the provider rename', async () => {
+    teamFindBySlug.mockResolvedValue({ id: 'other-team', slug: 'green-team' });
+
+    await expect(
+      teamAdmin.renameTeam({ classroomId: 'class-1', slugOrId: 'blue-team', newName: 'Green Team' })
+    ).rejects.toMatchObject({ code: 'name_collision' });
+
+    // The predicted slug is what catches it — GitHub is never asked to rename.
+    expect(teamFindBySlug).toHaveBeenCalledWith('green-team', 'class-1');
+    expect(updateTeam).not.toHaveBeenCalled();
+  });
+
+  it('still checks the slug GitHub actually returns', async () => {
+    // Predicted 'green-team' is free; GitHub hands back 'green-team-2', taken.
+    updateTeam.mockResolvedValue({ id: 7, slug: 'green-team-2', name: 'Green Team' });
+    teamFindBySlug.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'other-team' });
+
+    await expect(
+      teamAdmin.renameTeam({ classroomId: 'class-1', slugOrId: 'blue-team', newName: 'Green Team' })
+    ).rejects.toMatchObject({ code: 'name_collision' });
+    expect(teamRenameAndRepos).not.toHaveBeenCalled();
+  });
+
+  it('refuses a non-GitHub organization before resolving anything', async () => {
+    classroomFindById.mockResolvedValue({
+      ...CLASSROOM,
+      git_organization: { ...CLASSROOM.git_organization, provider: 'GITLAB' },
+    });
+
+    await expect(
+      teamAdmin.renameTeam({ classroomId: 'class-1', slugOrId: 'blue-team', newName: 'Green Team' })
+    ).rejects.toMatchObject({ code: 'provider_unsupported' });
+    expect(updateTeam).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown team with no provider call', async () => {
+    teamFindFirst.mockResolvedValue(null);
+
+    await expect(
+      teamAdmin.renameTeam({ classroomId: 'class-1', slugOrId: 'nope', newName: 'Green Team' })
+    ).rejects.toMatchObject({ code: 'team_not_found' });
+    expect(updateTeam).not.toHaveBeenCalled();
+  });
+
+  it('cascades the new slug onto matching repos and persists only the successes', async () => {
+    teamFindByIdWithRepositories.mockResolvedValue({
+      git_repos: [
+        { id: 'r1', name: 'hw1-blue-team' },
+        { id: 'r2', name: 'hw2-blue-team' },
+        { id: 'r3', name: 'unrelated-repo' },
+      ],
+    });
+    updateRepo.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('repo is archived'));
+
+    const result = await teamAdmin.renameTeam({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      newName: 'Green Team',
+    });
+
+    // The unrelated repo is skipped, so only two provider calls happen.
+    expect(updateRepo).toHaveBeenCalledTimes(2);
+    expect(updateRepo).toHaveBeenNthCalledWith(1, 'cs1-org', 'hw1-blue-team', {
+      name: 'hw1-green-team',
+    });
+
+    // A failed repo must not be written to the DB as if it had been renamed.
+    expect(teamRenameAndRepos).toHaveBeenCalledWith({
+      teamId: 'team-1',
+      newName: 'Green Team',
+      newSlug: 'green-team',
+      repoRenames: [{ id: 'r1', name: 'hw1-green-team' }],
+    });
+    expect(result.renamedRepos).toEqual(['hw1-green-team']);
+    expect(result.failed).toEqual([{ name: 'hw2-blue-team', error: 'repo is archived' }]);
+  });
+
+  it('rejects renaming onto a reserved classroom-team name', async () => {
+    await expect(
+      teamAdmin.renameTeam({
+        classroomId: 'class-1',
+        slugOrId: 'blue-team',
+        newName: 'cs1 25f students',
+      })
+    ).rejects.toMatchObject({ code: 'reserved_name' });
+    expect(updateTeam).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty new name', async () => {
+    await expect(
+      teamAdmin.renameTeam({ classroomId: 'class-1', slugOrId: 'blue-team', newName: '  ' })
+    ).rejects.toMatchObject({ code: 'invalid_name' });
+  });
+});
+
+describe('teamAdmin.addTeamMembers', () => {
+  it('adds each login to the provider team and the local membership', async () => {
+    userFindFirst.mockResolvedValue({ id: 'u-1', login: 'ada' });
+
+    const result = await teamAdmin.addTeamMembers({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      logins: ['ada'],
+    });
+
+    expect(addTeamMember).toHaveBeenCalledWith('cs1-org', 'blue-team', 'ada');
+    expect(addMemberToTeam).toHaveBeenCalledWith('team-1', 'u-1');
+    expect(result).toEqual({ succeeded: [{ login: 'ada' }], failed: [] });
+  });
+
+  it('reports per-member failures instead of swallowing them, and keeps going', async () => {
+    userFindFirst
+      .mockResolvedValueOnce({ id: 'u-1', login: 'ada' })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'u-3', login: 'grace' });
+    addTeamMember.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('not in org'));
+
+    const result = await teamAdmin.addTeamMembers({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      logins: ['ada', 'ghost', 'grace'],
+    });
+
+    expect(result.succeeded).toEqual([{ login: 'ada' }]);
+    expect(result.failed).toEqual([
+      { login: 'ghost', error: 'No user with that login' },
+      { login: 'grace', error: 'not in org' },
+    ]);
+    // The membership row is only written when the provider call succeeded.
+    expect(addMemberToTeam).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an unknown team with no provider call', async () => {
+    teamFindFirst.mockResolvedValue(null);
+
+    await expect(
+      teamAdmin.addTeamMembers({ classroomId: 'class-1', slugOrId: 'nope', logins: ['ada'] })
+    ).rejects.toMatchObject({ code: 'team_not_found' });
+    expect(addTeamMember).not.toHaveBeenCalled();
+  });
+});
+
+describe('teamAdmin.removeTeamMember', () => {
+  it('resolves the user BEFORE the provider removal', async () => {
+    userFindFirst.mockResolvedValue(null);
+
+    await expect(
+      teamAdmin.removeTeamMember({ classroomId: 'class-1', slugOrId: 'blue-team', login: 'ghost' })
+    ).rejects.toMatchObject({ code: 'user_not_found' });
+    expect(removeTeamMember).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when the membership row is already gone', async () => {
+    userFindFirst.mockResolvedValue({ id: 'u-1', login: 'ada' });
+    removeMemberFromTeam.mockResolvedValue({ count: 0 });
+
+    const result = await teamAdmin.removeTeamMember({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      login: 'ada',
+    });
+
+    expect(removeTeamMember).toHaveBeenCalledWith('cs1-org', 'blue-team', 'ada');
+    expect(result).toEqual({ teamId: 'team-1', login: 'ada', removed: false });
+  });
+
+  it('uses the stored login casing for the provider call', async () => {
+    userFindFirst.mockResolvedValue({ id: 'u-1', login: 'ada' });
+
+    await teamAdmin.removeTeamMember({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      login: 'Ada',
+    });
+
+    expect(userFindFirst.mock.calls[0][0].where).toEqual({
+      login: { equals: 'Ada', mode: 'insensitive' },
+    });
+    expect(removeTeamMember).toHaveBeenCalledWith('cs1-org', 'blue-team', 'ada');
+  });
+});
+
+describe('teamAdmin.addTeamTags', () => {
+  it('resolves the team through the classroom rather than trusting a caller id', async () => {
+    tagFindMany.mockResolvedValue([{ id: 'tag-ok' }]);
+
+    await teamAdmin.addTeamTags({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      tagIds: ['tag-ok'],
+    });
+
+    expect(teamFindFirst.mock.calls[0][0].where.classroom_id).toBe('class-1');
+    expect(teamTagCreate).toHaveBeenCalledWith('team-1', 'tag-ok');
+  });
+
+  it('rejects a tag id from another classroom and still attaches the valid ones', async () => {
+    tagFindMany.mockResolvedValue([{ id: 'tag-ok' }]);
+
+    const result = await teamAdmin.addTeamTags({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      tagIds: ['tag-ok', 'tag-elsewhere'],
+    });
+
+    expect(teamTagCreate).toHaveBeenCalledTimes(1);
+    expect(result.added).toEqual(['tag-ok']);
+    expect(result.failed).toEqual([
+      { tagId: 'tag-elsewhere', error: 'Tag does not belong to this classroom' },
+    ]);
+  });
+
+  it('treats an already-attached tag as added', async () => {
+    tagFindMany.mockResolvedValue([{ id: 'tag-ok' }]);
+    teamTagCreate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
+
+    const result = await teamAdmin.addTeamTags({
+      classroomId: 'class-1',
+      slugOrId: 'blue-team',
+      tagIds: ['tag-ok'],
+    });
+
+    expect(result).toEqual({ added: ['tag-ok'], failed: [] });
+  });
+
+  it('rejects an unknown team', async () => {
+    teamFindFirst.mockResolvedValue(null);
+
+    await expect(
+      teamAdmin.addTeamTags({ classroomId: 'class-1', slugOrId: 'nope', tagIds: ['tag-ok'] })
+    ).rejects.toMatchObject({ code: 'team_not_found' });
+    expect(teamTagCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('teamAdmin.removeTeamTag', () => {
+  it('resolves the TeamTag row through its team classroom before deleting', async () => {
+    teamTagFindFirst.mockResolvedValue({ id: 'tt-1', team_id: 'team-1', tag_id: 'tag-1' });
+
+    const result = await teamAdmin.removeTeamTag({ classroomId: 'class-1', teamTagId: 'tt-1' });
+
+    expect(teamTagFindFirst.mock.calls[0][0].where).toEqual({
+      id: 'tt-1',
+      team: { classroom_id: 'class-1' },
+    });
+    expect(teamTagDelete).toHaveBeenCalledWith('tt-1');
+    expect(result).toEqual({ teamTagId: 'tt-1', teamId: 'team-1', tagId: 'tag-1' });
+  });
+
+  it('does not delete a TeamTag that lives in another classroom', async () => {
+    teamTagFindFirst.mockResolvedValue(null);
+
+    await expect(
+      teamAdmin.removeTeamTag({ classroomId: 'class-1', teamTagId: 'tt-elsewhere' })
+    ).rejects.toMatchObject({ code: 'tag_not_found' });
+    expect(teamTagDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe('TeamServiceError', () => {
+  it('carries a code callers can switch on', () => {
+    const error = new TeamServiceError('team_not_found', 'nope');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('TeamServiceError');
+    expect(error.code).toBe('team_not_found');
+  });
+});

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -4,6 +4,7 @@ import * as classroomService from './classroom.service.ts';
 import * as classroomMembershipService from './classroomMembership.service.ts';
 import * as rosterService from './roster.service.ts';
 import * as assistantService from './assistant.service.ts';
+import * as teamAdminService from './teamAdmin.service.ts';
 import * as moduleService from './module.service.ts';
 import * as repositoryService from './repository.service.ts';
 import * as autogradingTestService from './autogradingTest.service.ts';
@@ -79,6 +80,7 @@ const ClassmojiService = {
   subscription: subscriptionService,
   teamMembership: teamMembershipService,
   team: teamService,
+  teamAdmin: teamAdminService,
   teamTag: teamTagService,
   token: tokenService,
   user: userService,
@@ -136,6 +138,7 @@ export {
   subscriptionService,
   teamMembershipService,
   teamService,
+  teamAdminService,
   teamTagService,
   tokenService,
   userService,

--- a/packages/services/src/classmoji/sleep.ts
+++ b/packages/services/src/classmoji/sleep.ts
@@ -1,0 +1,10 @@
+/**
+ * Throttle helper for provider-API loops.
+ *
+ * Lives in its own module so tests can `vi.mock` it away — a local `const sleep`
+ * inside a service cannot be intercepted, and the rename/add-member queues would
+ * otherwise make every unit test wait on real timers.
+ */
+export const sleep = async (ms: number): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};

--- a/packages/services/src/classmoji/team.service.ts
+++ b/packages/services/src/classmoji/team.service.ts
@@ -6,8 +6,13 @@ interface TeamCreatePayload {
   provider?: GitProvider | null;
   name: string;
   slug: string;
-  avatarUrl?: string | null;
-  privacy?: string | null;
+  /**
+   * Whether students who are not members can see the team. Defaults to false,
+   * matching the schema default. This used to be derived from a `privacy`
+   * string that every caller hard-coded to 'closed', so the visibility choice
+   * offered in the UI never reached the database.
+   */
+  isVisible?: boolean;
   classroomId: string;
   tag?: unknown;
 }
@@ -22,16 +27,7 @@ interface TeamCreateWithMembershipAndTagPayload {
 }
 
 export const create = async (payload: TeamCreatePayload) => {
-  const {
-    providerId,
-    provider,
-    name,
-    slug,
-    avatarUrl: _avatarUrl,
-    privacy,
-    classroomId,
-    tag,
-  } = payload;
+  const { providerId, provider, name, slug, isVisible = false, classroomId, tag } = payload;
   const teamCreateData: unknown = {
     provider_id: providerId ? String(providerId) : null,
     provider: provider || null,
@@ -39,7 +35,7 @@ export const create = async (payload: TeamCreatePayload) => {
     slug: slug,
     tag: tag,
     classroom_id: classroomId,
-    is_visible: privacy !== 'secret',
+    is_visible: isVisible,
   };
   // TODO: narrow further once legacy team relation writes are aligned with generated Prisma input types.
   return getPrisma().team.create({

--- a/packages/services/src/classmoji/teamAdmin.service.ts
+++ b/packages/services/src/classmoji/teamAdmin.service.ts
@@ -66,19 +66,29 @@ export interface TeamSummary {
   isVisible: boolean;
 }
 
+/**
+ * Closed vocabulary for per-item failures in the bulk operations.
+ *
+ * The raw provider/database message is logged server-side and never handed
+ * back: it carries organization internals, octokit request details and Prisma
+ * query text, none of which a caller needs (or should read) to understand that
+ * one item of a batch did not go through.
+ */
+export type TeamFailureReason = 'provider_error' | 'not_found' | 'db_error' | 'invalid';
+
 export interface TagFailure {
   tagId: string;
-  error: string;
+  error: TeamFailureReason;
 }
 
 export interface MemberFailure {
   login: string;
-  error: string;
+  error: TeamFailureReason;
 }
 
 export interface RepoRenameFailure {
   name: string;
-  error: string;
+  error: TeamFailureReason;
 }
 
 export interface CreateTeamResult {
@@ -94,6 +104,10 @@ export interface DeleteTeamResult {
   slug: string;
   /** false when the team was already gone on the provider side (404 tolerated). */
   removedFromProvider: boolean;
+  /** How many linked repository records went with the team. */
+  reposDeleted: number;
+  /** Names of those repositories, capped at MAX_REPORTED_REPO_NAMES. */
+  deletedRepoNames: string[];
 }
 
 export interface RenameTeamResult {
@@ -136,13 +150,48 @@ const isProviderNotFound = (error: unknown): boolean =>
 const isUniqueViolation = (error: unknown): boolean =>
   typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'P2002';
 
-const errorMessage = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error);
+/**
+ * Classify a thrown error into the closed failure vocabulary and log the raw
+ * one with context, so the detail stays in the server logs rather than in a
+ * response body. Octokit errors carry a numeric `.status`; Prisma errors carry
+ * a string `.code`; anything else falls back to the caller's default.
+ */
+const failureReason = (
+  context: string,
+  error: unknown,
+  fallback: TeamFailureReason
+): TeamFailureReason => {
+  console.error(`[team] ${context}`, error);
+  if (typeof error === 'object' && error !== null) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === 'number') return status === 404 ? 'not_found' : 'provider_error';
+    if (typeof (error as { code?: unknown }).code === 'string') return 'db_error';
+  }
+  return fallback;
+};
+
+const FAILURE_PHRASES: Record<TeamFailureReason, string> = {
+  provider_error: 'the git provider rejected the change',
+  not_found: 'not found',
+  db_error: 'the change could not be saved',
+  invalid: 'not valid for this classroom',
+};
+
+/**
+ * Turn a failure reason into a short phrase for a UI or tool response. Callers
+ * render the reason at their own boundary, so the vocabulary stays closed here
+ * and the wording stays in one place.
+ */
+export const describeTeamFailureReason = (reason: TeamFailureReason): string =>
+  FAILURE_PHRASES[reason] ?? 'the change could not be completed';
 
 /**
  * The slug GitHub will derive from a team name: lowercased, whitespace runs
- * collapsed to single hyphens. GitHub remains authoritative — this prediction
- * exists so collisions and reserved names can be caught BEFORE a provider write.
+ * collapsed to single hyphens. GitHub remains authoritative — it also strips
+ * and folds punctuation, which this prediction deliberately does not model.
+ * The prediction exists so collisions and reserved names can be caught BEFORE
+ * a provider write; every check it feeds is repeated against the slug the
+ * provider actually returns.
  */
 export const predictTeamSlug = (name: string): string =>
   name.trim().toLowerCase().replace(/\s+/g, '-');
@@ -151,9 +200,33 @@ export const predictTeamSlug = (name: string): string =>
  * Classroom teams are named `{classroom-slug}-students` / `-assistants` (see
  * getTeamNameForClassroom). A user-created team must never land on one of those
  * slugs, or managing it would manage the classroom's own membership team.
+ *
+ * Exported because the student self-service team form creates teams on its own
+ * path and has to apply the same rule.
  */
-const isReservedSlug = (slug: string): boolean =>
+export const isReservedSlug = (slug: string): boolean =>
   slug.endsWith('-students') || slug.endsWith('-assistants');
+
+/** How many repository names a delete result lists before it stops. */
+const MAX_REPORTED_REPO_NAMES = 20;
+
+/**
+ * Undo a provider team that failed the authoritative-slug checks.
+ *
+ * Best effort: the refusal is reported either way, and a cleanup that itself
+ * fails is logged so the stray provider team can be removed by hand.
+ */
+const rollbackProviderTeam = async (
+  gitProvider: { deleteTeam: (org: string, slug: string) => Promise<unknown> },
+  orgLogin: string,
+  slug: string
+): Promise<void> => {
+  try {
+    await gitProvider.deleteTeam(orgLogin, slug);
+  } catch (error: unknown) {
+    console.error(`[team] could not roll back provider team ${orgLogin}/${slug}`, error);
+  }
+};
 
 const requireName = (name: string | null | undefined): string => {
   const trimmed = typeof name === 'string' ? name.trim() : '';
@@ -222,7 +295,7 @@ const partitionClassroomTags = async (classroomId: string, tagIds: string[]) => 
     valid: unique.filter(id => found.has(id)),
     failed: unique
       .filter(id => !found.has(id))
-      .map(id => ({ tagId: id, error: 'Tag does not belong to this classroom' })),
+      .map(id => ({ tagId: id, error: 'invalid' as const })),
   };
 };
 
@@ -245,7 +318,10 @@ const attachTags = async (teamId: string, tagIds: string[]) => {
         added.push(tagId);
         continue;
       }
-      failed.push({ tagId, error: errorMessage(error) });
+      failed.push({
+        tagId,
+        error: failureReason(`attach tag ${tagId} to team ${teamId}`, error, 'db_error'),
+      });
     }
   }
 
@@ -264,8 +340,14 @@ const toSummary = (team: { id: string; name: string; slug: string; is_visible: b
  *
  * Order matters: the name is validated and the predicted slug is checked
  * against the reserved classroom-team suffixes and against the provider BEFORE
- * anything is created, so a rejected request never leaves an orphaned provider
- * team behind. Tag ids are resolved in the same pre-flight pass.
+ * anything is created, so a rejected request usually never reaches the
+ * provider at all. Tag ids are resolved in the same pre-flight pass.
+ *
+ * The prediction is not the last word, though — the provider derives the real
+ * slug and folds punctuation the prediction leaves alone, so both checks run
+ * again on the slug it returns. If the real slug fails one of them the
+ * provider team is deleted again and the call is refused, so no local row is
+ * ever created on a slug that the pre-flight checks would have rejected.
  *
  * `isVisible` maps to Team.is_visible, which decides whether students who are
  * not members can see the team. It defaults to false (the schema default, and
@@ -320,6 +402,27 @@ export const createTeam = async ({
 
   const providerTeam = await gitProvider.createTeam(orgLogin, trimmedName);
 
+  // The provider is authoritative for the slug and derives it from more than
+  // whitespace, so both pre-flight checks are repeated against the slug it
+  // actually returned. A team that lands on a slug those checks refuse is
+  // removed again before anything is stored locally.
+  const authoritativeSlug = providerTeam.slug;
+  if (isReservedSlug(authoritativeSlug)) {
+    await rollbackProviderTeam(gitProvider, orgLogin, authoritativeSlug);
+    throw new TeamServiceError(
+      'reserved_name',
+      `[team] "${trimmedName}" resolves to a reserved team slug`
+    );
+  }
+  const localCollision = await teamService.findBySlugAndClassroomId(authoritativeSlug, classroomId);
+  if (localCollision) {
+    await rollbackProviderTeam(gitProvider, orgLogin, authoritativeSlug);
+    throw new TeamServiceError(
+      'name_collision',
+      `[team] a team with slug "${authoritativeSlug}" already exists in this classroom`
+    );
+  }
+
   const team = await teamService.create({
     providerId: providerTeam.id,
     provider: gitOrganization.provider as GitProviderEnum,
@@ -346,6 +449,10 @@ export const createTeam = async ({
  * client-supplied slug and only then discover there was no local row to
  * delete). A provider 404 is tolerated — the team already being gone there is
  * the desired end state, and the local row still needs removing.
+ *
+ * The linked repository records go with the team (and take their submissions,
+ * grades and analytics with them), so they are counted BEFORE the delete and
+ * reported back: callers cannot describe what a delete cost afterwards.
  */
 export const deleteTeam = async ({
   classroomId,
@@ -358,6 +465,12 @@ export const deleteTeam = async ({
   const team = await resolveTeam(classroomId, slugOrId);
   const gitProvider = getGitProvider(gitOrganization);
 
+  const teamWithRepos = await teamService.findByIdWithRepositories(team.id);
+  const repositories = teamWithRepos?.git_repos ?? [];
+  const deletedRepoNames = repositories
+    .slice(0, MAX_REPORTED_REPO_NAMES)
+    .map((repo: { name: string }) => repo.name);
+
   let removedFromProvider = true;
   try {
     await gitProvider.deleteTeam(orgLogin, team.slug);
@@ -368,7 +481,14 @@ export const deleteTeam = async ({
 
   await teamService.deleteBySlug(classroomId, team.slug);
 
-  return { id: team.id, name: team.name, slug: team.slug, removedFromProvider };
+  return {
+    id: team.id,
+    name: team.name,
+    slug: team.slug,
+    removedFromProvider,
+    reposDeleted: repositories.length,
+    deletedRepoNames,
+  };
 };
 
 /**
@@ -433,7 +553,23 @@ export const renameTeam = async ({
   const updated = await gitProvider.updateTeam(orgLogin, team.slug, { name: trimmedName });
   const newSlug = updated.slug;
 
-  // GitHub is authoritative for the slug and may not produce the predicted one.
+  // GitHub is authoritative for the slug and may not produce the predicted one
+  // (it folds punctuation the prediction leaves alone), so BOTH pre-flight
+  // checks are repeated here. This runs before the repository cascade and
+  // before anything local is written, so a refusal leaves Classmoji untouched
+  // — but the provider rename has already happened, so the previous name is
+  // put back best-effort first.
+  if (isReservedSlug(newSlug)) {
+    try {
+      await gitProvider.updateTeam(orgLogin, newSlug, { name: team.name });
+    } catch (error: unknown) {
+      console.error(`[team] could not restore the provider name for ${orgLogin}/${newSlug}`, error);
+    }
+    throw new TeamServiceError(
+      'reserved_name',
+      `[team] "${trimmedName}" resolves to a reserved team slug`
+    );
+  }
   await assertSlugFree({ classroomId, slug: newSlug, teamId: team.id, currentSlug: team.slug });
 
   const oldSuffix = `-${team.slug}`;
@@ -449,7 +585,10 @@ export const renameTeam = async ({
       await gitProvider.updateRepo(orgLogin, repo.name, { name: newRepoName });
       succeeded.push({ id: repo.id, name: newRepoName });
     } catch (error: unknown) {
-      failed.push({ name: repo.name, error: errorMessage(error) });
+      failed.push({
+        name: repo.name,
+        error: failureReason(`rename repo ${orgLogin}/${repo.name}`, error, 'provider_error'),
+      });
     }
     await sleep(PROVIDER_THROTTLE_MS);
   }, 1);
@@ -525,7 +664,7 @@ export const addTeamMembers = async ({
     try {
       const user = await findUserByLogin(login);
       if (!user) {
-        failed.push({ login, error: 'No user with that login' });
+        failed.push({ login, error: 'not_found' });
         return;
       }
       const canonicalLogin = user.login ?? login;
@@ -533,7 +672,10 @@ export const addTeamMembers = async ({
       await teamMembershipService.addMemberToTeam(team.id, user.id);
       succeeded.push({ login: canonicalLogin });
     } catch (error: unknown) {
-      failed.push({ login, error: errorMessage(error) });
+      failed.push({
+        login,
+        error: failureReason(`add ${login} to team ${team.slug}`, error, 'provider_error'),
+      });
     }
     await sleep(PROVIDER_THROTTLE_MS);
   }, 1);

--- a/packages/services/src/classmoji/teamAdmin.service.ts
+++ b/packages/services/src/classmoji/teamAdmin.service.ts
@@ -1,0 +1,645 @@
+/**
+ * Team administration service.
+ *
+ * Create / delete / rename a classroom team, manage its members and its tags.
+ * Shared by the web admin.$class.teams* actions and (later) the MCP team tools
+ * so both take one code path — same precedent as roster.service.ts and
+ * assistant.service.ts.
+ *
+ * Two rules run through every function here:
+ *
+ * 1. RESOLVE FIRST. The team is always looked up by (classroom_id, slug|id)
+ *    before anything is sent to the git provider. The routes used to hand a
+ *    client-supplied slug/teamId straight to GitHub — so an unknown team was
+ *    deleted on GitHub before the local delete failed, and a tag could be
+ *    attached to a team in another classroom. Resolving first scopes every
+ *    mutation to the classroom the caller was authorized for, and it means the
+ *    classroom's own `-students` / `-assistants` GitHub teams (which have no
+ *    local Team row) can never be reached from here.
+ *
+ * 2. PARTIAL WORK IS REPORTED, NOT SWALLOWED. Bulk operations (members, tags,
+ *    the repo-rename cascade) collect per-item successes and failures and hand
+ *    both back; callers must surface `failed`.
+ *
+ * Authorization is NOT re-checked here. Callers (route auth gates / MCP tool
+ * scopes) own that, exactly as in roster.service.ts and assistant.service.ts.
+ */
+import { queue } from 'async';
+
+import getPrisma from '@classmoji/database';
+import type { GitProvider as GitProviderEnum } from '@prisma/client';
+
+import { getGitProvider } from '../git/index.ts';
+import { sleep } from './sleep.ts';
+import * as classroomService from './classroom.service.ts';
+import * as teamService from './team.service.ts';
+import * as teamMembershipService from './teamMembership.service.ts';
+import * as teamTagService from './teamTag.service.ts';
+
+/** Throttle between provider calls in the sequential queues (ms). */
+const PROVIDER_THROTTLE_MS = 250;
+
+/** Thrown for every caller-fixable failure so routes/tools can map it to a message. */
+export class TeamServiceError extends Error {
+  code:
+    | 'classroom_not_found'
+    | 'no_org_configured'
+    | 'provider_unsupported'
+    | 'team_not_found'
+    | 'invalid_name'
+    | 'reserved_name'
+    | 'name_collision'
+    | 'tag_not_found'
+    | 'user_not_found';
+
+  constructor(code: TeamServiceError['code'], message: string) {
+    super(message);
+    this.name = 'TeamServiceError';
+    this.code = code;
+  }
+}
+
+export interface TeamSummary {
+  id: string;
+  name: string;
+  slug: string;
+  isVisible: boolean;
+}
+
+export interface TagFailure {
+  tagId: string;
+  error: string;
+}
+
+export interface MemberFailure {
+  login: string;
+  error: string;
+}
+
+export interface RepoRenameFailure {
+  name: string;
+  error: string;
+}
+
+export interface CreateTeamResult {
+  team: TeamSummary;
+  /** Tag ids now attached to the team (includes tags that were already attached). */
+  tagsAdded: string[];
+  tagsFailed: TagFailure[];
+}
+
+export interface DeleteTeamResult {
+  id: string;
+  name: string;
+  slug: string;
+  /** false when the team was already gone on the provider side (404 tolerated). */
+  removedFromProvider: boolean;
+}
+
+export interface RenameTeamResult {
+  teamId: string;
+  newName: string;
+  newSlug: string;
+  /** New names of the repositories that were successfully renamed. */
+  renamedRepos: string[];
+  failed: RepoRenameFailure[];
+}
+
+export interface AddTeamMembersResult {
+  succeeded: { login: string }[];
+  failed: MemberFailure[];
+}
+
+export interface RemoveTeamMemberResult {
+  teamId: string;
+  login: string;
+  /** false when no membership row existed (the removal is idempotent). */
+  removed: boolean;
+}
+
+export interface AddTeamTagsResult {
+  added: string[];
+  failed: TagFailure[];
+}
+
+export interface RemoveTeamTagResult {
+  teamTagId: string;
+  teamId: string;
+  tagId: string;
+}
+
+/** A git provider 404 — the resource genuinely is not there. */
+const isProviderNotFound = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && (error as { status?: unknown }).status === 404;
+
+/** A Prisma unique-constraint violation (e.g. the tag is already on the team). */
+const isUniqueViolation = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'P2002';
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * The slug GitHub will derive from a team name: lowercased, whitespace runs
+ * collapsed to single hyphens. GitHub remains authoritative — this prediction
+ * exists so collisions and reserved names can be caught BEFORE a provider write.
+ */
+export const predictTeamSlug = (name: string): string =>
+  name.trim().toLowerCase().replace(/\s+/g, '-');
+
+/**
+ * Classroom teams are named `{classroom-slug}-students` / `-assistants` (see
+ * getTeamNameForClassroom). A user-created team must never land on one of those
+ * slugs, or managing it would manage the classroom's own membership team.
+ */
+const isReservedSlug = (slug: string): boolean =>
+  slug.endsWith('-students') || slug.endsWith('-assistants');
+
+const requireName = (name: string | null | undefined): string => {
+  const trimmed = typeof name === 'string' ? name.trim() : '';
+  if (!trimmed) {
+    throw new TeamServiceError('invalid_name', '[team] a team name is required');
+  }
+  return trimmed;
+};
+
+/**
+ * Load the classroom and narrow its git organization in one step, so callers
+ * get a non-null `orgLogin` instead of asserting one at every provider call.
+ */
+const loadClassroomOrg = async (classroomId: string) => {
+  const classroom = await classroomService.findById(classroomId);
+  if (!classroom) {
+    throw new TeamServiceError('classroom_not_found', `[team] classroom ${classroomId} not found`);
+  }
+  const gitOrganization = classroom.git_organization;
+  if (!gitOrganization?.login) {
+    throw new TeamServiceError(
+      'no_org_configured',
+      `[team] classroom ${classroomId} has no git organization`
+    );
+  }
+  return { classroom, gitOrganization, orgLogin: gitOrganization.login };
+};
+
+/**
+ * Resolve a team by slug OR id, ALWAYS scoped to the classroom. Every mutation
+ * starts here, which is what keeps a caller from naming a team in a classroom
+ * they were not authorized for (or a classroom team with no local row).
+ */
+const resolveTeam = async (classroomId: string, slugOrId: string) => {
+  const team = await getPrisma().team.findFirst({
+    where: {
+      classroom_id: classroomId,
+      OR: [{ slug: slugOrId }, { id: slugOrId }],
+    },
+  });
+  if (!team) {
+    throw new TeamServiceError(
+      'team_not_found',
+      `[team] no team "${slugOrId}" in classroom ${classroomId}`
+    );
+  }
+  return team;
+};
+
+/**
+ * Split the requested tag ids into ones that really are Tags of this classroom
+ * and ones that are not. Tag is classroom-scoped, so an id from another
+ * classroom is reported as a failure rather than silently attached.
+ */
+const partitionClassroomTags = async (classroomId: string, tagIds: string[]) => {
+  const unique = [...new Set(tagIds)];
+  if (unique.length === 0) return { valid: [] as string[], failed: [] as TagFailure[] };
+
+  const tags = await getPrisma().tag.findMany({
+    where: { id: { in: unique }, classroom_id: classroomId },
+    select: { id: true },
+  });
+  const found = new Set(tags.map((t: { id: string }) => t.id));
+
+  return {
+    valid: unique.filter(id => found.has(id)),
+    failed: unique
+      .filter(id => !found.has(id))
+      .map(id => ({ tagId: id, error: 'Tag does not belong to this classroom' })),
+  };
+};
+
+/**
+ * Attach tags one at a time so a single bad id cannot abort the rest (the
+ * routes used to Promise.all these and lose every result on the first reject).
+ * A unique-constraint violation means the tag is already on the team — that is
+ * the desired end state, so it counts as added.
+ */
+const attachTags = async (teamId: string, tagIds: string[]) => {
+  const added: string[] = [];
+  const failed: TagFailure[] = [];
+
+  for (const tagId of tagIds) {
+    try {
+      await teamTagService.create(teamId, tagId);
+      added.push(tagId);
+    } catch (error: unknown) {
+      if (isUniqueViolation(error)) {
+        added.push(tagId);
+        continue;
+      }
+      failed.push({ tagId, error: errorMessage(error) });
+    }
+  }
+
+  return { added, failed };
+};
+
+const toSummary = (team: { id: string; name: string; slug: string; is_visible: boolean }) => ({
+  id: team.id,
+  name: team.name,
+  slug: team.slug,
+  isVisible: team.is_visible,
+});
+
+/**
+ * Create a team on the git provider and mirror it locally.
+ *
+ * Order matters: the name is validated and the predicted slug is checked
+ * against the reserved classroom-team suffixes and against the provider BEFORE
+ * anything is created, so a rejected request never leaves an orphaned provider
+ * team behind. Tag ids are resolved in the same pre-flight pass.
+ *
+ * `isVisible` maps to Team.is_visible, which decides whether students who are
+ * not members can see the team. It defaults to false (the schema default, and
+ * what the "Secret" option in the web form has always meant — the form's choice
+ * previously had no effect and every team was stored visible).
+ *
+ * Tags are attached individually and reported per tag: creating the team
+ * succeeds even if some tags could not be attached.
+ */
+export const createTeam = async ({
+  classroomId,
+  name,
+  isVisible = false,
+  tagIds = [],
+}: {
+  classroomId: string;
+  name: string;
+  isVisible?: boolean;
+  tagIds?: string[];
+}): Promise<CreateTeamResult> => {
+  const trimmedName = requireName(name);
+  const { gitOrganization, orgLogin } = await loadClassroomOrg(classroomId);
+
+  const predictedSlug = predictTeamSlug(trimmedName);
+  if (isReservedSlug(predictedSlug)) {
+    throw new TeamServiceError(
+      'reserved_name',
+      `[team] "${trimmedName}" is reserved for classroom teams`
+    );
+  }
+
+  const { valid: validTagIds, failed: tagsFailed } = await partitionClassroomTags(
+    classroomId,
+    tagIds
+  );
+
+  const gitProvider = getGitProvider(gitOrganization);
+
+  // A team already sitting on the predicted slug would be silently adopted by
+  // the create call, so refuse. Only a 404 means the slug is free — a rate
+  // limit or a bad token must surface as itself, not as "name taken".
+  try {
+    await gitProvider.getTeam(orgLogin, predictedSlug);
+    throw new TeamServiceError(
+      'name_collision',
+      `[team] a team named "${trimmedName}" already exists in ${orgLogin}`
+    );
+  } catch (error: unknown) {
+    if (error instanceof TeamServiceError) throw error;
+    if (!isProviderNotFound(error)) throw error;
+  }
+
+  const providerTeam = await gitProvider.createTeam(orgLogin, trimmedName);
+
+  const team = await teamService.create({
+    providerId: providerTeam.id,
+    provider: gitOrganization.provider as GitProviderEnum,
+    name: providerTeam.name,
+    slug: providerTeam.slug,
+    classroomId,
+    isVisible,
+  });
+
+  const { added, failed } = await attachTags(team.id, validTagIds);
+
+  return {
+    team: toSummary(team),
+    tagsAdded: added,
+    tagsFailed: [...tagsFailed, ...failed],
+  };
+};
+
+/**
+ * Delete a team from the git provider and locally.
+ *
+ * The local row is resolved first: an unknown slug is rejected before anything
+ * reaches the provider (the route used to delete the provider team on a
+ * client-supplied slug and only then discover there was no local row to
+ * delete). A provider 404 is tolerated — the team already being gone there is
+ * the desired end state, and the local row still needs removing.
+ */
+export const deleteTeam = async ({
+  classroomId,
+  slugOrId,
+}: {
+  classroomId: string;
+  slugOrId: string;
+}): Promise<DeleteTeamResult> => {
+  const { gitOrganization, orgLogin } = await loadClassroomOrg(classroomId);
+  const team = await resolveTeam(classroomId, slugOrId);
+  const gitProvider = getGitProvider(gitOrganization);
+
+  let removedFromProvider = true;
+  try {
+    await gitProvider.deleteTeam(orgLogin, team.slug);
+  } catch (error: unknown) {
+    if (!isProviderNotFound(error)) throw error;
+    removedFromProvider = false;
+  }
+
+  await teamService.deleteBySlug(classroomId, team.slug);
+
+  return { id: team.id, name: team.name, slug: team.slug, removedFromProvider };
+};
+
+/**
+ * Rename a team and cascade the new slug onto every linked repository.
+ *
+ * The local collision check runs against the PREDICTED slug before the provider
+ * rename, so a name already taken in this classroom is refused while the
+ * provider team is still untouched. GitHub derives the real slug, so the check
+ * is repeated against the slug it returns.
+ *
+ * Repositories are renamed one at a time, throttled, and each failure is
+ * isolated: only successful renames are persisted (in one transaction with the
+ * team rename).
+ *
+ * IMPORTANT: a repository in `failed` CANNOT be recovered by running the rename
+ * again. The team already carries the new slug, so the old `-{oldSlug}` suffix
+ * no longer matches anything on a second pass — those repositories have to be
+ * renamed by hand on the provider. Callers must surface `failed`.
+ */
+export const renameTeam = async ({
+  classroomId,
+  slugOrId,
+  newName,
+}: {
+  classroomId: string;
+  slugOrId: string;
+  newName: string;
+}): Promise<RenameTeamResult> => {
+  const trimmedName = requireName(newName);
+  const { gitOrganization, orgLogin } = await loadClassroomOrg(classroomId);
+
+  if (gitOrganization.provider !== 'GITHUB') {
+    throw new TeamServiceError(
+      'provider_unsupported',
+      '[team] renaming a team is only supported for GitHub organizations'
+    );
+  }
+
+  const team = await resolveTeam(classroomId, slugOrId);
+
+  const predictedSlug = predictTeamSlug(trimmedName);
+  if (isReservedSlug(predictedSlug)) {
+    throw new TeamServiceError(
+      'reserved_name',
+      `[team] "${trimmedName}" is reserved for classroom teams`
+    );
+  }
+
+  // Pre-flight collision check against the predicted slug. The provider rename
+  // has no rollback, so the local conflict has to be caught before it runs.
+  await assertSlugFree({
+    classroomId,
+    slug: predictedSlug,
+    teamId: team.id,
+    currentSlug: team.slug,
+  });
+
+  const teamWithRepos = await teamService.findByIdWithRepositories(team.id);
+  const repositories = teamWithRepos?.git_repos ?? [];
+
+  const gitProvider = getGitProvider(gitOrganization);
+  const updated = await gitProvider.updateTeam(orgLogin, team.slug, { name: trimmedName });
+  const newSlug = updated.slug;
+
+  // GitHub is authoritative for the slug and may not produce the predicted one.
+  await assertSlugFree({ classroomId, slug: newSlug, teamId: team.id, currentSlug: team.slug });
+
+  const oldSuffix = `-${team.slug}`;
+  const failed: RepoRenameFailure[] = [];
+  const succeeded: { id: string; name: string }[] = [];
+
+  const renameQueue = queue<(typeof repositories)[number]>(async repo => {
+    if (!repo.name.includes(oldSuffix)) {
+      return;
+    }
+    const newRepoName = repo.name.split(oldSuffix).join(`-${newSlug}`);
+    try {
+      await gitProvider.updateRepo(orgLogin, repo.name, { name: newRepoName });
+      succeeded.push({ id: repo.id, name: newRepoName });
+    } catch (error: unknown) {
+      failed.push({ name: repo.name, error: errorMessage(error) });
+    }
+    await sleep(PROVIDER_THROTTLE_MS);
+  }, 1);
+
+  if (repositories.length > 0) {
+    renameQueue.push(repositories);
+    await renameQueue.drain();
+  }
+
+  await teamService.renameAndRepos({
+    teamId: team.id,
+    newName: updated.name,
+    newSlug,
+    repoRenames: succeeded,
+  });
+
+  return {
+    teamId: team.id,
+    newName: updated.name,
+    newSlug,
+    renamedRepos: succeeded.map(r => r.name),
+    failed,
+  };
+};
+
+const assertSlugFree = async ({
+  classroomId,
+  slug,
+  teamId,
+  currentSlug,
+}: {
+  classroomId: string;
+  slug: string;
+  teamId: string;
+  currentSlug: string;
+}) => {
+  if (slug === currentSlug) return;
+  const existing = await teamService.findBySlugAndClassroomId(slug, classroomId);
+  if (existing && existing.id !== teamId) {
+    throw new TeamServiceError(
+      'name_collision',
+      `[team] a team with slug "${slug}" already exists in this classroom`
+    );
+  }
+};
+
+/**
+ * Add members to a team by login, sequentially and throttled.
+ *
+ * Every login is reported: an unknown user, a provider rejection or a failed
+ * membership write lands in `failed` with its reason and the remaining logins
+ * still run. The route used to let the whole queue die on the first bad login
+ * and still report success. The local write is an upsert, so re-adding an
+ * existing member is a no-op rather than an error.
+ */
+export const addTeamMembers = async ({
+  classroomId,
+  slugOrId,
+  logins,
+}: {
+  classroomId: string;
+  slugOrId: string;
+  logins: string[];
+}): Promise<AddTeamMembersResult> => {
+  const { gitOrganization, orgLogin } = await loadClassroomOrg(classroomId);
+  const team = await resolveTeam(classroomId, slugOrId);
+  const gitProvider = getGitProvider(gitOrganization);
+
+  const succeeded: { login: string }[] = [];
+  const failed: MemberFailure[] = [];
+
+  const membersQueue = queue<string>(async login => {
+    try {
+      const user = await findUserByLogin(login);
+      if (!user) {
+        failed.push({ login, error: 'No user with that login' });
+        return;
+      }
+      const canonicalLogin = user.login ?? login;
+      await gitProvider.addTeamMember(orgLogin, team.slug, canonicalLogin);
+      await teamMembershipService.addMemberToTeam(team.id, user.id);
+      succeeded.push({ login: canonicalLogin });
+    } catch (error: unknown) {
+      failed.push({ login, error: errorMessage(error) });
+    }
+    await sleep(PROVIDER_THROTTLE_MS);
+  }, 1);
+
+  if (logins.length > 0) {
+    membersQueue.push(logins);
+    await membersQueue.drain();
+  }
+
+  return { succeeded, failed };
+};
+
+/**
+ * Remove one member from a team.
+ *
+ * Both the team AND the user are resolved before the provider call — the route
+ * used to fire the provider removal and only then blow up on a login that named
+ * nobody. The local removal is a deleteMany, so a membership row that is already
+ * gone is not an error.
+ */
+export const removeTeamMember = async ({
+  classroomId,
+  slugOrId,
+  login,
+}: {
+  classroomId: string;
+  slugOrId: string;
+  login: string;
+}): Promise<RemoveTeamMemberResult> => {
+  const { gitOrganization, orgLogin } = await loadClassroomOrg(classroomId);
+  const team = await resolveTeam(classroomId, slugOrId);
+
+  const user = await findUserByLogin(login);
+  if (!user) {
+    throw new TeamServiceError('user_not_found', `[team] no user with login ${login}`);
+  }
+  const canonicalLogin = user.login ?? login;
+
+  const gitProvider = getGitProvider(gitOrganization);
+  await gitProvider.removeTeamMember(orgLogin, team.slug, canonicalLogin);
+
+  const { count } = await teamMembershipService.removeMemberFromTeam(team.id, user.id);
+
+  return { teamId: team.id, login: canonicalLogin, removed: count > 0 };
+};
+
+/**
+ * Attach tags to a team.
+ *
+ * The team is resolved through the classroom (the route trusted a client-sent
+ * teamId with no classroom check) and every tag id is checked against this
+ * classroom's tags before anything is written. Results are per tag.
+ */
+export const addTeamTags = async ({
+  classroomId,
+  slugOrId,
+  tagIds,
+}: {
+  classroomId: string;
+  slugOrId: string;
+  tagIds: string[];
+}): Promise<AddTeamTagsResult> => {
+  const team = await resolveTeam(classroomId, slugOrId);
+  const { valid, failed: invalid } = await partitionClassroomTags(classroomId, tagIds);
+  const { added, failed } = await attachTags(team.id, valid);
+
+  return { added, failed: [...invalid, ...failed] };
+};
+
+/**
+ * Detach a tag from a team.
+ *
+ * The TeamTag row is resolved THROUGH its team's classroom, so an id that
+ * belongs to another classroom simply does not resolve (the plain delete it
+ * replaces took any id at all).
+ */
+export const removeTeamTag = async ({
+  classroomId,
+  teamTagId,
+}: {
+  classroomId: string;
+  teamTagId: string;
+}): Promise<RemoveTeamTagResult> => {
+  const teamTag = await getPrisma().teamTag.findFirst({
+    where: { id: teamTagId, team: { classroom_id: classroomId } },
+    select: { id: true, team_id: true, tag_id: true },
+  });
+  if (!teamTag) {
+    throw new TeamServiceError(
+      'tag_not_found',
+      `[team] no team tag ${teamTagId} in classroom ${classroomId}`
+    );
+  }
+
+  await teamTagService.delete(teamTag.id);
+
+  return { teamTagId: teamTag.id, teamId: teamTag.team_id, tagId: teamTag.tag_id };
+};
+
+/**
+ * Git logins are case-insensitive while Postgres is not, so match the stored
+ * login insensitively — 'Ada' and 'ada' are the same person. Only id/login are
+ * needed here, unlike user.service.findByLogin which pulls the whole graph.
+ */
+const findUserByLogin = async (login: string) =>
+  getPrisma().user.findFirst({
+    where: { login: { equals: login.replace('@', '').trim(), mode: 'insensitive' } },
+    select: { id: true, login: true },
+  });

--- a/packages/services/src/classmoji/teamMembership.service.ts
+++ b/packages/services/src/classmoji/teamMembership.service.ts
@@ -16,13 +16,16 @@ export const addMemberToTeam = async (teamId: string, userId: string) => {
   });
 };
 
+/**
+ * Idempotent by design: deleteMany reports `{ count: 0 }` for a membership that
+ * is already gone, where the previous `delete` threw P2025 and turned a
+ * repeated (or raced) removal into a 500.
+ */
 export const removeMemberFromTeam = async (teamId: string, userId: string) => {
-  return getPrisma().teamMembership.delete({
+  return getPrisma().teamMembership.deleteMany({
     where: {
-      team_id_user_id: {
-        team_id: teamId,
-        user_id: userId,
-      },
+      team_id: teamId,
+      user_id: userId,
     },
   });
 };

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -54,8 +54,14 @@ export { ClassmojiService, HelperService, StripeService, FlyCertService, Markdow
 // Admin service result/error shapes shared by the web routes and the MCP tools.
 export { AssistantServiceError } from './classmoji/assistant.service.ts';
 export type { AddAssistantResult, RemoveAssistantResult } from './classmoji/assistant.service.ts';
-export { TeamServiceError } from './classmoji/teamAdmin.service.ts';
+export {
+  TeamServiceError,
+  describeTeamFailureReason,
+  isReservedSlug,
+  predictTeamSlug,
+} from './classmoji/teamAdmin.service.ts';
 export type {
+  TeamFailureReason,
   CreateTeamResult,
   DeleteTeamResult,
   RenameTeamResult,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -54,6 +54,19 @@ export { ClassmojiService, HelperService, StripeService, FlyCertService, Markdow
 // Admin service result/error shapes shared by the web routes and the MCP tools.
 export { AssistantServiceError } from './classmoji/assistant.service.ts';
 export type { AddAssistantResult, RemoveAssistantResult } from './classmoji/assistant.service.ts';
+export { TeamServiceError } from './classmoji/teamAdmin.service.ts';
+export type {
+  CreateTeamResult,
+  DeleteTeamResult,
+  RenameTeamResult,
+  AddTeamMembersResult,
+  RemoveTeamMemberResult,
+  AddTeamTagsResult,
+  RemoveTeamTagResult,
+  MemberFailure,
+  TagFailure,
+  RepoRenameFailure,
+} from './classmoji/teamAdmin.service.ts';
 export { AssignGradersError } from './classmoji/gitRepoAssignmentGrader.service.ts';
 export type {
   AssignGradersMethod,


### PR DESCRIPTION
## Summary

Second batch of MCP admin tools: teams management, quiz CRUD, and classroom settings. 14 new tools (67 → 81), following the same shared-service architecture as #227.

### New MCP tools

**Teams** (OWNER):
| Tool | What it does |
|---|---|
| `team_create` | Create a team (GitHub team + local record), optional tags and visibility. Validates reserved names and collisions against the provider-assigned slug, with rollback on refusal. |
| `team_delete` | Delete a team (requires `confirm: true`). Response and audit record how many linked repo records were removed; description steers to rename when graded work exists. |
| `team_rename` | Rename incl. the member-repo suffix cascade; per-repo failures surfaced (they need manual fixing — re-running can't catch them). |
| `team_members_add` | Add members by login — restricted to members of the classroom; per-member success/failure reporting. |
| `team_member_remove` | Remove a member (idempotent). |
| `team_tag_add` / `team_tag_remove` | Manage team tags; tags resolve within the classroom, by name or id. |

**Quizzes** (OWNER + ASSISTANT, Pro-gated, `quizzes_enabled`-gated):
| Tool | What it does |
|---|---|
| `quiz_create` | Create (always DRAFT). Clamps mirror the service (question_count 1–20, max_attempts 0 = unlimited). |
| `quiz_update` | Partial update; status limited to DRAFT/CLOSED — publishing must go through `quiz_publish` so student notifications are never skipped. `due_date: null` clears the deadline. |
| `quiz_publish` | Publish + notify students (idempotent on re-publish). |
| `quiz_delete` | Delete (requires `confirm: true`); reports cascade-deleted attempts. |

**Settings** (OWNER):
| Tool | What it does |
|---|---|
| `classroom_settings_update` | Consolidated update: name, nav toggles (modules/pages/repos), slides/syllabus-bot/quizzes/recent-viewers toggles, extension pricing, late penalty, default student page, theme. Builds an explicit validated field object — LLM/API-key fields are web-UI-only by design. |
| `classroom_status_update` | ACTIVE / LOCKED / UNPUBLISHED + archive flag (idempotent). |
| `org_repo_settings_update` | GitHub org default repo permission + member repo creation. Requires `confirm: true` and is flagged destructive — it applies org-wide immediately. |

### Team service extraction (one shared code path)

The webapp's seven inline team mutations (create/delete/rename/members/tags) moved into `packages/services` (`teamAdmin.service.ts`), mirroring the roster/assistant precedent — web routes and MCP tools call the same functions. The extraction also hardens the shared path: team and tag lookups are resolved within the classroom before any GitHub call, the provider-assigned slug is re-validated after create/rename, per-item failures use a closed reason vocabulary instead of raw provider messages, and the student self-service team route gained the same reserved-name validation and classroom-scoped lookups.

Notable behavior fixes that come with the extraction:
- The team create form's Secret/Visible radio now actually persists (it was silently ignored; every team was stored visible). Webapp default remains visible; `list_teams` hides invisible teams from students.
- Team delete resolves the local record before touching GitHub (previously it deleted the GitHub team first and then failed).
- Rename/member operations report per-item failures instead of swallowing them; progress callouts now finalize on errors.

### Tests

- `packages/services`: 698 pass (+69 new)
- `apps/mcp`: 437 pass (+95 new)
- `apps/webapp`: 225 unit tests pass; typecheck carries only the two pre-existing unrelated errors

### Test steps

1. MCP as owner: `team_create` → team appears on GitHub + in `list_teams`; `team_members_add` with a roster login → member added both sides; `team_rename` → repos re-suffixed; `team_delete` (confirm) → response reports linked-repo count.
2. `quiz_create` → DRAFT; `quiz_publish` → students notified; `quiz_update` with `due_date: null` → deadline cleared; `quiz_delete` (confirm).
3. `classroom_settings_update` (e.g. `slides_enabled`) → reflected in `get_classroom_info`; `classroom_status_update` LOCKED → non-owner writes blocked, reads fine.
4. Webapp: teams create/edit/rename/delete flows unchanged; assistants + assign-graders from #227 unaffected.

### Known follow-ups

- Admin teams list has no visibility badge/toggle — a team created as Secret can't be seen or changed in the UI afterward.
- The admin quiz UI references an `ARCHIVED` status that isn't in the Prisma enum (latent 500 if submitted); MCP tools reject it by schema.
- Remaining admin gap catalog: module delete/reorder/site-visibility, repo delete/template-sync/release-now, resource linking, mapping deletes/defaults, membership letter-grade/comment, bulk token grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
