### PR TITLE
fix(authz): align draft-view, roster and team-list policy across surfaces

### DIFF
--- a/apps/mcp/src/authz/__tests__/classroomContext.test.ts
+++ b/apps/mcp/src/authz/__tests__/classroomContext.test.ts
@@ -2,12 +2,12 @@
  * Unit tests for resolveClassroomContext's ambiguity guard (finding A1) and
  * deterministic multi-role resolution (finding U6).
  *
- * A1: Classroom is unique only on (git_org_id, slug); the org login is matched
- * case-insensitively, so two case-variant twin orgs each owning the same slug
- * can return >1 row from findAll. The resolver must REFUSE such an ambiguous
- * reference with a non-leaking `not_found` rather than silently resolving to
- * matches[0] (the newest twin). A normal unambiguous reference must still
- * resolve; a zero-match must stay an indistinguishable clean not_found.
+ * A1: resolving through findAll returns a LIST, and a list of surprising length
+ * must never be silently reduced to matches[0]. Classroom.slug is globally
+ * unique today, so more than one match cannot occur in practice and the guard
+ * is defense in depth — but it must hold: a >1 match has to be refused with a
+ * non-leaking `not_found`. A normal unambiguous reference must still resolve;
+ * a zero-match must stay an indistinguishable clean not_found.
  *
  * U6: ClassroomMembership is unique on (classroom_id, user_id, role) and
  * findByClassroomAndUser is an UNORDERED findFirst, so a single role-filtered
@@ -67,10 +67,9 @@ beforeEach(() => {
 });
 
 describe('resolveClassroomContext ambiguity guard (A1)', () => {
-  it('REFUSES an ambiguous org/slug (two case-variant twin orgs) with not_found', async () => {
-    // Two orgs whose logins differ only by case ("Classmoji-Dev" vs
-    // "classmoji-dev") each own slug "winter-2025"; the insensitive match
-    // returns both rows.
+  it('REFUSES an ambiguous org/slug match with not_found', async () => {
+    // Two rows come back for one reference. Unreachable while the slug is
+    // globally unique; the guard has to hold anyway.
     findAll.mockResolvedValue([classroomRow('twin-a'), classroomRow('twin-b')]);
 
     const err = await resolveClassroomContext(VIEWER, REF).catch(e => e);
@@ -116,6 +115,29 @@ describe('deterministic multi-role resolution (U6)', () => {
     expect(ctx.membership.role).toBe('OWNER');
     // Full matching set, highest privilege first.
     expect(ctx.roles).toEqual(['OWNER', 'ASSISTANT']);
+  });
+
+  it('resolves an ASSISTANT+STUDENT caller to ASSISTANT under an any-member gate', async () => {
+    // The `list_slides` surface shape (roles: MEMBER). Its handler branches on
+    // ctx.role via isStaff(), so a TA who is also enrolled as a student has to
+    // resolve as staff here or the deck listing silently narrows for them.
+    holdRoles('STUDENT', 'ASSISTANT'); // held order must not matter
+
+    const ctx = await resolveClassroomContext(VIEWER, REF, {
+      allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT'],
+    });
+    expect(ctx.role).toBe('ASSISTANT');
+    expect(ctx.roles).toEqual(['ASSISTANT', 'STUDENT']);
+  });
+
+  it('resolves an OWNER+STUDENT caller to OWNER under an any-member gate', async () => {
+    holdRoles('STUDENT', 'OWNER');
+
+    const ctx = await resolveClassroomContext(VIEWER, REF, {
+      allowedRoles: ['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT'],
+    });
+    expect(ctx.role).toBe('OWNER');
+    expect(ctx.roles).toEqual(['OWNER', 'STUDENT']);
   });
 
   it('only considers roles the gate allows (OWNER+STUDENT under a student-only gate)', async () => {

--- a/apps/mcp/src/authz/classroomContext.ts
+++ b/apps/mcp/src/authz/classroomContext.ts
@@ -64,16 +64,18 @@ export async function resolveClassroomContext(
 ): Promise<ClassroomContext> {
   const { org, slug } = parseClassroomRef(classroomRef);
 
-  // Classroom.slug is unique per git org only (@@unique([git_org_id, slug])),
-  // so resolve through the org login. GitHub logins are case-insensitive.
+  // Classroom.slug is GLOBALLY unique (schema.prisma: `slug String @unique`,
+  // migration 20260818103726_classroom_slug_global_unique). The org login is
+  // still part of the lookup so a reference has to name the org that actually
+  // owns the classroom — matched case-insensitively, as GitHub logins are.
   const matches = (await ClassmojiService.classroom.findAll({
     slug,
     git_organization: { login: { equals: org, mode: 'insensitive' } },
   })) as Classroom[];
-  // Classroom is unique only on (git_org_id, slug). The case-insensitive
-  // org-login match means case-variant twin orgs each owning this slug can
-  // return >1 row, and taking matches[0] would silently resolve to the newest
-  // twin. Refuse an ambiguous reference; a zero-match stays indistinguishable
+  // Defense in depth: the global unique index means a slug cannot match more
+  // than one classroom, so this cannot fire today. It stays because resolving
+  // through findAll returns a list, and a list of surprising length must never
+  // be silently reduced to matches[0]. A zero-match stays indistinguishable
   // from it, so a probe never leaks whether a classroom exists (S1).
   if (matches.length !== 1) {
     throw new ToolError('not_found', `Classroom '${org}/${slug}' not found`);

--- a/apps/mcp/src/authz/pure.ts
+++ b/apps/mcp/src/authz/pure.ts
@@ -31,8 +31,11 @@ export interface ClassroomRef {
 
 /**
  * Parse a composite classroom reference of the form `org/slug`
- * (e.g. `dev-org/classmoji-dev-winter-2025`). Classroom.slug is only unique
- * per git org (`@@unique([git_org_id, slug])`), so a bare slug is ambiguous.
+ * (e.g. `dev-org/classmoji-dev-winter-2025`). The composite form is the locked
+ * addressing contract: Classroom.slug is globally unique (schema.prisma:
+ * `slug String @unique`) and would resolve on its own, but naming the owning
+ * org keeps a reference self-describing and makes a caller who means another
+ * org's classroom fail loudly instead of landing somewhere unexpected.
  */
 export function parseClassroomRef(ref: unknown): ClassroomRef {
   if (typeof ref !== 'string') {

--- a/apps/mcp/src/resources/__tests__/roster.test.ts
+++ b/apps/mcp/src/resources/__tests__/roster.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for the `roster` and `teams` resources (the read side of
+ * get_roster / list_teams).
+ *
+ * Two policies are pinned here:
+ *
+ * roster — the whole teaching team may read the roster, but the OWNER-only
+ * field split is part of the policy, not a detail: contact fields (email,
+ * school_id) and the membership grade fields (letter_grade, comment) are
+ * present for an OWNER and ABSENT — not null — for a TEACHER or ASSISTANT.
+ * The webapp roster route (admin.$class.students) applies the same split in
+ * its loader; the two are meant to stay in step.
+ *
+ * teams — a STUDENT sees the teams they are a member of, and only those.
+ * Membership is the whole test: the `is_visible` flag does not widen it. The
+ * teaching team continues to see every team in the classroom.
+ *
+ * `@classmoji/services` is mocked (factory idiom) so the real shaping runs
+ * against hand-built rows.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResourceDefinition, ToolContext } from '../../mcp/registry.ts';
+
+const findUsersByRole = vi.fn();
+const teamFindByClassroomId = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => findUsersByRole(...a) },
+    team: { findByClassroomId: (...a: unknown[]) => teamFindByClassroomId(...a) },
+  },
+}));
+
+const { rosterResource, teamsResource } = await import('../roster.ts');
+
+const VARS = { org: 'test-org', slug: 'winter-2025' };
+const URI = new URL('classmoji://test-org/winter-2025/roster');
+
+/** Resource handlers take (vars, ctx, uri); the uri is inert for these two. */
+const read = async <T>(resource: ResourceDefinition, ctx: ToolContext): Promise<T> =>
+  (await resource.handler(VARS, ctx, URI)) as T;
+
+type Role = 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
+
+function ctxFor(role: Role, userId: string): ToolContext {
+  return {
+    viewer: { userId, clientId: 'c', scopes: new Set(['read']) },
+    classroom: {
+      classroomId: 'class-1',
+      role,
+      status: 'ACTIVE',
+      membership: { id: 'm-1', role },
+      classroom: { settings: {} },
+    },
+  } as unknown as ToolContext;
+}
+
+const STUDENT_ROW = {
+  id: 'student-1',
+  name: 'Ada Lovelace',
+  login: 'ada',
+  image: 'https://example.test/ada.png',
+  email: 'ada@school.test',
+  school_id: 'F00123',
+  is_grader: false,
+  has_accepted_invite: true,
+  letter_grade: 'A-',
+  comment: 'strong on recursion',
+};
+
+const OWNER_ONLY_FIELDS = ['email', 'school_id', 'letter_grade', 'comment'] as const;
+
+beforeEach(() => {
+  findUsersByRole.mockReset();
+  teamFindByClassroomId.mockReset();
+  findUsersByRole.mockResolvedValue([STUDENT_ROW]);
+});
+
+// ─── roster: teaching-team read, OWNER-only fields ───────────────────────────
+
+describe('roster resource', () => {
+  it('gives an OWNER the identity fields plus the contact and grade fields', async () => {
+    const payload = await read<{
+      count: number;
+      students: Array<Record<string, unknown>>;
+    }>(rosterResource, ctxFor('OWNER', 'owner-1'));
+
+    expect(payload.count).toBe(1);
+    expect(payload.students[0]).toMatchObject({
+      id: 'student-1',
+      name: 'Ada Lovelace',
+      login: 'ada',
+      is_grader: false,
+      has_accepted_invite: true,
+      email: 'ada@school.test',
+      school_id: 'F00123',
+      letter_grade: 'A-',
+      comment: 'strong on recursion',
+    });
+  });
+
+  it.each([['TEACHER'], ['ASSISTANT']] as const)(
+    '%s reads the roster identity fields, with the owner-only fields absent (not null)',
+    async role => {
+      const payload = await read<{
+        count: number;
+        students: Array<Record<string, unknown>>;
+      }>(rosterResource, ctxFor(role, 'staff-1'));
+
+      expect(payload.count).toBe(1);
+      const row = payload.students[0];
+      // The roster is readable — identity and status still come through.
+      expect(row).toMatchObject({
+        id: 'student-1',
+        name: 'Ada Lovelace',
+        login: 'ada',
+        is_grader: false,
+        has_accepted_invite: true,
+      });
+      // The keys must be missing entirely, so nothing to reveal downstream.
+      for (const field of OWNER_ONLY_FIELDS) {
+        expect(field in row).toBe(false);
+      }
+      expect(JSON.stringify(payload)).not.toContain('ada@school.test');
+      expect(JSON.stringify(payload)).not.toContain('F00123');
+    }
+  );
+});
+
+// ─── teams: a student sees their own teams ───────────────────────────────────
+
+describe('teams resource', () => {
+  const member = (id: string) => ({ user: { id, name: id, login: id, image: null } });
+
+  const TEAMS = [
+    {
+      id: 't-own',
+      name: 'Team Own',
+      slug: 'team-own',
+      is_visible: false,
+      memberships: [member('student-1'), member('student-2')],
+      tags: [{ tag: { name: 'project-1' } }],
+    },
+    {
+      id: 't-other-visible',
+      name: 'Team Other Visible',
+      slug: 'team-other-visible',
+      is_visible: true,
+      memberships: [member('student-3')],
+      tags: [],
+    },
+    {
+      id: 't-other-hidden',
+      name: 'Team Other Hidden',
+      slug: 'team-other-hidden',
+      is_visible: false,
+      memberships: [member('student-4')],
+      tags: [],
+    },
+  ];
+
+  beforeEach(() => {
+    teamFindByClassroomId.mockResolvedValue(TEAMS);
+  });
+
+  it('returns a STUDENT only the teams they belong to, whatever is_visible says', async () => {
+    const payload = await read<{
+      count: number;
+      teams: Array<Record<string, unknown>>;
+    }>(teamsResource, ctxFor('STUDENT', 'student-1'));
+
+    expect(payload.count).toBe(1);
+    expect(payload.teams.map(t => t.id)).toEqual(['t-own']);
+    // The one visible team the student is not on is not part of their list.
+    expect(payload.teams.map(t => t.id)).not.toContain('t-other-visible');
+  });
+
+  it('returns an empty list for a STUDENT on no team', async () => {
+    const payload = await read<{ count: number; teams: unknown[] }>(
+      teamsResource,
+      ctxFor('STUDENT', 'student-99')
+    );
+
+    expect(payload.count).toBe(0);
+    expect(payload.teams).toEqual([]);
+  });
+
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)(
+    '%s still sees every team in the classroom',
+    async role => {
+      const payload = await read<{
+        count: number;
+        teams: Array<Record<string, unknown>>;
+      }>(teamsResource, ctxFor(role, 'staff-1'));
+
+      expect(payload.count).toBe(3);
+      expect(payload.teams.map(t => t.id)).toEqual(['t-own', 't-other-visible', 't-other-hidden']);
+    }
+  );
+
+  it('keeps the row shape narrow: public identity only, plus tag names', async () => {
+    const payload = await read<{ teams: Array<Record<string, unknown>> }>(
+      teamsResource,
+      ctxFor('STUDENT', 'student-1')
+    );
+
+    expect(payload.teams[0]).toEqual({
+      id: 't-own',
+      name: 'Team Own',
+      slug: 'team-own',
+      is_visible: false,
+      members: [
+        { id: 'student-1', name: 'student-1', login: 'student-1', avatar: null },
+        { id: 'student-2', name: 'student-2', login: 'student-2', avatar: null },
+      ],
+      tags: ['project-1'],
+    });
+  });
+});

--- a/apps/mcp/src/resources/content.ts
+++ b/apps/mcp/src/resources/content.ts
@@ -145,9 +145,11 @@ export const modulesResource: ResourceDefinition = {
       includeUnpublished: isStaff(role),
     })) as ModuleRow[];
 
-    // listForClassroom resolves by BARE slug (unique per git org only). Guard:
-    // if the slug resolved to a different classroom, refuse rather than serve
-    // another classroom's modules (S1).
+    // listForClassroom resolves by BARE slug. The slug is globally unique
+    // (schema.prisma: `slug String @unique`), so it agrees with the authorized
+    // classroom by construction; the guard is kept as defense in depth — if the
+    // slug ever resolved elsewhere, refuse rather than serve another
+    // classroom's modules (S1).
     if (modules.some(m => m.classroom_id !== classroomId)) {
       throw new ToolError(
         'internal',

--- a/apps/mcp/src/resources/grading.ts
+++ b/apps/mcp/src/resources/grading.ts
@@ -101,11 +101,13 @@ export async function loadGradingQueueData(
 /**
  * Shared leaderboard computation with the twin-classroom guard (S1).
  *
- * helper.calculateClassLeaderboard resolves by BARE slug (findBySlug), but
- * slugs are only unique per git org. Guard: if the bare slug resolves to a
- * different classroom than the org/slug the caller was authorized for, refuse
- * rather than leak another classroom's leaderboard. Both the leaderboard
- * resource and the `get_leaderboard` tool call this so the guard never drifts.
+ * helper.calculateClassLeaderboard resolves by BARE slug (findBySlug). The slug
+ * is globally unique (schema.prisma: `slug String @unique`), so that lookup and
+ * the authorized classroom agree by construction. The guard is kept as defense
+ * in depth — if the bare slug ever resolves to a different classroom than the
+ * org/slug the caller was authorized for, refuse rather than return another
+ * classroom's leaderboard. Both the leaderboard resource and the
+ * `get_leaderboard` tool call this so the guard never drifts.
  */
 export async function computeLeaderboard(
   slug: string,

--- a/apps/mcp/src/resources/roster.ts
+++ b/apps/mcp/src/resources/roster.ts
@@ -19,10 +19,11 @@
  *   rows; the student team view (student.$class.repos_.$repo.team) narrows to
  *   {id,name,login,provider_id}. Mirror the narrow select for everyone.
  *   Tiers: the teaching team sees every team in the classroom; a STUDENT sees
- *   the teams they are a member of, and only those. The web gives students no
- *   classroom-wide team list at all, so own-teams-only is the closest mirror;
- *   the self-formed team flow (student.$class.repos_.$repo.team) resolves its
- *   candidate teams by TAG through team.findByTagId and does not read this
+ *   the teams they are a member of, and only those. The web has no
+ *   classroom-wide team list for students, so own-teams-only is the closest
+ *   mirror. It does show a student teams they have not joined in one place —
+ *   the self-formed team flow (student.$class.repos_.$repo.team) — but that
+ *   scopes its candidates by TAG through team.findByTagId and never reads this
  *   resource, so it is unaffected.
  */
 
@@ -106,8 +107,10 @@ export const teamsResource: ResourceDefinition = {
 
     const viewerId = ctx.viewer.userId;
     // A student's team list is their OWN teams. Membership is the whole test —
-    // `is_visible` does not widen it, matching the web, which offers students
-    // no classroom-wide team list.
+    // `is_visible` does not widen it. The web has no classroom-wide team list
+    // for students; the one place it shows a student teams they are not in is
+    // the tag-scoped join flow, which selects candidates by TAG
+    // (team.findByTagId) rather than by this classroom-wide listing.
     const visible =
       role === 'STUDENT'
         ? teams.filter(t => (t.memberships ?? []).some(m => m.user?.id === viewerId))

--- a/apps/mcp/src/resources/roster.ts
+++ b/apps/mcp/src/resources/roster.ts
@@ -17,9 +17,13 @@
  * teams (any member):
  *   Web reality: admin.$class.teams (OWNER) returns members as FULL User
  *   rows; the student team view (student.$class.repos_.$repo.team) narrows to
- *   {id,name,login,provider_id}. Mirror the narrow select for everyone —
- *   staff additionally see invisible (is_visible=false) teams; students see
- *   visible teams plus any team they belong to.
+ *   {id,name,login,provider_id}. Mirror the narrow select for everyone.
+ *   Tiers: the teaching team sees every team in the classroom; a STUDENT sees
+ *   the teams they are a member of, and only those. The web gives students no
+ *   classroom-wide team list at all, so own-teams-only is the closest mirror;
+ *   the self-formed team flow (student.$class.repos_.$repo.team) resolves its
+ *   candidate teams by TAG through team.findByTagId and does not read this
+ *   resource, so it is unaffected.
  */
 
 import { ClassmojiService } from '@classmoji/services';
@@ -93,7 +97,7 @@ export const teamsResource: ResourceDefinition = {
   title: 'Teams',
   description:
     'Teams in the classroom with member identities (id, name, login only — no contact PII). ' +
-    'Students see visible teams and their own; staff see all teams.',
+    'Students see the teams they belong to; the teaching team sees all teams.',
   scope: 'read',
   roles: MEMBER,
   handler: async (_vars, ctx) => {
@@ -101,11 +105,12 @@ export const teamsResource: ResourceDefinition = {
     const teams = (await ClassmojiService.team.findByClassroomId(classroomId)) as TeamRow[];
 
     const viewerId = ctx.viewer.userId;
+    // A student's team list is their OWN teams. Membership is the whole test —
+    // `is_visible` does not widen it, matching the web, which offers students
+    // no classroom-wide team list.
     const visible =
       role === 'STUDENT'
-        ? teams.filter(
-            t => t.is_visible || (t.memberships ?? []).some(m => m.user?.id === viewerId)
-          )
+        ? teams.filter(t => (t.memberships ?? []).some(m => m.user?.id === viewerId))
         : teams;
 
     return {

--- a/apps/mcp/src/resources/shape.ts
+++ b/apps/mcp/src/resources/shape.ts
@@ -54,11 +54,20 @@ export const QUIZ_ROLES: readonly Role[] = ['OWNER', 'ASSISTANT', 'STUDENT'];
  * "Staff" = the classroom's teaching team, exactly OWNER/TEACHER/ASSISTANT
  * (i.e. TEACHING_TEAM as a set, STUDENT excluded).
  *
- * This is the intended tier for seeing UNPUBLISHED/DRAFT content in a read
- * path — module items, calendar-linked pages and decks, slide listings. All
- * three staff roles prepare course material together, so a draft being visible
- * to a colleague is the expected behaviour, not a leak; what stays narrower is
- * WRITING to it (see assertSlideEditable / the deck tools).
+ * This is the intended tier for seeing UNPUBLISHED/DRAFT content in the read
+ * paths that already use it — module items, calendar-linked pages and decks,
+ * slide listings. All three staff roles prepare course material together, so a
+ * draft being visible to a colleague is the expected behaviour, not a leak;
+ * what stays narrower is WRITING to it (see assertSlideEditable / the deck
+ * tools).
+ *
+ * NOT a licence to widen the remaining surfaces by default. The pages list
+ * (pagesResource / `list_pages`) deliberately still gives the FULL, draft-
+ * inclusive listing to OWNER/TEACHER only, with assistants on the published
+ * student-menu list alongside students — mirroring admin.$class.pages in the
+ * web app. That is out of scope for this policy change: whether assistants
+ * should read the whole page tree is its own product question, to be decided on
+ * its own evidence rather than by analogy to decks.
  */
 export const STAFF_ROLES: ReadonlySet<Role> = new Set(['OWNER', 'TEACHER', 'ASSISTANT']);
 export const isStaff = (role: Role): boolean => STAFF_ROLES.has(role);

--- a/apps/mcp/src/resources/shape.ts
+++ b/apps/mcp/src/resources/shape.ts
@@ -50,6 +50,16 @@ export const STUDENT_ONLY: readonly Role[] = ['STUDENT'];
 /** Quiz routes allow OWNER/ASSISTANT/STUDENT — TEACHER is genuinely excluded. */
 export const QUIZ_ROLES: readonly Role[] = ['OWNER', 'ASSISTANT', 'STUDENT'];
 
+/**
+ * "Staff" = the classroom's teaching team, exactly OWNER/TEACHER/ASSISTANT
+ * (i.e. TEACHING_TEAM as a set, STUDENT excluded).
+ *
+ * This is the intended tier for seeing UNPUBLISHED/DRAFT content in a read
+ * path — module items, calendar-linked pages and decks, slide listings. All
+ * three staff roles prepare course material together, so a draft being visible
+ * to a colleague is the expected behaviour, not a leak; what stays narrower is
+ * WRITING to it (see assertSlideEditable / the deck tools).
+ */
 export const STAFF_ROLES: ReadonlySet<Role> = new Set(['OWNER', 'TEACHER', 'ASSISTANT']);
 export const isStaff = (role: Role): boolean => STAFF_ROLES.has(role);
 

--- a/apps/mcp/src/tools/__tests__/deck.test.ts
+++ b/apps/mcp/src/tools/__tests__/deck.test.ts
@@ -254,6 +254,49 @@ describe('assertSlideEditable sub-gate on deck writes', () => {
   });
 });
 
+// ─── Reads are the WIDER tier (policy pin) ───────────────────────────────────
+
+describe('deck reads follow the view tier, not the edit tier', () => {
+  // POLICY: reading a deck belongs to the whole teaching team; only writing is
+  // narrowed to the creator / allow_team_edit. These cases use the exact deck
+  // that the write sub-gate above refuses for this same caller — an ASSISTANT
+  // who is neither the creator nor covered by allow_team_edit — so if someone
+  // adds assertSlideEditable to the read tools, these fail immediately.
+  // Failing here means the policy changed, not that the test is stale.
+  const READ_ARGS = { classroom: 'org/x', slide_id: SLIDE_ID };
+
+  it.each([
+    ['deck_outline', () => deckOutlineTool.handler(READ_ARGS, ASSISTANT_CTX)],
+    ['deck_get', () => deckGetTool.handler(READ_ARGS, ASSISTANT_CTX)],
+  ])('%s: a non-creator ASSISTANT reads a locked deck they may not edit', async (_name, run) => {
+    mocks.slideFindById.mockResolvedValue({
+      ...SLIDE,
+      created_by: 'someone-else',
+      allow_team_edit: false,
+    });
+
+    const payload = parse((await run()) as { content: Array<{ text: string }> });
+
+    expect(payload.slide_id).toBe(SLIDE_ID);
+    expect(mocks.loadDeck).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['deck_outline', () => deckOutlineTool.handler(READ_ARGS, ASSISTANT_CTX)],
+    ['deck_get', () => deckGetTool.handler(READ_ARGS, ASSISTANT_CTX)],
+  ])('%s: the same holds for a DRAFT deck', async (_name, run) => {
+    mocks.slideFindById.mockResolvedValue({
+      ...DRAFT_SLIDE,
+      created_by: 'someone-else',
+      allow_team_edit: false,
+    });
+
+    const payload = parse((await run()) as { content: Array<{ text: string }> });
+
+    expect(payload.slide_id).toBe(SLIDE_ID);
+  });
+});
+
 // ─── deck_outline ────────────────────────────────────────────────────────────
 
 describe('deck_outline', () => {

--- a/apps/mcp/src/tools/__tests__/reads.test.ts
+++ b/apps/mcp/src/tools/__tests__/reads.test.ts
@@ -48,9 +48,15 @@ vi.mock('@classmoji/services', () => ({
   },
 }));
 
-const { listSubmissionsTool, getLeaderboardTool, listTeachingTeamTool, gradingReportTool } =
-  await import('../reads.ts');
+const {
+  listSubmissionsTool,
+  getLeaderboardTool,
+  listTeachingTeamTool,
+  gradingReportTool,
+  listTeamsTool,
+} = await import('../reads.ts');
 const { gradingQueueResource, leaderboardResource } = await import('../../resources/grading.ts');
+const { teamsResource } = await import('../../resources/roster.ts');
 
 const CLASSROOM = 'test-org/winter-2025';
 
@@ -233,6 +239,42 @@ describe('list_teaching_team', () => {
     expect(byId.u3).toBeUndefined(); // students are not teaching team
     // Only id/login/name/roles — no PII (email/school_id) or avatar.
     expect(Object.keys(byId.u1).sort()).toEqual(['id', 'login', 'name', 'roles']);
+  });
+});
+
+// ─── Mirror-tool description drift ───────────────────────────────────────────
+
+/**
+ * `mirrorResourceTool` copies a resource's roles and handler but keeps its OWN
+ * description, so a policy change made on the resource does not propagate here.
+ * On MCP the description IS the contract — a client picks and interprets the
+ * tool from it — so a stale one is a real defect, not a comment nit.
+ *
+ * These assertions are deliberately about MEANING rather than exact wording, so
+ * the description can be reworded without churn but cannot go back to promising
+ * a capability the handler does not provide.
+ */
+describe('list_teams — the description matches the handler policy', () => {
+  it('does not claim students can browse teams they are not in', () => {
+    const description = listTeamsTool.description.toLowerCase();
+
+    // The withdrawn promise: browsing by team visibility.
+    expect(description).not.toContain('visible teams');
+    expect(description).not.toContain('is_visible');
+  });
+
+  it('states the tier the handler actually implements', () => {
+    const description = listTeamsTool.description.toLowerCase();
+
+    expect(description).toContain('students');
+    expect(description).toContain('belong to');
+  });
+
+  it('mirrors the resource it wraps: same roles, same handler', () => {
+    // The description is the one thing NOT copied, which is why it needs a guard.
+    expect(listTeamsTool.roles).toEqual(teamsResource.roles);
+    expect(listTeamsTool.scope).toBe(teamsResource.scope);
+    expect(listTeamsTool.description).not.toBe(teamsResource.description);
   });
 });
 

--- a/apps/mcp/src/tools/__tests__/slides.test.ts
+++ b/apps/mcp/src/tools/__tests__/slides.test.ts
@@ -5,8 +5,9 @@
  * Focus: S1 scoping (cross-classroom → scopedNotFound, no service touch),
  * the assertSlideEditable sub-gate matrix (OWNER/TEACHER pass via holdsRole,
  * ASSISTANT × creator × allow_team_edit, multi-role escape hatch), list_slides
- * role filtering (staff full incl. drafts; assistants/students published-only
- * with the minimal field set), delete's video-cleanup reporting, and audits.
+ * role filtering (the whole teaching team sees drafts — the VIEW tier, wider
+ * than the edit tier on purpose; students get the published-only list with the
+ * minimal field set), delete's video-cleanup reporting, and audits.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -219,47 +220,65 @@ describe('list_slides', () => {
     { ...SLIDE, id: 's-2', title: 'Draft', is_draft: true },
   ];
 
-  it('OWNER/TEACHER get the full list incl. drafts, with visibility flags', async () => {
-    mocks.findByClassroomId.mockResolvedValue(ROWS);
-
-    const payload = parse(await listSlidesTool.handler({ classroom: 'org/x' }, TEACHER_CTX));
-
-    expect(mocks.findByClassroomId).toHaveBeenCalledWith('class-1', { includeDrafts: true });
-    expect(payload.slides).toHaveLength(2);
-    expect(payload.slides[0]).toMatchObject({
-      id: 's-1',
-      title: 'Published',
-      slug: 'intro-week',
-      is_draft: false,
-      is_public: false,
-      allow_team_edit: false,
-      show_speaker_notes: false,
-      created_by: 'teacher-1',
-    });
-  });
-
-  it.each([['ASSISTANT'], ['STUDENT']] as const)(
-    '%s gets the published-only list with the minimal field set',
+  // POLICY: the listing follows the VIEW tier, which is the whole teaching
+  // team — including an ASSISTANT who neither created the draft nor has
+  // allow_team_edit on it. Editing is the narrower tier and is pinned
+  // separately by the assertSlideEditable suite above. If a change makes an
+  // ASSISTANT fall into the published-only branch again, that is a policy
+  // regression, not a test that needs updating.
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)(
+    '%s gets the full list incl. drafts, with visibility flags',
     async role => {
-      mocks.findByClassroomId.mockResolvedValue([ROWS[0]]);
+      mocks.findByClassroomId.mockResolvedValue(ROWS);
 
       const payload = parse(
-        await listSlidesTool.handler({ classroom: 'org/x' }, makeCtx(role as 'STUDENT'))
+        await listSlidesTool.handler({ classroom: 'org/x' }, makeCtx(role as 'OWNER'))
       );
 
-      expect(mocks.findByClassroomId).toHaveBeenCalledWith('class-1', { includeDrafts: false });
-      expect(payload.slides).toHaveLength(1);
-      expect(payload.slides[0]).toEqual({
+      expect(mocks.findByClassroomId).toHaveBeenCalledWith('class-1', { includeDrafts: true });
+      expect(payload.slides).toHaveLength(2);
+      expect(payload.slides[0]).toMatchObject({
         id: 's-1',
         title: 'Published',
         slug: 'intro-week',
-        updated_at: expect.anything(),
+        is_draft: false,
+        is_public: false,
+        allow_team_edit: false,
+        show_speaker_notes: false,
+        created_by: 'teacher-1',
       });
-      // No draft/visibility internals leak to non-staff.
-      expect('is_draft' in payload.slides[0]).toBe(false);
-      expect('allow_team_edit' in payload.slides[0]).toBe(false);
+      expect(payload.slides[1]).toMatchObject({ id: 's-2', title: 'Draft', is_draft: true });
     }
   );
+
+  it('lists a draft to an ASSISTANT who is neither its creator nor covered by allow_team_edit', async () => {
+    mocks.findByClassroomId.mockResolvedValue([
+      { ...ROWS[1], created_by: 'someone-else', allow_team_edit: false },
+    ]);
+
+    const payload = parse(await listSlidesTool.handler({ classroom: 'org/x' }, ASSISTANT_CTX));
+
+    expect(payload.slides).toHaveLength(1);
+    expect(payload.slides[0]).toMatchObject({ id: 's-2', is_draft: true });
+  });
+
+  it('STUDENT gets the published-only list with the minimal field set', async () => {
+    mocks.findByClassroomId.mockResolvedValue([ROWS[0]]);
+
+    const payload = parse(await listSlidesTool.handler({ classroom: 'org/x' }, makeCtx('STUDENT')));
+
+    expect(mocks.findByClassroomId).toHaveBeenCalledWith('class-1', { includeDrafts: false });
+    expect(payload.slides).toHaveLength(1);
+    expect(payload.slides[0]).toEqual({
+      id: 's-1',
+      title: 'Published',
+      slug: 'intro-week',
+      updated_at: expect.anything(),
+    });
+    // No draft/visibility internals reach a student.
+    expect('is_draft' in payload.slides[0]).toBe(false);
+    expect('allow_team_edit' in payload.slides[0]).toBe(false);
+  });
 });
 
 // ─── slide_create ────────────────────────────────────────────────────────────

--- a/apps/mcp/src/tools/deck.ts
+++ b/apps/mcp/src/tools/deck.ts
@@ -16,8 +16,17 @@
  * delete. A genuine same-slide conflict returns a structured per-unit report
  * instead of raw conflict markers. Discard = branch delete, main untouched.
  *
- * Tier: TEACHING_TEAM reads; writes add the assertSlideAccess edit-tier
- * sub-gate (OWNER/TEACHER any deck; ASSISTANT own or allow_team_edit).
+ * Tier — read and write are split ON PURPOSE, and the split is the policy:
+ *   READ  (deck_outline / deck_get) — TEACHING_TEAM, no further sub-gate. Any
+ *         OWNER/TEACHER/ASSISTANT of the classroom may read any of its decks,
+ *         drafts included. This is NOT an oversight: the same rule is what the
+ *         shared web gate applies for viewing (assertSlideAccess, view tier in
+ *         auth/server.ts) and what list_slides lists. Adding assertSlideEditable
+ *         to the read tools would narrow reading to the deck's creator — please
+ *         do not "fix" it that way.
+ *   WRITE (deck_apply / deck_preview_accept / deck_preview_discard) — the same
+ *         TEACHING_TEAM entry gate PLUS the assertSlideEditable sub-gate:
+ *         OWNER/TEACHER any deck; ASSISTANT own decks or allow_team_edit only.
  * S1: every tool loads the slide WITH its classroom chain and compares
  * classroom_id before touching GitHub (loadSlideInClassroom).
  *
@@ -267,6 +276,9 @@ export const deckOutlineTool: ToolDefinition<DeckOutlineArgs> = {
       .describe("Read target: 'main' (default) or the pending preview branch"),
   },
   handler: async (args, ctx) => {
+    // No assertSlideEditable here, deliberately: reading a deck is a
+    // teaching-team right (view tier), while editing it stays with the
+    // creator / allow_team_edit. See the read-vs-write note in the file header.
     const slide = await loadSlideInClassroom(args.slide_id, ctx);
     const status = await getDeckPreviewStatus(slide);
     const ref = previewReadRef(slide, args.at ?? 'main', status);
@@ -341,6 +353,9 @@ export const deckGetTool: ToolDefinition<DeckGetArgs> = {
       .describe("Read target: 'main' (default) or the pending preview branch"),
   },
   handler: async (args, ctx) => {
+    // No assertSlideEditable here, deliberately: reading a deck is a
+    // teaching-team right (view tier), while editing it stays with the
+    // creator / allow_team_edit. See the read-vs-write note in the file header.
     const slide = await loadSlideInClassroom(args.slide_id, ctx);
     const status = await getDeckPreviewStatus(slide);
     const ref = previewReadRef(slide, args.at ?? 'main', status);

--- a/apps/mcp/src/tools/reads.ts
+++ b/apps/mcp/src/tools/reads.ts
@@ -148,9 +148,13 @@ export const listTeamsTool = mirrorResourceTool({
   resource: teamsResource,
   name: 'list_teams',
   title: 'List teams',
+  // Kept in step with teamsResource by hand: mirrorResourceTool copies the
+  // resource's roles and handler but keeps its OWN description, and on MCP the
+  // description IS the contract the client reasons about. When the resource's
+  // policy changes, change this string too.
   description:
     'Teams in the classroom with member identities (id, name, login — no contact PII). Students ' +
-    'see visible teams and any team they belong to; staff see all teams.',
+    'see the teams they belong to, and only those; the teaching team sees every team.',
 });
 
 export const listReposTool = mirrorResourceTool({

--- a/apps/mcp/src/tools/slides.ts
+++ b/apps/mcp/src/tools/slides.ts
@@ -2,13 +2,18 @@
  * Slide tools (content-tools plan Phase 5, §7):
  * list_slides / slide_create / slide_update / slide_delete.
  *
- * Tier confirmed against the web routes: the slides list is OWNER/TEACHER for
- * the full listing (admin.$class.slides) with assistants and students getting
- * the published-only list (student.$class.slides, which the assistant route
- * re-exports). Writes are TEACHING_TEAM with the assertSlideAccess edit-tier
- * sub-gate (auth/server.ts): OWNER/TEACHER edit any deck; an ASSISTANT only
- * decks they created or decks with allow_team_edit (decided: slide_delete
- * mirrors the web too — assistants may delete own/team-edit decks).
+ * Tier: reading a deck and editing it are two different rules, deliberately.
+ *   VIEW  — the whole TEACHING TEAM (OWNER/TEACHER/ASSISTANT) sees every deck
+ *           of their classroom, drafts included; students see published decks
+ *           only. This matches the slides app's own list (apps/slides
+ *           routes/_index), which has always shown drafts to all three staff
+ *           roles, and the shared view gate (assertSlideAccess, auth/server.ts).
+ *   EDIT  — narrower and unchanged: OWNER/TEACHER edit any deck; an ASSISTANT
+ *           only decks they created or decks with allow_team_edit (decided:
+ *           slide_delete mirrors the web too — assistants may delete own /
+ *           team-edit decks). Enforced by the assertSlideEditable sub-gate.
+ * Do not collapse the two back together: a staff member reading a colleague's
+ * work-in-progress deck is expected; writing to it is not.
  *
  * S1: every by-id tool loads the slide WITH its classroom chain and compares
  * classroom_id before mutating (loadSlideInClassroom).
@@ -19,7 +24,7 @@ import type { Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolDefinition } from '../mcp/registry.ts';
-import { MEMBER } from '../resources/shape.ts';
+import { MEMBER, isStaff } from '../resources/shape.ts';
 import {
   assertSlideEditable,
   loadSlideInClassroom,
@@ -60,9 +65,9 @@ export const listSlidesTool: ToolDefinition<ListSlidesArgs> = {
   name: 'list_slides',
   title: 'List slide decks',
   description:
-    "Lists the classroom's slide decks. OWNER/TEACHER see every deck incl. drafts (with " +
-    'visibility flags); assistants and students see the published list, as the web app does. ' +
-    "Use deck_outline/deck_get to read a deck's content.",
+    "Lists the classroom's slide decks. The teaching team (OWNER/TEACHER/ASSISTANT) sees every " +
+    'deck incl. drafts (with visibility flags); students see the published list. Use ' +
+    "deck_outline/deck_get to read a deck's content.",
   scope: 'read',
   roles: MEMBER,
   inputSchema: {
@@ -71,9 +76,11 @@ export const listSlidesTool: ToolDefinition<ListSlidesArgs> = {
   handler: async (_args, ctx) => {
     const { classroomId, role } = requireClassroomCtx(ctx);
 
-    // Full listing mirrors admin.$class.slides: OWNER + TEACHER. Assistants get
-    // the published list (the assistant web route re-exports the student one).
-    if (role === 'OWNER' || role === 'TEACHER') {
+    // Full listing = the teaching team, matching the view tier of the shared
+    // slide gate and the slides app's own list. Keeping the listing in step
+    // with deck_get/deck_outline means a deck a staff member may open is also
+    // a deck they can find.
+    if (isStaff(role)) {
       const slides = (await slideService.findByClassroomId(classroomId, {
         includeDrafts: true,
       })) as SlideRow[];

--- a/apps/mcp/src/tools/teams.ts
+++ b/apps/mcp/src/tools/teams.ts
@@ -181,8 +181,9 @@ export const teamCreateTool: ToolDefinition<TeamCreateArgs> = {
     'Classmoji record. Owner only. GitHub derives the slug from the name. Names that would ' +
     "collide with an existing org team, or that end in '-students' / '-assistants' (reserved for " +
     "the classroom's own membership teams), are refused before anything is created. is_visible " +
-    'controls student visibility: false (the default) means only its own members see the team in ' +
-    'list_teams — other students do not. tag_ids attach classroom tags at creation time; a tag id ' +
+    'is recorded on the team but no read path currently varies on it: in list_teams a student ' +
+    'sees the teams they belong to and the teaching team sees them all, either way. tag_ids ' +
+    'attach classroom tags at creation time; a tag id ' +
     'from another classroom is reported in tags_failed and the team is still created. Add members ' +
     'afterwards with team_members_add.',
   scope: 'write',
@@ -197,8 +198,8 @@ export const teamCreateTool: ToolDefinition<TeamCreateArgs> = {
       .boolean()
       .optional()
       .describe(
-        'Whether students who are not members can see this team (default false — invisible ' +
-          'teams are hidden from non-member students in list_teams)'
+        'Stored on the team as a visibility hint (default false). No read path reads it today: ' +
+          'list_teams shows a student their own teams regardless of this flag.'
       ),
     tag_ids: tagIdsSchema.optional(),
   },

--- a/apps/webapp/app/constants/routes.ts
+++ b/apps/webapp/app/constants/routes.ts
@@ -159,7 +159,11 @@ export const routes = {
     link: '/students',
     label: 'Students',
     icon: IconUsers,
-    roles: ['OWNER'],
+    // Reading the roster is a teaching-team right, so assistants get the entry
+    // too; it resolves to /assistant/:class/students, which re-exports the
+    // admin loader and its OWNER-only field split. TEACHER is absent because
+    // that role has no path in roleSettings — see the note there.
+    roles: ['OWNER', 'ASSISTANT'],
     category: 'people',
   },
   teams: {

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -87,8 +87,8 @@ async function canMintOrgToken(org: Parameters<typeof getGitProvider>[0]): Promi
  * it keeps a [git_org_id, content_namespace] unique constraint and is no longer
  * user-editable — so a collision has to be resolved silently here instead of
  * being handed back as an error the user has no field to fix. Candidates, in
- * order: the org-prefix-stripped slug, the raw slug (unique per org), then
- * numeric suffixes.
+ * order: the org-prefix-stripped slug, the raw slug (itself globally unique),
+ * then numeric suffixes.
  */
 async function pickContentNamespace(gitOrgId: string, orgLogin: string, slug: string) {
   const suggested = suggestContentNamespace({ orgLogin, slug });

--- a/apps/webapp/app/routes/admin.$class.slides/__tests__/slidesAdmin.test.ts
+++ b/apps/webapp/app/routes/admin.$class.slides/__tests__/slidesAdmin.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for the admin slide-settings action.
+ *
+ * The action authorizes against the classroom in the URL, but the deck it acts
+ * on arrives as `slideId` in the form body. Those two facts have to be tied
+ * together in the query itself: every write is bound to
+ * `{ id, classroom_id }` and only counts when it matched exactly one row. A
+ * deck id belonging to some other classroom therefore changes nothing and comes
+ * back as the route's ordinary not-found result.
+ *
+ * The loader is already classroom-scoped (`where: { classroom_id }`); it is
+ * pinned here too so the pair cannot drift.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertClassroomAccess: vi.fn(),
+  assertClassroomMutationAllowed: vi.fn(),
+  findMany: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn(),
+  getRecentViewersForPaths: vi.fn(),
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => mocks.assertClassroomAccess(...a),
+  assertClassroomMutationAllowed: (...a: unknown[]) => mocks.assertClassroomMutationAllowed(...a),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    slide: {
+      findMany: (...a: unknown[]) => mocks.findMany(...a),
+      update: (...a: unknown[]) => mocks.update(...a),
+      updateMany: (...a: unknown[]) => mocks.updateMany(...a),
+    },
+  }),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    resourceView: {
+      getRecentViewersForPaths: (...a: unknown[]) => mocks.getRecentViewersForPaths(...a),
+    },
+  },
+}));
+
+// The loader/action are what is under test; the view layer only needs to import.
+vi.mock('~/components', () => ({ TableActionButtons: () => null, RecentViewers: () => null }));
+vi.mock('antd', () => ({
+  Table: () => null,
+  Button: () => null,
+  Tag: () => null,
+  Select: () => null,
+  Switch: () => null,
+  Tooltip: () => null,
+}));
+vi.mock('@tabler/icons-react', () => ({
+  IconPlus: () => null,
+  IconPresentation: () => null,
+  IconEyeOff: () => null,
+  IconLock: () => null,
+  IconWorld: () => null,
+  IconEdit: () => null,
+  IconNotes: () => null,
+}));
+vi.mock('react-router', () => ({ useFetcher: () => ({ submit: vi.fn() }) }));
+
+const route = await import('../route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+const OWN_SLIDE = 'slide-in-this-classroom';
+const FOREIGN_SLIDE = 'slide-in-another-classroom';
+
+const actionArgs = (body: Record<string, string>) => {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(body)) formData.append(key, value);
+  return {
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost/admin/${CLASS_SLUG}/slides`, {
+      method: 'POST',
+      body: formData,
+    }),
+  } as unknown as Parameters<typeof route.action>[0];
+};
+
+/** The `where` of the single write the action performed. */
+const writeWhere = () => mocks.updateMany.mock.calls[0][0].where as Record<string, unknown>;
+/** The `data` of the single write the action performed. */
+const writeData = () => mocks.updateMany.mock.calls[0][0].data as Record<string, unknown>;
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.assertClassroomAccess.mockResolvedValue({
+    userId: 'owner-1',
+    classroom: CLASSROOM,
+    membership: { id: 'm-1', role: 'OWNER' },
+  });
+  mocks.findMany.mockResolvedValue([]);
+  mocks.getRecentViewersForPaths.mockResolvedValue(new Map());
+  // One row matched = the deck really is in this classroom.
+  mocks.updateMany.mockResolvedValue({ count: 1 });
+});
+
+// ─── A deck of this classroom updates normally ───────────────────────────────
+
+describe('slides action — updating a deck of this classroom', () => {
+  it('writes the status pair bound to the classroom', async () => {
+    const result = await route.action(
+      actionArgs({ slideId: OWN_SLIDE, field: 'status', value: 'public' })
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(writeWhere()).toEqual({ id: OWN_SLIDE, classroom_id: 'class-1' });
+    expect(writeData()).toEqual({ is_draft: false, is_public: true });
+  });
+
+  it.each([
+    ['draft', { is_draft: true, is_public: false }],
+    ['private', { is_draft: false, is_public: false }],
+    ['public', { is_draft: false, is_public: true }],
+  ] as const)('maps status "%s" to its flag pair', async (value, expected) => {
+    await route.action(actionArgs({ slideId: OWN_SLIDE, field: 'status', value }));
+
+    expect(writeData()).toEqual(expected);
+  });
+
+  it.each([['allow_team_edit'], ['show_speaker_notes']] as const)(
+    'writes the %s toggle bound to the classroom',
+    async field => {
+      const result = await route.action(actionArgs({ slideId: OWN_SLIDE, field, value: 'true' }));
+
+      expect(result).toEqual({ success: true });
+      expect(writeWhere()).toEqual({ id: OWN_SLIDE, classroom_id: 'class-1' });
+      expect(writeData()).toEqual({ [field]: true });
+    }
+  );
+
+  it('reads "false" as false rather than as a truthy string', async () => {
+    await route.action(
+      actionArgs({ slideId: OWN_SLIDE, field: 'show_speaker_notes', value: 'false' })
+    );
+
+    expect(writeData()).toEqual({ show_speaker_notes: false });
+  });
+});
+
+// ─── A deck of ANOTHER classroom changes nothing ─────────────────────────────
+
+describe('slides action — a deck id from another classroom', () => {
+  beforeEach(() => {
+    // The classroom_id half of the where matches nothing.
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it.each([
+    ['status', 'public'],
+    ['allow_team_edit', 'true'],
+    ['show_speaker_notes', 'true'],
+  ] as const)('changes nothing and reports not-found for field "%s"', async (field, value) => {
+    const result = await route.action(actionArgs({ slideId: FOREIGN_SLIDE, field, value }));
+
+    expect(result).toEqual({ error: 'Slide not found' });
+    // The classroom the request was authorized for is part of the query, so the
+    // write could not have matched a deck outside it.
+    expect(writeWhere()).toEqual({ id: FOREIGN_SLIDE, classroom_id: 'class-1' });
+  });
+
+  it('never reaches an unscoped single-row update', async () => {
+    await route.action(actionArgs({ slideId: FOREIGN_SLIDE, field: 'status', value: 'draft' }));
+
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Everything else the action refuses ──────────────────────────────────────
+
+describe('slides action — inputs it will not act on', () => {
+  it('rejects an unknown field without writing', async () => {
+    const result = await route.action(
+      actionArgs({ slideId: OWN_SLIDE, field: 'created_by', value: 'someone-else' })
+    );
+
+    expect(result).toEqual({ error: 'Invalid field' });
+    expect(mocks.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing slideId without writing', async () => {
+    const result = await route.action(actionArgs({ field: 'status', value: 'public' }));
+
+    expect(result).toEqual({ error: 'Slide not found' });
+    expect(mocks.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('authorizes as OWNER/TEACHER and checks the mutation gate first', async () => {
+    await route.action(actionArgs({ slideId: OWN_SLIDE, field: 'status', value: 'public' }));
+
+    expect(mocks.assertClassroomAccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classroomSlug: CLASS_SLUG,
+        allowedRoles: ['OWNER', 'TEACHER'],
+        resourceType: 'SLIDES',
+        attemptedAction: 'update_slide_visibility',
+      })
+    );
+    expect(mocks.assertClassroomMutationAllowed).toHaveBeenCalledWith({
+      status: 'ACTIVE',
+      role: 'OWNER',
+    });
+  });
+
+  it('does not write when the authorization gate throws', async () => {
+    mocks.assertClassroomAccess.mockRejectedValue(new Response('Forbidden', { status: 403 }));
+
+    await expect(
+      route.action(actionArgs({ slideId: OWN_SLIDE, field: 'status', value: 'public' }))
+    ).rejects.toBeInstanceOf(Response);
+    expect(mocks.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+// ─── The loader is scoped the same way ───────────────────────────────────────
+
+describe('slides loader', () => {
+  it('lists only decks of the authorized classroom', async () => {
+    await route.loader({
+      params: { class: CLASS_SLUG },
+      request: new Request(`http://localhost/admin/${CLASS_SLUG}/slides`),
+    } as unknown as Parameters<typeof route.loader>[0]);
+
+    expect(mocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { classroom_id: 'class-1' } })
+    );
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.slides/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.slides/route.tsx
@@ -79,6 +79,30 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
 
+  if (!slideId) {
+    return { error: 'Slide not found' };
+  }
+
+  /**
+   * Apply an update to a deck OF THE CLASSROOM THIS REQUEST WAS AUTHORIZED FOR.
+   *
+   * The authorization above binds to the classroom in the URL, but `slideId`
+   * arrives in the form body, so the two have to be tied together explicitly:
+   * the update is bound to `{ id, classroom_id }` and is only treated as done
+   * when it matched exactly one row. Same pattern as the slides app's delete
+   * route, which re-checks the deck's classroom after its own gate.
+   */
+  const updateSlideInClassroom = async (data: Record<string, boolean>) => {
+    const { count } = await getPrisma().slide.updateMany({
+      where: { id: slideId, classroom_id: classroom.id },
+      data,
+    });
+    if (count !== 1) {
+      return { error: 'Slide not found' };
+    }
+    return { success: true };
+  };
+
   // Handle status changes (combines is_draft and is_public)
   if (field === 'status') {
     let is_draft = false;
@@ -95,22 +119,12 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       is_public = true;
     }
 
-    await getPrisma().slide.update({
-      where: { id: slideId },
-      data: { is_draft, is_public },
-    });
-
-    return { success: true };
+    return updateSlideInClassroom({ is_draft, is_public });
   }
 
   // Handle boolean toggles (allow_team_edit, show_speaker_notes)
   if (field === 'allow_team_edit' || field === 'show_speaker_notes') {
-    await getPrisma().slide.update({
-      where: { id: slideId },
-      data: { [field]: value === 'true' },
-    });
-
-    return { success: true };
+    return updateSlideInClassroom({ [field]: value === 'true' });
   }
 
   return { error: 'Invalid field' };

--- a/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
@@ -3,7 +3,7 @@ import { Table, Tag, Popconfirm } from 'antd';
 import { IconUserSearch, IconTrash } from '@tabler/icons-react';
 import { useState } from 'react';
 
-import { RequireRole, TableActionButtons, UserThumbnailView } from '~/components';
+import { TableActionButtons, UserThumbnailView } from '~/components';
 import { useGlobalFetcher } from '~/hooks';
 import { useCallout } from '@classmoji/ui-components';
 import { ActionTypes } from '~/constants';
@@ -13,8 +13,8 @@ interface Student {
   id: string;
   name: string | null;
   login: string | null;
-  email: string | null;
-  school_id: string | null;
+  email?: string | null;
+  school_id?: string | null;
   has_accepted_invite: boolean;
   _isInvite?: boolean;
   [key: string]: unknown;
@@ -24,9 +24,17 @@ interface StudentsTableProps {
   students: Student[];
   query: string;
   classroom?: Record<string, unknown>;
+  /**
+   * Whether the viewer owns this classroom, resolved server-side by the
+   * loader's membership. Everything the OWNER alone may see or do in this
+   * table hangs off it: the contact columns (which the loader does not even
+   * send to other staff), the row actions that post to the OWNER-only action,
+   * and the per-student detail page, whose own route is OWNER-gated.
+   */
+  isOwner: boolean;
 }
 
-const StudentsTable = ({ students, query }: StudentsTableProps) => {
+const StudentsTable = ({ students, query, isOwner }: StudentsTableProps) => {
   const { class: classSlug } = useParams();
   const { pathname } = useLocation();
   const navigate = useNavigate();
@@ -82,7 +90,14 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
       notify(ActionTypes.REMOVE_USER, 'Removing student...');
       fetcher!.submit(
         {
-          user: { id: student.id, login: student.login, name: student.name, email: student.email },
+          user: {
+            id: student.id,
+            login: student.login,
+            name: student.name,
+            // Only an OWNER reaches this path, and an OWNER's rows carry the
+            // email; the fallback keeps the payload well-formed regardless.
+            email: student.email ?? null,
+          },
         },
         {
           method: 'post',
@@ -92,6 +107,29 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
       );
     }
   };
+
+  // Contact columns are OWNER-only and are simply not built for anyone else —
+  // the underlying values are absent from the loader payload as well.
+  const contactColumns = isOwner
+    ? [
+        {
+          title: 'School ID',
+          dataIndex: 'school_id',
+          key: 'school_id',
+          width: 130,
+          render: (id: string | null) => (
+            <span className="font-mono text-sm text-gray-700">{id}</span>
+          ),
+        },
+        {
+          title: 'Email',
+          dataIndex: 'email',
+          key: 'email',
+          width: 240,
+          render: (email: string | null) => <span className="text-gray-700">{email}</span>,
+        },
+      ]
+    : [];
 
   const columns = [
     {
@@ -103,20 +141,7 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
         return <UserThumbnailView user={student} />;
       },
     },
-    {
-      title: 'School ID',
-      dataIndex: 'school_id',
-      key: 'school_id',
-      width: 130,
-      render: (id: string | null) => <span className="font-mono text-sm text-gray-700">{id}</span>,
-    },
-    {
-      title: 'Email',
-      dataIndex: 'email',
-      key: 'email',
-      width: 240,
-      render: (email: string | null) => <span className="text-gray-700">{email}</span>,
-    },
+    ...contactColumns,
     {
       title: 'Status',
       dataIndex: 'has_accepted_invite',
@@ -139,24 +164,28 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
       key: 'actions',
       width: 260,
       render: (_: unknown, student: Student) => {
+        // Every action in this column is OWNER-only: remove/revoke post to the
+        // OWNER-gated action, "View as" impersonates, and the detail page the
+        // View button opens is an OWNER-gated route. Other staff get a
+        // read-only row rather than controls that would be refused.
+        if (!isOwner) return null;
+
         // For invites, only show Remove action
         if (student._isInvite) {
           return (
-            <RequireRole roles={['OWNER']}>
-              <Popconfirm
-                title="Remove Invite"
-                description="Are you sure you want to remove this invite?"
-                onConfirm={() => removeStudent(student)}
-                okButtonProps={{ danger: true }}
-                okText="Remove"
-                cancelText="Cancel"
-              >
-                <div className="flex items-center gap-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 cursor-pointer">
-                  <IconTrash size={16} />
-                  <span>Remove</span>
-                </div>
-              </Popconfirm>
-            </RequireRole>
+            <Popconfirm
+              title="Remove Invite"
+              description="Are you sure you want to remove this invite?"
+              onConfirm={() => removeStudent(student)}
+              okButtonProps={{ danger: true }}
+              okText="Remove"
+              cancelText="Cancel"
+            >
+              <div className="flex items-center gap-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 cursor-pointer">
+                <IconTrash size={16} />
+                <span>Remove</span>
+              </div>
+            </Popconfirm>
           );
         }
 
@@ -168,35 +197,31 @@ const StudentsTable = ({ students, query }: StudentsTableProps) => {
               } else callout.show({ variant: 'error', title: 'Student has not accepted invite.' });
             }}
           >
-            <RequireRole roles={['OWNER']}>
-              <div
-                onClick={e => {
-                  e.stopPropagation();
-                  if (!impersonating) {
-                    handleImpersonate(student);
-                  }
-                }}
-                className={`flex items-center gap-1 whitespace-nowrap text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100 cursor-pointer ${impersonating ? 'opacity-50' : ''}`}
-              >
-                <IconUserSearch size={16} />
-                <span>View as</span>
+            <div
+              onClick={e => {
+                e.stopPropagation();
+                if (!impersonating) {
+                  handleImpersonate(student);
+                }
+              }}
+              className={`flex items-center gap-1 whitespace-nowrap text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100 cursor-pointer ${impersonating ? 'opacity-50' : ''}`}
+            >
+              <IconUserSearch size={16} />
+              <span>View as</span>
+            </div>
+            <Popconfirm
+              title="Remove Student"
+              description="Are you sure you want to remove this student? This action cannot be undone."
+              onConfirm={() => removeStudent(student)}
+              okButtonProps={{ danger: true }}
+              okText="Remove"
+              cancelText="Cancel"
+            >
+              <div className="flex items-center gap-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 cursor-pointer">
+                <IconTrash size={16} />
+                <span>Remove</span>
               </div>
-            </RequireRole>
-            <RequireRole roles={['OWNER']}>
-              <Popconfirm
-                title="Remove Student"
-                description="Are you sure you want to remove this student? This action cannot be undone."
-                onConfirm={() => removeStudent(student)}
-                okButtonProps={{ danger: true }}
-                okText="Remove"
-                cancelText="Cancel"
-              >
-                <div className="flex items-center gap-1 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 cursor-pointer">
-                  <IconTrash size={16} />
-                  <span>Remove</span>
-                </div>
-              </Popconfirm>
-            </RequireRole>
+            </Popconfirm>
           </TableActionButtons>
         );
       },

--- a/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
@@ -26,15 +26,21 @@ interface StudentsTableProps {
   classroom?: Record<string, unknown>;
   /**
    * Whether the viewer owns this classroom, resolved server-side by the
-   * loader's membership. Everything the OWNER alone may see or do in this
-   * table hangs off it: the contact columns (which the loader does not even
-   * send to other staff), the row actions that post to the OWNER-only action,
-   * and the per-student detail page, whose own route is OWNER-gated.
+   * loader's membership. This governs the FIELDS on show — the contact columns,
+   * which the loader does not even send to other staff.
    */
   isOwner: boolean;
+  /**
+   * Whether the viewer may mutate the roster FROM THIS PAGE. Also computed
+   * server-side, from the role AND the route prefix: the same loader serves the
+   * assistant prefix, which exports no action and has no nested detail route,
+   * so ownership alone is not enough to justify rendering a control. Everything
+   * that submits or navigates hangs off this rather than off `isOwner`.
+   */
+  canManage: boolean;
 }
 
-const StudentsTable = ({ students, query, isOwner }: StudentsTableProps) => {
+const StudentsTable = ({ students, query, isOwner, canManage }: StudentsTableProps) => {
   const { class: classSlug } = useParams();
   const { pathname } = useLocation();
   const navigate = useNavigate();
@@ -94,8 +100,9 @@ const StudentsTable = ({ students, query, isOwner }: StudentsTableProps) => {
             id: student.id,
             login: student.login,
             name: student.name,
-            // Only an OWNER reaches this path, and an OWNER's rows carry the
-            // email; the fallback keeps the payload well-formed regardless.
+            // Only a viewer with canManage reaches this path — necessarily an
+            // OWNER, whose rows carry the email; the fallback keeps the payload
+            // well-formed regardless.
             email: student.email ?? null,
           },
         },
@@ -164,11 +171,13 @@ const StudentsTable = ({ students, query, isOwner }: StudentsTableProps) => {
       key: 'actions',
       width: 260,
       render: (_: unknown, student: Student) => {
-        // Every action in this column is OWNER-only: remove/revoke post to the
-        // OWNER-gated action, "View as" impersonates, and the detail page the
-        // View button opens is an OWNER-gated route. Other staff get a
-        // read-only row rather than controls that would be refused.
-        if (!isOwner) return null;
+        // Every action in this column is OWNER-only AND admin-prefix-only:
+        // remove/revoke post to the OWNER-gated action with a relative action
+        // path, "View as" impersonates, and the detail page the View button
+        // opens is a nested OWNER-gated route. Under the assistant prefix none
+        // of those targets exist, so `canManage` — not `isOwner` — decides.
+        // Anyone else gets a read-only row rather than controls that would fail.
+        if (!canManage) return null;
 
         // For invites, only show Remove action
         if (student._isInvite) {

--- a/apps/webapp/app/routes/admin.$class.students/__tests__/roster.test.ts
+++ b/apps/webapp/app/routes/admin.$class.students/__tests__/roster.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for the students (roster) route.
+ *
+ * The policy this route implements has two halves that must not drift into
+ * one another:
+ *
+ *   READ  — the whole teaching team (OWNER/TEACHER/ASSISTANT) may see who is
+ *           in the class, but contact details (email, provider_email,
+ *           school_id) and the membership grade fields (letter_grade, comment)
+ *           are OWNER-only. The split happens in the LOADER, so the fields are
+ *           never serialized into the page for other staff — there is nothing
+ *           for the client to hide. The MCP roster resource applies the same
+ *           split; the two are meant to stay in step.
+ *   WRITE — removing a student and revoking an invite stay OWNER-only. The
+ *           action carries its own gate, so widening the read can never widen
+ *           the write. That is the case these tests pin hardest.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireClassroomTeachingTeam: vi.fn(),
+  requireClassroomAdmin: vi.fn(),
+  assertClassroomMutationAllowed: vi.fn(),
+  findUsersByRole: vi.fn(),
+  findInvitesByClassroomId: vi.fn(),
+  deleteInvite: vi.fn(),
+  taskTrigger: vi.fn(),
+  waitForRunCompletion: vi.fn(),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  requireClassroomTeachingTeam: (...a: unknown[]) => mocks.requireClassroomTeachingTeam(...a),
+  requireClassroomAdmin: (...a: unknown[]) => mocks.requireClassroomAdmin(...a),
+  assertClassroomMutationAllowed: (...a: unknown[]) => mocks.assertClassroomMutationAllowed(...a),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => mocks.findUsersByRole(...a) },
+    classroomInvite: {
+      findInvitesByClassroomId: (...a: unknown[]) => mocks.findInvitesByClassroomId(...a),
+      deleteInvite: (...a: unknown[]) => mocks.deleteInvite(...a),
+    },
+  },
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  tasks: { trigger: (...a: unknown[]) => mocks.taskTrigger(...a) },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  waitForRunCompletion: (...a: unknown[]) => mocks.waitForRunCompletion(...a),
+}));
+
+// Mirrors constants/actionTypes.ts — the `~/` specifiers are resolved by these
+// mock registrations, so every one the route imports needs an entry.
+vi.mock('~/constants', () => ({ ActionTypes: { REMOVE_USER: 'remove-user' } }));
+
+// The loader/action are what is under test; the view layer only needs to be
+// importable.
+vi.mock('../StudentsTable', () => ({ default: () => null }));
+vi.mock('~/components', () => ({ SearchInput: () => null }));
+vi.mock('antd', () => ({ Button: () => null }));
+vi.mock('@ant-design/icons', () => ({ PlusCircleOutlined: () => null }));
+
+const { loader, action } = await import('../route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+
+/** A roster row as the service returns it: the full User row + membership bits. */
+const STUDENT_ROW = {
+  id: 'student-1',
+  name: 'Ada Lovelace',
+  login: 'ada',
+  image: 'https://example.test/ada.png',
+  email: 'ada@school.test',
+  provider_email: 'ada@github.test',
+  school_id: 'F00123',
+  stripe_customer_id: 'cus_123',
+  banned: false,
+  ban_reason: null,
+  is_grader: false,
+  has_accepted_invite: true,
+  letter_grade: 'A-',
+  comment: 'strong on recursion',
+};
+
+const INVITE_ROW = {
+  id: 'invite-1',
+  student_name: 'Grace Hopper',
+  school_email: 'grace@school.test',
+  classroom_id: 'class-1',
+};
+
+const OWNER_ONLY_FIELDS = [
+  'email',
+  'provider_email',
+  'school_id',
+  'letter_grade',
+  'comment',
+] as const;
+
+const loaderArgs = () =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost/admin/${CLASS_SLUG}/students`),
+  }) as unknown as Parameters<typeof loader>[0];
+
+const actionArgs = (body: unknown, intent: string) =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost/admin/${CLASS_SLUG}/students?/${intent}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  }) as unknown as Parameters<typeof action>[0];
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.findUsersByRole.mockResolvedValue([STUDENT_ROW]);
+  mocks.findInvitesByClassroomId.mockResolvedValue([INVITE_ROW]);
+  mocks.taskTrigger.mockResolvedValue({ id: 'run-1' });
+  mocks.waitForRunCompletion.mockResolvedValue(undefined);
+  mocks.deleteInvite.mockResolvedValue(undefined);
+});
+
+function grantLoader(role: 'OWNER' | 'TEACHER' | 'ASSISTANT') {
+  mocks.requireClassroomTeachingTeam.mockResolvedValue({
+    userId: `${role.toLowerCase()}-1`,
+    classroom: CLASSROOM,
+    membership: { id: 'm-1', role },
+  });
+}
+
+// ─── Loader: the teaching team may read the roster ───────────────────────────
+
+describe('students loader — who may read the roster', () => {
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)(
+    'admits %s through the teaching-team gate',
+    async role => {
+      grantLoader(role);
+
+      const data = await loader(loaderArgs());
+
+      expect(mocks.requireClassroomTeachingTeam).toHaveBeenCalledWith(
+        expect.any(Request),
+        CLASS_SLUG,
+        { resourceType: 'STUDENT_ROSTER', action: 'view_roster' }
+      );
+      // The OWNER-only gate is not what guards the read.
+      expect(mocks.requireClassroomAdmin).not.toHaveBeenCalled();
+      expect(data.students).toHaveLength(1);
+      expect(data.students[0]).toMatchObject({ id: 'student-1', login: 'ada' });
+    }
+  );
+
+  it('reports ownership to the view so owner-only controls can be withheld', async () => {
+    grantLoader('ASSISTANT');
+    expect((await loader(loaderArgs())).isOwner).toBe(false);
+
+    grantLoader('OWNER');
+    expect((await loader(loaderArgs())).isOwner).toBe(true);
+  });
+});
+
+// ─── Loader: the OWNER-only field split ──────────────────────────────────────
+
+describe('students loader — field split', () => {
+  it('sends an OWNER the contact and grade fields', async () => {
+    grantLoader('OWNER');
+
+    const data = await loader(loaderArgs());
+
+    expect(data.students[0]).toMatchObject({
+      email: 'ada@school.test',
+      provider_email: 'ada@github.test',
+      school_id: 'F00123',
+      letter_grade: 'A-',
+      comment: 'strong on recursion',
+    });
+    expect(data.invitations[0]).toMatchObject({ school_email: 'grace@school.test' });
+  });
+
+  it.each([['TEACHER'], ['ASSISTANT']] as const)(
+    'omits the owner-only student fields entirely for %s',
+    async role => {
+      grantLoader(role);
+
+      const data = await loader(loaderArgs());
+      // Inspected as a bag of keys on purpose: the assertions below are about
+      // which keys EXIST, which the declared row type deliberately hides.
+      const student = data.students[0] as unknown as Record<string, unknown>;
+
+      // Identity and status still come through — the roster stays useful.
+      expect(student).toMatchObject({
+        id: 'student-1',
+        name: 'Ada Lovelace',
+        login: 'ada',
+        has_accepted_invite: true,
+      });
+      // The keys are ABSENT, not null: nothing to un-hide on the client.
+      for (const field of OWNER_ONLY_FIELDS) {
+        expect(field in student).toBe(false);
+      }
+      // The allowlist also keeps unrelated User columns off the wire.
+      expect('stripe_customer_id' in student).toBe(false);
+      expect('ban_reason' in student).toBe(false);
+
+      const serialized = JSON.stringify(data);
+      expect(serialized).not.toContain('ada@school.test');
+      expect(serialized).not.toContain('ada@github.test');
+      expect(serialized).not.toContain('F00123');
+      expect(serialized).not.toContain('strong on recursion');
+    }
+  );
+
+  it.each([['TEACHER'], ['ASSISTANT']] as const)(
+    "omits a pending invite's contact email for %s",
+    async role => {
+      grantLoader(role);
+
+      const data = await loader(loaderArgs());
+      const invite = data.invitations[0] as Record<string, unknown>;
+
+      expect(invite).toMatchObject({ id: 'invite-1', student_name: 'Grace Hopper' });
+      expect('school_email' in invite).toBe(false);
+      expect(JSON.stringify(data)).not.toContain('grace@school.test');
+    }
+  );
+});
+
+// ─── Action: mutations stay OWNER-only ───────────────────────────────────────
+
+describe('students action — mutations stay owner-only', () => {
+  it('guards every mutation with the OWNER gate, not the teaching-team gate', async () => {
+    mocks.requireClassroomAdmin.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: CLASSROOM,
+      membership: { id: 'm-1', role: 'OWNER' },
+    });
+
+    await action(actionArgs({ user: { id: 'student-1', login: 'ada' } }, 'removeStudent'));
+
+    expect(mocks.requireClassroomAdmin).toHaveBeenCalledWith(expect.any(Request), CLASS_SLUG, {
+      resourceType: 'STUDENT_ROSTER',
+      action: 'remove_student',
+    });
+    expect(mocks.requireClassroomTeachingTeam).not.toHaveBeenCalled();
+    expect(mocks.taskTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([['removeStudent'], ['revokeInvite']] as const)(
+    '%s is refused for non-OWNER staff, before any work happens',
+    async intent => {
+      // What requireClassroomAdmin does to a TEACHER/ASSISTANT: it throws.
+      mocks.requireClassroomAdmin.mockRejectedValue(new Response('Forbidden', { status: 403 }));
+
+      await expect(
+        action(actionArgs({ user: { id: 'student-1' }, inviteId: 'invite-1' }, intent))
+      ).rejects.toMatchObject({ status: 403 });
+
+      expect(mocks.taskTrigger).not.toHaveBeenCalled();
+      expect(mocks.deleteInvite).not.toHaveBeenCalled();
+    }
+  );
+
+  it('revokes an invite for an OWNER', async () => {
+    mocks.requireClassroomAdmin.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: CLASSROOM,
+      membership: { id: 'm-1', role: 'OWNER' },
+    });
+
+    const result = await action(actionArgs({ inviteId: 'invite-1' }, 'revokeInvite'));
+
+    expect(mocks.deleteInvite).toHaveBeenCalledWith('invite-1');
+    expect(result).toMatchObject({ action: 'REVOKE_INVITE' });
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.students/__tests__/roster.test.ts
+++ b/apps/webapp/app/routes/admin.$class.students/__tests__/roster.test.ts
@@ -102,10 +102,10 @@ const OWNER_ONLY_FIELDS = [
   'comment',
 ] as const;
 
-const loaderArgs = () =>
+const loaderArgs = (prefix: 'admin' | 'assistant' = 'admin') =>
   ({
     params: { class: CLASS_SLUG },
-    request: new Request(`http://localhost/admin/${CLASS_SLUG}/students`),
+    request: new Request(`http://localhost/${prefix}/${CLASS_SLUG}/students`),
   }) as unknown as Parameters<typeof loader>[0];
 
 const actionArgs = (body: unknown, intent: string) =>
@@ -157,12 +157,61 @@ describe('students loader — who may read the roster', () => {
     }
   );
 
-  it('reports ownership to the view so owner-only controls can be withheld', async () => {
+  it('reports ownership to the view so owner-only fields can be withheld', async () => {
     grantLoader('ASSISTANT');
     expect((await loader(loaderArgs())).isOwner).toBe(false);
 
     grantLoader('OWNER');
     expect((await loader(loaderArgs())).isOwner).toBe(true);
+  });
+
+  it('maps the stored image onto avatar_url, which the thumbnail reads', async () => {
+    // The User column is `image`; UserThumbnailView reads `avatar_url`. Without
+    // the mapping the roster rendered no avatars at all.
+    grantLoader('OWNER');
+
+    const student = (await loader(loaderArgs())).students[0];
+
+    expect(student.avatar_url).toBe('https://example.test/ada.png');
+  });
+});
+
+// ─── Loader: what may be DONE from this page, per prefix ─────────────────────
+
+/**
+ * `isOwner` answers "may this viewer see the owner-only fields". `canManage`
+ * answers a second, narrower question: "may this viewer act FROM THIS PAGE".
+ *
+ * They come apart because this loader also serves /assistant/:class/students,
+ * which exports no `action` and has no nested per-student route. An owner who
+ * hand-types that URL passes the role half and fails the prefix half — every
+ * control there submits or navigates relative to the current route, so
+ * rendering them would produce a 405 on submit and a 404 on View.
+ */
+describe('students loader — canManage follows the role AND the prefix', () => {
+  it('is true for an OWNER on the /admin prefix', async () => {
+    grantLoader('OWNER');
+
+    expect((await loader(loaderArgs('admin'))).canManage).toBe(true);
+  });
+
+  it('is false for an OWNER who arrived on the /assistant prefix', async () => {
+    grantLoader('OWNER');
+
+    const data = await loader(loaderArgs('assistant'));
+
+    // The fields still follow the role — only the controls follow the prefix.
+    expect(data.canManage).toBe(false);
+    expect(data.isOwner).toBe(true);
+    expect(data.students[0]).toMatchObject({ email: 'ada@school.test' });
+  });
+
+  it.each([['TEACHER'], ['ASSISTANT']] as const)('is false for %s on either prefix', async role => {
+    grantLoader(role);
+    expect((await loader(loaderArgs('admin'))).canManage).toBe(false);
+
+    grantLoader(role);
+    expect((await loader(loaderArgs('assistant'))).canManage).toBe(false);
   });
 });
 

--- a/apps/webapp/app/routes/admin.$class.students/__tests__/studentsTable.render.test.ts
+++ b/apps/webapp/app/routes/admin.$class.students/__tests__/studentsTable.render.test.ts
@@ -1,0 +1,266 @@
+/**
+ * REAL render tests for StudentsTable outside the plain OWNER-on-/admin shape.
+ *
+ * Why this file exists: until this branch the table only ever RENDERED for an
+ * owner with the full payload. The /admin layout's OWNER check is client-side
+ * (`RequireRole`) and its loader catches the thrown auth Response and degrades,
+ * so a non-owner reaching /admin/:class/students gets a 200 and an emptied
+ * shell — the table itself never drew. The assistant prefix changes that: it
+ * serves the same loader and the same component, so a TA now renders this table
+ * for real, and the loader STRIPS keys (email, provider_email, school_id,
+ * letter_grade, comment, school_email) from the payload rather than nulling
+ * them. Any column `render`, sorter or handler that touches an absent key would
+ * throw and blank the page for the whole teaching team.
+ *
+ * The table now takes TWO flags, and they are not the same question:
+ *   isOwner   — may this viewer see the contact columns.
+ *   canManage — may this viewer act from THIS page (owner AND /admin prefix).
+ * The third combination, isOwner=true with canManage=false, is what an owner
+ * gets if they hand-type the assistant URL, and it is covered below.
+ *
+ * apps/webapp has NO @testing-library/react (or /dom, or /jest-dom) — see
+ * package.json. Rather than fake a render, this mounts the component for real
+ * with `react-dom/server`, which executes every column `render` callback on
+ * every row exactly as the server render of the page does. Assertions run
+ * against the produced markup.
+ *
+ * Rows here are built to mirror the loader byte for byte: the non-OWNER rows
+ * OMIT the owner-only keys (they are not `null`), and the invite row is shaped
+ * the way the route component builds it from `invitations`.
+ */
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+// Real implementations, reached relatively because `~` is not aliased in
+// vitest.config.ts. These two are the whole view surface the table pulls from
+// the barrel, and UserThumbnailView is precisely the component fed a row that
+// no longer carries contact fields.
+vi.mock('~/components', async () => ({
+  TableActionButtons: (await import('../../../components/ui/buttons/TableActionButtons')).default,
+  UserThumbnailView: (await import('../../../components/features/profile/UserThumbnailView'))
+    .default,
+}));
+
+vi.mock('~/hooks', () => ({
+  useGlobalFetcher: () => ({ fetcher: { submit: vi.fn() }, notify: vi.fn() }),
+}));
+
+vi.mock('~/constants', () => ({ ActionTypes: { REMOVE_USER: 'remove-user' } }));
+
+vi.mock('@classmoji/ui-components', () => ({ useCallout: () => ({ show: vi.fn() }) }));
+
+vi.mock('@classmoji/auth/client', () => ({
+  authClient: { admin: { impersonateUser: vi.fn() } },
+}));
+
+const StudentsTable = (await import('../StudentsTable')).default;
+
+// ─── Row fixtures ───────────────────────────────────────────────────────────
+
+/**
+ * Exactly the keys the loader emits for a non-OWNER staff viewer. `image` is
+ * the User column; `avatar_url` is the alias UserThumbnailView actually reads,
+ * which the loader maps for it.
+ */
+const ASSISTANT_VISIBLE_ROW = {
+  id: 'student-1',
+  name: 'Ada Lovelace',
+  login: 'ada',
+  image: 'https://example.test/ada.png',
+  avatar_url: 'https://example.test/ada.png',
+  is_grader: false,
+  has_accepted_invite: true,
+};
+
+/** The same row as an OWNER receives it. */
+const OWNER_VISIBLE_ROW = {
+  ...ASSISTANT_VISIBLE_ROW,
+  email: 'ada@school.test',
+  provider_email: 'ada@github.test',
+  school_id: 'F00123',
+  letter_grade: 'A-',
+  comment: 'strong on recursion',
+};
+
+/** A student who never accepted — `login` is null, which the actions cell reads. */
+const PENDING_ROW = {
+  id: 'student-2',
+  name: 'Alan Turing',
+  login: null,
+  image: null,
+  avatar_url: null,
+  is_grader: false,
+  has_accepted_invite: false,
+};
+
+/**
+ * A pending invitation, shaped the way the route component builds it. For a
+ * non-OWNER `school_email` is absent from the loader payload, so `email` here
+ * is `undefined` — the case that would break any `.toLowerCase()` on it.
+ */
+const inviteRow = (schoolEmail?: string) => ({
+  id: 'invite-1',
+  name: 'Grace Hopper',
+  email: schoolEmail,
+  school_id: null,
+  login: 'pending-invite',
+  has_accepted_invite: false,
+  avatar_url: 'https://github.com/github.png?size=460',
+  _isInvite: true,
+});
+
+const render = (props: {
+  students: Record<string, unknown>[];
+  isOwner: boolean;
+  /** Defaults to isOwner — the /admin case, where the two flags agree. */
+  canManage?: boolean;
+  query?: string;
+}) =>
+  renderToStaticMarkup(
+    createElement(
+      MemoryRouter,
+      { initialEntries: ['/assistant/cs52-26f/students'] },
+      createElement(
+        Routes,
+        null,
+        createElement(Route, {
+          path: '/:role/:class/students',
+          element: createElement(StudentsTable, {
+            students: props.students as never,
+            classroom: { id: 'class-1' },
+            query: props.query ?? '',
+            isOwner: props.isOwner,
+            canManage: props.canManage ?? props.isOwner,
+          }),
+        })
+      )
+    )
+  );
+
+const OWNER_ONLY_VALUES = [
+  'ada@school.test',
+  'ada@github.test',
+  'F00123',
+  'strong on recursion',
+  'grace@school.test',
+];
+
+// ─── The branch that has never rendered before ──────────────────────────────
+
+describe('StudentsTable with isOwner=false (the assistant view)', () => {
+  const rows = [ASSISTANT_VISIBLE_ROW, PENDING_ROW, inviteRow()];
+
+  it('renders without throwing on rows whose owner-only keys are ABSENT', () => {
+    expect(() => render({ students: rows, isOwner: false })).not.toThrow();
+  });
+
+  it('still shows identity and status for every row', () => {
+    const html = render({ students: rows, isOwner: false });
+
+    expect(html).toContain('Ada Lovelace');
+    expect(html).toContain('@ada');
+    expect(html).toContain('Alan Turing');
+    expect(html).toContain('Grace Hopper');
+    expect(html).toContain('Active');
+    expect(html).toContain('Pending');
+  });
+
+  it('emits no contact or grade value anywhere in the markup', () => {
+    const html = render({ students: rows, isOwner: false });
+
+    for (const value of OWNER_ONLY_VALUES) {
+      expect(html).not.toContain(value);
+    }
+  });
+
+  it('builds no contact columns at all — not even the headers', () => {
+    const html = render({ students: rows, isOwner: false });
+
+    expect(html).not.toContain('School ID');
+    // 'Email' as a column header. The word appears nowhere else in this table.
+    expect(html).not.toContain('Email');
+  });
+
+  it('renders an empty actions cell — no remove, no view, no impersonation', () => {
+    const html = render({ students: rows, isOwner: false });
+
+    expect(html).not.toContain('View as');
+    expect(html).not.toContain('Remove');
+    expect(html).not.toContain('data-testid="table-action-view"');
+  });
+
+  it('renders the empty state without throwing when the roster is empty', () => {
+    expect(() => render({ students: [], isOwner: false })).not.toThrow();
+    expect(render({ students: [], isOwner: false })).toContain('No students enrolled yet');
+    expect(render({ students: [], isOwner: false, query: 'zzz' })).toContain('No students found');
+  });
+});
+
+// ─── The owner branch, so the assertions above are not vacuous ──────────────
+
+describe('StudentsTable with isOwner=true (the pre-existing view)', () => {
+  const rows = [OWNER_VISIBLE_ROW, PENDING_ROW, inviteRow('grace@school.test')];
+
+  it('renders without throwing', () => {
+    expect(() => render({ students: rows, isOwner: true })).not.toThrow();
+  });
+
+  it('does show the contact columns and their values', () => {
+    const html = render({ students: rows, isOwner: true });
+
+    expect(html).toContain('School ID');
+    expect(html).toContain('Email');
+    expect(html).toContain('ada@school.test');
+    expect(html).toContain('F00123');
+    expect(html).toContain('grace@school.test');
+  });
+
+  it('does show the owner-only row actions', () => {
+    const html = render({ students: rows, isOwner: true });
+
+    expect(html).toContain('View as');
+    expect(html).toContain('Remove');
+    expect(html).toContain('data-testid="table-action-view"');
+  });
+
+  it('renders the avatar the loader now supplies as avatar_url', () => {
+    // UserThumbnailView reads `avatar_url`; the User model calls the column
+    // `image`, so the loader maps it. Without the mapping no avatar drew at all.
+    const html = render({ students: rows, isOwner: true });
+
+    expect(html).toContain('https://example.test/ada.png');
+  });
+});
+
+// ─── An OWNER who arrived on the assistant prefix ───────────────────────────
+
+/**
+ * The combination the prefix split exists for. The same loader serves
+ * /assistant/:class/students, where the route exports no `action` and has no
+ * nested detail route — so an owner who hand-types that URL must see their
+ * fields but none of the controls, because every one of those controls resolves
+ * against the current prefix and would fail there.
+ */
+describe('StudentsTable with isOwner=true but canManage=false', () => {
+  const rows = [OWNER_VISIBLE_ROW, PENDING_ROW, inviteRow('grace@school.test')];
+  const html = () => render({ students: rows, isOwner: true, canManage: false });
+
+  it('renders without throwing', () => {
+    expect(() => html()).not.toThrow();
+  });
+
+  it('keeps the contact columns — those follow the role, not the prefix', () => {
+    expect(html()).toContain('School ID');
+    expect(html()).toContain('ada@school.test');
+    expect(html()).toContain('F00123');
+  });
+
+  it('renders no control that would post or navigate to a missing target', () => {
+    expect(html()).not.toContain('View as');
+    expect(html()).not.toContain('Remove');
+    expect(html()).not.toContain('data-testid="table-action-view"');
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.students/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/route.tsx
@@ -30,6 +30,8 @@ interface RosterStudent {
   name: string | null;
   login: string | null;
   image: string | null;
+  /** UserThumbnailView reads `avatar_url`; the User model calls it `image`. */
+  avatar_url: string | null;
   is_grader: boolean;
   has_accepted_invite: boolean;
   email?: string | null;
@@ -63,13 +65,27 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   // resource. Non-OWNER staff get identity + status only, and the split is done
   // HERE, server-side: the fields are never serialized into the page, so there
   // is nothing for the client to hide.
+  // `membership.role` is the caller's HIGHEST role in this classroom —
+  // assertClassroomAccess resolves it in privilege order, so an owner who also
+  // holds another role here still resolves as OWNER and keeps their own fields.
   const isOwner = membership?.role === 'OWNER';
+
+  // Whether the viewer may MUTATE the roster from this page, which takes the
+  // role AND the prefix they arrived on. This same loader serves
+  // /assistant/:class/students, where the route exports no `action` and no
+  // nested detail route exists — so an owner who hand-types that URL would
+  // otherwise be shown controls that post to a route with no action (405) and a
+  // View button pointing at a route that does not exist (404). Only the /admin
+  // prefix carries the mutations, so only it may render them.
+  const isAdminPrefix = new URL(request.url).pathname.startsWith('/admin/');
+  const canManage = isOwner && isAdminPrefix;
 
   const rosterStudents: RosterStudent[] = students.map(s => ({
     id: s.id,
     name: s.name,
     login: s.login,
     image: s.image,
+    avatar_url: s.image,
     is_grader: s.is_grader,
     has_accepted_invite: s.has_accepted_invite,
     ...(isOwner
@@ -91,11 +107,17 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     ...(isOwner ? { school_email: inv.school_email } : {}),
   }));
 
-  return { students: rosterStudents, classroom, invitations: rosterInvitations, isOwner };
+  return {
+    students: rosterStudents,
+    classroom,
+    invitations: rosterInvitations,
+    isOwner,
+    canManage,
+  };
 };
 
 const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
-  const { students, classroom, invitations, isOwner } = loaderData;
+  const { students, classroom, invitations, isOwner, canManage } = loaderData;
   const { class: classSlug } = useParams();
   const navigate = useNavigate();
   const [query, setQuery] = useState('');
@@ -115,16 +137,17 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
     return [...students, ...inviteList];
   }, [students, invitations]);
 
+  // Search over the fields the row actually carries. Name and login are always
+  // present; the contact fields exist only in an OWNER's payload, so they widen
+  // the search for an owner and are simply absent for other staff — which is
+  // why the placeholder promises name or login.
   const filteredStudents = !query
     ? allStudents
     : allStudents.filter(student => {
         const q = query.toLowerCase();
-        return (
-          student.name?.toLowerCase().includes(q) ||
-          student.login?.toLowerCase().includes(q) ||
-          student.email?.toLowerCase().includes(q) ||
-          (student as Record<string, unknown>).provider_email?.toString().toLowerCase().includes(q)
-        );
+        const row = student as Record<string, unknown>;
+        const haystack = [student.name, student.login, row.email, row.provider_email];
+        return haystack.some(field => typeof field === 'string' && field.toLowerCase().includes(q));
       });
 
   return (
@@ -143,7 +166,7 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
             />
           </span>
 
-          {isOwner && (
+          {canManage && (
             <Button
               icon={<PlusCircleOutlined />}
               onClick={() => navigate(`/admin/${classSlug}/students/add`)}
@@ -161,6 +184,7 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
         classroom={classroom}
         query={query}
         isOwner={isOwner}
+        canManage={canManage}
       />
     </div>
   );

--- a/apps/webapp/app/routes/admin.$class.students/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/route.tsx
@@ -10,14 +10,42 @@ import { ClassmojiService } from '@classmoji/services';
 import StudentsTable from './StudentsTable';
 import { ActionTypes } from '~/constants';
 import { waitForRunCompletion } from '~/utils/helpers';
-import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
-import { RequireRole, SearchInput } from '~/components';
+import {
+  requireClassroomAdmin,
+  requireClassroomTeachingTeam,
+  assertClassroomMutationAllowed,
+} from '~/utils/routeAuth.server';
+import { SearchInput } from '~/components';
 import type { Route } from './+types/route';
+
+/**
+ * A roster row as it leaves the loader.
+ *
+ * The contact and grade fields are OPTIONAL because they are only included for
+ * an OWNER (see the loader). Typing them as optional — rather than sending
+ * nulls — is what lets the payload omit the keys entirely for other staff.
+ */
+interface RosterStudent {
+  id: string;
+  name: string | null;
+  login: string | null;
+  image: string | null;
+  is_grader: boolean;
+  has_accepted_invite: boolean;
+  email?: string | null;
+  provider_email?: string | null;
+  school_id?: string | null;
+  letter_grade?: string | null;
+  comment?: string | null;
+}
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const classSlug = params.class!;
 
-  const { classroom } = await requireClassroomAdmin(request, classSlug, {
+  // Reading the roster is a teaching-team right: OWNER, TEACHER and ASSISTANT
+  // all need to know who is in the class. The MUTATIONS in this route stay
+  // OWNER-only and carry their own gate — see the action below.
+  const { classroom, membership } = await requireClassroomTeachingTeam(request, classSlug, {
     resourceType: 'STUDENT_ROSTER',
     action: 'view_roster',
   });
@@ -30,28 +58,60 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 
   const invitations = await ClassmojiService.classroomInvite.findInvitesByClassroomId(classroom.id);
 
-  return { students, classroom, invitations };
+  // Contact details (email, provider_email, school_id) and the membership grade
+  // fields (letter_grade, comment) are OWNER-only, matching the MCP roster
+  // resource. Non-OWNER staff get identity + status only, and the split is done
+  // HERE, server-side: the fields are never serialized into the page, so there
+  // is nothing for the client to hide.
+  const isOwner = membership?.role === 'OWNER';
+
+  const rosterStudents: RosterStudent[] = students.map(s => ({
+    id: s.id,
+    name: s.name,
+    login: s.login,
+    image: s.image,
+    is_grader: s.is_grader,
+    has_accepted_invite: s.has_accepted_invite,
+    ...(isOwner
+      ? {
+          email: s.email,
+          provider_email: s.provider_email,
+          school_id: s.school_id,
+          letter_grade: s.letter_grade,
+          comment: s.comment,
+        }
+      : {}),
+  }));
+
+  // Pending invites are shaped the same way: an invite's school_email is a
+  // contact field, so only an OWNER receives it.
+  const rosterInvitations = invitations.map(inv => ({
+    id: inv.id,
+    student_name: inv.student_name,
+    ...(isOwner ? { school_email: inv.school_email } : {}),
+  }));
+
+  return { students: rosterStudents, classroom, invitations: rosterInvitations, isOwner };
 };
 
 const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
-  const { students, classroom, invitations } = loaderData;
+  const { students, classroom, invitations, isOwner } = loaderData;
   const { class: classSlug } = useParams();
   const navigate = useNavigate();
   const [query, setQuery] = useState('');
   // Merge students and invitations into unified list
   const allStudents = useMemo(() => {
-    const inviteList = invitations.map(
-      (inv: { id: string; student_name: string; school_email: string }) => ({
-        id: inv.id,
-        name: inv.student_name,
-        email: inv.school_email,
-        school_id: null,
-        login: 'pending-invite',
-        has_accepted_invite: false,
-        avatar_url: 'https://github.com/github.png?size=460',
-        _isInvite: true,
-      })
-    );
+    const inviteList = invitations.map(inv => ({
+      id: inv.id,
+      name: inv.student_name,
+      // Present for an OWNER only — the loader omits it for other staff.
+      email: inv.school_email,
+      school_id: null,
+      login: 'pending-invite',
+      has_accepted_invite: false,
+      avatar_url: 'https://github.com/github.png?size=460',
+      _isInvite: true,
+    }));
     return [...students, ...inviteList];
   }, [students, invitations]);
 
@@ -83,7 +143,7 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
             />
           </span>
 
-          <RequireRole roles={['OWNER']}>
+          {isOwner && (
             <Button
               icon={<PlusCircleOutlined />}
               onClick={() => navigate(`/admin/${classSlug}/students/add`)}
@@ -92,11 +152,16 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
             >
               Add Students
             </Button>
-          </RequireRole>
+          )}
         </div>
       </div>
 
-      <StudentsTable students={filteredStudents} classroom={classroom} query={query} />
+      <StudentsTable
+        students={filteredStudents}
+        classroom={classroom}
+        query={query}
+        isOwner={isOwner}
+      />
     </div>
   );
 };
@@ -104,6 +169,9 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
 export const action = async ({ request, params }: Route.ActionArgs) => {
   const classSlug = params.class!;
 
+  // OWNER-only, deliberately narrower than the loader above: removing a student
+  // and revoking an invite are owner operations. This gate is the action's own —
+  // widening the roster read must never widen these.
   const { classroom, membership } = await requireClassroomAdmin(request, classSlug, {
     resourceType: 'STUDENT_ROSTER',
     action: 'remove_student',

--- a/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.teams.new/route.tsx
@@ -143,8 +143,10 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
         const { tagsFailed } = await ClassmojiService.teamAdmin.createTeam({
           classroomId: classroom.id,
           name,
-          // The form's "Secret" option finally has an effect: only "closed"
-          // (Visible) stores the team as visible to non-members.
+          // The form's choice is now carried through to Team.is_visible instead
+          // of being dropped — only "closed" (Visible) stores the team visible.
+          // The flag is recorded and echoed back, but no read path gates on it
+          // today, so the choice does not yet change who sees the team.
           isVisible: visibility === 'closed',
           tagIds: tags ?? [],
         });

--- a/apps/webapp/app/routes/assistant.$class_.slides/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.slides/route.tsx
@@ -1,2 +1,8 @@
-// Re-export from student route (already allows ASSISTANT in assertClassroomAccess)
+// Re-export from the student route, whose loader is role-aware: it allows the
+// whole teaching team in assertClassroomAccess and lists every deck — drafts
+// included, badged as such — for staff, while students get published decks
+// only. That keeps this list in step with the shared view gate, so a draft an
+// assistant may open by URL is also one they can find here. The list carries no
+// edit affordance for anyone; editing keeps its own creator/allow_team_edit
+// gate on the deck editor.
 export { loader, default } from '../student.$class.slides/route';

--- a/apps/webapp/app/routes/assistant.$class_.students/__tests__/route.test.ts
+++ b/apps/webapp/app/routes/assistant.$class_.students/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the roster under the ASSISTANT prefix.
+ *
+ * The admin roster loader already reads at the teaching-team tier, but until
+ * this route existed an assistant had no way to reach it: the /admin layout
+ * gates its outlet on OWNER, so the widened loader was unreachable in the
+ * product. This route is the reachable half, and it must widen the READ only:
+ *
+ *   READ  — the same loader, so the OWNER-only field split travels with it.
+ *   WRITE — absent. The route exports no `action`, so there is no POST target
+ *           under /assistant at all. That is what these tests pin hardest: a
+ *           future edit that re-exports the action would fail here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireClassroomTeachingTeam: vi.fn(),
+  requireClassroomAdmin: vi.fn(),
+  assertClassroomMutationAllowed: vi.fn(),
+  findUsersByRole: vi.fn(),
+  findInvitesByClassroomId: vi.fn(),
+  deleteInvite: vi.fn(),
+  taskTrigger: vi.fn(),
+  waitForRunCompletion: vi.fn(),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  requireClassroomTeachingTeam: (...a: unknown[]) => mocks.requireClassroomTeachingTeam(...a),
+  requireClassroomAdmin: (...a: unknown[]) => mocks.requireClassroomAdmin(...a),
+  assertClassroomMutationAllowed: (...a: unknown[]) => mocks.assertClassroomMutationAllowed(...a),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroomMembership: { findUsersByRole: (...a: unknown[]) => mocks.findUsersByRole(...a) },
+    classroomInvite: {
+      findInvitesByClassroomId: (...a: unknown[]) => mocks.findInvitesByClassroomId(...a),
+      deleteInvite: (...a: unknown[]) => mocks.deleteInvite(...a),
+    },
+  },
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  tasks: { trigger: (...a: unknown[]) => mocks.taskTrigger(...a) },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  waitForRunCompletion: (...a: unknown[]) => mocks.waitForRunCompletion(...a),
+}));
+
+vi.mock('~/constants', () => ({ ActionTypes: { REMOVE_USER: 'remove-user' } }));
+
+// The loader is what is under test; the view layer only needs to be importable.
+vi.mock('../../admin.$class.students/StudentsTable', () => ({ default: () => null }));
+vi.mock('~/components', () => ({ SearchInput: () => null }));
+vi.mock('antd', () => ({ Button: () => null }));
+vi.mock('@ant-design/icons', () => ({ PlusCircleOutlined: () => null }));
+
+const assistantRoute = await import('../route.tsx');
+const adminRoute = await import('../../admin.$class.students/route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+
+const STUDENT_ROW = {
+  id: 'student-1',
+  name: 'Ada Lovelace',
+  login: 'ada',
+  image: 'https://example.test/ada.png',
+  email: 'ada@school.test',
+  provider_email: 'ada@github.test',
+  school_id: 'F00123',
+  is_grader: false,
+  has_accepted_invite: true,
+  letter_grade: 'A-',
+  comment: 'strong on recursion',
+};
+
+const INVITE_ROW = {
+  id: 'invite-1',
+  student_name: 'Grace Hopper',
+  school_email: 'grace@school.test',
+  classroom_id: 'class-1',
+};
+
+const OWNER_ONLY_FIELDS = [
+  'email',
+  'provider_email',
+  'school_id',
+  'letter_grade',
+  'comment',
+] as const;
+
+const loaderArgs = () =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost/assistant/${CLASS_SLUG}/students`),
+  }) as unknown as Parameters<typeof assistantRoute.loader>[0];
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.findUsersByRole.mockResolvedValue([STUDENT_ROW]);
+  mocks.findInvitesByClassroomId.mockResolvedValue([INVITE_ROW]);
+  mocks.requireClassroomTeachingTeam.mockResolvedValue({
+    userId: 'assistant-1',
+    classroom: CLASSROOM,
+    membership: { id: 'm-1', role: 'ASSISTANT' },
+  });
+});
+
+// ─── The route is the admin route, reached under a different prefix ──────────
+
+describe('assistant students route — what it re-exports', () => {
+  it('serves the admin loader itself, so the field split cannot drift', () => {
+    expect(assistantRoute.loader).toBe(adminRoute.loader);
+  });
+
+  it('exports the admin component, not a copy', () => {
+    expect(assistantRoute.default).toBe(adminRoute.default);
+  });
+});
+
+// ─── The OWNER-only mutations are not reachable here ─────────────────────────
+
+describe('assistant students route — mutations are unreachable', () => {
+  it('exports no action, so the prefix has no POST target at all', () => {
+    expect('action' in assistantRoute).toBe(false);
+    expect((assistantRoute as Record<string, unknown>).action).toBeUndefined();
+  });
+
+  it('leaves the OWNER-only action behind on the admin route', () => {
+    // The mutations still exist — just not under this prefix.
+    expect(typeof adminRoute.action).toBe('function');
+  });
+});
+
+// ─── Reading the roster as an ASSISTANT ──────────────────────────────────────
+
+describe('assistant students route — loader payload', () => {
+  it('admits an ASSISTANT through the teaching-team gate', async () => {
+    const data = await assistantRoute.loader(loaderArgs());
+
+    expect(mocks.requireClassroomTeachingTeam).toHaveBeenCalledWith(
+      expect.any(Request),
+      CLASS_SLUG,
+      { resourceType: 'STUDENT_ROSTER', action: 'view_roster' }
+    );
+    expect(mocks.requireClassroomAdmin).not.toHaveBeenCalled();
+    expect(data.students).toHaveLength(1);
+    expect(data.students[0]).toMatchObject({ id: 'student-1', login: 'ada' });
+  });
+
+  it('withholds every owner-only field from the payload', async () => {
+    const data = await assistantRoute.loader(loaderArgs());
+    const student = data.students[0] as unknown as Record<string, unknown>;
+
+    // The keys are ABSENT, not null: nothing for the client to un-hide.
+    for (const field of OWNER_ONLY_FIELDS) {
+      expect(field in student).toBe(false);
+    }
+    expect('school_email' in (data.invitations[0] as Record<string, unknown>)).toBe(false);
+
+    const serialized = JSON.stringify(data);
+    expect(serialized).not.toContain('ada@school.test');
+    expect(serialized).not.toContain('ada@github.test');
+    expect(serialized).not.toContain('F00123');
+    expect(serialized).not.toContain('strong on recursion');
+    expect(serialized).not.toContain('grace@school.test');
+  });
+
+  it('reports isOwner false, which is what suppresses the owner-only UI', async () => {
+    // The add button, the contact columns and the whole actions cell hang off
+    // this one flag — see StudentsTable.
+    expect((await assistantRoute.loader(loaderArgs())).isOwner).toBe(false);
+  });
+});

--- a/apps/webapp/app/routes/assistant.$class_.students/__tests__/route.test.ts
+++ b/apps/webapp/app/routes/assistant.$class_.students/__tests__/route.test.ts
@@ -1,15 +1,21 @@
 /**
  * Unit tests for the roster under the ASSISTANT prefix.
  *
- * The admin roster loader already reads at the teaching-team tier, but until
- * this route existed an assistant had no way to reach it: the /admin layout
- * gates its outlet on OWNER, so the widened loader was unreachable in the
- * product. This route is the reachable half, and it must widen the READ only:
+ * The admin roster loader reads at the teaching-team tier, and it is reachable
+ * at BOTH prefixes. /admin's own OWNER check is not a server gate: the layout
+ * loader (routes/admin/route.tsx) CATCHES the thrown auth Response and degrades
+ * to an empty payload, and its `RequireRole` wrapper is client-side. So an
+ * assistant hitting /admin/:class/students gets a 200 from this loader and an
+ * emptied shell drawn around it. This route is the prefix where the same read
+ * is actually presented, and it must widen the READ only:
  *
  *   READ  — the same loader, so the OWNER-only field split travels with it.
  *   WRITE — absent. The route exports no `action`, so there is no POST target
  *           under /assistant at all. That is what these tests pin hardest: a
  *           future edit that re-exports the action would fail here.
+ *
+ * Because the loader is shared, it is also what tells the view which prefix it
+ * is on — see the `canManage` cases at the end.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -169,9 +175,41 @@ describe('assistant students route — loader payload', () => {
     expect(serialized).not.toContain('grace@school.test');
   });
 
-  it('reports isOwner false, which is what suppresses the owner-only UI', async () => {
-    // The add button, the contact columns and the whole actions cell hang off
-    // this one flag — see StudentsTable.
+  it('reports isOwner false, which is what withholds the owner-only fields', async () => {
+    // The contact columns hang off this flag — see StudentsTable.
     expect((await assistantRoute.loader(loaderArgs())).isOwner).toBe(false);
+  });
+
+  it('reports canManage false, which is what withholds every control', async () => {
+    // Separate from isOwner: this prefix has no action and no detail route, so
+    // nothing here may render a control regardless of who is looking.
+    expect((await assistantRoute.loader(loaderArgs())).canManage).toBe(false);
+  });
+});
+
+// ─── An OWNER who reaches this prefix ────────────────────────────────────────
+
+describe('assistant students route — an OWNER on this prefix', () => {
+  beforeEach(() => {
+    // Nothing stops an owner hand-typing /assistant/:class/students: the gate
+    // is the teaching-team one, which an owner naturally passes.
+    mocks.requireClassroomTeachingTeam.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: CLASSROOM,
+      membership: { id: 'm-1', role: 'OWNER' },
+    });
+  });
+
+  it('still receives the owner-only fields — those follow the role', async () => {
+    const data = await assistantRoute.loader(loaderArgs());
+
+    expect(data.isOwner).toBe(true);
+    expect(data.students[0]).toMatchObject({ email: 'ada@school.test' });
+  });
+
+  it('is refused the controls, because this prefix cannot service them', async () => {
+    // Both mutations post relative to the current route, which exports no
+    // action, and row "View" navigates to a nested route this prefix lacks.
+    expect((await assistantRoute.loader(loaderArgs())).canManage).toBe(false);
   });
 });

--- a/apps/webapp/app/routes/assistant.$class_.students/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.students/route.tsx
@@ -1,0 +1,10 @@
+// Re-export from the admin route, whose LOADER reads at the teaching-team tier
+// (requireClassroomTeachingTeam) and splits the payload server-side: contact
+// details and the membership grade fields are serialized for an OWNER only, so
+// an assistant's page never receives them.
+//
+// The `action` is deliberately NOT re-exported. Removing a student and revoking
+// an invite are OWNER-only, and a route with no action export has no POST target
+// at all — the mutations simply do not exist under the assistant prefix, rather
+// than existing and refusing. Do not add one.
+export { loader, default } from '../admin.$class.students/route';

--- a/apps/webapp/app/routes/student.$class.slides/__tests__/slides.test.ts
+++ b/apps/webapp/app/routes/student.$class.slides/__tests__/slides.test.ts
@@ -60,6 +60,11 @@ function whereClause() {
   return mocks.findMany.mock.calls[0][0].where as Record<string, unknown>;
 }
 
+/** The `select` the loader actually handed Prisma. */
+function selectClause() {
+  return mocks.findMany.mock.calls[0][0].select as Record<string, unknown>;
+}
+
 beforeEach(() => {
   for (const m of Object.values(mocks)) m.mockReset();
   mocks.findMany.mockResolvedValue([PUBLISHED_DECK, DRAFT_DECK]);
@@ -120,6 +125,43 @@ describe('slides loader — drafts follow the view tier', () => {
     await studentRoute.loader(loaderArgs('student'));
 
     expect(whereClause()).toEqual({ classroom_id: 'class-1', is_draft: false });
+  });
+});
+
+// ─── Only the columns the table renders leave the server ─────────────────────
+
+/**
+ * A Slide row carries multiplex_id and multiplex_secret. multiplex_id is a live
+ * capability — the slides socket server admits a follower on a matching share
+ * code — so it has no business riding along in a list payload. The loader
+ * therefore selects explicitly rather than returning the row.
+ */
+describe('slides loader — payload shape', () => {
+  it('selects only the fields the list renders', async () => {
+    grant('STUDENT');
+
+    await studentRoute.loader(loaderArgs('student'));
+
+    expect(selectClause()).toEqual({ id: true, title: true, is_draft: true });
+  });
+
+  it('never asks for the multiplex credentials', async () => {
+    grant('ASSISTANT');
+
+    await studentRoute.loader(loaderArgs('assistant'));
+
+    expect(selectClause()).not.toHaveProperty('multiplex_id');
+    expect(selectClause()).not.toHaveProperty('multiplex_secret');
+  });
+
+  it('selects the same narrow set for staff, who now also receive drafts', async () => {
+    // Drafts reaching more viewers is precisely why the row shape matters more
+    // than it used to.
+    grant('OWNER');
+
+    await studentRoute.loader(loaderArgs('assistant'));
+
+    expect(selectClause()).toEqual({ id: true, title: true, is_draft: true });
   });
 });
 

--- a/apps/webapp/app/routes/student.$class.slides/__tests__/slides.test.ts
+++ b/apps/webapp/app/routes/student.$class.slides/__tests__/slides.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the shared slides list (student route, re-exported by the
+ * assistant prefix).
+ *
+ * The list must follow the VIEW tier of the shared slide gate
+ * (assertSlideAccess): the teaching team may open a draft deck, so the list has
+ * to show it. Otherwise staff can reach a deck by URL that they cannot find —
+ * the same list/open mismatch that was fixed on the MCP side.
+ *
+ * Editing is a separate and narrower rule (creator or allow_team_edit) that
+ * lives on the deck editor. This list must never grow an edit affordance, so a
+ * draft an assistant may view but not edit stays view-only here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertClassroomAccess: vi.fn(),
+  findMany: vi.fn(),
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => mocks.assertClassroomAccess(...a),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({ slide: { findMany: (...a: unknown[]) => mocks.findMany(...a) } }),
+}));
+
+// The loader is what is under test; the view layer only needs to be importable.
+vi.mock('~/components', () => ({ TableActionButtons: () => null }));
+vi.mock('antd', () => ({ Table: () => null, Tag: () => null }));
+vi.mock('@tabler/icons-react', () => ({ IconEyeOff: () => null }));
+
+const studentRoute = await import('../route.tsx');
+const assistantRoute = await import('../../assistant.$class_.slides/route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+
+const PUBLISHED_DECK = { id: 'deck-1', title: 'Recursion', is_draft: false };
+const DRAFT_DECK = { id: 'deck-2', title: 'Work in progress', is_draft: true };
+
+const loaderArgs = (prefix: string) =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost/${prefix}/${CLASS_SLUG}/slides`),
+  }) as unknown as Parameters<typeof studentRoute.loader>[0];
+
+function grant(role: 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT') {
+  mocks.assertClassroomAccess.mockResolvedValue({
+    userId: `${role.toLowerCase()}-1`,
+    classroom: CLASSROOM,
+    membership: { id: 'm-1', role },
+  });
+}
+
+/** The `where` the loader actually handed Prisma. */
+function whereClause() {
+  return mocks.findMany.mock.calls[0][0].where as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.findMany.mockResolvedValue([PUBLISHED_DECK, DRAFT_DECK]);
+});
+
+// ─── Who is admitted at all ──────────────────────────────────────────────────
+
+describe('slides loader — access', () => {
+  it('reads at the classroom-member tier, staff and students alike', async () => {
+    grant('ASSISTANT');
+
+    await studentRoute.loader(loaderArgs('assistant'));
+
+    expect(mocks.assertClassroomAccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classroomSlug: CLASS_SLUG,
+        allowedRoles: ['STUDENT', 'OWNER', 'TEACHER', 'ASSISTANT'],
+        resourceType: 'SLIDES',
+        attemptedAction: 'view_slides',
+      })
+    );
+  });
+});
+
+// ─── Drafts are listed for staff and only for staff ──────────────────────────
+
+describe('slides loader — drafts follow the view tier', () => {
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)(
+    'lists drafts for %s by not filtering them out',
+    async role => {
+      grant(role);
+
+      const data = await studentRoute.loader(loaderArgs('assistant'));
+
+      // Asserted on the query, not the mocked rows: the filter is the policy.
+      expect(whereClause()).toEqual({ classroom_id: 'class-1' });
+      expect('is_draft' in whereClause()).toBe(false);
+      expect(data.slides).toContainEqual(DRAFT_DECK);
+    }
+  );
+
+  it('keeps a STUDENT on published decks only', async () => {
+    grant('STUDENT');
+
+    await studentRoute.loader(loaderArgs('student'));
+
+    expect(whereClause()).toEqual({ classroom_id: 'class-1', is_draft: false });
+  });
+
+  it('treats a viewer with no membership as a student, not as staff', async () => {
+    // Defensive: whatever admits a non-member must never widen the listing.
+    mocks.assertClassroomAccess.mockResolvedValue({
+      userId: null,
+      classroom: CLASSROOM,
+      membership: null,
+    });
+
+    await studentRoute.loader(loaderArgs('student'));
+
+    expect(whereClause()).toEqual({ classroom_id: 'class-1', is_draft: false });
+  });
+});
+
+// ─── The assistant prefix gets exactly this list, and no edit affordance ─────
+
+describe('assistant slides route', () => {
+  it('re-exports the shared loader, so the draft rule cannot drift', () => {
+    expect(assistantRoute.loader).toBe(studentRoute.loader);
+    expect(assistantRoute.default).toBe(studentRoute.default);
+  });
+
+  it('exports no action, so the list can mutate nothing', () => {
+    // Deck status/team-edit toggles live on the admin list; the deck editor
+    // keeps its own creator/allow_team_edit gate.
+    expect('action' in assistantRoute).toBe(false);
+    expect('action' in studentRoute).toBe(false);
+  });
+});

--- a/apps/webapp/app/routes/student.$class.slides/route.tsx
+++ b/apps/webapp/app/routes/student.$class.slides/route.tsx
@@ -22,6 +22,11 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   // deck by URL that they cannot find. Students stay on published decks only.
   // Editing is a separate, narrower rule and is not granted here: this list
   // offers no edit affordance to anyone.
+  //
+  // `membership.role` is the caller's HIGHEST role in this classroom
+  // (assertClassroomAccess resolves it in privilege order), so a TA who is also
+  // enrolled as a student is staff here — the same answer the slide gate gives
+  // them when they open one of these decks.
   const isStaff =
     membership?.role === 'OWNER' ||
     membership?.role === 'TEACHER' ||
@@ -32,6 +37,10 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
       classroom_id: classroom.id,
       ...(isStaff ? {} : { is_draft: false }),
     },
+    // Explicit: a Slide row carries multiplex_id / multiplex_secret, which are
+    // live presentation credentials rather than list data. Send only what the
+    // table below renders.
+    select: { id: true, title: true, is_draft: true },
     orderBy: { updated_at: 'desc' },
   });
 

--- a/apps/webapp/app/routes/student.$class.slides/route.tsx
+++ b/apps/webapp/app/routes/student.$class.slides/route.tsx
@@ -1,4 +1,5 @@
-import { Table } from 'antd';
+import { Table, Tag } from 'antd';
+import { IconEyeOff } from '@tabler/icons-react';
 import getPrisma from '@classmoji/database';
 import type { Route } from './+types/route';
 import { assertClassroomAccess } from '~/utils/helpers';
@@ -7,7 +8,7 @@ import { TableActionButtons } from '~/components';
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
   const { class: classSlug } = params;
 
-  const { classroom } = await assertClassroomAccess({
+  const { classroom, membership } = await assertClassroomAccess({
     request,
     classroomSlug: classSlug!,
     allowedRoles: ['STUDENT', 'OWNER', 'TEACHER', 'ASSISTANT'],
@@ -15,11 +16,21 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     attemptedAction: 'view_slides',
   });
 
-  // Get published slides for this classroom (exclude drafts for students)
+  // This route is shared: the assistant prefix re-exports it. Listing follows
+  // the VIEW tier of the shared slide gate (assertSlideAccess) — the teaching
+  // team may open a draft deck, so the list must show it, or staff can reach a
+  // deck by URL that they cannot find. Students stay on published decks only.
+  // Editing is a separate, narrower rule and is not granted here: this list
+  // offers no edit affordance to anyone.
+  const isStaff =
+    membership?.role === 'OWNER' ||
+    membership?.role === 'TEACHER' ||
+    membership?.role === 'ASSISTANT';
+
   const slides = await getPrisma().slide.findMany({
     where: {
       classroom_id: classroom.id,
-      is_draft: false, // Only show published slides to students
+      ...(isStaff ? {} : { is_draft: false }),
     },
     orderBy: { updated_at: 'desc' },
   });
@@ -39,14 +50,27 @@ export default function StudentSlides({ loaderData }: Route.ComponentProps) {
       title: 'Title',
       dataIndex: 'title',
       key: 'title',
-      render: (title: string) => <p className="font-medium">{title}</p>,
+      // Drafts only ever reach a staff viewer (the loader filters them out for
+      // students), so the badge marks the deck as a colleague's unpublished
+      // work — matching how the admin list labels the same state. It is a
+      // label, not a control: changing a deck's status stays on the admin page.
+      render: (title: string, record: { is_draft: boolean }) => (
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{title}</span>
+          {record.is_draft && (
+            <Tag color="default" className="flex items-center gap-1 w-fit m-0">
+              <IconEyeOff size={12} />
+              Draft
+            </Tag>
+          )}
+        </div>
+      ),
     },
     {
       title: 'Repository',
       dataIndex: 'repository',
       key: 'repository',
-      render: (repository: string | null) =>
-        repository || <span className="text-ink-4">—</span>,
+      render: (repository: string | null) => repository || <span className="text-ink-4">—</span>,
     },
     {
       title: 'Actions',

--- a/packages/auth/src/__tests__/classroomAccess.test.ts
+++ b/packages/auth/src/__tests__/classroomAccess.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for the role RESOLUTION inside `assertClassroomAccess` — the gate
+ * behind requireClassroomAdmin / requireClassroomStaff /
+ * requireClassroomTeachingTeam, and therefore behind nearly every webapp
+ * loader.
+ *
+ * ClassroomMembership is unique on (classroom_id, user_id, role), so one person
+ * routinely holds several roles in the same classroom: promoting a student to
+ * assistant ADDS a row rather than replacing one, and the primary dev identity
+ * holds OWNER, ASSISTANT and STUDENT at once. The underlying service lookup is
+ * an unordered `findFirst`, so asking it once for a set of roles hands back an
+ * arbitrary member of that set.
+ *
+ * That matters because callers do not merely pass or fail this gate — they read
+ * `membership.role` back out of it to decide what to SEND: the roster's
+ * owner-only contact fields, the slide list's drafts. An arbitrary role means
+ * an owner can lose their own columns, or a TA who is also enrolled can lose
+ * the drafts they are allowed to open.
+ *
+ * The gate therefore resolves the caller's HIGHEST role. These tests pin that,
+ * and pin that the role FILTER still bounds the answer — a route that admits
+ * only students must not start resolving the caller as an owner.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  findBySlug: vi.fn(),
+  findByClassroomAndUser: vi.fn(),
+  auditCreate: vi.fn(),
+  getClassroomForUI: vi.fn(),
+}));
+
+vi.mock('better-auth', () => ({
+  betterAuth: () => ({ api: { getSession: (...a: unknown[]) => mocks.getSession(...a) } }),
+}));
+vi.mock('better-auth/adapters/prisma', () => ({ prismaAdapter: () => ({}) }));
+vi.mock('better-auth/plugins', () => ({ admin: () => ({}), mcp: () => ({}) }));
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroom: {
+      findBySlug: (...a: unknown[]) => mocks.findBySlug(...a),
+      getClassroomForUI: (...a: unknown[]) => mocks.getClassroomForUI(...a),
+    },
+    classroomMembership: {
+      findByClassroomAndUser: (...a: unknown[]) => mocks.findByClassroomAndUser(...a),
+    },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+    githubUserToken: { getGitHubTokenForUser: vi.fn() },
+  },
+}));
+
+const { assertClassroomAccess, requireClassroomAdmin, requireClassroomTeachingTeam } =
+  await import('../server.ts');
+
+type Role = 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE', settings: {} };
+
+const request = () => new Request(`http://localhost/admin/${CLASS_SLUG}/students`);
+
+/**
+ * Sign the caller in holding `roles`. The gate probes one role per lookup, so
+ * the mock answers per requested role — the arbitrary ordering an unfiltered
+ * `findFirst` would impose is deliberately NOT modelled, because the gate must
+ * not depend on it.
+ */
+function signedInHolding(roles: Role[], userId = 'user-1') {
+  mocks.getSession.mockResolvedValue({ user: { id: userId, name: userId } });
+  mocks.findByClassroomAndUser.mockImplementation(
+    (_classroomId: unknown, _userId: unknown, requested: unknown) => {
+      const wanted = Array.isArray(requested) ? (requested as Role[]) : null;
+      const match = wanted ? wanted.find(role => roles.includes(role)) : roles[0];
+      return Promise.resolve(match ? { id: `m-${match}`, role: match } : null);
+    }
+  );
+}
+
+const accessAs = (allowedRoles: Role[]) =>
+  assertClassroomAccess({
+    request: request(),
+    classroomSlug: CLASS_SLUG,
+    allowedRoles,
+    resourceType: 'STUDENT_ROSTER',
+    attemptedAction: 'view_roster',
+  });
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.findBySlug.mockResolvedValue(CLASSROOM);
+  mocks.getClassroomForUI.mockImplementation((c: unknown) => c);
+  mocks.auditCreate.mockResolvedValue(undefined);
+});
+
+// ─── The single-role case is unchanged ───────────────────────────────────────
+
+describe('assertClassroomAccess — a caller holding one role', () => {
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)('resolves %s as itself', async role => {
+    signedInHolding([role]);
+
+    const result = await accessAs(['OWNER', 'TEACHER', 'ASSISTANT']);
+
+    expect(result.membership).toMatchObject({ role });
+  });
+
+  it('refuses a caller with no membership at all', async () => {
+    signedInHolding([]);
+
+    await expect(accessAs(['OWNER'])).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+// ─── Multi-role callers resolve to their highest role ────────────────────────
+
+describe('assertClassroomAccess — a caller holding several roles', () => {
+  it('resolves OWNER+STUDENT as OWNER', async () => {
+    signedInHolding(['OWNER', 'STUDENT']);
+
+    const result = await accessAs(['OWNER', 'TEACHER', 'ASSISTANT']);
+
+    expect(result.membership).toMatchObject({ role: 'OWNER' });
+  });
+
+  it('resolves ASSISTANT+STUDENT as ASSISTANT', async () => {
+    signedInHolding(['ASSISTANT', 'STUDENT']);
+
+    const result = await accessAs(['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT']);
+
+    expect(result.membership).toMatchObject({ role: 'ASSISTANT' });
+  });
+
+  it('resolves OWNER+ASSISTANT+STUDENT — the dev identity — as OWNER', async () => {
+    signedInHolding(['OWNER', 'ASSISTANT', 'STUDENT']);
+
+    const result = await accessAs(['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT']);
+
+    expect(result.membership).toMatchObject({ role: 'OWNER' });
+  });
+
+  it('is not swayed by the order the roles happen to exist in', async () => {
+    signedInHolding(['STUDENT', 'ASSISTANT', 'OWNER']);
+
+    const result = await accessAs(['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT']);
+
+    expect(result.membership).toMatchObject({ role: 'OWNER' });
+  });
+
+  it('probes each candidate role separately rather than in one filtered lookup', async () => {
+    // The mechanism, pinned: a single lookup over four roles is exactly the
+    // unordered query whose answer was arbitrary.
+    signedInHolding(['OWNER', 'STUDENT']);
+
+    await accessAs(['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT']);
+
+    for (const call of mocks.findByClassroomAndUser.mock.calls) {
+      expect(call[2]).toHaveLength(1);
+    }
+  });
+});
+
+// ─── The role filter still bounds the answer ─────────────────────────────────
+
+describe('assertClassroomAccess — the allowed-role filter still applies', () => {
+  it('resolves an OWNER+STUDENT as STUDENT on a student-only route', async () => {
+    // Highest-role-wins picks among the roles the ROUTE allows — it never
+    // reaches outside them.
+    signedInHolding(['OWNER', 'STUDENT']);
+
+    const result = await accessAs(['STUDENT']);
+
+    expect(result.membership).toMatchObject({ role: 'STUDENT' });
+  });
+
+  it('still refuses a STUDENT-only caller on an owner-only route', async () => {
+    signedInHolding(['STUDENT']);
+
+    await expect(accessAs(['OWNER'])).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+// ─── What this buys the routes that read membership.role back ────────────────
+
+describe('the gates the roster and slide-list routes actually call', () => {
+  it('requireClassroomAdmin admits an OWNER who is also a STUDENT', async () => {
+    signedInHolding(['OWNER', 'STUDENT']);
+
+    const result = await requireClassroomAdmin(request(), CLASS_SLUG);
+
+    expect(result.membership).toMatchObject({ role: 'OWNER' });
+  });
+
+  it('requireClassroomTeachingTeam reports OWNER for an OWNER who is also a STUDENT', async () => {
+    // This is what `isOwner` in the students loader hangs off: resolving the
+    // STUDENT row would strip an owner of their own columns and actions.
+    signedInHolding(['OWNER', 'STUDENT']);
+
+    const result = await requireClassroomTeachingTeam(request(), CLASS_SLUG);
+
+    expect(result.membership?.role).toBe('OWNER');
+  });
+
+  it('requireClassroomTeachingTeam reports ASSISTANT for a TA who is also enrolled', async () => {
+    // And this is what the slides list's `isStaff` hangs off — a TA enrolled as
+    // a student must still be shown the drafts they are allowed to open.
+    signedInHolding(['ASSISTANT', 'STUDENT']);
+
+    const result = await requireClassroomTeachingTeam(request(), CLASS_SLUG);
+
+    expect(result.membership?.role).toBe('ASSISTANT');
+  });
+});

--- a/packages/auth/src/__tests__/slideAccess.test.ts
+++ b/packages/auth/src/__tests__/slideAccess.test.ts
@@ -76,6 +76,25 @@ function signedInAs(role: Role | null, userId: string) {
   mocks.findByClassroomAndUser.mockResolvedValue(role ? { id: 'm-1', role } : null);
 }
 
+/**
+ * Sign the caller in holding SEVERAL roles at once.
+ *
+ * ClassroomMembership is unique on (classroom_id, user_id, role), so this is a
+ * routine shape: promoting a student to assistant adds a row rather than
+ * replacing one. The gate probes one role at a time, so the mock answers per
+ * requested role — which is exactly what makes the resolution deterministic.
+ */
+function signedInHolding(roles: Role[], userId: string) {
+  mocks.getSession.mockResolvedValue({ user: { id: userId, name: userId } });
+  mocks.findByClassroomAndUser.mockImplementation(
+    (_classroomId: unknown, _userId: unknown, requested: unknown) => {
+      const wanted = Array.isArray(requested) ? (requested as Role[]) : null;
+      const match = wanted ? wanted.find(role => roles.includes(role)) : roles[0];
+      return Promise.resolve(match ? { id: `m-${match}`, role: match } : null);
+    }
+  );
+}
+
 const accessTo = (slide: typeof DRAFT, accessType: 'view' | 'edit' | 'present' | 'speakerNotes') =>
   assertSlideAccess({ request: request(), slideId: SLIDE_ID, slide, accessType });
 
@@ -197,5 +216,150 @@ describe('view and edit are separate rules', () => {
     expect(result.canView).toBe(true);
     expect(result.accessGrantedVia).toBe('membership');
     expect(result.canEdit).toBe(false);
+  });
+});
+
+// ─── PRESENT and SPEAKER NOTES on a draft ────────────────────────────────────
+
+/**
+ * The two access types that were previously untested on a draft, which is why
+ * widening the draft view tier moved them without anyone noticing.
+ *
+ * PRESENT stays pinned to edit rights: reading a colleague's unfinished deck is
+ * expected, driving it in front of a class is not.
+ *
+ * SPEAKER NOTES follow staff-ness, not editability — `canViewSpeakerNotes` is
+ * `isStaff || (show_speaker_notes && canView)`. Since staff may now view a
+ * draft, an assistant gets the notes on a draft they cannot edit. That is the
+ * ACCEPTED policy (staff already get notes unconditionally on any deck they can
+ * view); these tests exist so a future change has to say so out loud.
+ */
+describe('draft deck — who may PRESENT', () => {
+  it.each([['OWNER'], ['TEACHER']] as const)('allows %s, who may also edit it', async role => {
+    signedInAs(role, 'staff-1');
+
+    const result = await accessTo(DRAFT, 'present');
+
+    expect(result.canPresent).toBe(true);
+  });
+
+  it('allows the ASSISTANT who created the deck', async () => {
+    signedInAs('ASSISTANT', CREATOR_ID);
+
+    expect((await accessTo(DRAFT, 'present')).canPresent).toBe(true);
+  });
+
+  it('allows any ASSISTANT once allow_team_edit is set', async () => {
+    signedInAs('ASSISTANT', 'ta-1');
+
+    expect((await accessTo({ ...DRAFT, allow_team_edit: true }, 'present')).canPresent).toBe(true);
+  });
+
+  it('still refuses an ASSISTANT who may VIEW the draft but not edit it', async () => {
+    // The pairing is the point: the same call would pass `view`.
+    signedInAs('ASSISTANT', 'ta-1');
+    expect((await accessTo(DRAFT, 'view')).canView).toBe(true);
+
+    signedInAs('ASSISTANT', 'ta-1');
+    await expect(accessTo(DRAFT, 'present')).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('refuses a STUDENT', async () => {
+    signedInAs('STUDENT', 'student-1');
+
+    await expect(accessTo(DRAFT, 'present')).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe('draft deck — who may read SPEAKER NOTES', () => {
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)(
+    'allows %s even with show_speaker_notes off',
+    async role => {
+      signedInAs(role, 'staff-1');
+
+      const result = await accessTo(DRAFT, 'speakerNotes');
+
+      expect(result.canViewSpeakerNotes).toBe(true);
+    }
+  );
+
+  it('allows an ASSISTANT on a draft they may view but NOT edit — accepted policy', async () => {
+    signedInAs('ASSISTANT', 'ta-1');
+
+    const result = await accessTo(DRAFT, 'speakerNotes');
+
+    expect(result.canViewSpeakerNotes).toBe(true);
+    expect(result.canEdit).toBe(false);
+  });
+
+  it('refuses a STUDENT, because notes ride on being able to view the deck', async () => {
+    // Even with the flag on: a student cannot view a draft, so there is nothing
+    // for show_speaker_notes to extend.
+    signedInAs('STUDENT', 'student-1');
+
+    await expect(
+      accessTo({ ...DRAFT, show_speaker_notes: true }, 'speakerNotes')
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('extends to a STUDENT on a PUBLISHED deck when show_speaker_notes is on', async () => {
+    // The flag governs non-staff viewers; this is the case it exists for.
+    signedInAs('STUDENT', 'student-1');
+
+    const result = await accessTo(
+      { ...DRAFT, is_draft: false, show_speaker_notes: true },
+      'speakerNotes'
+    );
+
+    expect(result.canViewSpeakerNotes).toBe(true);
+  });
+});
+
+// ─── Users holding more than one role in the same classroom ──────────────────
+
+/**
+ * ClassroomMembership is unique on (classroom_id, user_id, role), so holding
+ * several roles in one classroom is normal — adding an assistant does not
+ * remove their existing student row. The gate resolves the caller's HIGHEST
+ * role, so the staff half of a dual-role membership decides the outcome.
+ */
+describe('a user holding several roles in the classroom', () => {
+  it('treats OWNER+STUDENT as an OWNER on a draft', async () => {
+    signedInHolding(['OWNER', 'STUDENT'], 'prof-1');
+
+    const result = await accessTo(DRAFT, 'view');
+
+    expect(result.membership).toMatchObject({ role: 'OWNER' });
+    expect(result.canView).toBe(true);
+    expect(result.canEdit).toBe(true);
+  });
+
+  it('treats ASSISTANT+STUDENT as an ASSISTANT on a draft', async () => {
+    signedInHolding(['ASSISTANT', 'STUDENT'], 'ta-1');
+
+    const result = await accessTo(DRAFT, 'view');
+
+    expect(result.membership).toMatchObject({ role: 'ASSISTANT' });
+    expect(result.canView).toBe(true);
+    // Still not an editor — the wider VIEW tier is all the assistant half buys.
+    expect(result.canEdit).toBe(false);
+  });
+
+  it('does not let the STUDENT half deny a draft the staff half may read', async () => {
+    // The regression this pins: an unordered lookup could resolve the STUDENT
+    // row and refuse a deck the same person may open as staff.
+    signedInHolding(['ASSISTANT', 'STUDENT'], 'ta-1');
+    await expect(accessTo(DRAFT, 'view')).resolves.toMatchObject({ canView: true });
+
+    signedInHolding(['ASSISTANT', 'STUDENT'], 'ta-1');
+    await expect(accessTo(DRAFT, 'speakerNotes')).resolves.toMatchObject({
+      canViewSpeakerNotes: true,
+    });
+  });
+
+  it('resolves the same way whichever order the roles come back in', async () => {
+    signedInHolding(['STUDENT', 'ASSISTANT'], 'ta-1');
+
+    expect((await accessTo(DRAFT, 'view')).membership).toMatchObject({ role: 'ASSISTANT' });
   });
 });

--- a/packages/auth/src/__tests__/slideAccess.test.ts
+++ b/packages/auth/src/__tests__/slideAccess.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for `assertSlideAccess` — the shared slide gate behind every
+ * slides-app route and the webapp's deck links.
+ *
+ * The invariant under test is that VIEW and EDIT are two different rules for a
+ * DRAFT deck, and that only the view side is the wide one:
+ *
+ *   VIEW  — any member of the classroom's teaching team (OWNER, TEACHER,
+ *           ASSISTANT) may open a draft deck. Staff prepare course material
+ *           together, and the slides app's own list has always shown every
+ *           draft to all three roles; refusing to open what it lists was the
+ *           mismatch this gate now resolves.
+ *   EDIT  — unchanged and narrower: OWNER/TEACHER may edit any deck, an
+ *           ASSISTANT only decks they created or decks with allow_team_edit.
+ *
+ * The pairing matters more than either half: several cases below assert that
+ * the SAME assistant on the SAME draft passes 'view' and is refused 'edit'.
+ * If a future change collapses the two rules back together, they fail.
+ *
+ * A pre-fetched `slide` is passed so no Prisma lookup happens; better-auth and
+ * the services layer are mocked so the real decision logic runs.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  findByClassroomAndUser: vi.fn(),
+  auditCreate: vi.fn(),
+  getGitHubTokenForUser: vi.fn(),
+}));
+
+vi.mock('better-auth', () => ({
+  betterAuth: () => ({ api: { getSession: (...a: unknown[]) => mocks.getSession(...a) } }),
+}));
+vi.mock('better-auth/adapters/prisma', () => ({ prismaAdapter: () => ({}) }));
+vi.mock('better-auth/plugins', () => ({ admin: () => ({}), mcp: () => ({}) }));
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    classroomMembership: {
+      findByClassroomAndUser: (...a: unknown[]) => mocks.findByClassroomAndUser(...a),
+    },
+    audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
+    githubUserToken: {
+      getGitHubTokenForUser: (...a: unknown[]) => mocks.getGitHubTokenForUser(...a),
+    },
+  },
+}));
+
+const { assertSlideAccess } = await import('../server.ts');
+
+type Role = 'OWNER' | 'TEACHER' | 'ASSISTANT' | 'STUDENT';
+
+const SLIDE_ID = 'slide-1';
+const CREATOR_ID = 'creator-1';
+
+/** A private draft nobody but its creator may edit. */
+const DRAFT = {
+  id: SLIDE_ID,
+  classroom_id: 'class-1',
+  created_by: CREATOR_ID,
+  allow_team_edit: false,
+  is_draft: true,
+  is_public: false,
+  multiplex_id: null,
+  show_speaker_notes: false,
+};
+
+const request = () => new Request('http://localhost/slides/slide-1');
+
+/** Sign the caller in as `userId` holding `role` in the deck's classroom. */
+function signedInAs(role: Role | null, userId: string) {
+  mocks.getSession.mockResolvedValue({ user: { id: userId, name: userId } });
+  mocks.findByClassroomAndUser.mockResolvedValue(role ? { id: 'm-1', role } : null);
+}
+
+const accessTo = (slide: typeof DRAFT, accessType: 'view' | 'edit' | 'present' | 'speakerNotes') =>
+  assertSlideAccess({ request: request(), slideId: SLIDE_ID, slide, accessType });
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.getGitHubTokenForUser.mockResolvedValue(null);
+  mocks.auditCreate.mockResolvedValue(undefined);
+});
+
+// ─── VIEW: the whole teaching team ───────────────────────────────────────────
+
+describe('draft deck — who may VIEW', () => {
+  it.each([['OWNER'], ['TEACHER'], ['ASSISTANT']] as const)(
+    'admits %s, including one who did not create the deck',
+    async role => {
+      signedInAs(role, 'staff-1');
+
+      const result = await accessTo(DRAFT, 'view');
+
+      expect(result.canView).toBe(true);
+      expect(result.membership).toMatchObject({ role });
+      expect(mocks.auditCreate).not.toHaveBeenCalled();
+    }
+  );
+
+  it('refuses a STUDENT of the same classroom', async () => {
+    signedInAs('STUDENT', 'student-1');
+
+    await expect(accessTo(DRAFT, 'view')).rejects.toMatchObject({ status: 403 });
+    // The refusal is recorded, as for any denied member.
+    expect(mocks.auditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'ACCESS_DENIED', resource_type: 'SLIDE' })
+    );
+  });
+
+  it('refuses someone with no membership in the classroom', async () => {
+    signedInAs(null, 'outsider-1');
+
+    await expect(accessTo(DRAFT, 'view')).rejects.toMatchObject({ status: 403 });
+    // Nothing to audit for a non-member — there is no membership to attribute.
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an anonymous request', async () => {
+    mocks.getSession.mockResolvedValue(null);
+
+    await expect(accessTo(DRAFT, 'view')).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+// ─── EDIT: unchanged, and narrower ───────────────────────────────────────────
+
+describe('draft deck — who may EDIT', () => {
+  it('still refuses an ASSISTANT who is neither the creator nor covered by allow_team_edit', async () => {
+    signedInAs('ASSISTANT', 'ta-1');
+
+    await expect(accessTo(DRAFT, 'edit')).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('allows the ASSISTANT who created the deck', async () => {
+    signedInAs('ASSISTANT', CREATOR_ID);
+
+    const result = await accessTo(DRAFT, 'edit');
+
+    expect(result.canEdit).toBe(true);
+    expect(result.accessGrantedVia).toBe('ownership');
+  });
+
+  it('allows any ASSISTANT once allow_team_edit is set', async () => {
+    signedInAs('ASSISTANT', 'ta-1');
+
+    const result = await accessTo({ ...DRAFT, allow_team_edit: true }, 'edit');
+
+    expect(result.canEdit).toBe(true);
+    expect(result.accessGrantedVia).toBe('team_edit');
+  });
+
+  it.each([['OWNER'], ['TEACHER']] as const)('allows %s on any deck', async role => {
+    signedInAs(role, 'staff-1');
+
+    const result = await accessTo(DRAFT, 'edit');
+
+    expect(result.canEdit).toBe(true);
+    expect(result.accessGrantedVia).toBe('role');
+  });
+
+  it('refuses a STUDENT', async () => {
+    signedInAs('STUDENT', 'student-1');
+
+    await expect(accessTo(DRAFT, 'edit')).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+// ─── The split itself ────────────────────────────────────────────────────────
+
+describe('view and edit are separate rules', () => {
+  it('one assistant, one draft: may view it, may not edit it', async () => {
+    signedInAs('ASSISTANT', 'ta-1');
+    const viewed = await accessTo(DRAFT, 'view');
+
+    expect(viewed.canView).toBe(true);
+    expect(viewed.canEdit).toBe(false);
+
+    signedInAs('ASSISTANT', 'ta-1');
+    await expect(accessTo(DRAFT, 'edit')).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('reports the view as granted by role, not by ownership or team_edit', async () => {
+    signedInAs('ASSISTANT', 'ta-1');
+
+    expect((await accessTo(DRAFT, 'view')).accessGrantedVia).toBe('role');
+  });
+
+  it('leaves published decks alone: a student still views a published private deck', async () => {
+    signedInAs('STUDENT', 'student-1');
+
+    const result = await accessTo({ ...DRAFT, is_draft: false }, 'view');
+
+    expect(result.canView).toBe(true);
+    expect(result.accessGrantedVia).toBe('membership');
+    expect(result.canEdit).toBe(false);
+  });
+});

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -928,7 +928,8 @@ export function assertClassroomMutationAllowed(args: ClassroomStatusInput): void
  * Handles draft mode, public/private visibility, and team editing permissions.
  *
  * Visibility tiers (checked in order):
- * 1. Draft: Only visible to users who can edit (owner/teacher/assistant with team_edit)
+ * 1. Draft: Visible to the classroom's teaching team (OWNER/TEACHER/ASSISTANT).
+ *    VIEW is deliberately wider than EDIT here — see the draft branch below.
  * 2. Public: World-readable (no auth required)
  * 3. Private: Classroom members only
  *
@@ -992,20 +993,29 @@ export async function assertSlideAccess({
   const isMember = !!membership;
   const isCreator = userId && slide.created_by === userId;
 
-  // Compute edit permission (used for draft visibility and edit access)
+  // Compute edit permission (used for edit access)
   // Owner/Teacher can edit any slide
   // Assistant can edit their own OR slides with allow_team_edit
   const canEdit = isOwnerOrTeacher || (isAssistant && (isCreator || slide.allow_team_edit));
+
+  // The classroom's teaching team (staff): OWNER, TEACHER, ASSISTANT.
+  const isStaff = isOwnerOrTeacher || isAssistant;
 
   // Compute view permission based on visibility tier
   let canView = false;
   let accessGrantedVia: SlideAccessResult['accessGrantedVia'] = null;
 
   if (slide.is_draft) {
-    // DRAFT MODE: Only those who can edit can view
+    // DRAFT MODE: any teaching-team member of the classroom may VIEW the deck.
+    // View is deliberately wider than edit: staff can read a colleague's
+    // work-in-progress deck, while editing stays with the creator (or decks
+    // that opt in via allow_team_edit). Keep these two rules separate.
     if (canEdit) {
       canView = true;
       accessGrantedVia = isOwnerOrTeacher ? 'role' : isCreator ? 'ownership' : 'team_edit';
+    } else if (isStaff) {
+      canView = true;
+      accessGrantedVia = 'role';
     }
   } else if (slide.is_public) {
     // PUBLIC: Anyone can view
@@ -1029,7 +1039,6 @@ export async function assertSlideAccess({
   // Speaker notes permission:
   // - Staff (Owner/Teacher/Assistant) always have access
   // - If show_speaker_notes=true, extend to whoever can view
-  const isStaff = isOwnerOrTeacher || isAssistant;
   const canViewSpeakerNotes = isStaff || (slide.show_speaker_notes && canView);
 
   // Check requested access type
@@ -1066,7 +1075,8 @@ export async function assertSlideAccess({
     // Provide specific error messages
     let errorMessage = 'Access denied';
     if (accessType === 'view') {
-      if (slide.is_draft && !canEdit) {
+      if (slide.is_draft) {
+        // Reaching here means the viewer is not on the teaching team.
         errorMessage = 'This slide is still in draft mode';
       } else if (!slide.is_public && !isMember) {
         errorMessage = 'Not a member of this classroom';

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -140,6 +140,48 @@ interface ClassroomAccessResult {
   accessGrantedVia: 'role' | 'ownership' | null;
 }
 
+/** Privilege order for deterministic multi-role resolution (highest first). */
+const ROLE_PRIORITY: readonly Role[] = ['OWNER', 'TEACHER', 'ASSISTANT', 'STUDENT'];
+
+/**
+ * Resolve the CALLER's membership in a classroom, deterministically.
+ *
+ * ClassroomMembership is unique on (classroom_id, user_id, role), so one person
+ * can hold several roles in the same classroom — routinely so: adding an
+ * assistant does not remove an existing student row. The service's
+ * `findByClassroomAndUser` is an unordered `findFirst`, so a single lookup over
+ * several allowed roles hands back an arbitrary one of them. Callers here then
+ * read `membership.role` to decide what the caller may see or do, so an
+ * arbitrary pick means arbitrary policy.
+ *
+ * Resolve each candidate role separately, in privilege order, and return the
+ * caller's HIGHEST role: "may this caller do X" is monotone in privilege, so
+ * the highest role is the right answer for every gate. `roles = null` means any
+ * membership.
+ *
+ * This is the same idiom the MCP server uses (apps/mcp/src/authz/
+ * classroomContext.ts). It is deliberately NOT pushed down into
+ * `findByClassroomAndUser`, because that function is also used to look up
+ * ANOTHER user's membership in a specific role (e.g. reading a student's grade
+ * comment, or confirming that someone is an assistant), where "highest role"
+ * is the wrong answer.
+ */
+const resolveHighestMembership = async (
+  classroomId: string,
+  userId: string,
+  roles: Role[] | null
+): Promise<ClassroomMembershipRecord> => {
+  const candidates =
+    roles && roles.length > 0 ? ROLE_PRIORITY.filter(role => roles.includes(role)) : ROLE_PRIORITY;
+
+  const found = await Promise.all(
+    candidates.map(role =>
+      ClassmojiService.classroomMembership.findByClassroomAndUser(classroomId, userId, [role])
+    )
+  );
+  return found.find(Boolean) ?? null;
+};
+
 // In-memory cache for access tokens (process-local, no persistence, no security risk)
 // Replaces file-based cache to avoid plaintext secrets on disk
 const tokenCache = new Map<string, TokenCacheEntry>();
@@ -662,7 +704,12 @@ export const assertClassroomAccess = async ({
       ...selfAccessRoles,
     ]),
   ];
-  const membership = await ClassmojiService.classroomMembership.findByClassroomAndUser(
+  // The caller's HIGHEST role among those looked up — see
+  // resolveHighestMembership. Callers read `membership.role` to shape what they
+  // return (the roster's owner-only fields, the slides list's drafts), so the
+  // resolution has to be deterministic rather than whichever row Postgres
+  // happened to return first.
+  const membership = await resolveHighestMembership(
     classroom.id,
     authData.userId,
     rolesForLookup.length ? rolesForLookup : null
@@ -884,7 +931,6 @@ import {
   type ClassroomStatusInput,
 } from './predicates.ts';
 
-
 /**
  * Throws a 403 Response with a JSON body `{ error: ClassroomStatusError, message: string }`.
  * This intentionally diverges from the plain-text 403s used elsewhere in this module —
@@ -933,6 +979,20 @@ export function assertClassroomMutationAllowed(args: ClassroomStatusInput): void
  * 2. Public: World-readable (no auth required)
  * 3. Private: Classroom members only
  *
+ * The four access types do not move together, on purpose:
+ * - view          — the tier above.
+ * - edit          — OWNER/TEACHER on any deck; an ASSISTANT only on decks they
+ *                   created or decks with allow_team_edit.
+ * - present       — on a DRAFT this requires edit rights, so an assistant who
+ *                   may read a colleague's draft still cannot present it.
+ * - speakerNotes  — staff get notes on any deck they can view, unconditionally.
+ *                   Since staff may view drafts, that includes a draft they are
+ *                   NOT allowed to edit. This is intended: speaker notes are
+ *                   preparation material shared across the teaching team, and
+ *                   the same staff-wide rule already applies to every published
+ *                   deck. The show_speaker_notes flag governs non-staff
+ *                   viewers, not colleagues.
+ *
  * @param {Object} options
  * @param {Request} options.request - The request object
  * @param {string} options.slideId - Slide ID to check access for
@@ -978,12 +1038,11 @@ export async function assertSlideAccess({
   let membership: SlideAccessMembership | null = null;
   const userId = authData?.userId || null;
 
-  // Get membership if authenticated
+  // Get membership if authenticated. Resolved at the caller's HIGHEST role: a
+  // teaching-team member who is also enrolled as a student in the same
+  // classroom is, for this gate, staff.
   if (userId) {
-    membership = await ClassmojiService.classroomMembership.findByClassroomAndUser(
-      slide.classroom_id,
-      userId
-    );
+    membership = await resolveHighestMembership(slide.classroom_id, userId, null);
   }
 
   const role = membership?.role;
@@ -1033,12 +1092,20 @@ export async function assertSlideAccess({
   }
 
   // Present permission: Owner/Teacher/Assistant for non-draft slides they can view
-  // For draft slides, only those who can edit can present
+  // For draft slides, only those who can edit can present. Deliberately NOT
+  // widened alongside view: reading a colleague's unfinished deck is expected,
+  // driving it in front of a class is not.
   const canPresent = slide.is_draft ? canEdit : isOwnerOrTeacher || isAssistant;
 
   // Speaker notes permission:
   // - Staff (Owner/Teacher/Assistant) always have access
   // - If show_speaker_notes=true, extend to whoever can view
+  //
+  // Because staff can now view drafts, this grants notes on a draft a staff
+  // member cannot edit. That is the intended policy, not a side effect: notes
+  // are teaching-team preparation material, staff already get them on every
+  // deck they can view, and show_speaker_notes exists to govern students and
+  // the public rather than colleagues.
   const canViewSpeakerNotes = isStaff || (slide.show_speaker_notes && canView);
 
   // Check requested access type

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -2,7 +2,7 @@ import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { admin, mcp } from 'better-auth/plugins';
 import getPrisma from '@classmoji/database';
-import type { Role, ClassroomStatus } from '@prisma/client';
+import type { Role } from '@prisma/client';
 import { ClassmojiService } from '@classmoji/services';
 
 // The signing secret and the cookie prefix live in ./secret.ts so that modules

--- a/packages/services/src/classmoji/__tests__/user.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/user.service.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // findRepositoriesPerStudent builds two user.findMany queries. The isolation
 // invariant under test: the STUDENT query must scope by classroom_id, NOT slug.
-// Classroom.slug is unique only per git org (@@unique([git_org_id, slug])), so a
-// slug filter would match same-slug twin classrooms across DIFFERENT orgs and
-// leak another org's students + grades. We mock prisma and assert the where
-// clause the query is built with.
+// Classroom.slug is globally unique today (schema.prisma: `slug String @unique`),
+// but the id is the classroom's actual identity — scoping by it keeps the query
+// isolated by construction rather than by a property of another column. We mock
+// prisma and assert the where clause the query is built with.
 const findManyMock = vi.fn();
 
 vi.mock('@classmoji/database', () => ({

--- a/packages/services/src/classmoji/teamAdmin.service.ts
+++ b/packages/services/src/classmoji/teamAdmin.service.ts
@@ -349,13 +349,18 @@ const toSummary = (team: { id: string; name: string; slug: string; is_visible: b
  * provider team is deleted again and the call is refused, so no local row is
  * ever created on a slug that the pre-flight checks would have rejected.
  *
- * `isVisible` maps to Team.is_visible. It defaults to false (the schema
- * default, and what the "Secret" option in the web form has always meant — the
- * form's choice previously had no effect and every team was stored visible).
- * The field is currently WRITE-ONLY across the product: the webapp never reads
- * it, and the MCP team list shows a student their own teams and the teaching
- * team every team, without consulting the flag. Whether it should drive a read
- * path again is an open product question — hence the column stays.
+ * `isVisible` maps to Team.is_visible and defaults to false here, which is the
+ * schema default and what the "Secret" option in the web form has always meant.
+ * That default is this path's, not the product's: teams a student forms for
+ * themselves (team.createWithMembershipAndTag) and teams brought in by the
+ * GitHub Classroom import are both stored is_visible = true.
+ *
+ * No read path GATES on the flag anywhere in the product. Several places read
+ * it and echo it back — the MCP teams resource returns it on each row, and
+ * team_create reports it — but nothing filters or hides a team by it: the MCP
+ * team list shows a student their own teams and the teaching team every team,
+ * whatever the flag says. Whether it should drive a read path again is an open
+ * product question, which is why the column stays.
  *
  * Tags are attached individually and reported per tag: creating the team
  * succeeds even if some tags could not be attached.

--- a/packages/services/src/classmoji/teamAdmin.service.ts
+++ b/packages/services/src/classmoji/teamAdmin.service.ts
@@ -349,10 +349,13 @@ const toSummary = (team: { id: string; name: string; slug: string; is_visible: b
  * provider team is deleted again and the call is refused, so no local row is
  * ever created on a slug that the pre-flight checks would have rejected.
  *
- * `isVisible` maps to Team.is_visible, which decides whether students who are
- * not members can see the team. It defaults to false (the schema default, and
- * what the "Secret" option in the web form has always meant — the form's choice
- * previously had no effect and every team was stored visible).
+ * `isVisible` maps to Team.is_visible. It defaults to false (the schema
+ * default, and what the "Secret" option in the web form has always meant — the
+ * form's choice previously had no effect and every team was stored visible).
+ * The field is currently WRITE-ONLY across the product: the webapp never reads
+ * it, and the MCP team list shows a student their own teams and the teaching
+ * team every team, without consulting the flag. Whether it should drive a read
+ * path again is an open product question — hence the column stays.
  *
  * Tags are attached individually and reported per tag: creating the team
  * succeeds even if some tags could not be attached.

--- a/packages/services/src/classmoji/user.service.ts
+++ b/packages/services/src/classmoji/user.service.ts
@@ -168,11 +168,12 @@ export const findRepositoriesPerStudent = async (classroom: StudentRepositoryCla
   };
 
   // 1. find student repos
-  // Scope by classroom_id, NOT slug: Classroom.slug is unique only per git org
-  // (@@unique([git_org_id, slug])), so a slug filter matches same-slug twin
-  // classrooms across DIFFERENT orgs and would leak another org's students +
-  // grades (cross-org isolation break). The team query below already scopes by
-  // classroom_id — keep both consistent.
+  // Scope by classroom_id, NOT slug. Classroom.slug is GLOBALLY unique today
+  // (schema.prisma: `slug String @unique`), so a slug filter would no longer
+  // match twin classrooms in different orgs — but the id is the classroom's
+  // actual identity, and scoping by it keeps this query isolated by
+  // construction rather than by a property of another column. The team query
+  // below already scopes by classroom_id — keep both consistent.
   const studentWithRepos = await getPrisma().user.findMany({
     where: {
       classroom_memberships: {


### PR DESCRIPTION
## Summary

Aligns three access policies so the webapp and the MCP server agree on who can see what, following an audit of all 84 MCP tools. Two policies widen deliberately (owner-approved), one narrows, plus correctness fixes found in review.

### The policies

| Policy | Rule |
|---|---|
| **Draft slide decks** | **Viewing** is now any teaching-team member (owner/teacher/assistant). **Editing** is unchanged — deck creator or `allow_team_edit`. This also removes a contradiction inside the slides app itself, which already *listed* drafts to all staff while the gate refused to open them. |
| **Roster** | Readable by the teaching team on both surfaces. Contact and grade fields (email, provider email, school ID, letter grade, comment) remain owner-only. All roster **mutations** stay owner-only. |
| **Team list** | Students now see only teams they belong to, matching the webapp, which has no student-facing classroom-wide team list. |

Assistants get a students page of their own (`/assistant/:class/students`, re-exporting the admin route per the documented cross-role pattern) so the widened read is actually reachable, plus a nav entry. The assistant slides list now shows drafts with a Draft badge, so what's listed matches what can be opened.

### Correctness fixes from review

- **Slide settings action is now classroom-scoped.** It authorized against the classroom in the URL but updated by an id from the form body, so a staff member could change visibility flags on a deck outside their classroom. Now bound to `{ id, classroom_id }` with a count check.
- **Classroom roles resolve deterministically.** A user can hold several roles in one classroom (promoting an enrolled student to TA leaves the student row in place), and the lookup returned an arbitrary one. Access gates now resolve the caller's *highest* role (owner > teacher > assistant > student), so a TA who is also a student gets staff treatment consistently — previously they could be shown no drafts in a list while still being able to open one.
- **Student slides list sends only what it renders** (`id`, `title`, `is_draft`) instead of whole rows.
- **Owner-only controls follow the route prefix.** An owner on the assistant path no longer renders management buttons that post to a route with no action.
- Field-visibility and management permissions are separated, so contact columns and row actions are governed independently.
- Long-broken student avatars in the roster now render; roster search matches the fields actually present.
- Several stale comments corrected (classroom slug uniqueness, team visibility semantics, staff-tier docs, the `list_teams` tool description — which is the contract an agent reads).

### Tests

- `packages/auth`: 87 (+30) — the full four-access-type matrix on drafts per role, including `present` (still edit-only) and speaker notes
- `apps/webapp`: 311 (+31) — including real render tests of the students table for a non-owner, a branch that had never rendered in the product before
- `apps/mcp`: 479 (+5); `packages/services` unchanged from baseline

### Test steps

1. As an assistant: `/assistant/:class/students` lists the roster with no contact/grade columns and no row actions; the slides list shows drafts badged; opening a draft deck works, editing one you don't own still refuses.
2. As an owner: `/admin/:class/students` unchanged — contact columns, add, remove, revoke all present and working.
3. Over MCP: `list_slides` shows drafts to staff and not to students; `list_teams` as a student returns only their own teams.
4. Slide settings toggles on the admin slides page still work for decks in your own classroom.

### Follow-ups (not in this PR)

- Teachers have no route prefix in the webapp at all, so the widened reads are reachable for assistants and owners but not teachers.
- `Team.is_visible` is stored and echoed but no read path gates on it; the create form still offers Secret/Visible. Worth either wiring it into the tag-scoped join flow or dropping the control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
