### PR TITLE
feat(mcp): resource linking tools

### DIFF
--- a/apps/mcp/src/suggestions.ts
+++ b/apps/mcp/src/suggestions.ts
@@ -27,6 +27,7 @@ export const FACULTY_SUGGESTIONS: readonly string[] = [
   'What assignments are due this week?',
   'How is grading going across my TAs — who still has submissions outstanding?',
   'Draft a quiz on this week’s material, then publish it when I say so.',
+  'Attach my slides for this week to the right assignment so students can find them.',
 ];
 
 /** Student-facing starters (upcoming work, grades, tokens, regrades). */

--- a/apps/mcp/src/tools/__tests__/resourceLinks.test.ts
+++ b/apps/mcp/src/tools/__tests__/resourceLinks.test.ts
@@ -107,6 +107,7 @@ describe('resource_link_add', () => {
     targetId: 'repo-1',
     order: 0,
     createdAt: CREATED_AT,
+    manifestSynced: true,
   };
 
   it('links through the service using the ctx classroomId and audits the write', async () => {
@@ -131,6 +132,7 @@ describe('resource_link_add', () => {
       target_id: 'repo-1',
       order: 0,
       created_at: '2026-01-02T03:04:05.000Z',
+      manifest_synced: true,
     });
 
     const audit = auditRow();
@@ -152,6 +154,7 @@ describe('resource_link_add', () => {
     expect(Object.keys(result).sort()).toEqual([
       'created_at',
       'link_id',
+      'manifest_synced',
       'message',
       'order',
       'resource_id',
@@ -160,6 +163,16 @@ describe('resource_link_add', () => {
       'target_id',
       'target_type',
     ]);
+  });
+
+  it('reports a manifest commit that did not land instead of implying it did', async () => {
+    // The link row is committed regardless; the GitHub push is best effort, so
+    // the caller is told which of the two actually happened.
+    mocks.addLink.mockResolvedValue({ ...LINK, manifestSynced: false });
+
+    const result = parse(await resourceLinkAddTool.handler(ARGS, CTX));
+
+    expect(result).toMatchObject({ success: true, manifest_synced: false });
   });
 
   it.each([
@@ -215,7 +228,6 @@ describe('resource_link_add', () => {
   it('rejects an unknown resource_type at the schema before the service is reached', () => {
     expect(resourceLinkAddTool.inputSchema.resource_type.safeParse('quiz').success).toBe(false);
     expect(resourceLinkAddTool.inputSchema.target_type.safeParse('module').success).toBe(false);
-    expect(mocks.addLink).not.toHaveBeenCalled();
   });
 
   it('is a non-destructive, outward-reaching OWNER/TEACHER write', () => {
@@ -224,13 +236,22 @@ describe('resource_link_add', () => {
     expect(resourceLinkAddTool.roles).toEqual(['OWNER', 'TEACHER']);
     expect(resourceLinkAddTool.annotations).toEqual({ destructive: false, openWorld: true });
   });
+
+  it('is throttled below the default bucket', () => {
+    // Every call rebuilds the whole classroom manifest and pushes a commit.
+    expect(resourceLinkAddTool.rateLimit).toEqual({ capacity: 5, refillPerSecond: 0.05 });
+  });
 });
 
 describe('resource_link_remove', () => {
   const ARGS = { classroom: 'org/w26', resource_type: 'slide' as const, link_id: 'link-9' };
 
   it('removes through the service using the ctx classroomId and audits the delete', async () => {
-    mocks.removeLink.mockResolvedValue({ id: 'link-9', resourceType: 'slide' });
+    mocks.removeLink.mockResolvedValue({
+      id: 'link-9',
+      resourceType: 'slide',
+      manifestSynced: true,
+    });
 
     const result = parse(await resourceLinkRemoveTool.handler(ARGS, CTX));
 
@@ -239,7 +260,13 @@ describe('resource_link_remove', () => {
       resourceType: 'slide',
       linkId: 'link-9',
     });
-    expect(result).toMatchObject({ success: true, link_id: 'link-9', resource_type: 'slide' });
+    expect(result).toEqual({
+      success: true,
+      link_id: 'link-9',
+      resource_type: 'slide',
+      manifest_synced: true,
+      message: 'Link removed — the page/slide deck itself was not deleted.',
+    });
 
     const audit = auditRow();
     expect(audit).toMatchObject({
@@ -263,13 +290,29 @@ describe('resource_link_remove', () => {
     expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
 
-  it('is explicitly non-destructive despite being a delete', () => {
-    // Only the link row goes; the page/deck and repo/assignment survive and the
-    // link can be recreated. The registry defaults an unset `destructive` on a
-    // write to true, so this must be stated.
+  it('reports a manifest commit that did not land instead of implying it did', async () => {
+    mocks.removeLink.mockResolvedValue({
+      id: 'link-9',
+      resourceType: 'slide',
+      manifestSynced: false,
+    });
+
+    const result = parse(await resourceLinkRemoveTool.handler(ARGS, CTX));
+
+    expect(result).toMatchObject({ success: true, manifest_synced: false });
+  });
+
+  it('is a destructive, outward-reaching OWNER/TEACHER write', () => {
+    // A delete is annotated destructive by the registry's convention, and this
+    // one takes student-facing visibility with it — the content stops appearing
+    // on the repo/assignment page.
     expect(resourceLinkRemoveTool.scope).toBe('write');
     expect(resourceLinkRemoveTool.roles).toEqual(['OWNER', 'TEACHER']);
-    expect(resourceLinkRemoveTool.annotations).toEqual({ destructive: false, openWorld: true });
+    expect(resourceLinkRemoveTool.annotations).toEqual({ destructive: true, openWorld: true });
+  });
+
+  it('is throttled below the default bucket', () => {
+    expect(resourceLinkRemoveTool.rateLimit).toEqual({ capacity: 5, refillPerSecond: 0.05 });
   });
 });
 
@@ -313,6 +356,8 @@ describe('resource_links_list', () => {
     });
     expect(result).toEqual({
       count: 2,
+      total_matched: 2,
+      truncated: false,
       links: [
         {
           id: 'link-1',
@@ -391,7 +436,26 @@ describe('resource_links_list', () => {
       targetType: 'assignment',
       targetId: 'assign-1',
     });
-    expect(result).toEqual({ count: 0, links: [] });
+    expect(result).toEqual({ count: 0, total_matched: 0, truncated: false, links: [] });
+  });
+
+  it('caps the page at limit and says the rest was cut off', async () => {
+    mocks.listLinks.mockResolvedValue([REPO_LINK, ASSIGNMENT_LINK]);
+
+    const result = parse(
+      await resourceLinksListTool.handler({ classroom: 'org/w26', limit: 1 }, CTX)
+    );
+
+    expect(result.count).toBe(1);
+    expect(result.total_matched).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(result.links.map((l: { id: string }) => l.id)).toEqual(['link-1']);
+  });
+
+  it('refuses a limit above the maximum at the schema', () => {
+    expect(resourceLinksListTool.inputSchema.limit.safeParse(501).success).toBe(false);
+    expect(resourceLinksListTool.inputSchema.limit.safeParse(0).success).toBe(false);
+    expect(resourceLinksListTool.inputSchema.limit.safeParse(500).success).toBe(true);
   });
 
   it('is a read at the OWNER/TEACHER tier and writes no audit row', async () => {

--- a/apps/mcp/src/tools/__tests__/resourceLinks.test.ts
+++ b/apps/mcp/src/tools/__tests__/resourceLinks.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Unit tests for resource_link_add / resource_link_remove / resource_links_list.
+ *
+ * Security focus: the classroomId handed to every service call comes from the
+ * ToolContext, never from args; the service's caller-fixable failures map onto
+ * the right ToolError kinds (an unknown id and another classroom's record are
+ * the SAME scopedNotFound, so a probe cannot enumerate foreign pages, decks,
+ * repos or assignments); no mutation is left un-audited; and no raw service row
+ * reaches the caller — every response field is allow-listed.
+ *
+ * `@classmoji/services` is mocked (factory idiom) INCLUDING
+ * ResourceLinkServiceError, so the handlers' `instanceof` mapping runs against
+ * the same class the test throws — no database and no manifest pushes.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ToolContext } from '../../mcp/registry.ts';
+
+const mocks = vi.hoisted(() => ({
+  addLink: vi.fn(),
+  removeLink: vi.fn(),
+  listLinks: vi.fn(),
+  auditCreate: vi.fn(),
+}));
+
+vi.mock('@classmoji/services', () => {
+  // Same shape as the real service error; the tools branch on `instanceof`, so
+  // the class the handler imports must be the class the test constructs.
+  class ResourceLinkServiceError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'ResourceLinkServiceError';
+      this.code = code;
+    }
+  }
+  return {
+    ResourceLinkServiceError,
+    ClassmojiService: {
+      resourceLink: {
+        addLink: (...a: unknown[]) => mocks.addLink(...a),
+        removeLink: (...a: unknown[]) => mocks.removeLink(...a),
+        listLinks: (...a: unknown[]) => mocks.listLinks(...a),
+      },
+      audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+    },
+  };
+});
+
+const { ResourceLinkServiceError } = await import('@classmoji/services');
+const { resourceLinkAddTool, resourceLinkRemoveTool, resourceLinksListTool } =
+  await import('../resourceLinks.ts');
+
+const CTX: ToolContext = {
+  viewer: { userId: 'teacher-1', clientId: 'c', scopes: new Set(['read', 'write']) },
+  classroom: {
+    classroomId: 'class-1',
+    role: 'TEACHER',
+    status: 'ACTIVE',
+    membership: { id: 'm-1', role: 'TEACHER' },
+    classroom: { settings: {} },
+  },
+} as unknown as ToolContext;
+
+const CREATED_AT = new Date('2026-01-02T03:04:05.000Z');
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+/** The audit row the handler wrote (first call). */
+function auditRow() {
+  return mocks.auditCreate.mock.calls[0][0] as {
+    action: string;
+    classroom_id: string;
+    resource_type: string;
+    resource_id?: string | null;
+    data: Record<string, unknown>;
+  };
+}
+
+/** Run a handler and hand back whatever it threw. */
+const failure = (promise: Promise<unknown>) =>
+  promise.then(
+    () => null,
+    (e: unknown) => e as { kind?: string; message?: string }
+  );
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.auditCreate.mockResolvedValue(undefined);
+});
+
+describe('resource_link_add', () => {
+  const ARGS = {
+    classroom: 'org/w26',
+    resource_type: 'page' as const,
+    resource_id: 'page-1',
+    target_type: 'repository' as const,
+    target_id: 'repo-1',
+  };
+  const LINK = {
+    id: 'link-1',
+    resourceType: 'page',
+    resourceId: 'page-1',
+    targetType: 'repository',
+    targetId: 'repo-1',
+    order: 0,
+    createdAt: CREATED_AT,
+  };
+
+  it('links through the service using the ctx classroomId and audits the write', async () => {
+    mocks.addLink.mockResolvedValue(LINK);
+
+    const result = parse(await resourceLinkAddTool.handler(ARGS, CTX));
+
+    // classroomId is the AUTHORIZED classroom, never an arg.
+    expect(mocks.addLink).toHaveBeenCalledExactlyOnceWith({
+      classroomId: 'class-1',
+      resourceType: 'page',
+      resourceId: 'page-1',
+      targetType: 'repository',
+      targetId: 'repo-1',
+    });
+    expect(result).toMatchObject({
+      success: true,
+      link_id: 'link-1',
+      resource_type: 'page',
+      resource_id: 'page-1',
+      target_type: 'repository',
+      target_id: 'repo-1',
+      order: 0,
+      created_at: '2026-01-02T03:04:05.000Z',
+    });
+
+    const audit = auditRow();
+    expect(audit).toMatchObject({
+      action: 'CREATE',
+      classroom_id: 'class-1',
+      resource_type: 'RESOURCES',
+      // The LINK id — it is what keeps back-to-back links as separate rows.
+      resource_id: 'link-1',
+    });
+    expect(audit.data).toMatchObject({ tool: 'resource_link_add', link_id: 'link-1' });
+  });
+
+  it('does not leak raw service fields into the response', async () => {
+    mocks.addLink.mockResolvedValue({ ...LINK, page_id: 'page-1', internal_note: 'secret' });
+
+    const result = parse(await resourceLinkAddTool.handler(ARGS, CTX));
+
+    expect(Object.keys(result).sort()).toEqual([
+      'created_at',
+      'link_id',
+      'message',
+      'order',
+      'resource_id',
+      'resource_type',
+      'success',
+      'target_id',
+      'target_type',
+    ]);
+  });
+
+  it.each([
+    ['page', 'Page'],
+    ['slide', 'Slide'],
+  ])(
+    'reports a foreign %s as the uniform scoped not_found, un-audited',
+    async (resourceType, label) => {
+      mocks.addLink.mockRejectedValue(new ResourceLinkServiceError('resource_not_found', 'nope'));
+
+      const error = await failure(
+        resourceLinkAddTool.handler(
+          { ...ARGS, resource_type: resourceType as 'page' | 'slide' },
+          CTX
+        )
+      );
+
+      expect(error?.kind).toBe('not_found');
+      expect(error?.message).toBe(`${label} not found in this classroom`);
+      // Nothing was written, so nothing may be audited.
+      expect(mocks.auditCreate).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    ['repository', 'Repository'],
+    ['assignment', 'Assignment'],
+  ])('reports a foreign %s target as the uniform scoped not_found', async (targetType, label) => {
+    mocks.addLink.mockRejectedValue(new ResourceLinkServiceError('target_not_found', 'nope'));
+
+    const error = await failure(
+      resourceLinkAddTool.handler(
+        { ...ARGS, target_type: targetType as 'repository' | 'assignment' },
+        CTX
+      )
+    );
+
+    expect(error?.kind).toBe('not_found');
+    expect(error?.message).toBe(`${label} not found in this classroom`);
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('reports an existing link as invalid_params rather than a missing record', async () => {
+    mocks.addLink.mockRejectedValue(new ResourceLinkServiceError('already_linked', 'dupe'));
+
+    const error = await failure(resourceLinkAddTool.handler(ARGS, CTX));
+
+    expect(error?.kind).toBe('invalid_params');
+    expect(error?.message).toContain('already linked');
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown resource_type at the schema before the service is reached', () => {
+    expect(resourceLinkAddTool.inputSchema.resource_type.safeParse('quiz').success).toBe(false);
+    expect(resourceLinkAddTool.inputSchema.target_type.safeParse('module').success).toBe(false);
+    expect(mocks.addLink).not.toHaveBeenCalled();
+  });
+
+  it('is a non-destructive, outward-reaching OWNER/TEACHER write', () => {
+    expect(resourceLinkAddTool.scope).toBe('write');
+    // The web resources kanban is ['OWNER','TEACHER'] — ASSISTANT is excluded.
+    expect(resourceLinkAddTool.roles).toEqual(['OWNER', 'TEACHER']);
+    expect(resourceLinkAddTool.annotations).toEqual({ destructive: false, openWorld: true });
+  });
+});
+
+describe('resource_link_remove', () => {
+  const ARGS = { classroom: 'org/w26', resource_type: 'slide' as const, link_id: 'link-9' };
+
+  it('removes through the service using the ctx classroomId and audits the delete', async () => {
+    mocks.removeLink.mockResolvedValue({ id: 'link-9', resourceType: 'slide' });
+
+    const result = parse(await resourceLinkRemoveTool.handler(ARGS, CTX));
+
+    expect(mocks.removeLink).toHaveBeenCalledExactlyOnceWith({
+      classroomId: 'class-1',
+      resourceType: 'slide',
+      linkId: 'link-9',
+    });
+    expect(result).toMatchObject({ success: true, link_id: 'link-9', resource_type: 'slide' });
+
+    const audit = auditRow();
+    expect(audit).toMatchObject({
+      action: 'DELETE',
+      classroom_id: 'class-1',
+      resource_type: 'RESOURCES',
+      resource_id: 'link-9',
+    });
+    expect(audit.data).toMatchObject({ tool: 'resource_link_remove', link_id: 'link-9' });
+  });
+
+  it('reports a missing or foreign link as one uniform not_found, un-audited', async () => {
+    // The service's classroom compound matched nothing — an unknown id and
+    // another classroom's link are indistinguishable here by design.
+    mocks.removeLink.mockRejectedValue(new ResourceLinkServiceError('link_not_found', 'nope'));
+
+    const error = await failure(resourceLinkRemoveTool.handler(ARGS, CTX));
+
+    expect(error?.kind).toBe('not_found');
+    expect(error?.message).toBe('Link not found in this classroom');
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('is explicitly non-destructive despite being a delete', () => {
+    // Only the link row goes; the page/deck and repo/assignment survive and the
+    // link can be recreated. The registry defaults an unset `destructive` on a
+    // write to true, so this must be stated.
+    expect(resourceLinkRemoveTool.scope).toBe('write');
+    expect(resourceLinkRemoveTool.roles).toEqual(['OWNER', 'TEACHER']);
+    expect(resourceLinkRemoveTool.annotations).toEqual({ destructive: false, openWorld: true });
+  });
+});
+
+describe('resource_links_list', () => {
+  const REPO_LINK = {
+    id: 'link-1',
+    resourceType: 'page',
+    targetType: 'repository',
+    order: 0,
+    createdAt: CREATED_AT,
+    resource: { id: 'page-1', title: 'Setup', slug: 'setup' },
+    target: { id: 'repo-1', title: 'Lab 1', slug: 'lab-1' },
+  };
+  const ASSIGNMENT_LINK = {
+    id: 'link-2',
+    resourceType: 'slide',
+    targetType: 'assignment',
+    order: 1,
+    createdAt: CREATED_AT,
+    resource: { id: 'slide-1', title: 'Week 1', slug: 'week-1' },
+    target: {
+      id: 'assign-1',
+      title: 'Part A',
+      slug: 'part-a',
+      repositoryId: 'repo-1',
+      repositoryTitle: 'Lab 1',
+    },
+  };
+
+  it('returns a counted, allow-listed list scoped to the ctx classroom', async () => {
+    mocks.listLinks.mockResolvedValue([REPO_LINK, ASSIGNMENT_LINK]);
+
+    const result = parse(await resourceLinksListTool.handler({ classroom: 'org/w26' }, CTX));
+
+    expect(mocks.listLinks).toHaveBeenCalledExactlyOnceWith({
+      classroomId: 'class-1',
+      resourceType: undefined,
+      resourceId: undefined,
+      targetType: undefined,
+      targetId: undefined,
+    });
+    expect(result).toEqual({
+      count: 2,
+      links: [
+        {
+          id: 'link-1',
+          resource_type: 'page',
+          resource: { id: 'page-1', title: 'Setup', slug: 'setup' },
+          target_type: 'repository',
+          target: { id: 'repo-1', title: 'Lab 1', slug: 'lab-1' },
+          order: 0,
+          created_at: '2026-01-02T03:04:05.000Z',
+        },
+        {
+          id: 'link-2',
+          resource_type: 'slide',
+          resource: { id: 'slide-1', title: 'Week 1', slug: 'week-1' },
+          target_type: 'assignment',
+          // An assignment target also names the repository it sits in.
+          target: {
+            id: 'assign-1',
+            title: 'Part A',
+            slug: 'part-a',
+            repository_id: 'repo-1',
+            repository_title: 'Lab 1',
+          },
+          order: 1,
+          created_at: '2026-01-02T03:04:05.000Z',
+        },
+      ],
+    });
+  });
+
+  it('does not leak raw service fields through the summaries', async () => {
+    mocks.listLinks.mockResolvedValue([
+      {
+        ...REPO_LINK,
+        page_id: 'page-1',
+        resource: { ...REPO_LINK.resource, content_path: 'secret/path.json' },
+        target: { ...REPO_LINK.target, classroom_id: 'class-1' },
+      },
+    ]);
+
+    const { links } = parse(await resourceLinksListTool.handler({ classroom: 'org/w26' }, CTX));
+
+    expect(Object.keys(links[0]).sort()).toEqual([
+      'created_at',
+      'id',
+      'order',
+      'resource',
+      'resource_type',
+      'target',
+      'target_type',
+    ]);
+    expect(links[0].resource).toEqual({ id: 'page-1', title: 'Setup', slug: 'setup' });
+    expect(links[0].target).toEqual({ id: 'repo-1', title: 'Lab 1', slug: 'lab-1' });
+  });
+
+  it('passes every filter straight through to the service', async () => {
+    mocks.listLinks.mockResolvedValue([]);
+
+    const result = parse(
+      await resourceLinksListTool.handler(
+        {
+          classroom: 'org/w26',
+          resource_type: 'slide',
+          resource_id: 'slide-1',
+          target_type: 'assignment',
+          target_id: 'assign-1',
+        },
+        CTX
+      )
+    );
+
+    expect(mocks.listLinks).toHaveBeenCalledExactlyOnceWith({
+      classroomId: 'class-1',
+      resourceType: 'slide',
+      resourceId: 'slide-1',
+      targetType: 'assignment',
+      targetId: 'assign-1',
+    });
+    expect(result).toEqual({ count: 0, links: [] });
+  });
+
+  it('is a read at the OWNER/TEACHER tier and writes no audit row', async () => {
+    mocks.listLinks.mockResolvedValue([]);
+    await resourceLinksListTool.handler({ classroom: 'org/w26' }, CTX);
+
+    expect(resourceLinksListTool.scope).toBe('read');
+    expect(resourceLinksListTool.roles).toEqual(['OWNER', 'TEACHER']);
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -57,6 +57,11 @@ import {
   orgRepoSettingsUpdateTool,
 } from './settings.ts';
 import {
+  resourceLinkAddTool,
+  resourceLinkRemoveTool,
+  resourceLinksListTool,
+} from './resourceLinks.ts';
+import {
   teamCreateTool,
   teamDeleteTool,
   teamRenameTool,
@@ -172,6 +177,14 @@ export function registerAllTools(): void {
   registerToolDefinition(classroomSettingsUpdateTool);
   registerToolDefinition(classroomStatusUpdateTool);
   registerToolDefinition(orgRepoSettingsUpdateTool);
+
+  // Resource links (OWNER+TEACHER — the web resources kanban tier, which
+  // deliberately excludes ASSISTANT). Attaching a page/deck to a repo or
+  // assignment is what makes it visible to students there; both writes also
+  // commit an updated content manifest to the classroom content repo.
+  registerToolDefinition(resourceLinkAddTool);
+  registerToolDefinition(resourceLinkRemoveTool);
+  registerToolDefinition(resourceLinksListTool);
 
   // Teams (OWNER — the write surface behind list_teams). create/rename/members
   // touch real GitHub teams; delete is destructive and confirm-gated; the tag

--- a/apps/mcp/src/tools/resourceLinks.ts
+++ b/apps/mcp/src/tools/resourceLinks.ts
@@ -12,11 +12,13 @@
  * OWNER_TEACHER here, NOT the OWNER_ONLY most admin tools use. ASSISTANT is
  * excluded, exactly as on the web route.
  *
- * Backbone: ClassmojiService.resourceLink.*, extracted in phase 1 so the web
- * route and these tools take ONE code path (same precedent as roster/assistant/
- * teamAdmin). The service owns the scoping: it proves BOTH ends of a link live
- * in the classroom before writing, and deletes through a classroom compound
- * `where` that makes a foreign link id a no-op rather than a leak.
+ * Backbone: ClassmojiService.resourceLink.*, extracted in phase 1 so the
+ * resources kanban and these tools share that path (same precedent as roster/
+ * assistant/teamAdmin) — other writers of the link tables exist elsewhere and
+ * are not routed through it. The service owns the scoping: it proves BOTH ends
+ * of a link live in the classroom before writing, deletes through a classroom
+ * compound `where` that makes a foreign link id a no-op rather than a leak, and
+ * drops read rows whose target resolves into another classroom.
  *
  * S1: classroomId is ALWAYS ctx.classroom.classroomId, never request input. An
  * id that names nothing and an id belonging to another classroom come back as
@@ -102,12 +104,19 @@ export const resourceLinkAddTool: ToolDefinition<ResourceLinkAddArgs> = {
     'content visible to students on that repo/assignment page, so it is how you publish existing ' +
     'content to a place students will find it. Owner and teacher only. Use list_pages / ' +
     'list_slides for resource ids and list_repos for repository and assignment ids, and ' +
-    'resource_links_list to see what is already linked. A successful link also commits an updated ' +
-    'content manifest to the classroom content repository on GitHub. Distinct from ' +
-    'module_item_add, which places content in a curriculum module, and from calendar event links, ' +
-    'which attach content to a scheduled session.',
+    'resource_links_list to see what is already linked. Each successful link also rebuilds the ' +
+    'classroom content manifest and commits it to the content repository on GitHub: that commit ' +
+    'is best effort and its outcome is reported as manifest_synced, and because every call pays ' +
+    'for a whole-classroom rebuild plus a git write, heavy looping is deliberately throttled — ' +
+    'link in small batches rather than in a tight loop. Distinct from module_item_add, which ' +
+    'places content in a curriculum module, and from calendar event links, which attach content ' +
+    'to a scheduled session.',
   scope: 'write',
   roles: OWNER_TEACHER,
+  // Tighter than the default bucket: every call rebuilds the whole classroom
+  // manifest and pushes a commit through the process-wide write queue, so cap
+  // it at a burst of 5 and roughly 3 per minute sustained.
+  rateLimit: { capacity: 5, refillPerSecond: 0.05 },
   inputSchema: {
     classroom: classroomArg,
     resource_type: resourceTypeArg,
@@ -161,6 +170,9 @@ export const resourceLinkAddTool: ToolDefinition<ResourceLinkAddArgs> = {
       target_id: link.targetId,
       order: link.order,
       created_at: link.createdAt.toISOString(),
+      // The link row is committed either way; this says whether the manifest
+      // commit that follows it actually landed.
+      manifest_synced: link.manifestSynced,
       message: `Linked ${link.resourceType} ${link.resourceId} to ${link.targetType} ${link.targetId} — students will now see it there.`,
     });
   },
@@ -174,21 +186,28 @@ interface ResourceLinkRemoveArgs {
 
 export const resourceLinkRemoveTool: ToolDefinition<ResourceLinkRemoveArgs> = {
   name: 'resource_link_remove',
-  // Deletes the LINK row only: the page/slide and the repo/assignment both
-  // survive untouched and the link can simply be added again, so this is not
-  // destructive. Set explicitly — the registry defaults an unset `destructive`
-  // on a write to true. openWorld for the manifest commit, as with add.
-  annotations: { destructive: false, openWorld: true },
+  // Deletes a row, and student-facing visibility goes with it — the content
+  // disappears from the repo/assignment page. The registry's convention is that
+  // deletes are destructive, so this is one, even though the page/slide deck
+  // and the repo/assignment survive and the link can be added back. openWorld
+  // for the manifest commit, as with add.
+  annotations: { destructive: true, openWorld: true },
   title: 'Unlink a page or slide deck',
   description:
     'Removes a link between a page or slide deck and a repository or assignment. Owner and ' +
     'teacher only. Only the link is deleted — the page/slide deck and the repo/assignment are ' +
-    'left untouched, and the link can be recreated with resource_link_add. Students stop seeing ' +
-    'that content on the repo/assignment page. Get link ids from resource_links_list. A ' +
-    'successful removal also commits an updated content manifest to the classroom content ' +
-    'repository on GitHub.',
+    'left untouched, and the link can be recreated with resource_link_add — but students stop ' +
+    'seeing that content on the repo/assignment page, so it changes what the class can reach. ' +
+    'Get link ids from resource_links_list. Each successful removal also rebuilds the classroom ' +
+    'content manifest and commits it to the content repository on GitHub: that commit is best ' +
+    'effort and its outcome is reported as manifest_synced, and because every call pays for a ' +
+    'whole-classroom rebuild plus a git write, heavy looping is deliberately throttled — unlink ' +
+    'in small batches rather than in a tight loop.',
   scope: 'write',
   roles: OWNER_TEACHER,
+  // Same bucket as resource_link_add, and for the same reason: a manifest
+  // rebuild plus a git commit per call.
+  rateLimit: { capacity: 5, refillPerSecond: 0.05 },
   inputSchema: {
     classroom: classroomArg,
     resource_type: resourceTypeArg,
@@ -201,11 +220,12 @@ export const resourceLinkRemoveTool: ToolDefinition<ResourceLinkRemoveArgs> = {
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
 
+    let removed;
     try {
       // The service deletes through a classroom compound `where` and treats a
       // count other than 1 as a miss, so another classroom's link id is a no-op
       // reported as the same not-found an unknown id gets.
-      await ClassmojiService.resourceLink.removeLink({
+      removed = await ClassmojiService.resourceLink.removeLink({
         classroomId: classroom.classroomId,
         resourceType: args.resource_type,
         linkId: args.link_id,
@@ -229,10 +249,17 @@ export const resourceLinkRemoveTool: ToolDefinition<ResourceLinkRemoveArgs> = {
       success: true,
       link_id: args.link_id,
       resource_type: args.resource_type,
+      // The delete is committed either way; this says whether the manifest
+      // commit that follows it actually landed.
+      manifest_synced: removed.manifestSynced,
       message: 'Link removed — the page/slide deck itself was not deleted.',
     });
   },
 };
+
+/** A classroom's whole link graph can be long; cap what one call returns. */
+const LIST_LINKS_LIMIT_DEFAULT = 200;
+const LIST_LINKS_LIMIT_MAX = 500;
 
 interface ResourceLinksListArgs {
   classroom: string;
@@ -240,6 +267,7 @@ interface ResourceLinksListArgs {
   resource_id?: string;
   target_type?: TargetType;
   target_id?: string;
+  limit?: number;
 }
 
 export const resourceLinksListTool: ToolDefinition<ResourceLinksListArgs> = {
@@ -251,7 +279,9 @@ export const resourceLinksListTool: ToolDefinition<ResourceLinksListArgs> = {
     'only. Filter by resource_type/resource_id to see where one page or deck appears, or by ' +
     'target_type/target_id to see everything attached to one repo or assignment. The link ids ' +
     'returned here are what resource_link_remove takes; use list_pages, list_slides and ' +
-    'list_repos for the page, deck, repository and assignment ids that resource_link_add takes.',
+    `list_repos for the page, deck, repository and assignment ids that resource_link_add takes. ` +
+    `Returns at most ${LIST_LINKS_LIMIT_DEFAULT} links by default; total_matched and truncated ` +
+    'say whether a filter or a larger limit is needed to see the rest.',
   scope: 'read',
   roles: OWNER_TEACHER,
   inputSchema: {
@@ -276,6 +306,13 @@ export const resourceLinksListTool: ToolDefinition<ResourceLinksListArgs> = {
       .max(100)
       .optional()
       .describe('Only links pointing at this one repository or assignment'),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(LIST_LINKS_LIMIT_MAX)
+      .optional()
+      .describe(`Max links to return (default ${LIST_LINKS_LIMIT_DEFAULT})`),
   },
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
@@ -288,10 +325,17 @@ export const resourceLinksListTool: ToolDefinition<ResourceLinksListArgs> = {
       targetId: args.target_id,
     });
 
+    // Paged after the read, as list_submissions does: the service has no limit
+    // param, and `truncated` tells the caller when it is seeing a slice.
+    const limit = Math.min(args.limit ?? LIST_LINKS_LIMIT_DEFAULT, LIST_LINKS_LIMIT_MAX);
+    const page = links.slice(0, limit);
+
     // Allow-listed field by field — the service summaries are never spread.
     return ok({
-      count: links.length,
-      links: links.map(link => ({
+      count: page.length,
+      total_matched: links.length,
+      truncated: links.length > page.length,
+      links: page.map(link => ({
         id: link.id,
         resource_type: link.resourceType,
         resource: {

--- a/apps/mcp/src/tools/resourceLinks.ts
+++ b/apps/mcp/src/tools/resourceLinks.ts
@@ -1,0 +1,320 @@
+/**
+ * Resource link tools — resource_link_add / resource_link_remove /
+ * resource_links_list.
+ *
+ * A resource link attaches a page or slide deck to a repository (the assignment
+ * container) or to one specific assignment inside it. It is how content becomes
+ * VISIBLE to students: the student repo/assignment pages list exactly what is
+ * linked here, so adding and removing links is load-bearing, not decorative.
+ *
+ * ROUTE-DERIVED TIER: the web surface is admin.$class.resources/action.ts, gated
+ * by assertClassroomAccess with allowedRoles ['OWNER','TEACHER'] — so
+ * OWNER_TEACHER here, NOT the OWNER_ONLY most admin tools use. ASSISTANT is
+ * excluded, exactly as on the web route.
+ *
+ * Backbone: ClassmojiService.resourceLink.*, extracted in phase 1 so the web
+ * route and these tools take ONE code path (same precedent as roster/assistant/
+ * teamAdmin). The service owns the scoping: it proves BOTH ends of a link live
+ * in the classroom before writing, and deletes through a classroom compound
+ * `where` that makes a foreign link id a no-op rather than a leak.
+ *
+ * S1: classroomId is ALWAYS ctx.classroom.classroomId, never request input. An
+ * id that names nothing and an id belonging to another classroom come back as
+ * the same typed error and map to the same scopedNotFound, so a cross-classroom
+ * probe cannot enumerate foreign pages, decks, repos or assignments.
+ */
+
+import { ClassmojiService, ResourceLinkServiceError } from '@classmoji/services';
+import { z } from 'zod';
+import { ToolError } from '../mcp/errors.ts';
+import type { ToolDefinition } from '../mcp/registry.ts';
+import { ok, OWNER_TEACHER, requireClassroomCtx, scopedNotFound, writeAudit } from './shared.ts';
+
+/** Audit vocabulary — the same resourceType the web route logs its denials under. */
+const AUDIT_RESOURCE_TYPE = 'RESOURCES';
+
+type ResourceType = 'page' | 'slide';
+type TargetType = 'repository' | 'assignment';
+
+/**
+ * Map the service's caller-fixable failures onto tool errors.
+ *
+ * - `resource_not_found` / `target_not_found` / `link_not_found` → the uniform
+ *   scopedNotFound, named for what the caller was pointing at so the message is
+ *   useful without revealing whether the record exists somewhere else.
+ * - `already_linked` → invalid_params: the link is already there, so the call
+ *   is a no-op the caller should stop making rather than a missing record.
+ *
+ * Anything else is returned unchanged for the registry's generic wrapper.
+ */
+function mapResourceLinkError(
+  error: unknown,
+  resourceType: ResourceType,
+  targetType?: TargetType
+): unknown {
+  if (!(error instanceof ResourceLinkServiceError)) return error;
+  switch (error.code) {
+    case 'resource_not_found':
+      return scopedNotFound(resourceType === 'page' ? 'Page' : 'Slide');
+    case 'target_not_found':
+      return scopedNotFound(targetType === 'repository' ? 'Repository' : 'Assignment');
+    case 'already_linked':
+      return new ToolError(
+        'invalid_params',
+        `This ${resourceType} is already linked to that ${targetType ?? 'target'} — nothing to do`
+      );
+    case 'link_not_found':
+      return scopedNotFound('Link');
+    default:
+      return error;
+  }
+}
+
+const classroomArg = z.string().describe("Classroom reference as 'org/slug'");
+const resourceTypeArg = z
+  .enum(['page', 'slide'])
+  .describe("Which kind of content to link: 'page' or 'slide' (a slide deck)");
+const targetTypeArg = z
+  .enum(['repository', 'assignment'])
+  .describe(
+    "What to link it to: 'repository' (shows on the whole assignment container) or " +
+      "'assignment' (shows on that one assignment only)"
+  );
+
+interface ResourceLinkAddArgs {
+  classroom: string;
+  resource_type: ResourceType;
+  resource_id: string;
+  target_type: TargetType;
+  target_id: string;
+}
+
+export const resourceLinkAddTool: ToolDefinition<ResourceLinkAddArgs> = {
+  name: 'resource_link_add',
+  // Creates one link row — nothing is removed, so not destructive. openWorld
+  // because the successful write also commits an updated content manifest to
+  // the classroom content repo on GitHub.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Link a page or slide deck to a repo or assignment',
+  description:
+    'Links a page or slide deck to a repository (the assignment container — the content then ' +
+    'appears on that repo page) or to one specific assignment inside it. This is what makes the ' +
+    'content visible to students on that repo/assignment page, so it is how you publish existing ' +
+    'content to a place students will find it. Owner and teacher only. Use list_pages / ' +
+    'list_slides for resource ids and list_repos for repository and assignment ids, and ' +
+    'resource_links_list to see what is already linked. A successful link also commits an updated ' +
+    'content manifest to the classroom content repository on GitHub. Distinct from ' +
+    'module_item_add, which places content in a curriculum module, and from calendar event links, ' +
+    'which attach content to a scheduled session.',
+  scope: 'write',
+  roles: OWNER_TEACHER,
+  inputSchema: {
+    classroom: classroomArg,
+    resource_type: resourceTypeArg,
+    resource_id: z.string().min(1).max(100).describe('Id of the page or slide deck to link'),
+    target_type: targetTypeArg,
+    target_id: z.string().min(1).max(100).describe('Id of the repository or assignment to link to'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    let link;
+    try {
+      // classroomId is ALWAYS the authorized classroom, never request input —
+      // so the service's own scope checks on both ids are already classroom-bound.
+      link = await ClassmojiService.resourceLink.addLink({
+        classroomId: classroom.classroomId,
+        resourceType: args.resource_type,
+        resourceId: args.resource_id,
+        targetType: args.target_type,
+        targetId: args.target_id,
+      });
+    } catch (error) {
+      throw mapResourceLinkError(error, args.resource_type, args.target_type);
+    }
+
+    // Audit right after the service call: the row is already committed, so
+    // nothing downstream may leave the mutation un-audited (plan §5.1).
+    // resource_id is the LINK id — it is also what keeps back-to-back links
+    // from collapsing into one audit row inside the dedup window.
+    await writeAudit(ctx, {
+      resource_type: AUDIT_RESOURCE_TYPE,
+      resource_id: link.id,
+      action: 'CREATE',
+      data: {
+        tool: 'resource_link_add',
+        link_id: link.id,
+        resource_type: link.resourceType,
+        resource_id: link.resourceId,
+        target_type: link.targetType,
+        target_id: link.targetId,
+      },
+    });
+
+    // Allow-listed: the service row is never handed back as-is.
+    return ok({
+      success: true,
+      link_id: link.id,
+      resource_type: link.resourceType,
+      resource_id: link.resourceId,
+      target_type: link.targetType,
+      target_id: link.targetId,
+      order: link.order,
+      created_at: link.createdAt.toISOString(),
+      message: `Linked ${link.resourceType} ${link.resourceId} to ${link.targetType} ${link.targetId} — students will now see it there.`,
+    });
+  },
+};
+
+interface ResourceLinkRemoveArgs {
+  classroom: string;
+  resource_type: ResourceType;
+  link_id: string;
+}
+
+export const resourceLinkRemoveTool: ToolDefinition<ResourceLinkRemoveArgs> = {
+  name: 'resource_link_remove',
+  // Deletes the LINK row only: the page/slide and the repo/assignment both
+  // survive untouched and the link can simply be added again, so this is not
+  // destructive. Set explicitly — the registry defaults an unset `destructive`
+  // on a write to true. openWorld for the manifest commit, as with add.
+  annotations: { destructive: false, openWorld: true },
+  title: 'Unlink a page or slide deck',
+  description:
+    'Removes a link between a page or slide deck and a repository or assignment. Owner and ' +
+    'teacher only. Only the link is deleted — the page/slide deck and the repo/assignment are ' +
+    'left untouched, and the link can be recreated with resource_link_add. Students stop seeing ' +
+    'that content on the repo/assignment page. Get link ids from resource_links_list. A ' +
+    'successful removal also commits an updated content manifest to the classroom content ' +
+    'repository on GitHub.',
+  scope: 'write',
+  roles: OWNER_TEACHER,
+  inputSchema: {
+    classroom: classroomArg,
+    resource_type: resourceTypeArg,
+    link_id: z
+      .string()
+      .min(1)
+      .max(100)
+      .describe('Id of the link to remove, as returned by resource_links_list'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    try {
+      // The service deletes through a classroom compound `where` and treats a
+      // count other than 1 as a miss, so another classroom's link id is a no-op
+      // reported as the same not-found an unknown id gets.
+      await ClassmojiService.resourceLink.removeLink({
+        classroomId: classroom.classroomId,
+        resourceType: args.resource_type,
+        linkId: args.link_id,
+      });
+    } catch (error) {
+      throw mapResourceLinkError(error, args.resource_type);
+    }
+
+    await writeAudit(ctx, {
+      resource_type: AUDIT_RESOURCE_TYPE,
+      resource_id: args.link_id,
+      action: 'DELETE',
+      data: {
+        tool: 'resource_link_remove',
+        link_id: args.link_id,
+        resource_type: args.resource_type,
+      },
+    });
+
+    return ok({
+      success: true,
+      link_id: args.link_id,
+      resource_type: args.resource_type,
+      message: 'Link removed — the page/slide deck itself was not deleted.',
+    });
+  },
+};
+
+interface ResourceLinksListArgs {
+  classroom: string;
+  resource_type?: ResourceType;
+  resource_id?: string;
+  target_type?: TargetType;
+  target_id?: string;
+}
+
+export const resourceLinksListTool: ToolDefinition<ResourceLinksListArgs> = {
+  name: 'resource_links_list',
+  title: 'List page and slide deck links',
+  description:
+    'Lists every page and slide deck link in the classroom — which content is attached to which ' +
+    'repository or assignment, and therefore what students see on those pages. Owner and teacher ' +
+    'only. Filter by resource_type/resource_id to see where one page or deck appears, or by ' +
+    'target_type/target_id to see everything attached to one repo or assignment. The link ids ' +
+    'returned here are what resource_link_remove takes; use list_pages, list_slides and ' +
+    'list_repos for the page, deck, repository and assignment ids that resource_link_add takes.',
+  scope: 'read',
+  roles: OWNER_TEACHER,
+  inputSchema: {
+    classroom: classroomArg,
+    resource_type: z
+      .enum(['page', 'slide'])
+      .optional()
+      .describe('Only links for pages, or only links for slide decks'),
+    resource_id: z
+      .string()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Only links for this one page or slide deck'),
+    target_type: z
+      .enum(['repository', 'assignment'])
+      .optional()
+      .describe('Only links pointing at repositories, or only links pointing at assignments'),
+    target_id: z
+      .string()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Only links pointing at this one repository or assignment'),
+  },
+  handler: async (args, ctx) => {
+    const classroom = requireClassroomCtx(ctx);
+
+    const links = await ClassmojiService.resourceLink.listLinks({
+      classroomId: classroom.classroomId,
+      resourceType: args.resource_type,
+      resourceId: args.resource_id,
+      targetType: args.target_type,
+      targetId: args.target_id,
+    });
+
+    // Allow-listed field by field — the service summaries are never spread.
+    return ok({
+      count: links.length,
+      links: links.map(link => ({
+        id: link.id,
+        resource_type: link.resourceType,
+        resource: {
+          id: link.resource.id,
+          title: link.resource.title,
+          slug: link.resource.slug,
+        },
+        target_type: link.targetType,
+        target: {
+          id: link.target.id,
+          title: link.target.title,
+          slug: link.target.slug,
+          // Assignment targets only — names the repo the assignment sits in.
+          ...(link.target.repositoryId
+            ? {
+                repository_id: link.target.repositoryId,
+                repository_title: link.target.repositoryTitle ?? null,
+              }
+            : {}),
+        },
+        order: link.order,
+        created_at: link.createdAt.toISOString(),
+      })),
+    });
+  },
+};

--- a/apps/webapp/app/routes/admin.$class.resources/ResourcesKanban.tsx
+++ b/apps/webapp/app/routes/admin.$class.resources/ResourcesKanban.tsx
@@ -7,8 +7,10 @@ import {
   type DragStartEvent,
   type DragEndEvent,
 } from '@dnd-kit/core';
-import { useFetcher, useRevalidator } from 'react-router';
+import { useFetcher } from 'react-router';
+import { useEffect } from 'react';
 import { Input, Switch } from 'antd';
+import { useCallout } from '@classmoji/ui-components';
 import { IconSearch, IconFile, IconPresentation } from '@tabler/icons-react';
 import { useResourcesBoard } from './useResourcesBoard';
 import { ModuleColumn, SourceColumn } from './KanbanColumn';
@@ -36,7 +38,20 @@ interface ResourcesKanbanProps {
 
 const ResourcesKanban = ({ repositories, pages, slides }: ResourcesKanbanProps) => {
   const fetcher = useFetcher();
-  const revalidator = useRevalidator();
+  const callout = useCallout();
+
+  // The action RETURNS its failures rather than throwing them (a thrown
+  // Response would skip fetcher.data and take over the page via the root error
+  // boundary), so a rejected link surfaces here as a callout and the board
+  // stays put. Returning also lets React Router revalidate on its own, which is
+  // what refreshes the stale loader data behind a rejected duplicate drag.
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data?.error) {
+      callout.show({ variant: 'error', title: fetcher.data.error, autoDismissMs: 3000 });
+    }
+    // `callout` is stable per CalloutProvider, so it is not a dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetcher.state, fetcher.data]);
 
   const {
     allPages,
@@ -85,12 +100,15 @@ const ResourcesKanban = ({ repositories, pages, slides }: ResourcesKanbanProps) 
 
     if (!targetType || !targetId) return;
 
-    // Check if already linked
+    // Drop-time duplicate check. It reads loader data that may be a moment
+    // behind the server, so it is a courtesy, not the guard — the service
+    // re-checks and reports `already_linked`, which lands in the callout above.
     if (isLinked(resource, resourceType, targetType, targetId)) {
       return;
     }
 
-    // Submit to server
+    // React Router revalidates once the action resolves, so the board refreshes
+    // from the server rather than from a timer racing the manifest push.
     fetcher.submit(
       {
         resourceId: resource.id,
@@ -104,9 +122,6 @@ const ResourcesKanban = ({ repositories, pages, slides }: ResourcesKanbanProps) 
         encType: 'application/json',
       }
     );
-
-    // Revalidate to get updated data
-    setTimeout(() => revalidator.revalidate(), 100);
   };
 
   const handleDragCancel = () => {
@@ -122,8 +137,6 @@ const ResourcesKanban = ({ repositories, pages, slides }: ResourcesKanbanProps) 
         encType: 'application/json',
       }
     );
-
-    setTimeout(() => revalidator.revalidate(), 100);
   };
 
   return (

--- a/apps/webapp/app/routes/admin.$class.resources/__tests__/removeLink.test.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/__tests__/removeLink.test.ts
@@ -1,36 +1,47 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * removeLink deletes by a `linkId` that arrives in an untyped JSON body, scoped
- * by a compound `where`. That compound only narrows the delete while `linkId` is
- * a real string: Prisma drops an `undefined` value from a `where`, and the id
- * field accepts a `StringFilter` object, either of which would leave
- * `deleteMany` matching every link in the classroom.
+ * The linking itself now lives in ClassmojiService.resourceLink (shared with the
+ * MCP resource-link tools), so this suite pins what the ROUTE still owns:
  *
- * Driven directly, like the api.quiz gating test: the auth seam and Prisma are
- * mocked, so the assertion is that the delete is never ISSUED.
+ * - `linkId` / `resourceId` / `targetId` arrive in an untyped JSON body. Prisma
+ *   drops an `undefined` value from a `where` and its id fields also accept a
+ *   `StringFilter` object, either of which would leave the service's compound
+ *   `where` matching every link in the classroom. The route rejects those with
+ *   a 400 and the service is never reached.
+ * - The classroom the service is called with is the AUTHORIZED one, never
+ *   anything from the request body.
+ * - The service's typed failures map back onto the responses this route has
+ *   always sent.
+ *
+ * Driven directly, like the api.quiz gating test: the auth seam and the service
+ * are mocked, so the assertion is that the mutation is never ISSUED.
  */
 
-const pageLinkDeleteMany = vi.fn();
-const slideLinkDeleteMany = vi.fn();
-const saveManifest = vi.fn();
+const addLink = vi.fn();
+const removeLinkService = vi.fn();
 
-vi.mock('@classmoji/database', () => ({
-  default: () => ({
-    pageLink: { deleteMany: pageLinkDeleteMany },
-    slideLink: { deleteMany: slideLinkDeleteMany },
-    page: { findFirst: vi.fn() },
-    slide: { findFirst: vi.fn() },
-    repository: { findFirst: vi.fn() },
-    assignment: { findFirst: vi.fn() },
-  }),
-}));
-
-vi.mock('@classmoji/services', () => ({
-  ClassmojiService: {
-    contentManifest: { saveManifest: (...a: unknown[]) => saveManifest(...a) },
-  },
-}));
+vi.mock('@classmoji/services', () => {
+  // The route branches on `instanceof`, so the class it imports must be the
+  // class this test throws.
+  class ResourceLinkServiceError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'ResourceLinkServiceError';
+      this.code = code;
+    }
+  }
+  return {
+    ResourceLinkServiceError,
+    ClassmojiService: {
+      resourceLink: {
+        addLink: (...a: unknown[]) => addLink(...a),
+        removeLink: (...a: unknown[]) => removeLinkService(...a),
+      },
+    },
+  };
+});
 
 vi.mock('~/utils/helpers', () => ({
   assertClassroomAccess: vi.fn(async () => ({
@@ -40,11 +51,12 @@ vi.mock('~/utils/helpers', () => ({
   assertClassroomMutationAllowed: vi.fn(),
 }));
 
+const { ResourceLinkServiceError } = await import('@classmoji/services');
 const { action } = await import('../action.ts');
 
-const removeLink = (body: unknown) =>
+const submit = (intent: 'addLink' | 'removeLink', body: unknown) =>
   action({
-    request: new Request('http://localhost/admin/cs52/resources?/removeLink', {
+    request: new Request(`http://localhost/admin/cs52/resources?/${intent}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -53,7 +65,9 @@ const removeLink = (body: unknown) =>
     context: {},
   } as never);
 
-/** Values that survive `if (!linkId)` but widen the scoped `where`. */
+const removeLink = (body: unknown) => submit('removeLink', body);
+
+/** Values that survive `if (!id)` but widen a scoped `where`. */
 const unusableIds: [string, unknown][] = [
   ['undefined', undefined],
   ['null', null],
@@ -73,8 +87,7 @@ describe('admin.$class.resources removeLink', () => {
 
     expect(res).toBeInstanceOf(Response);
     expect(res.status).toBe(400);
-    expect(pageLinkDeleteMany).not.toHaveBeenCalled();
-    expect(slideLinkDeleteMany).not.toHaveBeenCalled();
+    expect(removeLinkService).not.toHaveBeenCalled();
   });
 
   it.each(unusableIds)('rejects %s as a slide linkId without deleting', async (_l, linkId) => {
@@ -84,32 +97,112 @@ describe('admin.$class.resources removeLink', () => {
 
     expect(res).toBeInstanceOf(Response);
     expect(res.status).toBe(400);
-    expect(pageLinkDeleteMany).not.toHaveBeenCalled();
-    expect(slideLinkDeleteMany).not.toHaveBeenCalled();
+    expect(removeLinkService).not.toHaveBeenCalled();
   });
 
-  it('deletes a real page link scoped to the classroom and saves the manifest', async () => {
-    pageLinkDeleteMany.mockResolvedValue({ count: 1 });
+  it('removes a real page link through the service, scoped to the authorized classroom', async () => {
+    removeLinkService.mockResolvedValue({ id: 'link-1', resourceType: 'page' });
 
     await expect(removeLink({ linkId: 'link-1', resourceType: 'page' })).resolves.toEqual({
       success: true,
     });
-    expect(pageLinkDeleteMany).toHaveBeenCalledExactlyOnceWith({
-      where: { id: 'link-1', page: { classroom_id: 'classroom-1' } },
+    // classroomId is the AUTHORIZED classroom, never request-body input.
+    expect(removeLinkService).toHaveBeenCalledExactlyOnceWith({
+      classroomId: 'classroom-1',
+      resourceType: 'page',
+      linkId: 'link-1',
     });
-    expect(saveManifest).toHaveBeenCalledWith('classroom-1');
   });
 
-  it('leaves the manifest alone when the link was not this classroom', async () => {
-    slideLinkDeleteMany.mockResolvedValue({ count: 0 });
+  it('treats any non-page resourceType as a slide rather than passing it through', async () => {
+    removeLinkService.mockResolvedValue({ id: 'link-1', resourceType: 'slide' });
+
+    await removeLink({ linkId: 'link-1', resourceType: { not: '' } });
+
+    expect(removeLinkService).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceType: 'slide' })
+    );
+  });
+
+  it('reports a link that was not this classroom as a 404', async () => {
+    // The service's deleteMany matched nothing, so nothing was deleted and the
+    // manifest was left alone — the route just relays that.
+    removeLinkService.mockRejectedValue(
+      new ResourceLinkServiceError('link_not_found', 'not found')
+    );
 
     const res = (await removeLink({ linkId: 'link-1', resourceType: 'slide' }).catch(
       (e: unknown) => e
     )) as Response;
 
     expect(res.status).toBe(404);
-    // `id` is the primary key, so count 0 means nothing was deleted — the
-    // manifest cannot end up describing links that are gone.
-    expect(saveManifest).not.toHaveBeenCalled();
+    await expect(res.text()).resolves.toBe('Link not found in classroom');
+  });
+});
+
+describe('admin.$class.resources addLink', () => {
+  const BODY = {
+    resourceId: 'page-1',
+    resourceType: 'page',
+    targetType: 'repository',
+    targetId: 'repo-1',
+  };
+
+  it.each(unusableIds)('rejects %s as a resourceId without linking', async (_l, resourceId) => {
+    const res = (await submit('addLink', { ...BODY, resourceId }).catch(
+      (e: unknown) => e
+    )) as Response;
+
+    expect(res.status).toBe(400);
+    expect(addLink).not.toHaveBeenCalled();
+  });
+
+  it.each(unusableIds)('rejects %s as a targetId without linking', async (_l, targetId) => {
+    const res = (await submit('addLink', { ...BODY, targetId }).catch(
+      (e: unknown) => e
+    )) as Response;
+
+    expect(res.status).toBe(400);
+    expect(addLink).not.toHaveBeenCalled();
+  });
+
+  it('links through the service using the authorized classroom', async () => {
+    addLink.mockResolvedValue({ id: 'link-1' });
+
+    await expect(submit('addLink', BODY)).resolves.toEqual({ success: true });
+    expect(addLink).toHaveBeenCalledExactlyOnceWith({
+      classroomId: 'classroom-1',
+      resourceType: 'page',
+      resourceId: 'page-1',
+      targetType: 'repository',
+      targetId: 'repo-1',
+    });
+  });
+
+  const errorCases = [
+    ['resource_not_found', 404, 'Page not found in classroom'],
+    ['target_not_found', 404, 'Repository not found in classroom'],
+    ['already_linked', 409, 'Already linked'],
+  ] as const;
+
+  it.each(errorCases)('maps %s onto the route response', async (code, status, text) => {
+    addLink.mockRejectedValue(new ResourceLinkServiceError(code, 'nope'));
+
+    const res = (await submit('addLink', BODY).catch((e: unknown) => e)) as Response;
+
+    expect(res.status).toBe(status);
+    await expect(res.text()).resolves.toBe(text);
+  });
+
+  it('names the slide/assignment halves of the not-found responses', async () => {
+    addLink.mockRejectedValue(new ResourceLinkServiceError('target_not_found', 'nope'));
+
+    const res = (await submit('addLink', {
+      ...BODY,
+      resourceType: 'slide',
+      targetType: 'assignment',
+    }).catch((e: unknown) => e)) as Response;
+
+    await expect(res.text()).resolves.toBe('Assignment not found in classroom');
   });
 });

--- a/apps/webapp/app/routes/admin.$class.resources/__tests__/removeLink.test.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/__tests__/removeLink.test.ts
@@ -7,12 +7,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * - `linkId` / `resourceId` / `targetId` arrive in an untyped JSON body. Prisma
  *   drops an `undefined` value from a `where` and its id fields also accept a
  *   `StringFilter` object, either of which would leave the service's compound
- *   `where` matching every link in the classroom. The route rejects those with
- *   a 400 and the service is never reached.
+ *   `where` matching every link in the classroom. The route rejects those and
+ *   the service is never reached.
  * - The classroom the service is called with is the AUTHORIZED one, never
  *   anything from the request body.
- * - The service's typed failures map back onto the responses this route has
- *   always sent.
+ * - The service's typed failures come back as RETURNED `{ error }` payloads,
+ *   which is what puts them in `fetcher.data` for the kanban's callout instead
+ *   of in the root error boundary — and what leaves React Router free to
+ *   revalidate the board afterwards. A thrown Response would do neither.
  *
  * Driven directly, like the api.quiz gating test: the auth seam and the service
  * are mocked, so the assertion is that the mutation is never ISSUED.
@@ -81,30 +83,29 @@ beforeEach(() => {
 
 describe('admin.$class.resources removeLink', () => {
   it.each(unusableIds)('rejects %s as a page linkId without deleting', async (_l, linkId) => {
-    const res = (await removeLink({ linkId, resourceType: 'page' }).catch(
-      (e: unknown) => e
-    )) as Response;
-
-    expect(res).toBeInstanceOf(Response);
-    expect(res.status).toBe(400);
+    await expect(removeLink({ linkId, resourceType: 'page' })).resolves.toEqual({
+      error: 'Invalid link id',
+    });
     expect(removeLinkService).not.toHaveBeenCalled();
   });
 
   it.each(unusableIds)('rejects %s as a slide linkId without deleting', async (_l, linkId) => {
-    const res = (await removeLink({ linkId, resourceType: 'slide' }).catch(
-      (e: unknown) => e
-    )) as Response;
-
-    expect(res).toBeInstanceOf(Response);
-    expect(res.status).toBe(400);
+    await expect(removeLink({ linkId, resourceType: 'slide' })).resolves.toEqual({
+      error: 'Invalid link id',
+    });
     expect(removeLinkService).not.toHaveBeenCalled();
   });
 
   it('removes a real page link through the service, scoped to the authorized classroom', async () => {
-    removeLinkService.mockResolvedValue({ id: 'link-1', resourceType: 'page' });
+    removeLinkService.mockResolvedValue({
+      id: 'link-1',
+      resourceType: 'page',
+      manifestSynced: true,
+    });
 
     await expect(removeLink({ linkId: 'link-1', resourceType: 'page' })).resolves.toEqual({
       success: true,
+      manifest_synced: true,
     });
     // classroomId is the AUTHORIZED classroom, never request-body input.
     expect(removeLinkService).toHaveBeenCalledExactlyOnceWith({
@@ -114,8 +115,25 @@ describe('admin.$class.resources removeLink', () => {
     });
   });
 
+  it('relays a manifest push that did not land rather than reporting a plain success', async () => {
+    removeLinkService.mockResolvedValue({
+      id: 'link-1',
+      resourceType: 'page',
+      manifestSynced: false,
+    });
+
+    await expect(removeLink({ linkId: 'link-1', resourceType: 'page' })).resolves.toEqual({
+      success: true,
+      manifest_synced: false,
+    });
+  });
+
   it('treats any non-page resourceType as a slide rather than passing it through', async () => {
-    removeLinkService.mockResolvedValue({ id: 'link-1', resourceType: 'slide' });
+    removeLinkService.mockResolvedValue({
+      id: 'link-1',
+      resourceType: 'slide',
+      manifestSynced: true,
+    });
 
     await removeLink({ linkId: 'link-1', resourceType: { not: '' } });
 
@@ -124,19 +142,17 @@ describe('admin.$class.resources removeLink', () => {
     );
   });
 
-  it('reports a link that was not this classroom as a 404', async () => {
+  it('returns a link that was not this classroom as an error payload, not a thrown response', async () => {
     // The service's deleteMany matched nothing, so nothing was deleted and the
-    // manifest was left alone — the route just relays that.
+    // manifest was left alone — the route relays that into fetcher.data, where
+    // the kanban can show it without the page being replaced by a boundary.
     removeLinkService.mockRejectedValue(
       new ResourceLinkServiceError('link_not_found', 'not found')
     );
 
-    const res = (await removeLink({ linkId: 'link-1', resourceType: 'slide' }).catch(
-      (e: unknown) => e
-    )) as Response;
-
-    expect(res.status).toBe(404);
-    await expect(res.text()).resolves.toBe('Link not found in classroom');
+    await expect(removeLink({ linkId: 'link-1', resourceType: 'slide' })).resolves.toEqual({
+      error: 'Link not found in classroom',
+    });
   });
 });
 
@@ -149,27 +165,26 @@ describe('admin.$class.resources addLink', () => {
   };
 
   it.each(unusableIds)('rejects %s as a resourceId without linking', async (_l, resourceId) => {
-    const res = (await submit('addLink', { ...BODY, resourceId }).catch(
-      (e: unknown) => e
-    )) as Response;
-
-    expect(res.status).toBe(400);
+    await expect(submit('addLink', { ...BODY, resourceId })).resolves.toEqual({
+      error: 'Invalid resource id',
+    });
     expect(addLink).not.toHaveBeenCalled();
   });
 
   it.each(unusableIds)('rejects %s as a targetId without linking', async (_l, targetId) => {
-    const res = (await submit('addLink', { ...BODY, targetId }).catch(
-      (e: unknown) => e
-    )) as Response;
-
-    expect(res.status).toBe(400);
+    await expect(submit('addLink', { ...BODY, targetId })).resolves.toEqual({
+      error: 'Invalid target id',
+    });
     expect(addLink).not.toHaveBeenCalled();
   });
 
   it('links through the service using the authorized classroom', async () => {
-    addLink.mockResolvedValue({ id: 'link-1' });
+    addLink.mockResolvedValue({ id: 'link-1', manifestSynced: true });
 
-    await expect(submit('addLink', BODY)).resolves.toEqual({ success: true });
+    await expect(submit('addLink', BODY)).resolves.toEqual({
+      success: true,
+      manifest_synced: true,
+    });
     expect(addLink).toHaveBeenCalledExactlyOnceWith({
       classroomId: 'classroom-1',
       resourceType: 'page',
@@ -179,30 +194,50 @@ describe('admin.$class.resources addLink', () => {
     });
   });
 
-  const errorCases = [
-    ['resource_not_found', 404, 'Page not found in classroom'],
-    ['target_not_found', 404, 'Repository not found in classroom'],
-    ['already_linked', 409, 'Already linked'],
-  ] as const;
+  it('relays a manifest push that did not land rather than reporting a plain success', async () => {
+    addLink.mockResolvedValue({ id: 'link-1', manifestSynced: false });
 
-  it.each(errorCases)('maps %s onto the route response', async (code, status, text) => {
-    addLink.mockRejectedValue(new ResourceLinkServiceError(code, 'nope'));
-
-    const res = (await submit('addLink', BODY).catch((e: unknown) => e)) as Response;
-
-    expect(res.status).toBe(status);
-    await expect(res.text()).resolves.toBe(text);
+    await expect(submit('addLink', BODY)).resolves.toEqual({
+      success: true,
+      manifest_synced: false,
+    });
   });
 
-  it('names the slide/assignment halves of the not-found responses', async () => {
+  const errorCases = [
+    ['resource_not_found', 'Page not found in classroom'],
+    ['target_not_found', 'Repository not found in classroom'],
+    ['already_linked', 'Already linked'],
+  ] as const;
+
+  it.each(errorCases)('returns %s as an error payload the fetcher can read', async (code, text) => {
+    // Returned, not thrown: a thrown Response never reaches fetcher.data, and a
+    // 4xx would also stop React Router revalidating the board — which is what
+    // clears the stale card behind an "Already linked" rejection.
+    addLink.mockRejectedValue(new ResourceLinkServiceError(code, 'nope'));
+
+    await expect(submit('addLink', BODY)).resolves.toEqual({ error: text });
+  });
+
+  it('names the slide/assignment halves of the not-found messages', async () => {
     addLink.mockRejectedValue(new ResourceLinkServiceError('target_not_found', 'nope'));
 
-    const res = (await submit('addLink', {
-      ...BODY,
-      resourceType: 'slide',
-      targetType: 'assignment',
-    }).catch((e: unknown) => e)) as Response;
+    await expect(
+      submit('addLink', { ...BODY, resourceType: 'slide', targetType: 'assignment' })
+    ).resolves.toEqual({ error: 'Assignment not found in classroom' });
+  });
 
-    await expect(res.text()).resolves.toBe('Assignment not found in classroom');
+  it('lets a code it has no phrasing for reach the error boundary', async () => {
+    // Only failures this route can explain are turned into user-facing copy; an
+    // unrecognised one is a bug, not a message, so it is not swallowed.
+    const futureCode = 'something_new' as ConstructorParameters<typeof ResourceLinkServiceError>[0];
+    addLink.mockRejectedValue(new ResourceLinkServiceError(futureCode, 'nope'));
+
+    await expect(submit('addLink', BODY)).rejects.toBeInstanceOf(ResourceLinkServiceError);
+  });
+
+  it('lets an unrelated failure through untouched', async () => {
+    addLink.mockRejectedValue(new Error('connection lost'));
+
+    await expect(submit('addLink', BODY)).rejects.toThrow('connection lost');
   });
 });

--- a/apps/webapp/app/routes/admin.$class.resources/action.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/action.ts
@@ -7,33 +7,48 @@ import type { Route } from './+types/route';
  * Link management for the resources kanban.
  *
  * The linking itself lives in ClassmojiService.resourceLink so this route and
- * the MCP resource-link tools take one code path. What stays HERE is the part
- * that is genuinely route-shaped: the auth gate, and the untyped-JSON-body
- * guards below. The service is classroom-scoped and re-checks ids itself, but
- * these 400s are what tell a browser client it sent nonsense rather than
- * reporting a record that "does not exist".
+ * the MCP resource-link tools share one path. What stays HERE is the part that
+ * is genuinely route-shaped: the auth gate, and the untyped-JSON-body guards
+ * below. The service is classroom-scoped and re-checks ids itself, but these
+ * guards are what tell a browser client it sent nonsense rather than reporting
+ * a record that "does not exist".
+ *
+ * EVERY failure is RETURNED as `{ error }`, never thrown, and never with a 4xx.
+ * Two reasons, both load-bearing:
+ *
+ * 1. This action is only ever reached by a fetcher. A thrown Response does not
+ *    land in `fetcher.data` — React Router routes it to the nearest error
+ *    boundary, which for this route tree is the root one, so a rejected drag
+ *    would replace the whole admin UI with an error page.
+ * 2. React Router skips post-action revalidation when the action's status is
+ *    4xx or higher. The most likely rejection here is a duplicate drag decided
+ *    against STALE loader data — precisely the case that needs the board
+ *    refreshed. A 409 would suppress the refresh and leave the stale card in
+ *    place, so the board could never recover on its own.
+ *
+ * The kanban reads `error` off the fetcher and shows a callout, matching how
+ * the other admin list routes surface fetcher failures.
  */
 
-/** Map the service's typed failures back onto the responses this route has always sent. */
-const linkErrorResponse = (
+/** Map the service's typed failures onto the message the kanban shows. */
+const linkErrorMessage = (
   error: unknown,
   { resourceType, targetType }: { resourceType?: unknown; targetType?: unknown }
-): Response => {
+): string => {
   if (!(error instanceof ResourceLinkServiceError)) throw error;
   switch (error.code) {
     case 'resource_not_found':
-      return new Response(`${resourceType === 'page' ? 'Page' : 'Slide'} not found in classroom`, {
-        status: 404,
-      });
+      return `${resourceType === 'page' ? 'Page' : 'Slide'} not found in classroom`;
     case 'target_not_found':
-      return new Response(
-        `${targetType === 'repository' ? 'Repository' : 'Assignment'} not found in classroom`,
-        { status: 404 }
-      );
+      return `${targetType === 'repository' ? 'Repository' : 'Assignment'} not found in classroom`;
     case 'already_linked':
-      return new Response('Already linked', { status: 409 });
+      return 'Already linked';
     case 'link_not_found':
-      return new Response('Link not found in classroom', { status: 404 });
+      return 'Link not found in classroom';
+    // A code this route has never seen is not something it can phrase for a
+    // user; let it reach the error boundary as the unexpected failure it is.
+    default:
+      throw error;
   }
 };
 
@@ -57,14 +72,15 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       // from a `where` rather than rejecting it, so an unusable id would widen
       // the service's scope checks instead of narrowing them.
       if (typeof resourceId !== 'string' || !resourceId) {
-        throw new Response('Invalid resource id', { status: 400 });
+        return { error: 'Invalid resource id' };
       }
       if (typeof targetId !== 'string' || !targetId) {
-        throw new Response('Invalid target id', { status: 400 });
+        return { error: 'Invalid target id' };
       }
 
+      let link;
       try {
-        await ClassmojiService.resourceLink.addLink({
+        link = await ClassmojiService.resourceLink.addLink({
           classroomId: classroom.id,
           resourceType: resourceType === 'page' ? 'page' : 'slide',
           resourceId,
@@ -72,11 +88,12 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
           targetId,
         });
       } catch (error) {
-        throw linkErrorResponse(error, { resourceType, targetType });
+        return { error: linkErrorMessage(error, { resourceType, targetType }) };
       }
 
-      // The service refreshes the content manifest on success (best effort).
-      return { success: true };
+      // The link is committed; the manifest push that follows it is best effort,
+      // so report which of the two actually happened rather than just "ok".
+      return { success: true, manifest_synced: link.manifestSynced };
     },
 
     async removeLink() {
@@ -87,20 +104,21 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       // `undefined` value or a `{ not: '' }` filter object would otherwise
       // leave `deleteMany` matching every link in the classroom.
       if (typeof linkId !== 'string' || !linkId) {
-        throw new Response('Invalid link id', { status: 400 });
+        return { error: 'Invalid link id' };
       }
 
+      let removed;
       try {
-        await ClassmojiService.resourceLink.removeLink({
+        removed = await ClassmojiService.resourceLink.removeLink({
           classroomId: classroom.id,
           resourceType: resourceType === 'page' ? 'page' : 'slide',
           linkId,
         });
       } catch (error) {
-        throw linkErrorResponse(error, { resourceType });
+        return { error: linkErrorMessage(error, { resourceType }) };
       }
 
-      return { success: true };
+      return { success: true, manifest_synced: removed.manifestSynced };
     },
   });
 };

--- a/apps/webapp/app/routes/admin.$class.resources/action.ts
+++ b/apps/webapp/app/routes/admin.$class.resources/action.ts
@@ -1,8 +1,41 @@
 import { namedAction } from 'remix-utils/named-action';
-import getPrisma from '@classmoji/database';
-import { ClassmojiService } from '@classmoji/services';
+import { ClassmojiService, ResourceLinkServiceError } from '@classmoji/services';
 import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import type { Route } from './+types/route';
+
+/**
+ * Link management for the resources kanban.
+ *
+ * The linking itself lives in ClassmojiService.resourceLink so this route and
+ * the MCP resource-link tools take one code path. What stays HERE is the part
+ * that is genuinely route-shaped: the auth gate, and the untyped-JSON-body
+ * guards below. The service is classroom-scoped and re-checks ids itself, but
+ * these 400s are what tell a browser client it sent nonsense rather than
+ * reporting a record that "does not exist".
+ */
+
+/** Map the service's typed failures back onto the responses this route has always sent. */
+const linkErrorResponse = (
+  error: unknown,
+  { resourceType, targetType }: { resourceType?: unknown; targetType?: unknown }
+): Response => {
+  if (!(error instanceof ResourceLinkServiceError)) throw error;
+  switch (error.code) {
+    case 'resource_not_found':
+      return new Response(`${resourceType === 'page' ? 'Page' : 'Slide'} not found in classroom`, {
+        status: 404,
+      });
+    case 'target_not_found':
+      return new Response(
+        `${targetType === 'repository' ? 'Repository' : 'Assignment'} not found in classroom`,
+        { status: 404 }
+      );
+    case 'already_linked':
+      return new Response('Already linked', { status: 409 });
+    case 'link_not_found':
+      return new Response('Link not found in classroom', { status: 404 });
+  }
+};
 
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
@@ -16,44 +49,13 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
-  // `resourceId`, `targetId` and `linkId` all arrive in the request body, so each
-  // has to be proven to live in the authorized classroom before it is joined or
-  // deleted. Page, Slide and Repository carry `classroom_id` directly; Assignment
-  // does not, and is reached through its Repository.
-  const prisma = getPrisma();
-
-  const assertFound = (what: string, found: { id: string } | null) => {
-    if (!found) throw new Response(`${what} not found in classroom`, { status: 404 });
-  };
-
-  const assertTargetInClassroom = async (targetType: string, targetId: string) => {
-    if (targetType === 'repository') {
-      assertFound(
-        'Repository',
-        await prisma.repository.findFirst({
-          where: { id: targetId, classroom_id: classroom.id },
-          select: { id: true },
-        })
-      );
-      return;
-    }
-    assertFound(
-      'Assignment',
-      await prisma.assignment.findFirst({
-        where: { id: targetId, repository: { classroom_id: classroom.id } },
-        select: { id: true },
-      })
-    );
-  };
-
   return namedAction(request, {
     async addLink() {
       const { resourceId, resourceType, targetType, targetId } = await request.json();
 
-      // Same untyped-body hazard as removeLink: an `undefined` id is dropped from
-      // the `where` rather than rejected, so the scope checks below would match an
-      // arbitrary row in the classroom, pass, and then create a link pointing at
-      // nothing.
+      // Same untyped-body hazard as removeLink: Prisma DROPS an `undefined` id
+      // from a `where` rather than rejecting it, so an unusable id would widen
+      // the service's scope checks instead of narrowing them.
       if (typeof resourceId !== 'string' || !resourceId) {
         throw new Response('Invalid resource id', { status: 400 });
       }
@@ -61,78 +63,42 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         throw new Response('Invalid target id', { status: 400 });
       }
 
-      await assertTargetInClassroom(targetType, targetId);
-
-      if (resourceType === 'page') {
-        assertFound(
-          'Page',
-          await prisma.page.findFirst({
-            where: { id: resourceId, classroom_id: classroom.id },
-            select: { id: true },
-          })
-        );
-        await prisma.pageLink.create({
-          data: {
-            page_id: resourceId,
-            repository_id: targetType === 'repository' ? targetId : null,
-            assignment_id: targetType === 'assignment' ? targetId : null,
-          },
+      try {
+        await ClassmojiService.resourceLink.addLink({
+          classroomId: classroom.id,
+          resourceType: resourceType === 'page' ? 'page' : 'slide',
+          resourceId,
+          targetType: targetType === 'repository' ? 'repository' : 'assignment',
+          targetId,
         });
-      } else {
-        assertFound(
-          'Slide',
-          await prisma.slide.findFirst({
-            where: { id: resourceId, classroom_id: classroom.id },
-            select: { id: true },
-          })
-        );
-        await prisma.slideLink.create({
-          data: {
-            slide_id: resourceId,
-            repository_id: targetType === 'repository' ? targetId : null,
-            assignment_id: targetType === 'assignment' ? targetId : null,
-          },
-        });
+      } catch (error) {
+        throw linkErrorResponse(error, { resourceType, targetType });
       }
 
-      // Update manifest after adding link
-      await ClassmojiService.contentManifest.saveManifest(classroom.id);
-
+      // The service refreshes the content manifest on success (best effort).
       return { success: true };
     },
 
     async removeLink() {
       const { linkId, resourceType } = await request.json();
 
-      // `linkId` is untyped request-body data, and the compound below only
-      // narrows the delete while it is a real string: Prisma drops an
-      // `undefined` value from a `where` rather than rejecting it, and the id
-      // field also accepts a filter object, so `undefined` or `{ not: '' }`
-      // would leave `deleteMany` matching every link in the classroom.
+      // `linkId` is untyped request-body data, and the service's compound
+      // `where` only narrows the delete while it is a real string: an
+      // `undefined` value or a `{ not: '' }` filter object would otherwise
+      // leave `deleteMany` matching every link in the classroom.
       if (typeof linkId !== 'string' || !linkId) {
         throw new Response('Invalid link id', { status: 400 });
       }
 
-      // deleteMany takes the compound that `delete` cannot. Past the guard `id`
-      // is the primary key, so the compound matches at most one row: a count
-      // other than 1 means zero rows matched, the link was not this classroom's,
-      // and nothing was deleted — so the throw below cannot leave the manifest
-      // describing links that are gone.
-      const { count } =
-        resourceType === 'page'
-          ? await prisma.pageLink.deleteMany({
-              where: { id: linkId, page: { classroom_id: classroom.id } },
-            })
-          : await prisma.slideLink.deleteMany({
-              where: { id: linkId, slide: { classroom_id: classroom.id } },
-            });
-
-      if (count !== 1) {
-        throw new Response('Link not found in classroom', { status: 404 });
+      try {
+        await ClassmojiService.resourceLink.removeLink({
+          classroomId: classroom.id,
+          resourceType: resourceType === 'page' ? 'page' : 'slide',
+          linkId,
+        });
+      } catch (error) {
+        throw linkErrorResponse(error, { resourceType });
       }
-
-      // Update manifest after removing link
-      await ClassmojiService.contentManifest.saveManifest(classroom.id);
 
       return { success: true };
     },

--- a/packages/services/src/classmoji/__tests__/resourceLink.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/resourceLink.service.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for resourceLink — the page/slide link management extracted from
+ * the web admin.$class.resources action so the MCP resource-link tools share it.
+ *
+ * Prisma and the content manifest are mocked. The tests pin the invariants the
+ * extraction exists to establish: both ends of a link are proven to be in the
+ * caller's classroom BEFORE anything is written, a duplicate is refused in SQL
+ * rather than relying on the kanban's client-side guard, a remove that matched
+ * nothing leaves the manifest alone, and a manifest push that fails never turns
+ * a committed write into a failed call.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const pageFindFirst = vi.fn();
+const slideFindFirst = vi.fn();
+const repositoryFindFirst = vi.fn();
+const assignmentFindFirst = vi.fn();
+const pageLinkFindFirst = vi.fn();
+const slideLinkFindFirst = vi.fn();
+const pageLinkCreate = vi.fn();
+const slideLinkCreate = vi.fn();
+const pageLinkDeleteMany = vi.fn();
+const slideLinkDeleteMany = vi.fn();
+const pageLinkFindMany = vi.fn();
+const slideLinkFindMany = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    page: { findFirst: (...a: unknown[]) => pageFindFirst(...a) },
+    slide: { findFirst: (...a: unknown[]) => slideFindFirst(...a) },
+    repository: { findFirst: (...a: unknown[]) => repositoryFindFirst(...a) },
+    assignment: { findFirst: (...a: unknown[]) => assignmentFindFirst(...a) },
+    pageLink: {
+      findFirst: (...a: unknown[]) => pageLinkFindFirst(...a),
+      create: (...a: unknown[]) => pageLinkCreate(...a),
+      deleteMany: (...a: unknown[]) => pageLinkDeleteMany(...a),
+      findMany: (...a: unknown[]) => pageLinkFindMany(...a),
+    },
+    slideLink: {
+      findFirst: (...a: unknown[]) => slideLinkFindFirst(...a),
+      create: (...a: unknown[]) => slideLinkCreate(...a),
+      deleteMany: (...a: unknown[]) => slideLinkDeleteMany(...a),
+      findMany: (...a: unknown[]) => slideLinkFindMany(...a),
+    },
+  }),
+}));
+
+const saveManifest = vi.fn();
+vi.mock('../contentManifest.service.ts', () => ({
+  saveManifest: (...a: unknown[]) => saveManifest(...a),
+}));
+
+const { addLink, removeLink, listLinks, ResourceLinkServiceError } =
+  await import('../resourceLink.service.ts');
+
+const CLASSROOM = 'classroom-1';
+const CREATED_AT = new Date('2026-01-02T03:04:05Z');
+
+/** Every write path the service can take — nothing may reach these on a rejection. */
+const writeMocks = [pageLinkCreate, slideLinkCreate, pageLinkDeleteMany, slideLinkDeleteMany];
+const expectNoWrites = () => {
+  for (const m of writeMocks) expect(m).not.toHaveBeenCalled();
+};
+
+/** Grab the thrown ResourceLinkServiceError, or fail loudly if nothing threw. */
+async function codeOf(promise: Promise<unknown>): Promise<string> {
+  const error = await promise.then(
+    () => null,
+    (e: unknown) => e
+  );
+  expect(error).toBeInstanceOf(ResourceLinkServiceError);
+  return (error as InstanceType<typeof ResourceLinkServiceError>).code;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  saveManifest.mockResolvedValue(undefined);
+  // Default: both ends resolve, no duplicate exists.
+  pageFindFirst.mockResolvedValue({ id: 'page-1' });
+  slideFindFirst.mockResolvedValue({ id: 'slide-1' });
+  repositoryFindFirst.mockResolvedValue({ id: 'repo-1' });
+  assignmentFindFirst.mockResolvedValue({ id: 'assign-1' });
+  pageLinkFindFirst.mockResolvedValue(null);
+  slideLinkFindFirst.mockResolvedValue(null);
+  pageLinkCreate.mockResolvedValue({ id: 'link-1', order: 0, created_at: CREATED_AT });
+  slideLinkCreate.mockResolvedValue({ id: 'link-2', order: 0, created_at: CREATED_AT });
+});
+
+describe('addLink', () => {
+  const PAGE_TO_REPO = {
+    classroomId: CLASSROOM,
+    resourceType: 'page',
+    resourceId: 'page-1',
+    targetType: 'repository',
+    targetId: 'repo-1',
+  } as const;
+
+  it('creates a page→repository link scoped to the classroom and refreshes the manifest', async () => {
+    await expect(addLink({ ...PAGE_TO_REPO })).resolves.toEqual({
+      id: 'link-1',
+      resourceType: 'page',
+      resourceId: 'page-1',
+      targetType: 'repository',
+      targetId: 'repo-1',
+      order: 0,
+      createdAt: CREATED_AT,
+    });
+
+    // Both ends were proven to be in THIS classroom before the insert.
+    expect(pageFindFirst).toHaveBeenCalledWith({
+      where: { id: 'page-1', classroom_id: CLASSROOM },
+      select: { id: true },
+    });
+    expect(repositoryFindFirst).toHaveBeenCalledWith({
+      where: { id: 'repo-1', classroom_id: CLASSROOM },
+      select: { id: true },
+    });
+    // The unset target column is written as an explicit null.
+    expect(pageLinkCreate.mock.calls[0][0].data).toEqual({
+      page_id: 'page-1',
+      repository_id: 'repo-1',
+      assignment_id: null,
+    });
+    expect(saveManifest).toHaveBeenCalledExactlyOnceWith(CLASSROOM);
+  });
+
+  it('reaches an assignment target through its repository classroom chain', async () => {
+    await addLink({
+      classroomId: CLASSROOM,
+      resourceType: 'slide',
+      resourceId: 'slide-1',
+      targetType: 'assignment',
+      targetId: 'assign-1',
+    });
+
+    // Assignment has no classroom_id of its own.
+    expect(assignmentFindFirst).toHaveBeenCalledWith({
+      where: { id: 'assign-1', repository: { classroom_id: CLASSROOM } },
+      select: { id: true },
+    });
+    expect(slideLinkCreate.mock.calls[0][0].data).toEqual({
+      slide_id: 'slide-1',
+      repository_id: null,
+      assignment_id: 'assign-1',
+    });
+  });
+
+  it('rejects a resource from another classroom without writing or touching the manifest', async () => {
+    pageFindFirst.mockResolvedValue(null);
+
+    expect(await codeOf(addLink({ ...PAGE_TO_REPO }))).toBe('resource_not_found');
+    expectNoWrites();
+    expect(saveManifest).not.toHaveBeenCalled();
+  });
+
+  it('rejects a target from another classroom without writing', async () => {
+    repositoryFindFirst.mockResolvedValue(null);
+
+    expect(await codeOf(addLink({ ...PAGE_TO_REPO }))).toBe('target_not_found');
+    expectNoWrites();
+    expect(saveManifest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a StringFilter object', { not: '' }],
+    ['a number', 7],
+  ])('refuses %s as a resource id before any lookup runs', async (_label, resourceId) => {
+    // A non-string id is DROPPED from a Prisma `where` rather than rejected, so
+    // the classroom scope check would match an arbitrary row and pass.
+    expect(
+      await codeOf(addLink({ ...PAGE_TO_REPO, resourceId: resourceId as unknown as string }))
+    ).toBe('resource_not_found');
+    expect(pageFindFirst).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it('refuses a non-string target id before any lookup runs', async () => {
+    expect(
+      await codeOf(addLink({ ...PAGE_TO_REPO, targetId: { not: '' } as unknown as string }))
+    ).toBe('target_not_found');
+    expect(repositoryFindFirst).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it('reports an existing identical link as already_linked instead of duplicating it', async () => {
+    // The kanban hides linked targets client-side; an API caller has no such
+    // guard, and the nulls-distinct unique index would happily take a second row.
+    pageLinkFindFirst.mockResolvedValue({ id: 'link-existing' });
+
+    expect(await codeOf(addLink({ ...PAGE_TO_REPO }))).toBe('already_linked');
+    expect(pageLinkFindFirst).toHaveBeenCalledWith({
+      where: { page_id: 'page-1', repository_id: 'repo-1', assignment_id: null },
+      select: { id: true },
+    });
+    expectNoWrites();
+    expect(saveManifest).not.toHaveBeenCalled();
+  });
+
+  it('maps a P2002 unique violation to already_linked as a race backstop', async () => {
+    pageLinkCreate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
+
+    expect(await codeOf(addLink({ ...PAGE_TO_REPO }))).toBe('already_linked');
+    expect(saveManifest).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-unique database failure unchanged', async () => {
+    pageLinkCreate.mockRejectedValue(
+      Object.assign(new Error('connection lost'), { code: 'P1001' })
+    );
+
+    const error = await addLink({ ...PAGE_TO_REPO }).catch((e: unknown) => e);
+    expect(error).not.toBeInstanceOf(ResourceLinkServiceError);
+    expect((error as Error).message).toBe('connection lost');
+  });
+
+  it('still succeeds when the manifest push fails', async () => {
+    // The row is already committed; a git push that did not land must not be
+    // reported to the caller as "nothing happened".
+    saveManifest.mockRejectedValue(new Error('github is down'));
+
+    await expect(addLink({ ...PAGE_TO_REPO })).resolves.toMatchObject({ id: 'link-1' });
+  });
+});
+
+describe('removeLink', () => {
+  it('deletes a page link through the classroom compound and refreshes the manifest', async () => {
+    pageLinkDeleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      removeLink({ classroomId: CLASSROOM, resourceType: 'page', linkId: 'link-1' })
+    ).resolves.toEqual({ id: 'link-1', resourceType: 'page' });
+
+    expect(pageLinkDeleteMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: 'link-1', page: { classroom_id: CLASSROOM } },
+    });
+    expect(saveManifest).toHaveBeenCalledExactlyOnceWith(CLASSROOM);
+  });
+
+  it('deletes a slide link through the slide classroom compound', async () => {
+    slideLinkDeleteMany.mockResolvedValue({ count: 1 });
+
+    await removeLink({ classroomId: CLASSROOM, resourceType: 'slide', linkId: 'link-2' });
+
+    expect(slideLinkDeleteMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: 'link-2', slide: { classroom_id: CLASSROOM } },
+    });
+  });
+
+  it('leaves the manifest alone when the link was not this classroom', async () => {
+    // `id` is the primary key past the guard, so count 0 means nothing was
+    // deleted — the manifest cannot end up describing links that are still there.
+    slideLinkDeleteMany.mockResolvedValue({ count: 0 });
+
+    expect(
+      await codeOf(removeLink({ classroomId: CLASSROOM, resourceType: 'slide', linkId: 'link-2' }))
+    ).toBe('link_not_found');
+    expect(saveManifest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a StringFilter object', { not: '' }],
+    ['a number', 7],
+  ])('refuses %s as a link id without issuing the delete', async (_label, linkId) => {
+    expect(
+      await codeOf(
+        removeLink({
+          classroomId: CLASSROOM,
+          resourceType: 'page',
+          linkId: linkId as unknown as string,
+        })
+      )
+    ).toBe('link_not_found');
+    expectNoWrites();
+  });
+
+  it('still succeeds when the manifest push fails', async () => {
+    pageLinkDeleteMany.mockResolvedValue({ count: 1 });
+    saveManifest.mockRejectedValue(new Error('github is down'));
+
+    await expect(
+      removeLink({ classroomId: CLASSROOM, resourceType: 'page', linkId: 'link-1' })
+    ).resolves.toEqual({ id: 'link-1', resourceType: 'page' });
+  });
+});
+
+describe('listLinks', () => {
+  const pageRow = {
+    id: 'link-1',
+    order: 0,
+    created_at: CREATED_AT,
+    page: { id: 'page-1', title: 'Setup', slug: 'setup' },
+    repository: { id: 'repo-1', title: 'Lab 1', slug: 'lab-1' },
+    assignment: null,
+  };
+  const slideRow = {
+    id: 'link-2',
+    order: 1,
+    created_at: CREATED_AT,
+    slide: { id: 'slide-1', title: 'Week 1', slug: 'week-1' },
+    repository: null,
+    assignment: {
+      id: 'assign-1',
+      title: 'Part A',
+      slug: 'part-a',
+      repository: { id: 'repo-1', title: 'Lab 1' },
+    },
+  };
+
+  beforeEach(() => {
+    pageLinkFindMany.mockResolvedValue([pageRow]);
+    slideLinkFindMany.mockResolvedValue([slideRow]);
+  });
+
+  it('resolves both resource types to named resource and target shapes', async () => {
+    await expect(listLinks({ classroomId: CLASSROOM })).resolves.toEqual([
+      {
+        id: 'link-1',
+        resourceType: 'page',
+        targetType: 'repository',
+        order: 0,
+        createdAt: CREATED_AT,
+        resource: { id: 'page-1', title: 'Setup', slug: 'setup' },
+        target: { id: 'repo-1', title: 'Lab 1', slug: 'lab-1' },
+      },
+      {
+        id: 'link-2',
+        resourceType: 'slide',
+        targetType: 'assignment',
+        order: 1,
+        createdAt: CREATED_AT,
+        resource: { id: 'slide-1', title: 'Week 1', slug: 'week-1' },
+        // An assignment target also names the repository it sits in.
+        target: {
+          id: 'assign-1',
+          title: 'Part A',
+          slug: 'part-a',
+          repositoryId: 'repo-1',
+          repositoryTitle: 'Lab 1',
+        },
+      },
+    ]);
+  });
+
+  it('scopes every query to the classroom through the parent resource', async () => {
+    await listLinks({ classroomId: CLASSROOM });
+
+    // Neither link table carries classroom_id, so the scope goes through page/slide.
+    expect(pageLinkFindMany.mock.calls[0][0].where).toMatchObject({
+      page: { classroom_id: CLASSROOM },
+    });
+    expect(slideLinkFindMany.mock.calls[0][0].where).toMatchObject({
+      slide: { classroom_id: CLASSROOM },
+    });
+  });
+
+  it('skips the other table entirely when resource_type narrows the read', async () => {
+    await listLinks({ classroomId: CLASSROOM, resourceType: 'page' });
+    expect(slideLinkFindMany).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    slideLinkFindMany.mockResolvedValue([]);
+    await listLinks({ classroomId: CLASSROOM, resourceType: 'slide' });
+    expect(pageLinkFindMany).not.toHaveBeenCalled();
+  });
+
+  it('narrows by resource id', async () => {
+    await listLinks({ classroomId: CLASSROOM, resourceType: 'page', resourceId: 'page-1' });
+
+    expect(pageLinkFindMany.mock.calls[0][0].where).toMatchObject({ page_id: 'page-1' });
+  });
+
+  it.each([
+    ['repository', { repository_id: { not: null } }],
+    ['assignment', { assignment_id: { not: null } }],
+  ])('narrows to %s targets when no target id is given', async (targetType, expected) => {
+    await listLinks({
+      classroomId: CLASSROOM,
+      resourceType: 'page',
+      targetType: targetType as 'repository' | 'assignment',
+    });
+
+    expect(pageLinkFindMany.mock.calls[0][0].where).toMatchObject(expected);
+  });
+
+  it('narrows to a specific target when both type and id are given', async () => {
+    await listLinks({
+      classroomId: CLASSROOM,
+      resourceType: 'page',
+      targetType: 'assignment',
+      targetId: 'assign-1',
+    });
+
+    expect(pageLinkFindMany.mock.calls[0][0].where).toMatchObject({ assignment_id: 'assign-1' });
+  });
+
+  it('matches either kind of target when an id is given without a type', async () => {
+    await listLinks({ classroomId: CLASSROOM, resourceType: 'page', targetId: 'repo-1' });
+
+    expect(pageLinkFindMany.mock.calls[0][0].where).toMatchObject({
+      OR: [{ repository_id: 'repo-1' }, { assignment_id: 'repo-1' }],
+    });
+  });
+
+  it('drops a row whose target is gone rather than reporting a hole', async () => {
+    pageLinkFindMany.mockResolvedValue([{ ...pageRow, repository: null, assignment: null }]);
+    slideLinkFindMany.mockResolvedValue([]);
+
+    await expect(listLinks({ classroomId: CLASSROOM })).resolves.toEqual([]);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/resourceLink.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/resourceLink.service.test.ts
@@ -4,10 +4,12 @@
  *
  * Prisma and the content manifest are mocked. The tests pin the invariants the
  * extraction exists to establish: both ends of a link are proven to be in the
- * caller's classroom BEFORE anything is written, a duplicate is refused in SQL
- * rather than relying on the kanban's client-side guard, a remove that matched
- * nothing leaves the manifest alone, and a manifest push that fails never turns
- * a committed write into a failed call.
+ * caller's classroom BEFORE anything is written, reads drop a row whose target
+ * resolves outside the classroom, a duplicate is refused by the service's own
+ * pre-check rather than by the kanban's drop-time guard on loader data, a
+ * remove that matched nothing leaves the manifest alone, and a manifest push
+ * that fails is reported rather than turning a committed write into a failed
+ * call.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -73,9 +75,12 @@ async function codeOf(promise: Promise<unknown>): Promise<string> {
   return (error as InstanceType<typeof ResourceLinkServiceError>).code;
 }
 
+/** The read path warns about every row it drops; keep it quiet AND assertable. */
+const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
 beforeEach(() => {
   vi.clearAllMocks();
-  saveManifest.mockResolvedValue(undefined);
+  saveManifest.mockResolvedValue(true);
   // Default: both ends resolve, no duplicate exists.
   pageFindFirst.mockResolvedValue({ id: 'page-1' });
   slideFindFirst.mockResolvedValue({ id: 'slide-1' });
@@ -105,6 +110,7 @@ describe('addLink', () => {
       targetId: 'repo-1',
       order: 0,
       createdAt: CREATED_AT,
+      manifestSynced: true,
     });
 
     // Both ends were proven to be in THIS classroom before the insert.
@@ -139,11 +145,35 @@ describe('addLink', () => {
       where: { id: 'assign-1', repository: { classroom_id: CLASSROOM } },
       select: { id: true },
     });
+    // The unused target column is an explicit null in the duplicate lookup too.
+    // `repository_id: undefined` would be DROPPED from the `where` by Prisma,
+    // which would match this slide's link to ANY repository and report a
+    // duplicate that is not one.
+    expect(slideLinkFindFirst).toHaveBeenCalledExactlyOnceWith({
+      where: { slide_id: 'slide-1', repository_id: null, assignment_id: 'assign-1' },
+      select: { id: true },
+    });
     expect(slideLinkCreate.mock.calls[0][0].data).toEqual({
       slide_id: 'slide-1',
       repository_id: null,
       assignment_id: 'assign-1',
     });
+  });
+
+  it.each([
+    ['an empty resourceType', { resourceType: '' }, 'resource_not_found'],
+    ['a miscased resourceType', { resourceType: 'Page' }, 'resource_not_found'],
+    ['an empty targetType', { targetType: '' }, 'target_not_found'],
+    ['a miscased targetType', { targetType: 'Assignment' }, 'target_not_found'],
+  ])('refuses %s instead of writing a row that points nowhere', async (_l, override, expected) => {
+    // The classroom check and the insert derive their columns from the SAME
+    // switch, so a value that is neither literal is refused outright rather
+    // than validated as one kind and written as the other.
+    const args = { ...PAGE_TO_REPO, ...override } as Parameters<typeof addLink>[0];
+
+    expect(await codeOf(addLink(args))).toBe(expected);
+    expectNoWrites();
+    expect(saveManifest).not.toHaveBeenCalled();
   });
 
   it('rejects a resource from another classroom without writing or touching the manifest', async () => {
@@ -186,8 +216,9 @@ describe('addLink', () => {
   });
 
   it('reports an existing identical link as already_linked instead of duplicating it', async () => {
-    // The kanban hides linked targets client-side; an API caller has no such
-    // guard, and the nulls-distinct unique index would happily take a second row.
+    // This pre-check is the whole guard: the kanban's drop-time check reads
+    // loader data that may be stale, an API caller has no check at all, and the
+    // nulls-distinct unique index would happily take a second row.
     pageLinkFindFirst.mockResolvedValue({ id: 'link-existing' });
 
     expect(await codeOf(addLink({ ...PAGE_TO_REPO }))).toBe('already_linked');
@@ -199,7 +230,10 @@ describe('addLink', () => {
     expect(saveManifest).not.toHaveBeenCalled();
   });
 
-  it('maps a P2002 unique violation to already_linked as a race backstop', async () => {
+  it('translates a unique violation into already_linked rather than a raw db error', async () => {
+    // The nulls-distinct index cannot actually fire on these rows, so this is
+    // not race coverage — it pins that IF a unique violation ever arrives (a
+    // tightened index later), the caller gets the typed failure, not P2002.
     pageLinkCreate.mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
 
     expect(await codeOf(addLink({ ...PAGE_TO_REPO }))).toBe('already_linked');
@@ -216,12 +250,23 @@ describe('addLink', () => {
     expect((error as Error).message).toBe('connection lost');
   });
 
-  it('still succeeds when the manifest push fails', async () => {
+  it('still succeeds when the manifest push fails, and says the push did not land', async () => {
     // The row is already committed; a git push that did not land must not be
-    // reported to the caller as "nothing happened".
+    // reported to the caller as "nothing happened" — but it must not be
+    // reported as a synced manifest either.
     saveManifest.mockRejectedValue(new Error('github is down'));
 
-    await expect(addLink({ ...PAGE_TO_REPO })).resolves.toMatchObject({ id: 'link-1' });
+    await expect(addLink({ ...PAGE_TO_REPO })).resolves.toMatchObject({
+      id: 'link-1',
+      manifestSynced: false,
+    });
+  });
+
+  it('relays a manifest push that was skipped rather than attempted', async () => {
+    // saveManifest reports false when there is no git organization to push to.
+    saveManifest.mockResolvedValue(false);
+
+    await expect(addLink({ ...PAGE_TO_REPO })).resolves.toMatchObject({ manifestSynced: false });
   });
 });
 
@@ -231,7 +276,7 @@ describe('removeLink', () => {
 
     await expect(
       removeLink({ classroomId: CLASSROOM, resourceType: 'page', linkId: 'link-1' })
-    ).resolves.toEqual({ id: 'link-1', resourceType: 'page' });
+    ).resolves.toEqual({ id: 'link-1', resourceType: 'page', manifestSynced: true });
 
     expect(pageLinkDeleteMany).toHaveBeenCalledExactlyOnceWith({
       where: { id: 'link-1', page: { classroom_id: CLASSROOM } },
@@ -278,13 +323,32 @@ describe('removeLink', () => {
     expectNoWrites();
   });
 
-  it('still succeeds when the manifest push fails', async () => {
+  it('still succeeds when the manifest push fails, and says the push did not land', async () => {
     pageLinkDeleteMany.mockResolvedValue({ count: 1 });
     saveManifest.mockRejectedValue(new Error('github is down'));
 
     await expect(
       removeLink({ classroomId: CLASSROOM, resourceType: 'page', linkId: 'link-1' })
-    ).resolves.toEqual({ id: 'link-1', resourceType: 'page' });
+    ).resolves.toEqual({ id: 'link-1', resourceType: 'page', manifestSynced: false });
+  });
+
+  it.each([
+    ['an empty string', ''],
+    ['a miscased literal', 'Page'],
+  ])('refuses %s as a resourceType instead of deleting from the slide table', async (_l, kind) => {
+    // resourceType picks the table, so an unrecognised value must not fall
+    // through to slides and issue a delete against the wrong one.
+    expect(
+      await codeOf(
+        removeLink({
+          classroomId: CLASSROOM,
+          resourceType: kind as 'page' | 'slide',
+          linkId: 'link-1',
+        })
+      )
+    ).toBe('link_not_found');
+    expectNoWrites();
+    expect(saveManifest).not.toHaveBeenCalled();
   });
 });
 
@@ -294,7 +358,9 @@ describe('listLinks', () => {
     order: 0,
     created_at: CREATED_AT,
     page: { id: 'page-1', title: 'Setup', slug: 'setup' },
-    repository: { id: 'repo-1', title: 'Lab 1', slug: 'lab-1' },
+    // classroom_id rides along on both repository selects: the `where` can only
+    // scope the page/slide side, so the target side is checked per row.
+    repository: { id: 'repo-1', title: 'Lab 1', slug: 'lab-1', classroom_id: CLASSROOM },
     assignment: null,
   };
   const slideRow = {
@@ -307,7 +373,7 @@ describe('listLinks', () => {
       id: 'assign-1',
       title: 'Part A',
       slug: 'part-a',
-      repository: { id: 'repo-1', title: 'Lab 1' },
+      repository: { id: 'repo-1', title: 'Lab 1', classroom_id: CLASSROOM },
     },
   };
 
@@ -406,10 +472,56 @@ describe('listLinks', () => {
     });
   });
 
-  it('drops a row whose target is gone rather than reporting a hole', async () => {
+  it('drops a row whose target is gone rather than reporting a hole, and says so', async () => {
     pageLinkFindMany.mockResolvedValue([{ ...pageRow, repository: null, assignment: null }]);
     slideLinkFindMany.mockResolvedValue([]);
 
     await expect(listLinks({ classroomId: CLASSROOM })).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('neither a repository'));
+  });
+
+  it.each([
+    [
+      'a repository',
+      {
+        repository: { id: 'repo-9', title: 'Other', slug: 'other', classroom_id: 'classroom-2' },
+        assignment: null,
+      },
+    ],
+    [
+      'an assignment',
+      {
+        repository: null,
+        assignment: {
+          id: 'assign-9',
+          title: 'Other',
+          slug: 'other',
+          repository: { id: 'repo-9', title: 'Other', classroom_id: 'classroom-2' },
+        },
+      },
+    ],
+  ])('drops a row pointing at %s in another classroom', async (_label, target) => {
+    // The link tables carry no classroom, so the `where` scopes the page side
+    // only and the target relations come back unfiltered. Not every writer of
+    // these tables scopes its target, so the row is confirmed here.
+    pageLinkFindMany.mockResolvedValue([{ ...pageRow, ...target }]);
+    slideLinkFindMany.mockResolvedValue([]);
+
+    await expect(listLinks({ classroomId: CLASSROOM })).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('another classroom'));
+  });
+
+  it('reports the repository half of a row that names both targets', async () => {
+    // A row naming both does not describe one place; the repository is the
+    // wider of the two, so it is what gets reported — loudly.
+    pageLinkFindMany.mockResolvedValue([{ ...pageRow, assignment: slideRow.assignment }]);
+    slideLinkFindMany.mockResolvedValue([]);
+
+    await expect(listLinks({ classroomId: CLASSROOM })).resolves.toMatchObject([
+      { id: 'link-1', targetType: 'repository' },
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('both a repository and an assignment')
+    );
   });
 });

--- a/packages/services/src/classmoji/contentManifest.service.ts
+++ b/packages/services/src/classmoji/contentManifest.service.ts
@@ -18,10 +18,19 @@ interface ManifestModuleEntry {
  */
 
 /**
- * Save the content manifest to GitHub
- * @param {number} classroomId - The classroom ID
+ * Save the content manifest to GitHub.
+ *
+ * Returns whether the manifest actually reached the content repo: `true` only
+ * after the commit lands, `false` when the push was skipped (no git
+ * organization configured) or failed. Callers that report a manifest state to a
+ * user should relay it; the ones that only refresh the manifest as a side
+ * effect can keep ignoring it. Throwing behaviour is unchanged — a GitHub
+ * failure is still swallowed, since the database write it follows is already
+ * committed.
+ *
+ * @param {string} classroomId - The classroom ID
  */
-export async function saveManifest(classroomId: string): Promise<void> {
+export async function saveManifest(classroomId: string): Promise<boolean> {
   // Get classroom with git organization
   const classroom = await getPrisma().classroom.findUnique({
     where: { id: classroomId },
@@ -30,7 +39,7 @@ export async function saveManifest(classroomId: string): Promise<void> {
 
   if (!classroom?.git_organization) {
     console.warn('Cannot save manifest: git organization not configured');
-    return;
+    return false;
   }
 
   // Build manifest from database
@@ -107,5 +116,8 @@ export async function saveManifest(classroomId: string): Promise<void> {
       'Failed to save content manifest:',
       error instanceof Error ? error.message : String(error)
     );
+    return false;
   }
+
+  return true;
 }

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -5,6 +5,7 @@ import * as classroomMembershipService from './classroomMembership.service.ts';
 import * as rosterService from './roster.service.ts';
 import * as assistantService from './assistant.service.ts';
 import * as teamAdminService from './teamAdmin.service.ts';
+import * as resourceLinkService from './resourceLink.service.ts';
 import * as moduleService from './module.service.ts';
 import * as repositoryService from './repository.service.ts';
 import * as autogradingTestService from './autogradingTest.service.ts';
@@ -57,6 +58,7 @@ const ClassmojiService = {
   classroomMembership: classroomMembershipService,
   roster: rosterService,
   assistant: assistantService,
+  resourceLink: resourceLinkService,
   module: moduleService,
   repository: repositoryService,
   autogradingTest: autogradingTestService,
@@ -115,6 +117,7 @@ export {
   classroomMembershipService,
   rosterService,
   assistantService,
+  resourceLinkService,
   moduleService,
   repositoryService,
   autogradingTestService,

--- a/packages/services/src/classmoji/resourceLink.service.ts
+++ b/packages/services/src/classmoji/resourceLink.service.ts
@@ -4,8 +4,11 @@
  * A "resource link" associates a page or a slide deck with either a repository
  * (the assignment container — content shows on the repo page) or one specific
  * assignment inside it. Extracted from the web admin.$class.resources action so
- * that route and the MCP resource-link tools take ONE code path — same
- * precedent as roster.service.ts, assistant.service.ts and teamAdmin.service.ts.
+ * that the resources kanban and the MCP resource-link tools share this path —
+ * same precedent as roster.service.ts, assistant.service.ts and
+ * teamAdmin.service.ts. It is not the only writer of these tables: the
+ * repository form route, page.service.linkPage and the slides importer all
+ * create links of their own and do not come through here.
  *
  * Three rules run through every function here:
  *
@@ -15,22 +18,31 @@
  *    Repository carry `classroom_id` directly; Assignment does not, and is
  *    reached through its Repository. A record that does not exist and a record
  *    belonging to another classroom raise the SAME typed error, so a probe
- *    cannot tell them apart.
+ *    cannot tell them apart. Reads apply the same rule to BOTH ends: a row
+ *    whose target resolves outside the classroom is dropped rather than
+ *    reported, since the writers above are not all classroom-scoped.
  *
- * 2. DUPLICATES ARE CAUGHT IN SQL, NOT IN THE UI. The web kanban hides
- *    already-linked targets client-side; an API caller has no such guard. The
- *    @@unique on (page_id, repository_id, assignment_id) does NOT catch this on
- *    its own: exactly one of the two target columns is always NULL, and the
- *    Postgres unique index is nulls-distinct (see the migration — no
- *    `NULLS NOT DISTINCT`), so a second identical row inserts happily. Hence the
- *    explicit pre-check below, with the P2002 catch kept as a race backstop.
+ * 2. DUPLICATES ARE CAUGHT BY THE PRE-CHECK, AND ONLY BY THE PRE-CHECK. The
+ *    kanban drops a duplicate drag before submitting, but it decides that from
+ *    loader data that may be stale, and an API caller has no such check at all.
+ *    The @@unique on (page_id, repository_id, assignment_id) cannot stand in
+ *    for one either: exactly one of the two target columns is always NULL, and
+ *    the Postgres unique index is nulls-distinct (see the migration — no
+ *    `NULLS NOT DISTINCT`), so a second identical row inserts happily. The
+ *    read-then-write pre-check below is therefore the whole guard, and two
+ *    identical adds racing each other can both pass it — a duplicate row from
+ *    concurrent adds is an ACCEPTED outcome here, not a prevented one. It is
+ *    cosmetic (the manifest keys content by slug, and either row can be
+ *    removed), and ruling it out needs an index change the existing rows would
+ *    have to be de-duplicated for first.
  *
- * 3. THE MANIFEST IS BEST EFFORT. Every successful write rebuilds
+ * 3. THE MANIFEST IS BEST EFFORT, AND SAYS SO. Every successful write rebuilds
  *    `.classmoji/manifest.json` in the classroom content repo. That push talks
  *    to a git host and must never turn a committed database write into a failed
- *    request, so it is wrapped: a failure is logged and the mutation still
- *    reports success. It runs ONLY after a write actually happened — a rejected
- *    add or a no-op remove leaves the manifest untouched.
+ *    request, so it is wrapped — but the outcome is not hidden: every mutation
+ *    reports `manifestSynced`, false when the push was skipped or failed. It
+ *    runs ONLY after a write actually happened — a rejected add or a no-op
+ *    remove leaves the manifest untouched.
  *
  * Authorization is NOT re-checked here. Callers (route auth gates / MCP tool
  * scopes) own that, exactly as in the sibling services above.
@@ -64,12 +76,16 @@ export interface CreatedResourceLink {
   targetId: string;
   order: number;
   createdAt: Date;
+  /** Whether the manifest push that follows the write actually landed. */
+  manifestSynced: boolean;
 }
 
 /** The row removed by `removeLink`. */
 export interface RemovedResourceLink {
   id: string;
   resourceType: ResourceLinkResourceType;
+  /** Whether the manifest push that follows the delete actually landed. */
+  manifestSynced: boolean;
 }
 
 /** One row of `listLinks`, resolved to human-readable resource and target names. */
@@ -90,7 +106,7 @@ export interface ResourceLinkSummary {
   };
 }
 
-/** A Prisma unique-constraint violation (the race backstop for a duplicate link). */
+/** A Prisma unique-constraint violation, mapped rather than surfaced raw. */
 const isUniqueViolation = (error: unknown): boolean =>
   typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'P2002';
 
@@ -112,51 +128,94 @@ function assertUsableId(
   }
 }
 
-/** Prove the page/slide being linked lives in this classroom. */
-async function assertResourceInClassroom(
+/** The resource half of a link row — exactly one of the two id columns. */
+type ResourceColumn = { page_id: string } | { slide_id: string };
+/** The target half — exactly one id, the other written as an explicit NULL. */
+type TargetColumns = { repository_id: string | null; assignment_id: string | null };
+
+/**
+ * Prove the page/slide being linked lives in this classroom, and hand back the
+ * column the write will use.
+ *
+ * `resourceType` is caller input like the ids are. Validating it in one place
+ * and returning the column from the SAME switch is what keeps the check and the
+ * write on the same side: a value that is neither literal cannot be validated
+ * as one kind and written as the other, it is refused here before any query
+ * runs — as the same not-found an unknown id gets.
+ */
+async function resolveResource(
   classroomId: string,
   resourceType: ResourceLinkResourceType,
   resourceId: string
-): Promise<void> {
+): Promise<ResourceColumn> {
   const where = { id: resourceId, classroom_id: classroomId };
-  const found =
-    resourceType === 'page'
-      ? await getPrisma().page.findFirst({ where, select: { id: true } })
-      : await getPrisma().slide.findFirst({ where, select: { id: true } });
-
-  if (!found) {
-    throw new ResourceLinkServiceError(
+  const notFound = () =>
+    new ResourceLinkServiceError(
       'resource_not_found',
       `[resourceLink] ${resourceType} ${resourceId} not found in classroom ${classroomId}`
     );
+
+  switch (resourceType) {
+    case 'page': {
+      const found = await getPrisma().page.findFirst({ where, select: { id: true } });
+      if (!found) throw notFound();
+      return { page_id: resourceId };
+    }
+    case 'slide': {
+      const found = await getPrisma().slide.findFirst({ where, select: { id: true } });
+      if (!found) throw notFound();
+      return { slide_id: resourceId };
+    }
+    default:
+      throw new ResourceLinkServiceError(
+        'resource_not_found',
+        `[resourceLink] ${String(resourceType)} is not a resource type`
+      );
   }
 }
 
 /**
- * Prove the link target lives in this classroom. Repository carries
- * `classroom_id` directly; Assignment is reached through its Repository.
+ * Prove the link target lives in this classroom, and hand back the pair of
+ * target columns the write will use. Repository carries `classroom_id`
+ * directly; Assignment is reached through its Repository.
+ *
+ * One switch decides both halves, for the same reason as `resolveResource`: an
+ * unrecognised `targetType` is refused before any query rather than checked
+ * against one table and written as the other.
  */
-async function assertTargetInClassroom(
+async function resolveTarget(
   classroomId: string,
   targetType: ResourceLinkTargetType,
   targetId: string
-): Promise<void> {
-  const found =
-    targetType === 'repository'
-      ? await getPrisma().repository.findFirst({
-          where: { id: targetId, classroom_id: classroomId },
-          select: { id: true },
-        })
-      : await getPrisma().assignment.findFirst({
-          where: { id: targetId, repository: { classroom_id: classroomId } },
-          select: { id: true },
-        });
-
-  if (!found) {
-    throw new ResourceLinkServiceError(
+): Promise<TargetColumns> {
+  const notFound = () =>
+    new ResourceLinkServiceError(
       'target_not_found',
       `[resourceLink] ${targetType} ${targetId} not found in classroom ${classroomId}`
     );
+
+  switch (targetType) {
+    case 'repository': {
+      const found = await getPrisma().repository.findFirst({
+        where: { id: targetId, classroom_id: classroomId },
+        select: { id: true },
+      });
+      if (!found) throw notFound();
+      return { repository_id: targetId, assignment_id: null };
+    }
+    case 'assignment': {
+      const found = await getPrisma().assignment.findFirst({
+        where: { id: targetId, repository: { classroom_id: classroomId } },
+        select: { id: true },
+      });
+      if (!found) throw notFound();
+      return { repository_id: null, assignment_id: targetId };
+    }
+    default:
+      throw new ResourceLinkServiceError(
+        'target_not_found',
+        `[resourceLink] ${String(targetType)} is not a target type`
+      );
   }
 }
 
@@ -166,16 +225,19 @@ async function assertTargetInClassroom(
  * Best effort by contract: the manifest describes the link graph for the
  * content repo, and the link row is already committed by the time this runs.
  * Failing the mutation because a git push did not land would report "nothing
- * happened" for a change that DID happen, so a failure is logged instead.
+ * happened" for a change that DID happen, so a failure is logged instead — and
+ * reported, as the boolean every mutation passes back to its caller. Best
+ * effort is not the same as invisible.
  */
-async function syncManifest(classroomId: string): Promise<void> {
+async function syncManifest(classroomId: string): Promise<boolean> {
   try {
-    await contentManifestService.saveManifest(classroomId);
+    return await contentManifestService.saveManifest(classroomId);
   } catch (error: unknown) {
     console.error(
       '[resourceLink] failed to update the content manifest:',
       error instanceof Error ? error.message : String(error)
     );
+    return false;
   }
 }
 
@@ -184,7 +246,8 @@ async function syncManifest(classroomId: string): Promise<void> {
  *
  * Both ends are proven to be in `classroomId` BEFORE the row is created, and an
  * existing identical link is reported as `already_linked` rather than inserted
- * twice. On success the content manifest is refreshed (best effort).
+ * twice. On success the content manifest is refreshed (best effort — the result
+ * comes back as `manifestSynced`).
  */
 export const addLink = async ({
   classroomId,
@@ -202,27 +265,23 @@ export const addLink = async ({
   assertUsableId(resourceId, 'resource_not_found', 'resourceId');
   assertUsableId(targetId, 'target_not_found', 'targetId');
 
-  await assertResourceInClassroom(classroomId, resourceType, resourceId);
-  await assertTargetInClassroom(classroomId, targetType, targetId);
-
-  // Exactly one target column is set; the other is explicitly NULL so the
-  // duplicate lookup and the insert describe the same row.
-  const repositoryId = targetType === 'repository' ? targetId : null;
-  const assignmentId = targetType === 'assignment' ? targetId : null;
-
-  const duplicateWhere =
-    resourceType === 'page'
-      ? { page_id: resourceId, repository_id: repositoryId, assignment_id: assignmentId }
-      : { slide_id: resourceId, repository_id: repositoryId, assignment_id: assignmentId };
+  // Each resolve validates its discriminant, proves its end of the link is in
+  // this classroom, and returns the columns for that end. Building the row from
+  // those return values is what makes the duplicate lookup and the insert
+  // describe the same row: the unset target column is an explicit NULL in both,
+  // never an `undefined` that Prisma would drop from the `where`.
+  const resourceColumn = await resolveResource(classroomId, resourceType, resourceId);
+  const targetColumns = await resolveTarget(classroomId, targetType, targetId);
+  const columns = { ...resourceColumn, ...targetColumns };
 
   const existing =
     resourceType === 'page'
       ? await getPrisma().pageLink.findFirst({
-          where: duplicateWhere as { page_id: string },
+          where: columns as { page_id: string },
           select: { id: true },
         })
       : await getPrisma().slideLink.findFirst({
-          where: duplicateWhere as { slide_id: string },
+          where: columns as { slide_id: string },
           select: { id: true },
         });
 
@@ -238,25 +297,18 @@ export const addLink = async ({
     created =
       resourceType === 'page'
         ? await getPrisma().pageLink.create({
-            data: {
-              page_id: resourceId,
-              repository_id: repositoryId,
-              assignment_id: assignmentId,
-            },
+            data: columns as { page_id: string } & TargetColumns,
             select: { id: true, order: true, created_at: true },
           })
         : await getPrisma().slideLink.create({
-            data: {
-              slide_id: resourceId,
-              repository_id: repositoryId,
-              assignment_id: assignmentId,
-            },
+            data: columns as { slide_id: string } & TargetColumns,
             select: { id: true, order: true, created_at: true },
           });
   } catch (error: unknown) {
-    // Race backstop for the pre-check above. It only fires where the unique
-    // index actually bites, but a concurrent add must never surface as an
-    // opaque database failure.
+    // The nulls-distinct index cannot fire on the rows written here (rule 2
+    // above), so this is not a race backstop — it is cheap insurance for the
+    // day the indexes are tightened, and it keeps a unique violation from
+    // reaching a caller as an opaque database failure either way.
     if (!isUniqueViolation(error)) throw error;
     throw new ResourceLinkServiceError(
       'already_linked',
@@ -264,7 +316,7 @@ export const addLink = async ({
     );
   }
 
-  await syncManifest(classroomId);
+  const manifestSynced = await syncManifest(classroomId);
 
   return {
     id: created.id,
@@ -274,6 +326,7 @@ export const addLink = async ({
     targetId,
     order: created.order,
     createdAt: created.created_at,
+    manifestSynced,
   };
 };
 
@@ -286,6 +339,10 @@ export const addLink = async ({
  * classroom's and nothing was deleted. That distinction is what keeps the
  * manifest from being rewritten to describe links that are still there (and
  * makes a cross-classroom delete a safe no-op rather than a leak).
+ *
+ * `resourceType` picks the table, so it is validated in the same switch that
+ * issues the delete: an unrecognised value is refused rather than falling
+ * through to the slide table and deleting from the wrong one.
  */
 export const removeLink = async ({
   classroomId,
@@ -298,14 +355,24 @@ export const removeLink = async ({
 }): Promise<RemovedResourceLink> => {
   assertUsableId(linkId, 'link_not_found', 'linkId');
 
-  const { count } =
-    resourceType === 'page'
-      ? await getPrisma().pageLink.deleteMany({
-          where: { id: linkId, page: { classroom_id: classroomId } },
-        })
-      : await getPrisma().slideLink.deleteMany({
-          where: { id: linkId, slide: { classroom_id: classroomId } },
-        });
+  let count: number;
+  switch (resourceType) {
+    case 'page':
+      ({ count } = await getPrisma().pageLink.deleteMany({
+        where: { id: linkId, page: { classroom_id: classroomId } },
+      }));
+      break;
+    case 'slide':
+      ({ count } = await getPrisma().slideLink.deleteMany({
+        where: { id: linkId, slide: { classroom_id: classroomId } },
+      }));
+      break;
+    default:
+      throw new ResourceLinkServiceError(
+        'link_not_found',
+        `[resourceLink] ${String(resourceType)} is not a resource type`
+      );
+  }
 
   if (count !== 1) {
     throw new ResourceLinkServiceError(
@@ -314,20 +381,25 @@ export const removeLink = async ({
     );
   }
 
-  await syncManifest(classroomId);
+  const manifestSynced = await syncManifest(classroomId);
 
-  return { id: linkId, resourceType };
+  return { id: linkId, resourceType, manifestSynced };
 };
 
-/** The include shared by both link queries — resolves names in ONE round trip each. */
+/**
+ * The include shared by both link queries — resolves names in ONE round trip
+ * each. `classroom_id` rides along on both repository selects because the
+ * `where` can only scope the RESOURCE side (that is where the classroom lives);
+ * the target side is checked per row in `toSummary`.
+ */
 const LINK_INCLUDE = {
-  repository: { select: { id: true, title: true, slug: true } },
+  repository: { select: { id: true, title: true, slug: true, classroom_id: true } },
   assignment: {
     select: {
       id: true,
       title: true,
       slug: true,
-      repository: { select: { id: true, title: true } },
+      repository: { select: { id: true, title: true, classroom_id: true } },
     },
   },
 } as const;
@@ -336,25 +408,51 @@ type LinkRow = {
   id: string;
   order: number;
   created_at: Date;
-  repository: { id: string; title: string; slug: string | null } | null;
+  repository: { id: string; title: string; slug: string | null; classroom_id: string } | null;
   assignment: {
     id: string;
     title: string;
     slug: string | null;
-    repository: { id: string; title: string } | null;
+    repository: { id: string; title: string; classroom_id: string } | null;
   } | null;
 };
 
-/** Fold a raw link row plus its resource into the allow-listed summary shape. */
+/**
+ * Fold a raw link row plus its resource into the allow-listed summary shape,
+ * or drop the row.
+ *
+ * A row is only reported when its target resolves to exactly one record IN THIS
+ * CLASSROOM. That second half matters because the `where` cannot express it —
+ * PageLink/SlideLink carry no classroom, so the query scopes the page/slide
+ * side and the target relations come back unfiltered. Not every writer of these
+ * tables is classroom-scoped, so a row pointing at another classroom's
+ * repository or assignment is possible; it is dropped and logged rather than
+ * folded into a list that claims to be one classroom's.
+ */
 function toSummary(
   row: LinkRow,
   resourceType: ResourceLinkResourceType,
-  resource: { id: string; title: string; slug: string | null }
+  resource: { id: string; title: string; slug: string | null },
+  classroomId: string
 ): ResourceLinkSummary | null {
-  // Exactly one of the two target columns is set. A row with neither is
-  // corrupt (or the target was deleted mid-read) and is dropped rather than
-  // reported with a hole in it.
+  const drop = (why: string) => {
+    console.warn(`[resourceLink] dropping ${resourceType} link ${row.id}: ${why}`);
+    return null;
+  };
+
+  // Exactly one of the two target columns is expected to be set.
+  if (row.repository && row.assignment) {
+    // Both set: the row does not describe one place, so report the narrower
+    // target (the repository the assignment sits in is a superset of it).
+    console.warn(
+      `[resourceLink] ${resourceType} link ${row.id} names both a repository and an assignment; using the repository`
+    );
+  }
+
   if (row.repository) {
+    if (row.repository.classroom_id !== classroomId) {
+      return drop('its repository target is in another classroom');
+    }
     return {
       id: row.id,
       resourceType,
@@ -365,7 +463,15 @@ function toSummary(
       target: { id: row.repository.id, title: row.repository.title, slug: row.repository.slug },
     };
   }
+
   if (row.assignment) {
+    // Assignment has no classroom of its own; its repository is what places it.
+    if (!row.assignment.repository) {
+      return drop('its assignment target has no repository to place it in a classroom');
+    }
+    if (row.assignment.repository.classroom_id !== classroomId) {
+      return drop('its assignment target is in another classroom');
+    }
     return {
       id: row.id,
       resourceType,
@@ -377,16 +483,15 @@ function toSummary(
         id: row.assignment.id,
         title: row.assignment.title,
         slug: row.assignment.slug,
-        ...(row.assignment.repository
-          ? {
-              repositoryId: row.assignment.repository.id,
-              repositoryTitle: row.assignment.repository.title,
-            }
-          : {}),
+        repositoryId: row.assignment.repository.id,
+        repositoryTitle: row.assignment.repository.title,
       },
     };
   }
-  return null;
+
+  // Neither column set — the row is corrupt, or the target was deleted
+  // mid-read. Dropped rather than reported with a hole in it.
+  return drop('it names neither a repository nor an assignment');
 }
 
 /**
@@ -413,7 +518,9 @@ function targetWhere(
  *
  * At most two queries (one per resource type, skipped when `resourceType`
  * narrows to one), each resolving its resource and target names through
- * includes — no per-row lookups.
+ * includes — no per-row lookups. The `where` scopes the page/slide side, which
+ * is the side that carries the classroom; the target side is confirmed row by
+ * row in `toSummary`, which drops anything resolving elsewhere.
  */
 export const listLinks = async ({
   classroomId,
@@ -443,7 +550,7 @@ export const listLinks = async ({
       orderBy: [{ created_at: 'asc' }],
     });
     for (const row of rows) {
-      const summary = toSummary(row as unknown as LinkRow, 'page', row.page);
+      const summary = toSummary(row as unknown as LinkRow, 'page', row.page, classroomId);
       if (summary) links.push(summary);
     }
   }
@@ -459,7 +566,7 @@ export const listLinks = async ({
       orderBy: [{ created_at: 'asc' }],
     });
     for (const row of rows) {
-      const summary = toSummary(row as unknown as LinkRow, 'slide', row.slide);
+      const summary = toSummary(row as unknown as LinkRow, 'slide', row.slide, classroomId);
       if (summary) links.push(summary);
     }
   }

--- a/packages/services/src/classmoji/resourceLink.service.ts
+++ b/packages/services/src/classmoji/resourceLink.service.ts
@@ -1,0 +1,468 @@
+/**
+ * Resource link service.
+ *
+ * A "resource link" associates a page or a slide deck with either a repository
+ * (the assignment container — content shows on the repo page) or one specific
+ * assignment inside it. Extracted from the web admin.$class.resources action so
+ * that route and the MCP resource-link tools take ONE code path — same
+ * precedent as roster.service.ts, assistant.service.ts and teamAdmin.service.ts.
+ *
+ * Three rules run through every function here:
+ *
+ * 1. EVERYTHING IS SCOPED TO THE CLASSROOM. `resourceId`, `targetId` and
+ *    `linkId` all originate as caller input, so each is proven to live in the
+ *    caller's classroom before it is joined or deleted. Page, Slide and
+ *    Repository carry `classroom_id` directly; Assignment does not, and is
+ *    reached through its Repository. A record that does not exist and a record
+ *    belonging to another classroom raise the SAME typed error, so a probe
+ *    cannot tell them apart.
+ *
+ * 2. DUPLICATES ARE CAUGHT IN SQL, NOT IN THE UI. The web kanban hides
+ *    already-linked targets client-side; an API caller has no such guard. The
+ *    @@unique on (page_id, repository_id, assignment_id) does NOT catch this on
+ *    its own: exactly one of the two target columns is always NULL, and the
+ *    Postgres unique index is nulls-distinct (see the migration — no
+ *    `NULLS NOT DISTINCT`), so a second identical row inserts happily. Hence the
+ *    explicit pre-check below, with the P2002 catch kept as a race backstop.
+ *
+ * 3. THE MANIFEST IS BEST EFFORT. Every successful write rebuilds
+ *    `.classmoji/manifest.json` in the classroom content repo. That push talks
+ *    to a git host and must never turn a committed database write into a failed
+ *    request, so it is wrapped: a failure is logged and the mutation still
+ *    reports success. It runs ONLY after a write actually happened — a rejected
+ *    add or a no-op remove leaves the manifest untouched.
+ *
+ * Authorization is NOT re-checked here. Callers (route auth gates / MCP tool
+ * scopes) own that, exactly as in the sibling services above.
+ */
+import getPrisma from '@classmoji/database';
+
+import * as contentManifestService from './contentManifest.service.ts';
+
+/** Which kind of content is being linked. */
+export type ResourceLinkResourceType = 'page' | 'slide';
+/** What the content is being linked TO. */
+export type ResourceLinkTargetType = 'repository' | 'assignment';
+
+/** Thrown for every caller-fixable failure so routes/tools can map it to a message. */
+export class ResourceLinkServiceError extends Error {
+  code: 'resource_not_found' | 'target_not_found' | 'already_linked' | 'link_not_found';
+
+  constructor(code: ResourceLinkServiceError['code'], message: string) {
+    super(message);
+    this.name = 'ResourceLinkServiceError';
+    this.code = code;
+  }
+}
+
+/** The row created by `addLink`, in an allow-listed shape safe to hand to a client. */
+export interface CreatedResourceLink {
+  id: string;
+  resourceType: ResourceLinkResourceType;
+  resourceId: string;
+  targetType: ResourceLinkTargetType;
+  targetId: string;
+  order: number;
+  createdAt: Date;
+}
+
+/** The row removed by `removeLink`. */
+export interface RemovedResourceLink {
+  id: string;
+  resourceType: ResourceLinkResourceType;
+}
+
+/** One row of `listLinks`, resolved to human-readable resource and target names. */
+export interface ResourceLinkSummary {
+  id: string;
+  resourceType: ResourceLinkResourceType;
+  targetType: ResourceLinkTargetType;
+  order: number;
+  createdAt: Date;
+  resource: { id: string; title: string; slug: string | null };
+  target: {
+    id: string;
+    title: string;
+    slug: string | null;
+    /** Present for assignment targets only — the repository the assignment sits in. */
+    repositoryId?: string;
+    repositoryTitle?: string;
+  };
+}
+
+/** A Prisma unique-constraint violation (the race backstop for a duplicate link). */
+const isUniqueViolation = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'P2002';
+
+/**
+ * Ids reach this service from untyped request bodies. Prisma DROPS an
+ * `undefined` value from a `where` rather than rejecting it, and its id fields
+ * also accept a filter object, so a non-string id would silently WIDEN a
+ * classroom-scoped lookup or delete instead of narrowing it. Reject anything
+ * that is not a real string up front, as the same not-found the caller would
+ * get for an id that names nothing.
+ */
+function assertUsableId(
+  value: unknown,
+  code: ResourceLinkServiceError['code'],
+  what: string
+): asserts value is string {
+  if (typeof value !== 'string' || !value) {
+    throw new ResourceLinkServiceError(code, `[resourceLink] ${what} is not a usable id`);
+  }
+}
+
+/** Prove the page/slide being linked lives in this classroom. */
+async function assertResourceInClassroom(
+  classroomId: string,
+  resourceType: ResourceLinkResourceType,
+  resourceId: string
+): Promise<void> {
+  const where = { id: resourceId, classroom_id: classroomId };
+  const found =
+    resourceType === 'page'
+      ? await getPrisma().page.findFirst({ where, select: { id: true } })
+      : await getPrisma().slide.findFirst({ where, select: { id: true } });
+
+  if (!found) {
+    throw new ResourceLinkServiceError(
+      'resource_not_found',
+      `[resourceLink] ${resourceType} ${resourceId} not found in classroom ${classroomId}`
+    );
+  }
+}
+
+/**
+ * Prove the link target lives in this classroom. Repository carries
+ * `classroom_id` directly; Assignment is reached through its Repository.
+ */
+async function assertTargetInClassroom(
+  classroomId: string,
+  targetType: ResourceLinkTargetType,
+  targetId: string
+): Promise<void> {
+  const found =
+    targetType === 'repository'
+      ? await getPrisma().repository.findFirst({
+          where: { id: targetId, classroom_id: classroomId },
+          select: { id: true },
+        })
+      : await getPrisma().assignment.findFirst({
+          where: { id: targetId, repository: { classroom_id: classroomId } },
+          select: { id: true },
+        });
+
+  if (!found) {
+    throw new ResourceLinkServiceError(
+      'target_not_found',
+      `[resourceLink] ${targetType} ${targetId} not found in classroom ${classroomId}`
+    );
+  }
+}
+
+/**
+ * Rebuild and push the content manifest after a successful write.
+ *
+ * Best effort by contract: the manifest describes the link graph for the
+ * content repo, and the link row is already committed by the time this runs.
+ * Failing the mutation because a git push did not land would report "nothing
+ * happened" for a change that DID happen, so a failure is logged instead.
+ */
+async function syncManifest(classroomId: string): Promise<void> {
+  try {
+    await contentManifestService.saveManifest(classroomId);
+  } catch (error: unknown) {
+    console.error(
+      '[resourceLink] failed to update the content manifest:',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}
+
+/**
+ * Link a page or slide deck to a repository or a specific assignment.
+ *
+ * Both ends are proven to be in `classroomId` BEFORE the row is created, and an
+ * existing identical link is reported as `already_linked` rather than inserted
+ * twice. On success the content manifest is refreshed (best effort).
+ */
+export const addLink = async ({
+  classroomId,
+  resourceType,
+  resourceId,
+  targetType,
+  targetId,
+}: {
+  classroomId: string;
+  resourceType: ResourceLinkResourceType;
+  resourceId: string;
+  targetType: ResourceLinkTargetType;
+  targetId: string;
+}): Promise<CreatedResourceLink> => {
+  assertUsableId(resourceId, 'resource_not_found', 'resourceId');
+  assertUsableId(targetId, 'target_not_found', 'targetId');
+
+  await assertResourceInClassroom(classroomId, resourceType, resourceId);
+  await assertTargetInClassroom(classroomId, targetType, targetId);
+
+  // Exactly one target column is set; the other is explicitly NULL so the
+  // duplicate lookup and the insert describe the same row.
+  const repositoryId = targetType === 'repository' ? targetId : null;
+  const assignmentId = targetType === 'assignment' ? targetId : null;
+
+  const duplicateWhere =
+    resourceType === 'page'
+      ? { page_id: resourceId, repository_id: repositoryId, assignment_id: assignmentId }
+      : { slide_id: resourceId, repository_id: repositoryId, assignment_id: assignmentId };
+
+  const existing =
+    resourceType === 'page'
+      ? await getPrisma().pageLink.findFirst({
+          where: duplicateWhere as { page_id: string },
+          select: { id: true },
+        })
+      : await getPrisma().slideLink.findFirst({
+          where: duplicateWhere as { slide_id: string },
+          select: { id: true },
+        });
+
+  if (existing) {
+    throw new ResourceLinkServiceError(
+      'already_linked',
+      `[resourceLink] ${resourceType} ${resourceId} is already linked to ${targetType} ${targetId}`
+    );
+  }
+
+  let created: { id: string; order: number; created_at: Date };
+  try {
+    created =
+      resourceType === 'page'
+        ? await getPrisma().pageLink.create({
+            data: {
+              page_id: resourceId,
+              repository_id: repositoryId,
+              assignment_id: assignmentId,
+            },
+            select: { id: true, order: true, created_at: true },
+          })
+        : await getPrisma().slideLink.create({
+            data: {
+              slide_id: resourceId,
+              repository_id: repositoryId,
+              assignment_id: assignmentId,
+            },
+            select: { id: true, order: true, created_at: true },
+          });
+  } catch (error: unknown) {
+    // Race backstop for the pre-check above. It only fires where the unique
+    // index actually bites, but a concurrent add must never surface as an
+    // opaque database failure.
+    if (!isUniqueViolation(error)) throw error;
+    throw new ResourceLinkServiceError(
+      'already_linked',
+      `[resourceLink] ${resourceType} ${resourceId} is already linked to ${targetType} ${targetId}`
+    );
+  }
+
+  await syncManifest(classroomId);
+
+  return {
+    id: created.id,
+    resourceType,
+    resourceId,
+    targetType,
+    targetId,
+    order: created.order,
+    createdAt: created.created_at,
+  };
+};
+
+/**
+ * Remove a link by id.
+ *
+ * `deleteMany` takes the classroom compound that `delete` cannot. Past the id
+ * guard `id` is the primary key, so the compound matches AT MOST one row: a
+ * count other than 1 means zero rows matched — the link was not this
+ * classroom's and nothing was deleted. That distinction is what keeps the
+ * manifest from being rewritten to describe links that are still there (and
+ * makes a cross-classroom delete a safe no-op rather than a leak).
+ */
+export const removeLink = async ({
+  classroomId,
+  resourceType,
+  linkId,
+}: {
+  classroomId: string;
+  resourceType: ResourceLinkResourceType;
+  linkId: string;
+}): Promise<RemovedResourceLink> => {
+  assertUsableId(linkId, 'link_not_found', 'linkId');
+
+  const { count } =
+    resourceType === 'page'
+      ? await getPrisma().pageLink.deleteMany({
+          where: { id: linkId, page: { classroom_id: classroomId } },
+        })
+      : await getPrisma().slideLink.deleteMany({
+          where: { id: linkId, slide: { classroom_id: classroomId } },
+        });
+
+  if (count !== 1) {
+    throw new ResourceLinkServiceError(
+      'link_not_found',
+      `[resourceLink] link ${linkId} not found in classroom ${classroomId}`
+    );
+  }
+
+  await syncManifest(classroomId);
+
+  return { id: linkId, resourceType };
+};
+
+/** The include shared by both link queries — resolves names in ONE round trip each. */
+const LINK_INCLUDE = {
+  repository: { select: { id: true, title: true, slug: true } },
+  assignment: {
+    select: {
+      id: true,
+      title: true,
+      slug: true,
+      repository: { select: { id: true, title: true } },
+    },
+  },
+} as const;
+
+type LinkRow = {
+  id: string;
+  order: number;
+  created_at: Date;
+  repository: { id: string; title: string; slug: string | null } | null;
+  assignment: {
+    id: string;
+    title: string;
+    slug: string | null;
+    repository: { id: string; title: string } | null;
+  } | null;
+};
+
+/** Fold a raw link row plus its resource into the allow-listed summary shape. */
+function toSummary(
+  row: LinkRow,
+  resourceType: ResourceLinkResourceType,
+  resource: { id: string; title: string; slug: string | null }
+): ResourceLinkSummary | null {
+  // Exactly one of the two target columns is set. A row with neither is
+  // corrupt (or the target was deleted mid-read) and is dropped rather than
+  // reported with a hole in it.
+  if (row.repository) {
+    return {
+      id: row.id,
+      resourceType,
+      targetType: 'repository',
+      order: row.order,
+      createdAt: row.created_at,
+      resource,
+      target: { id: row.repository.id, title: row.repository.title, slug: row.repository.slug },
+    };
+  }
+  if (row.assignment) {
+    return {
+      id: row.id,
+      resourceType,
+      targetType: 'assignment',
+      order: row.order,
+      createdAt: row.created_at,
+      resource,
+      target: {
+        id: row.assignment.id,
+        title: row.assignment.title,
+        slug: row.assignment.slug,
+        ...(row.assignment.repository
+          ? {
+              repositoryId: row.assignment.repository.id,
+              repositoryTitle: row.assignment.repository.title,
+            }
+          : {}),
+      },
+    };
+  }
+  return null;
+}
+
+/**
+ * Build the target half of the `where`. Filters only ever NARROW: the classroom
+ * scope is applied separately and is never caller-supplied, so a filter can at
+ * worst return fewer of this classroom's own rows.
+ */
+function targetWhere(
+  targetType?: ResourceLinkTargetType,
+  targetId?: string
+): Record<string, unknown> {
+  if (targetType === 'repository') {
+    return targetId ? { repository_id: targetId } : { repository_id: { not: null } };
+  }
+  if (targetType === 'assignment') {
+    return targetId ? { assignment_id: targetId } : { assignment_id: { not: null } };
+  }
+  // No target type given: an id may name either kind of target.
+  return targetId ? { OR: [{ repository_id: targetId }, { assignment_id: targetId }] } : {};
+}
+
+/**
+ * List every page/slide link in a classroom, optionally filtered.
+ *
+ * At most two queries (one per resource type, skipped when `resourceType`
+ * narrows to one), each resolving its resource and target names through
+ * includes — no per-row lookups.
+ */
+export const listLinks = async ({
+  classroomId,
+  resourceType,
+  resourceId,
+  targetType,
+  targetId,
+}: {
+  classroomId: string;
+  resourceType?: ResourceLinkResourceType;
+  resourceId?: string;
+  targetType?: ResourceLinkTargetType;
+  targetId?: string;
+}): Promise<ResourceLinkSummary[]> => {
+  const target = targetWhere(targetType, targetId);
+  const links: ResourceLinkSummary[] = [];
+
+  if (resourceType !== 'slide') {
+    const rows = await getPrisma().pageLink.findMany({
+      where: {
+        // Classroom scope through the parent — PageLink has no classroom_id.
+        page: { classroom_id: classroomId },
+        ...(resourceId ? { page_id: resourceId } : {}),
+        ...target,
+      },
+      include: { ...LINK_INCLUDE, page: { select: { id: true, title: true, slug: true } } },
+      orderBy: [{ created_at: 'asc' }],
+    });
+    for (const row of rows) {
+      const summary = toSummary(row as unknown as LinkRow, 'page', row.page);
+      if (summary) links.push(summary);
+    }
+  }
+
+  if (resourceType !== 'page') {
+    const rows = await getPrisma().slideLink.findMany({
+      where: {
+        slide: { classroom_id: classroomId },
+        ...(resourceId ? { slide_id: resourceId } : {}),
+        ...target,
+      },
+      include: { ...LINK_INCLUDE, slide: { select: { id: true, title: true, slug: true } } },
+      orderBy: [{ created_at: 'asc' }],
+    });
+    for (const row of rows) {
+      const summary = toSummary(row as unknown as LinkRow, 'slide', row.slide);
+      if (summary) links.push(summary);
+    }
+  }
+
+  return links;
+};

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -73,6 +73,14 @@ export type {
   TagFailure,
   RepoRenameFailure,
 } from './classmoji/teamAdmin.service.ts';
+export { ResourceLinkServiceError } from './classmoji/resourceLink.service.ts';
+export type {
+  ResourceLinkResourceType,
+  ResourceLinkTargetType,
+  CreatedResourceLink,
+  RemovedResourceLink,
+  ResourceLinkSummary,
+} from './classmoji/resourceLink.service.ts';
 export { AssignGradersError } from './classmoji/gitRepoAssignmentGrader.service.ts';
 export type {
   AssignGradersMethod,


### PR DESCRIPTION
## Summary

Third batch of MCP admin tools: resource linking — associating pages and slide decks with repositories or specific assignments (the drag-and-drop kanban's mechanism, now scriptable). 3 new tools (81 → 84).

### New MCP tools (OWNER + TEACHER, matching the webapp's resources surface)

| Tool | What it does |
|---|---|
| `resource_link_add` | Link a page or slide deck to a repository (container-level) or a specific assignment. Linked content appears to students on that repo/assignment page. Commits an updated content manifest to the classroom's content repo (best-effort, reported via `manifest_synced`). |
| `resource_link_remove` | Unlink (destructive-flagged — it changes student-facing visibility; the content itself survives). |
| `resource_links_list` | Enumerate current links with resource/target details and filters; feeds ids to the remove tool. |

Both write tools carry a tight rate limit since each call commits a manifest update.

### Service extraction + webapp fixes

The inline `addLink`/`removeLink` logic moved to `packages/services` (`resourceLink.service.ts`) — webapp route and MCP tools share one path. Along the way:

- **Duplicate links are now refused.** The unique index on link tables can't enforce this (one target column is always NULL, and Postgres treats NULLs as distinct), and the kanban's client-side guard raced its own stale loader data — so duplicates inserted silently. The service now pre-checks.
- **Fetcher errors no longer crash the admin UI.** The action returned thrown Responses that escaped to the root error boundary — a double-drag would unmount the whole admin app. Errors now return as payloads and surface as inline callouts; the racy 100ms revalidation timer is gone (React Router's own post-action revalidation takes over).
- `resource_links_list` verifies target records belong to the classroom before including them, and warns on malformed rows instead of silently skipping.
- Manifest sync results are reported (`manifest_synced`) instead of being silently swallowed.

### Tests

- `packages/services`: 738 pass (+40 new)
- `apps/mcp`: 459 pass (+22 new)
- `apps/webapp`: 243 pass (route tests extended to 28)

### Test steps

1. MCP as owner/teacher: `resource_link_add` page → repository; page appears on the student repo page; `.classmoji/manifest.json` commit lands in the content repo; `resource_links_list` shows it; `resource_link_remove` undoes it.
2. Duplicate add → clean "already linked" refusal.
3. Webapp: resources kanban drag/drop works; dragging an already-linked card shows an inline error callout instead of a full-page error.

### Known follow-ups

- Proper duplicate enforcement at the DB level needs a data cleanup plus partial unique indexes (or `NULLS NOT DISTINCT` on PG15+) — tracked separately.
- `repository.findByClassroomSlug`'s options parameter is ignored (`_options`) — assignments are always included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
