### PR TITLE
fix(webapp): bind quiz-attempt lookups to the authorized quiz

### DIFF
--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
@@ -25,6 +25,7 @@ vi.mock('@classmoji/services', () => ({
     quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
     quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
   },
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 
 vi.mock('~/utils/helpers', () => ({
@@ -51,6 +52,11 @@ vi.mock('antd', () => ({
 }));
 
 const route = await import('../route.tsx');
+// The service's own "no such attempt" signal, taken from the mocked module so
+// the route's instanceof check sees the same class it does in production.
+const { QuizAttemptNotFoundError } = (await import('@classmoji/services')) as unknown as {
+  QuizAttemptNotFoundError: new (message?: string) => Error;
+};
 
 const CLASS_SLUG = 'cs52-26f';
 const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
@@ -137,12 +143,24 @@ describe('quiz attempt transcript loader — reads stay inside the authorized cl
 
     // `findWithMessages` throws rather than returning null when there is no
     // such attempt; both paths have to end at the same answer.
-    findWithMessagesMock.mockRejectedValue(new Error('Attempt not found'));
+    findWithMessagesMock.mockRejectedValue(new QuizAttemptNotFoundError('Attempt not found'));
     const missing = (await load('attempt-missing').catch(e => e)) as Response;
 
     expect(missing).toBeInstanceOf(Response);
     expect(missing.status).toBe(foreign.status);
     expect(await missing.text()).toBe(await foreign.text());
+  });
+
+  it('lets a query failure surface instead of reporting the attempt as absent', async () => {
+    // Only the service's "no such attempt" becomes a 404. A dropped connection
+    // read as one would tell staff the transcript does not exist, and log
+    // nothing that says otherwise.
+    findWithMessagesMock.mockRejectedValue(new Error('connection pool timeout'));
+
+    const thrown = (await load().catch(e => e)) as Error;
+
+    expect(thrown).not.toBeInstanceOf(Response);
+    expect(thrown.message).toBe('connection pool timeout');
   });
 
   it('refuses a quiz belonging to another classroom before it looks at the attempt', async () => {

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The instructor transcript view — reads stay inside the authorized classroom.
+ *
+ * The policy this loader implements is deliberately broad: staff read any of
+ * their students' attempts, with no ownership check. What makes that safe is
+ * the chain of bindings underneath it. `params.class` authorizes a classroom,
+ * step 2 holds the quiz against that classroom, and step 3 holds the attempt
+ * against that quiz — `quizAttempt.findWithMessages` resolves an attempt by id
+ * alone, so without the last link "any student's attempt" reaches every
+ * transcript in the database, other classrooms included.
+ *
+ * The route is re-exported unchanged at the /teacher and /assistant prefixes,
+ * so the same loader is what those roles get.
+ */
+
+const quizFindByIdMock = vi.fn();
+const findWithMessagesMock = vi.fn();
+const assertAccessMock = vi.fn();
+const assertProTierMock = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
+    quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => assertAccessMock(...a),
+  assertProTier: (...a: unknown[]) => assertProTierMock(...a),
+}));
+
+// The loader is what is under test; the view layer only needs to import.
+vi.mock('~/hooks', () => ({
+  useRouteDrawer: () => ({ opened: true }),
+  useDarkMode: () => ({ isDarkMode: false }),
+}));
+vi.mock('~/components', () => ({ QuizAttemptInterface: () => null }));
+vi.mock('react-router', () => ({
+  useLocation: () => ({ pathname: '/admin/cs52-26f/quizzes/quiz-1/attempt/attempt-1' }),
+  useNavigate: () => () => {},
+  useParams: () => ({}),
+}));
+vi.mock('antd', () => ({
+  Drawer: () => null,
+  ConfigProvider: () => null,
+  Modal: () => null,
+  theme: { darkAlgorithm: {}, defaultAlgorithm: {} },
+}));
+
+const route = await import('../route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+const QUIZ_ID = 'quiz-1';
+const QUIZ = { id: QUIZ_ID, name: 'Recursion', classroom_id: 'class-1' };
+
+/** A student's attempt on this classroom's quiz — the case staff must see. */
+const STUDENT_ATTEMPT = {
+  id: 'attempt-1',
+  quiz_id: QUIZ_ID,
+  user_id: 'student-1',
+  completed_at: new Date('2026-02-01'),
+  total_duration_ms: 1000,
+  unfocused_duration_ms: 250,
+  agent_config: { anthropic_api_key: 'sk-must-not-leak' },
+  user: { id: 'student-1', name: 'Ada Lovelace', login: 'ada' },
+  quiz: { id: QUIZ_ID, classroom: { id: 'class-1', settings: { anthropic_api_key: 'sk-nope' } } },
+};
+
+/** The same shape, but sat on a quiz in another classroom entirely. */
+const FOREIGN_ATTEMPT = {
+  ...STUDENT_ATTEMPT,
+  id: 'attempt-elsewhere',
+  quiz_id: 'quiz-elsewhere',
+  user_id: 'student-9',
+  quiz: { id: 'quiz-elsewhere', classroom: { id: 'class-2', settings: {} } },
+};
+
+const loaderArgs = (attemptId: string) =>
+  ({
+    params: { class: CLASS_SLUG, quizId: QUIZ_ID, attemptId },
+    request: new Request(
+      `http://localhost/admin/${CLASS_SLUG}/quizzes/${QUIZ_ID}/attempt/${attemptId}`
+    ),
+  }) as unknown as Parameters<typeof route.loader>[0];
+
+const load = (attemptId = 'attempt-1') => route.loader(loaderArgs(attemptId));
+
+describe('quiz attempt transcript loader — reads stay inside the authorized classroom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    assertAccessMock.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: CLASSROOM,
+      membership: { role: 'OWNER' },
+    });
+    assertProTierMock.mockResolvedValue(undefined);
+    quizFindByIdMock.mockResolvedValue(QUIZ);
+    findWithMessagesMock.mockResolvedValue({
+      attempt: STUDENT_ATTEMPT,
+      messages: [{ id: 'm1', role: 'assistant', content: 'Question 1' }],
+    });
+  });
+
+  it("serves a student's transcript to staff who never sat it", async () => {
+    // The policy: no ownership check. Staff read their students' attempts.
+    const data = await load();
+
+    expect(data.quiz).toEqual(QUIZ);
+    expect(data.attempt.id).toBe('attempt-1');
+    expect(data.studentName).toBe('Ada Lovelace');
+    expect(data.messages).toHaveLength(1);
+    expect(data.readOnly).toBe(true);
+    expect(data.focusMetrics).toEqual({ totalMs: 1000, focusedMs: 750, percentage: 75 });
+    // Nothing carrying a key reaches the browser.
+    expect(data.attempt).not.toHaveProperty('agent_config');
+    expect(data.attempt.quiz.classroom).toEqual({ id: 'class-1', settings: undefined });
+  });
+
+  it("refuses an attempt sat on another classroom's quiz", async () => {
+    findWithMessagesMock.mockResolvedValue({ attempt: FOREIGN_ATTEMPT, messages: [] });
+
+    const thrown = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown.status).toBe(404);
+    expect(await thrown.text()).toBe('Attempt not found');
+  });
+
+  it('answers an out-of-scope attempt id exactly as it answers one that names nothing', async () => {
+    findWithMessagesMock.mockResolvedValue({ attempt: FOREIGN_ATTEMPT, messages: [] });
+    const foreign = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    // `findWithMessages` throws rather than returning null when there is no
+    // such attempt; both paths have to end at the same answer.
+    findWithMessagesMock.mockRejectedValue(new Error('Attempt not found'));
+    const missing = (await load('attempt-missing').catch(e => e)) as Response;
+
+    expect(missing).toBeInstanceOf(Response);
+    expect(missing.status).toBe(foreign.status);
+    expect(await missing.text()).toBe(await foreign.text());
+  });
+
+  it('refuses a quiz belonging to another classroom before it looks at the attempt', async () => {
+    quizFindByIdMock.mockResolvedValue({ ...QUIZ, classroom_id: 'class-2' });
+
+    const thrown = (await load().catch(e => e)) as Response;
+
+    expect(thrown.status).toBe(404);
+    expect(await thrown.text()).toBe('Quiz not found');
+    expect(findWithMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it('reads nothing when the authorization gate throws', async () => {
+    assertAccessMock.mockRejectedValue(new Response('Forbidden', { status: 403 }));
+
+    await expect(load()).rejects.toBeInstanceOf(Response);
+    expect(quizFindByIdMock).not.toHaveBeenCalled();
+    expect(findWithMessagesMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/route.tsx
@@ -33,13 +33,21 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw new Response('Quiz not found', { status: 404 });
   }
 
-  // 3. Fetch attempt with messages
-  const attemptData = await ClassmojiService.quizAttempt.findWithMessages(attemptId);
-  if (!attemptData?.attempt) {
+  // 3. Fetch attempt with messages, bound to the quiz resolved above.
+  // `findWithMessages` resolves an attempt by id alone and throws when there is
+  // none, so both an id naming nothing and an id naming another quiz's attempt
+  // land on the same 404 — a foreign id tells the caller nothing.
+  const attemptData = await ClassmojiService.quizAttempt
+    .findWithMessages(attemptId)
+    .catch(() => null);
+  if (!attemptData?.attempt || attemptData.attempt.quiz_id.toString() !== quiz.id.toString()) {
     throw new Response('Attempt not found', { status: 404 });
   }
 
-  // 4. Admins can view any student's attempt (no ownership check needed)
+  // 4. Any attempt OF THIS QUIZ is readable here, whoever sat it: staff read
+  // their own students' transcripts, so there is no ownership check. Step 2
+  // binds the quiz to the authorized classroom and step 3 binds the attempt to
+  // that quiz, which is what keeps "any attempt" inside this classroom.
 
   // 5. Calculate focus metrics for completed attempts
   const totalMs = Number(attemptData.attempt.total_duration_ms || 0);

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.attempt.$attemptId/route.tsx
@@ -7,7 +7,7 @@ import { assertClassroomAccess, assertProTier } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { ClassmojiService } = await import('@classmoji/services');
+  const { ClassmojiService, QuizAttemptNotFoundError } = await import('@classmoji/services');
   const classSlug = params.class!;
   const quizId = params.quizId!;
   const attemptId = params.attemptId!;
@@ -36,10 +36,14 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   // 3. Fetch attempt with messages, bound to the quiz resolved above.
   // `findWithMessages` resolves an attempt by id alone and throws when there is
   // none, so both an id naming nothing and an id naming another quiz's attempt
-  // land on the same 404 — a foreign id tells the caller nothing.
+  // land on the same 404 — a foreign id tells the caller nothing. Only that
+  // one error becomes a 404; anything else the query raises still surfaces.
   const attemptData = await ClassmojiService.quizAttempt
     .findWithMessages(attemptId)
-    .catch(() => null);
+    .catch((error: unknown) => {
+      if (error instanceof QuizAttemptNotFoundError) return null;
+      throw error;
+    });
   if (!attemptData?.attempt || attemptData.attempt.quiz_id.toString() !== quiz.id.toString()) {
     throw new Response('Attempt not found', { status: 404 });
   }

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/__tests__/previewScope.test.ts
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/__tests__/previewScope.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The instructor quiz-preview view — reads stay inside the authorized classroom.
+ *
+ * Preview is stricter than the transcript view next door: staff preview as
+ * themselves, so the attempt has to be their own. That ownership check was
+ * already here, but it was the only thing holding the attempt down —
+ * `quizAttempt.findWithMessages` resolves by id alone, so an attempt sat on a
+ * quiz in some other classroom still rendered under this classroom's quiz.
+ *
+ * Order matters in the two checks: the quiz binding answers 404 first, so an id
+ * from elsewhere is never confirmed to exist by a 403.
+ */
+
+const quizFindByIdMock = vi.fn();
+const findWithMessagesMock = vi.fn();
+const assertAccessMock = vi.fn();
+const assertProTierMock = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
+    quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => assertAccessMock(...a),
+  assertProTier: (...a: unknown[]) => assertProTierMock(...a),
+}));
+
+// The loader is what is under test; the view layer only needs to import.
+vi.mock('~/hooks', () => ({
+  useRouteDrawer: () => ({ opened: true }),
+  useDarkMode: () => ({ isDarkMode: false }),
+}));
+vi.mock('~/components', () => ({ QuizAttemptInterface: () => null }));
+vi.mock('react-router', () => ({
+  useLocation: () => ({ pathname: '/admin/cs52-26f/quizzes/quiz-1/preview/attempt-1' }),
+  useNavigate: () => () => {},
+  useParams: () => ({}),
+}));
+vi.mock('antd', () => ({
+  Drawer: () => null,
+  ConfigProvider: () => null,
+  Modal: () => null,
+  theme: { darkAlgorithm: {}, defaultAlgorithm: {} },
+}));
+
+const route = await import('../route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+const QUIZ_ID = 'quiz-1';
+const QUIZ = { id: QUIZ_ID, name: 'Recursion', classroom_id: 'class-1' };
+
+/** The previewing instructor's own attempt on this classroom's quiz. */
+const OWN_ATTEMPT = {
+  id: 'attempt-1',
+  quiz_id: QUIZ_ID,
+  user_id: 'owner-1',
+  completed_at: null,
+  total_duration_ms: 0,
+  unfocused_duration_ms: 0,
+  agent_config: { instructorRepoName: 'demo-repo' },
+  user: { id: 'owner-1', name: 'Grace Hopper', login: 'grace' },
+  quiz: { id: QUIZ_ID, classroom: { id: 'class-1', settings: { anthropic_api_key: 'sk-nope' } } },
+};
+
+const loaderArgs = (attemptId: string) =>
+  ({
+    params: { class: CLASS_SLUG, quizId: QUIZ_ID, attemptId },
+    request: new Request(
+      `http://localhost/admin/${CLASS_SLUG}/quizzes/${QUIZ_ID}/preview/${attemptId}`
+    ),
+  }) as unknown as Parameters<typeof route.loader>[0];
+
+const load = (attemptId = 'attempt-1') => route.loader(loaderArgs(attemptId));
+
+describe('quiz preview loader — reads stay inside the authorized classroom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    assertAccessMock.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: CLASSROOM,
+      membership: { role: 'OWNER' },
+    });
+    assertProTierMock.mockResolvedValue(undefined);
+    quizFindByIdMock.mockResolvedValue(QUIZ);
+    findWithMessagesMock.mockResolvedValue({ attempt: OWN_ATTEMPT, messages: [] });
+  });
+
+  it("serves the instructor's own preview attempt on this quiz", async () => {
+    const data = await load();
+
+    expect(data.quiz).toEqual(QUIZ);
+    expect(data.attempt.id).toBe('attempt-1');
+    expect(data.readOnly).toBe(false);
+    expect(data.attempt).not.toHaveProperty('agent_config');
+    expect(data.attempt.quiz.classroom).toEqual({ id: 'class-1', settings: undefined });
+  });
+
+  it("refuses an attempt sat on another classroom's quiz, before checking whose it is", async () => {
+    // Owned by the caller, so ownership alone would have let it through — the
+    // quiz binding is what stops it, and it answers 404 rather than 403.
+    findWithMessagesMock.mockResolvedValue({
+      attempt: { ...OWN_ATTEMPT, id: 'attempt-elsewhere', quiz_id: 'quiz-elsewhere' },
+      messages: [],
+    });
+
+    const thrown = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown.status).toBe(404);
+    expect(await thrown.text()).toBe('Attempt not found');
+  });
+
+  it('answers an out-of-scope attempt id exactly as it answers one that names nothing', async () => {
+    findWithMessagesMock.mockResolvedValue({
+      attempt: { ...OWN_ATTEMPT, id: 'attempt-elsewhere', quiz_id: 'quiz-elsewhere' },
+      messages: [],
+    });
+    const foreign = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    // `findWithMessages` throws rather than returning null when there is no
+    // such attempt; both paths have to end at the same answer.
+    findWithMessagesMock.mockRejectedValue(new Error('Attempt not found'));
+    const missing = (await load('attempt-missing').catch(e => e)) as Response;
+
+    expect(missing).toBeInstanceOf(Response);
+    expect(missing.status).toBe(foreign.status);
+    expect(await missing.text()).toBe(await foreign.text());
+  });
+
+  it("keeps refusing another user's attempt on this same quiz", async () => {
+    // Preview is sat as yourself: a student's attempt on this quiz stays 403,
+    // which is what the transcript route next door is for.
+    findWithMessagesMock.mockResolvedValue({
+      attempt: { ...OWN_ATTEMPT, id: 'attempt-student', user_id: 'student-1' },
+      messages: [],
+    });
+
+    const thrown = (await load('attempt-student').catch(e => e)) as Response;
+
+    expect(thrown.status).toBe(403);
+  });
+
+  it('reads nothing when the authorization gate throws', async () => {
+    assertAccessMock.mockRejectedValue(new Response('Forbidden', { status: 403 }));
+
+    await expect(load()).rejects.toBeInstanceOf(Response);
+    expect(quizFindByIdMock).not.toHaveBeenCalled();
+    expect(findWithMessagesMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/__tests__/previewScope.test.ts
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/__tests__/previewScope.test.ts
@@ -23,6 +23,7 @@ vi.mock('@classmoji/services', () => ({
     quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
     quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
   },
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 
 vi.mock('~/utils/helpers', () => ({
@@ -49,6 +50,11 @@ vi.mock('antd', () => ({
 }));
 
 const route = await import('../route.tsx');
+// The service's own "no such attempt" signal, taken from the mocked module so
+// the route's instanceof check sees the same class it does in production.
+const { QuizAttemptNotFoundError } = (await import('@classmoji/services')) as unknown as {
+  QuizAttemptNotFoundError: new (message?: string) => Error;
+};
 
 const CLASS_SLUG = 'cs52-26f';
 const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
@@ -126,12 +132,23 @@ describe('quiz preview loader — reads stay inside the authorized classroom', (
 
     // `findWithMessages` throws rather than returning null when there is no
     // such attempt; both paths have to end at the same answer.
-    findWithMessagesMock.mockRejectedValue(new Error('Attempt not found'));
+    findWithMessagesMock.mockRejectedValue(new QuizAttemptNotFoundError('Attempt not found'));
     const missing = (await load('attempt-missing').catch(e => e)) as Response;
 
     expect(missing).toBeInstanceOf(Response);
     expect(missing.status).toBe(foreign.status);
     expect(await missing.text()).toBe(await foreign.text());
+  });
+
+  it('lets a query failure surface instead of reporting the attempt as absent', async () => {
+    // Only the service's "no such attempt" becomes a 404; a dropped connection
+    // keeps its error, and its log line.
+    findWithMessagesMock.mockRejectedValue(new Error('connection pool timeout'));
+
+    const thrown = (await load().catch(e => e)) as Error;
+
+    expect(thrown).not.toBeInstanceOf(Response);
+    expect(thrown.message).toBe('connection pool timeout');
   });
 
   it("keeps refusing another user's attempt on this same quiz", async () => {

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/route.tsx
@@ -29,9 +29,15 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw new Response('Quiz not found', { status: 404 });
   }
 
-  // 3. Fetch attempt with messages
-  const attemptData = await ClassmojiService.quizAttempt.findWithMessages(attemptId);
-  if (!attemptData?.attempt) {
+  // 3. Fetch attempt with messages, bound to the quiz resolved above.
+  // `findWithMessages` resolves an attempt by id alone and throws when there is
+  // none, so both an id naming nothing and an id naming another quiz's attempt
+  // land on the same 404 — checked before ownership, so a foreign id is never
+  // confirmed to exist.
+  const attemptData = await ClassmojiService.quizAttempt
+    .findWithMessages(attemptId)
+    .catch(() => null);
+  if (!attemptData?.attempt || attemptData.attempt.quiz_id.toString() !== quiz.id.toString()) {
     throw new Response('Attempt not found', { status: 404 });
   }
 

--- a/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.quizzes_.$quizId.preview.$attemptId/route.tsx
@@ -7,7 +7,7 @@ import { assertClassroomAccess, assertProTier } from '~/utils/helpers';
 import type { Route } from './+types/route';
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { ClassmojiService } = await import('@classmoji/services');
+  const { ClassmojiService, QuizAttemptNotFoundError } = await import('@classmoji/services');
   const classSlug = params.class!;
   const quizId = params.quizId!;
   const attemptId = params.attemptId!;
@@ -33,10 +33,14 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   // `findWithMessages` resolves an attempt by id alone and throws when there is
   // none, so both an id naming nothing and an id naming another quiz's attempt
   // land on the same 404 — checked before ownership, so a foreign id is never
-  // confirmed to exist.
+  // confirmed to exist. Only that one error becomes a 404; anything else the
+  // query raises still surfaces.
   const attemptData = await ClassmojiService.quizAttempt
     .findWithMessages(attemptId)
-    .catch(() => null);
+    .catch((error: unknown) => {
+      if (error instanceof QuizAttemptNotFoundError) return null;
+      throw error;
+    });
   if (!attemptData?.attempt || attemptData.attempt.quiz_id.toString() !== quiz.id.toString()) {
     throw new Response('Attempt not found', { status: 404 });
   }

--- a/apps/webapp/app/routes/api.quiz/__tests__/ai-gating.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/ai-gating.test.ts
@@ -42,6 +42,9 @@ vi.mock('@classmoji/services', () => ({
     classroom: { findById: vi.fn() },
     quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
   },
+  // The action destructures this alongside ClassmojiService to tell "no such
+  // attempt" apart from a query that failed for another reason.
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 vi.mock('../../student.$class.quizzes/helpers.server', () => ({
   getInstallationToken: vi.fn(),

--- a/apps/webapp/app/routes/api.quiz/__tests__/restartQuizScope.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/restartQuizScope.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * api.quiz restartQuiz — which session the restart is allowed to end.
+ *
+ * `restartQuiz` takes a quizId and an optional attemptId. The quizId resolves
+ * the classroom the caller is authorized against; the attemptId only names the
+ * ai-agent session to tear down before `createNew` opens a fresh attempt — and
+ * that fresh attempt always belongs to the caller.
+ *
+ * So the teardown target has to be the caller's own attempt on that same quiz.
+ * The gate admits students alongside staff, so without both halves of that
+ * binding a classroom member could name any attempt id in the database and end
+ * a stranger's in-progress quiz.
+ *
+ * An id that fails the binding is skipped rather than refused: an id naming a
+ * deleted attempt has always been tolerated here (the restart still proceeds),
+ * and answering a foreign id any differently would report whether it exists.
+ */
+
+const quizFindByIdMock = vi.fn();
+const attemptFindByIdMock = vi.fn();
+const createNewMock = vi.fn();
+const updateAgentConfigMock = vi.fn();
+
+const assertAccessMock = vi.fn();
+const assertProTierMock = vi.fn();
+const assertMutationMock = vi.fn();
+const getAuthSessionMock = vi.fn();
+const endQuizSessionMock = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
+    quizAttempt: {
+      findById: (...a: unknown[]) => attemptFindByIdMock(...a),
+      createNew: (...a: unknown[]) => createNewMock(...a),
+      updateAgentConfig: (...a: unknown[]) => updateAgentConfigMock(...a),
+      findWithMessages: vi.fn(),
+    },
+    aiConversation: { addMessage: vi.fn() },
+    audit: { create: vi.fn() },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => assertAccessMock(...a),
+  assertProTier: (...a: unknown[]) => assertProTierMock(...a),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  assertClassroomMutationAllowed: (...a: unknown[]) => assertMutationMock(...a),
+}));
+
+vi.mock('~/utils/aiFeatures.server', () => ({
+  isAIAgentConfigured: () => true,
+}));
+
+vi.mock('~/utils/backgroundTask.server', () => ({
+  runBackgroundTask: vi.fn(),
+}));
+
+vi.mock('../../student.$class.quizzes/helpers.server', () => ({
+  getInstallationToken: vi.fn(async () => 'install-token'),
+}));
+
+vi.mock('../../student.$class.quizzes/aiAgent.server', () => ({
+  initializeQuizViaAgent: vi.fn(),
+  sendMessageToAgent: vi.fn(),
+  endQuizSession: (...a: unknown[]) => endQuizSessionMock(...a),
+}));
+
+vi.mock('@classmoji/auth/server', () => ({
+  getAuthSession: (...a: unknown[]) => getAuthSessionMock(...a),
+}));
+
+const { action } = await import('../route.ts');
+
+const QUIZ_ID = 'quiz-1';
+const NEW_ATTEMPT = 'attempt-new';
+/** The caller's own in-progress attempt on QUIZ_ID. */
+const OWN_ATTEMPT = 'attempt-own';
+/** Another student's attempt, on another classroom's quiz. */
+const FOREIGN_ATTEMPT = 'attempt-foreign';
+/** The caller's own attempt, but on a different quiz. */
+const OWN_OTHER_QUIZ_ATTEMPT = 'attempt-own-other-quiz';
+/** A student's attempt on QUIZ_ID — a quiz its own staff administer. */
+const STUDENT_ATTEMPT = 'attempt-student';
+const MISSING_ATTEMPT = 'attempt-missing';
+
+const ATTEMPTS: Record<string, { id: string; quiz_id: string; user_id: string }> = {
+  [OWN_ATTEMPT]: { id: OWN_ATTEMPT, quiz_id: QUIZ_ID, user_id: 'student-1' },
+  [FOREIGN_ATTEMPT]: { id: FOREIGN_ATTEMPT, quiz_id: 'quiz-elsewhere', user_id: 'student-2' },
+  [OWN_OTHER_QUIZ_ATTEMPT]: {
+    id: OWN_OTHER_QUIZ_ATTEMPT,
+    quiz_id: 'quiz-elsewhere',
+    user_id: 'student-1',
+  },
+  [STUDENT_ATTEMPT]: { id: STUDENT_ATTEMPT, quiz_id: QUIZ_ID, user_id: 'student-1' },
+};
+
+const postRequest = (body: unknown) =>
+  new Request('http://localhost/api/quiz', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const restart = (attemptId?: string | null) =>
+  action({
+    request: postRequest({ _action: 'restartQuiz', quizId: QUIZ_ID, attemptId }),
+  } as unknown as Parameters<typeof action>[0]) as Promise<Response>;
+
+describe('api.quiz restartQuiz — writes stay inside the authorized classroom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    quizFindByIdMock.mockResolvedValue({
+      id: QUIZ_ID,
+      classroom_id: 'class-1',
+      classroom: { slug: 'test-class' },
+    });
+    attemptFindByIdMock.mockImplementation(async (id: string) => ATTEMPTS[id] ?? null);
+    createNewMock.mockResolvedValue({ success: true, attemptId: NEW_ATTEMPT });
+    updateAgentConfigMock.mockResolvedValue(undefined);
+
+    assertAccessMock.mockResolvedValue({
+      userId: 'student-1',
+      classroom: { status: 'ACTIVE', slug: 'test-class' },
+      membership: { role: 'STUDENT' },
+    });
+    assertProTierMock.mockResolvedValue(undefined);
+    assertMutationMock.mockReturnValue(undefined);
+    getAuthSessionMock.mockResolvedValue({ token: 'ghu_token', session: {} });
+  });
+
+  it("ends the caller's own session on this quiz, then opens the new attempt", async () => {
+    const response = await restart(OWN_ATTEMPT);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true, attemptId: NEW_ATTEMPT });
+    expect(endQuizSessionMock).toHaveBeenCalledWith(OWN_ATTEMPT);
+    expect(createNewMock).toHaveBeenCalledWith(QUIZ_ID, 'student-1', { role: 'STUDENT' });
+    // The teardown has to precede the new attempt, or the restart races itself.
+    expect(endQuizSessionMock.mock.invocationCallOrder[0]).toBeLessThan(
+      createNewMock.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("leaves another member's attempt running, and says nothing a missing id would not", async () => {
+    const foreign = await restart(FOREIGN_ATTEMPT);
+    const foreignBody = await foreign.json();
+
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    quizFindByIdMock.mockResolvedValue({ id: QUIZ_ID, classroom_id: 'class-1' });
+    attemptFindByIdMock.mockImplementation(async (id: string) => ATTEMPTS[id] ?? null);
+    createNewMock.mockResolvedValue({ success: true, attemptId: NEW_ATTEMPT });
+    getAuthSessionMock.mockResolvedValue({ token: 'ghu_token', session: {} });
+
+    const missing = await restart(MISSING_ATTEMPT);
+    const missingBody = await missing.json();
+
+    // Identical answers: an attempt id that exists but is out of scope is
+    // indistinguishable from one that names nothing at all.
+    expect(foreign.status).toBe(missing.status);
+    expect(foreignBody).toEqual(missingBody);
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the caller's own attempt on another quiz alone", async () => {
+    // Owning the attempt is not enough — the restart is of THIS quiz, so the
+    // session it ends must belong to this quiz too.
+    const response = await restart(OWN_OTHER_QUIZ_ATTEMPT);
+
+    expect(response.status).toBe(200);
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+    expect(createNewMock).toHaveBeenCalled();
+  });
+
+  it("staff do not end a student's session by naming it, even on their own quiz", async () => {
+    // Staff restarting means starting their own preview attempt; `createNew`
+    // opens it under the staff member, so ending the student's session would
+    // strand that student mid-quiz for nothing.
+    assertAccessMock.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: { status: 'ACTIVE', slug: 'test-class' },
+      membership: { role: 'OWNER' },
+    });
+
+    const response = await restart(STUDENT_ATTEMPT);
+
+    expect(response.status).toBe(200);
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+    expect(createNewMock).toHaveBeenCalledWith(QUIZ_ID, 'owner-1', { role: 'OWNER' });
+  });
+
+  it('ends the session when an admin drives it through impersonation', async () => {
+    // Same exemption the other attempt-bound branches carry for "View As".
+    assertAccessMock.mockResolvedValue({
+      userId: 'owner-1',
+      classroom: { status: 'ACTIVE', slug: 'test-class' },
+      membership: { role: 'OWNER' },
+    });
+    getAuthSessionMock.mockResolvedValue({
+      token: 'ghu_token',
+      session: { session: { impersonatedBy: 'owner-1' } },
+    });
+
+    await restart(STUDENT_ATTEMPT);
+
+    expect(endQuizSessionMock).toHaveBeenCalledWith(STUDENT_ATTEMPT);
+  });
+
+  it('restarts with no attemptId named at all — the plain student flow', async () => {
+    const response = await restart(null);
+
+    expect(response.status).toBe(200);
+    expect(attemptFindByIdMock).not.toHaveBeenCalled();
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+    expect(createNewMock).toHaveBeenCalledWith(QUIZ_ID, 'student-1', { role: 'STUDENT' });
+  });
+
+  it('resolves the named attempt before ending anything', async () => {
+    await restart(OWN_ATTEMPT);
+
+    expect(attemptFindByIdMock).toHaveBeenCalledWith(OWN_ATTEMPT);
+    expect(attemptFindByIdMock.mock.invocationCallOrder[0]).toBeLessThan(
+      endQuizSessionMock.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/apps/webapp/app/routes/api.quiz/__tests__/restartQuizScope.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/restartQuizScope.test.ts
@@ -41,6 +41,7 @@ vi.mock('@classmoji/services', () => ({
     aiConversation: { addMessage: vi.fn() },
     audit: { create: vi.fn() },
   },
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 
 vi.mock('~/utils/helpers', () => ({
@@ -84,8 +85,8 @@ const OWN_ATTEMPT = 'attempt-own';
 const FOREIGN_ATTEMPT = 'attempt-foreign';
 /** The caller's own attempt, but on a different quiz. */
 const OWN_OTHER_QUIZ_ATTEMPT = 'attempt-own-other-quiz';
-/** A student's attempt on QUIZ_ID — a quiz its own staff administer. */
-const STUDENT_ATTEMPT = 'attempt-student';
+/** Another member's in-progress attempt on QUIZ_ID: same quiz, different sitter. */
+const PEER_ATTEMPT = 'attempt-peer';
 const MISSING_ATTEMPT = 'attempt-missing';
 
 const ATTEMPTS: Record<string, { id: string; quiz_id: string; user_id: string }> = {
@@ -96,7 +97,7 @@ const ATTEMPTS: Record<string, { id: string; quiz_id: string; user_id: string }>
     quiz_id: 'quiz-elsewhere',
     user_id: 'student-1',
   },
-  [STUDENT_ATTEMPT]: { id: STUDENT_ATTEMPT, quiz_id: QUIZ_ID, user_id: 'student-1' },
+  [PEER_ATTEMPT]: { id: PEER_ATTEMPT, quiz_id: QUIZ_ID, user_id: 'student-2' },
 };
 
 const postRequest = (body: unknown) =>
@@ -169,6 +170,17 @@ describe('api.quiz restartQuiz — writes stay inside the authorized classroom',
     expect(endQuizSessionMock).not.toHaveBeenCalled();
   });
 
+  it("does not end a peer's session on the quiz the caller is restarting", async () => {
+    // The plain case the binding exists for: one classroom member naming
+    // another member's in-progress attempt on a quiz they can both reach.
+    const response = await restart(PEER_ATTEMPT);
+
+    expect(response.status).toBe(200);
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+    // The caller still gets their own restart; only the teardown is withheld.
+    expect(createNewMock).toHaveBeenCalledWith(QUIZ_ID, 'student-1', { role: 'STUDENT' });
+  });
+
   it("leaves the caller's own attempt on another quiz alone", async () => {
     // Owning the attempt is not enough — the restart is of THIS quiz, so the
     // session it ends must belong to this quiz too.
@@ -189,7 +201,7 @@ describe('api.quiz restartQuiz — writes stay inside the authorized classroom',
       membership: { role: 'OWNER' },
     });
 
-    const response = await restart(STUDENT_ATTEMPT);
+    const response = await restart(PEER_ATTEMPT);
 
     expect(response.status).toBe(200);
     expect(endQuizSessionMock).not.toHaveBeenCalled();
@@ -208,13 +220,26 @@ describe('api.quiz restartQuiz — writes stay inside the authorized classroom',
       session: { session: { impersonatedBy: 'owner-1' } },
     });
 
-    await restart(STUDENT_ATTEMPT);
+    await restart(PEER_ATTEMPT);
 
-    expect(endQuizSessionMock).toHaveBeenCalledWith(STUDENT_ATTEMPT);
+    expect(endQuizSessionMock).toHaveBeenCalledWith(PEER_ATTEMPT);
   });
 
   it('restarts with no attemptId named at all — the plain student flow', async () => {
     const response = await restart(null);
+
+    expect(response.status).toBe(200);
+    expect(attemptFindByIdMock).not.toHaveBeenCalled();
+    expect(endQuizSessionMock).not.toHaveBeenCalled();
+    expect(createNewMock).toHaveBeenCalledWith(QUIZ_ID, 'student-1', { role: 'STUDENT' });
+  });
+
+  it('treats an attemptId that is not a string as naming nothing', async () => {
+    // The column is text, so handing Prisma a number raises a validation error
+    // rather than simply missing. The type is checked before the query.
+    const response = (await action({
+      request: postRequest({ _action: 'restartQuiz', quizId: QUIZ_ID, attemptId: 123 }),
+    } as unknown as Parameters<typeof action>[0])) as Response;
 
     expect(response.status).toBe(200);
     expect(attemptFindByIdMock).not.toHaveBeenCalled();

--- a/apps/webapp/app/routes/api.quiz/__tests__/startQuiz.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/startQuiz.test.ts
@@ -47,6 +47,9 @@ vi.mock('@classmoji/services', () => ({
     gitRepo: { findByStudent: (...a: unknown[]) => gitRepoFindByStudentMock(...a) },
     aiConversation: { addMessage: (...a: unknown[]) => addMessageMock(...a) },
   },
+  // The action destructures this alongside ClassmojiService to tell "no such
+  // attempt" apart from a query that failed for another reason.
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 
 vi.mock('~/utils/helpers', () => ({

--- a/apps/webapp/app/routes/api.quiz/__tests__/startQuizScope.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/startQuizScope.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * api.quiz startQuiz — which attempt the resume path is allowed to open.
+ *
+ * `startQuiz` resolves its classroom from quizId, and every gate in front of
+ * the branch answers for THAT quiz's classroom: the membership and role check,
+ * the mutation check, the pro-tier check. The resume path then took attemptId
+ * and verified only that the caller owned it, so a caller's own attempt on a
+ * quiz in some other classroom could be driven under this classroom's gates —
+ * past a tier or status that the attempt's own classroom would have refused.
+ *
+ * Binding the attempt to quizId is what makes the gates and the session answer
+ * for the same classroom. Ownership still applies on top, and is still checked
+ * second, so an attempt from elsewhere reads as absent rather than forbidden.
+ */
+
+const quizFindByIdMock = vi.fn();
+const findWithMessagesMock = vi.fn();
+const createNewMock = vi.fn();
+
+const assertAccessMock = vi.fn();
+const assertProTierMock = vi.fn();
+const assertMutationMock = vi.fn();
+const getAuthSessionMock = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
+    quizAttempt: {
+      findById: vi.fn(),
+      findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a),
+      createNew: (...a: unknown[]) => createNewMock(...a),
+      updateAgentConfig: vi.fn(),
+      incrementQuestionsAsked: vi.fn(),
+    },
+    gitRepo: { findByStudent: vi.fn() },
+    aiConversation: { addMessage: vi.fn() },
+    audit: { create: vi.fn() },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => assertAccessMock(...a),
+  assertProTier: (...a: unknown[]) => assertProTierMock(...a),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  assertClassroomMutationAllowed: (...a: unknown[]) => assertMutationMock(...a),
+}));
+
+vi.mock('~/utils/aiFeatures.server', () => ({
+  isAIAgentConfigured: () => true,
+}));
+
+vi.mock('~/utils/backgroundTask.server', () => ({
+  runBackgroundTask: vi.fn(),
+}));
+
+vi.mock('../../student.$class.quizzes/helpers.server', () => ({
+  getInstallationToken: vi.fn(async () => 'install-token'),
+}));
+
+vi.mock('../../student.$class.quizzes/aiAgent.server', () => ({
+  initializeQuizViaAgent: vi.fn(),
+  sendMessageToAgent: vi.fn(),
+  endQuizSession: vi.fn(),
+}));
+
+vi.mock('@classmoji/auth/server', () => ({
+  getAuthSession: (...a: unknown[]) => getAuthSessionMock(...a),
+}));
+
+const { action } = await import('../route.ts');
+
+const QUIZ_ID = 'quiz-1';
+/** The caller's own attempt on QUIZ_ID — the resume the flow is built for. */
+const OWN_ATTEMPT = 'attempt-own';
+/** The caller's own attempt, but on a quiz in another classroom. */
+const OWN_ELSEWHERE_ATTEMPT = 'attempt-own-elsewhere';
+/** Another member's attempt on QUIZ_ID. */
+const PEER_ATTEMPT = 'attempt-peer';
+const MISSING_ATTEMPT = 'attempt-missing';
+
+const buildAttempt = (id: string, quizId: string, userId: string) => ({
+  id,
+  quiz_id: quizId,
+  user_id: userId,
+  quiz: {
+    id: quizId,
+    classroom_id: quizId === QUIZ_ID ? 'class-1' : 'class-2',
+    repository_id: null,
+    include_code_context: false,
+    classroom: { slug: 'test-class', settings: {}, git_organization: { login: 'test-org' } },
+  },
+});
+
+const ATTEMPTS: Record<string, ReturnType<typeof buildAttempt>> = {
+  [OWN_ATTEMPT]: buildAttempt(OWN_ATTEMPT, QUIZ_ID, 'student-1'),
+  [OWN_ELSEWHERE_ATTEMPT]: buildAttempt(OWN_ELSEWHERE_ATTEMPT, 'quiz-elsewhere', 'student-1'),
+  [PEER_ATTEMPT]: buildAttempt(PEER_ATTEMPT, QUIZ_ID, 'student-2'),
+};
+
+const postRequest = (body: unknown) =>
+  new Request('http://localhost/api/quiz', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const start = (attemptId?: string) =>
+  action({
+    request: postRequest({ _action: 'startQuiz', quizId: QUIZ_ID, attemptId }),
+  } as unknown as Parameters<typeof action>[0]) as Promise<Response>;
+
+describe('api.quiz startQuiz — writes stay inside the authorized classroom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    quizFindByIdMock.mockResolvedValue({
+      id: QUIZ_ID,
+      classroom_id: 'class-1',
+      classroom: { slug: 'test-class' },
+    });
+    // An attempt that already has messages: the action returns its id straight
+    // back, so these tests never reach the ai-agent seam.
+    findWithMessagesMock.mockImplementation(async (id: string) => {
+      const attempt = ATTEMPTS[id];
+      if (!attempt) throw new Error('Attempt not found');
+      return { attempt, messages: [{ id: 'm1', role: 'assistant', content: 'Question 1' }] };
+    });
+    createNewMock.mockResolvedValue({ success: true, attemptId: 'attempt-new' });
+
+    assertAccessMock.mockResolvedValue({
+      userId: 'student-1',
+      classroom: { status: 'ACTIVE', slug: 'test-class' },
+      membership: { role: 'STUDENT' },
+    });
+    assertProTierMock.mockResolvedValue(undefined);
+    assertMutationMock.mockReturnValue(undefined);
+    getAuthSessionMock.mockResolvedValue({ token: 'ghu_token', session: {} });
+  });
+
+  it("resumes the caller's own attempt on this quiz", async () => {
+    const response = await start(OWN_ATTEMPT);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ attemptId: OWN_ATTEMPT });
+    expect(createNewMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses the caller's own attempt on a quiz in another classroom", async () => {
+    // Ownership holds, so ownership alone would have opened it — the quiz
+    // binding is what keeps the session under the gates that were applied.
+    const response = await start(OWN_ELSEWHERE_ATTEMPT);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Attempt not found' });
+  });
+
+  it('answers an out-of-scope attempt id exactly as it answers one that names nothing', async () => {
+    const foreign = await start(OWN_ELSEWHERE_ATTEMPT);
+    const foreignBody = await foreign.json();
+
+    const missing = await start(MISSING_ATTEMPT);
+    const missingBody = await missing.json();
+
+    expect(missing.status).toBe(foreign.status);
+    expect(missingBody).toEqual(foreignBody);
+  });
+
+  it("keeps refusing another member's attempt on this same quiz", async () => {
+    const response = await start(PEER_ATTEMPT);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('creates a new attempt when none is named, leaving the resume path alone', async () => {
+    await start(undefined);
+
+    expect(createNewMock).toHaveBeenCalledWith(QUIZ_ID, 'student-1', { role: 'STUDENT' });
+  });
+});

--- a/apps/webapp/app/routes/api.quiz/__tests__/startQuizScope.test.ts
+++ b/apps/webapp/app/routes/api.quiz/__tests__/startQuizScope.test.ts
@@ -38,6 +38,7 @@ vi.mock('@classmoji/services', () => ({
     aiConversation: { addMessage: vi.fn() },
     audit: { create: vi.fn() },
   },
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 
 vi.mock('~/utils/helpers', () => ({
@@ -72,6 +73,11 @@ vi.mock('@classmoji/auth/server', () => ({
 }));
 
 const { action } = await import('../route.ts');
+// The service's own "no such attempt" signal, taken from the mocked module so
+// the action's instanceof check sees the same class it does in production.
+const { QuizAttemptNotFoundError } = (await import('@classmoji/services')) as unknown as {
+  QuizAttemptNotFoundError: new (message?: string) => Error;
+};
 
 const QUIZ_ID = 'quiz-1';
 /** The caller's own attempt on QUIZ_ID — the resume the flow is built for. */
@@ -126,7 +132,7 @@ describe('api.quiz startQuiz — writes stay inside the authorized classroom', (
     // back, so these tests never reach the ai-agent seam.
     findWithMessagesMock.mockImplementation(async (id: string) => {
       const attempt = ATTEMPTS[id];
-      if (!attempt) throw new Error('Attempt not found');
+      if (!attempt) throw new QuizAttemptNotFoundError('Attempt not found');
       return { attempt, messages: [{ id: 'm1', role: 'assistant', content: 'Question 1' }] };
     });
     createNewMock.mockResolvedValue({ success: true, attemptId: 'attempt-new' });
@@ -174,6 +180,17 @@ describe('api.quiz startQuiz — writes stay inside the authorized classroom', (
 
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('lets a query failure surface instead of reporting the attempt as absent', async () => {
+    // Only the service's "no such attempt" becomes a 404; a dropped connection
+    // keeps its 500, so a student mid-quiz is not told their attempt is gone.
+    findWithMessagesMock.mockRejectedValue(new Error('connection pool timeout'));
+
+    const response = await start(OWN_ATTEMPT);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'connection pool timeout' });
   });
 
   it('creates a new attempt when none is named, leaving the resume path alone', async () => {

--- a/apps/webapp/app/routes/api.quiz/route.ts
+++ b/apps/webapp/app/routes/api.quiz/route.ts
@@ -61,7 +61,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   // Import server-only repositories
-  const { ClassmojiService } = await import('@classmoji/services');
+  const { ClassmojiService, QuizAttemptNotFoundError } = await import('@classmoji/services');
   const { getInstallationToken } = await import('../student.$class.quizzes/helpers.server');
   const { initializeQuizViaAgent, sendMessageToAgent, endQuizSession } =
     await import('../student.$class.quizzes/aiAgent.server');
@@ -162,10 +162,13 @@ export async function action({ request }: Route.ActionArgs) {
           // `attemptId` names the session to tear down and nothing else — the
           // attempt this branch creates always belongs to the caller. Resolve it
           // here so the branch below can hold it against this quiz and this
-          // caller before ending anything.
-          const attempt = data.attemptId
-            ? await ClassmojiService.quizAttempt.findById(data.attemptId)
-            : null;
+          // caller before ending anything. Anything that is not a string names
+          // no attempt: the column is text, and handing Prisma a number raises
+          // a validation error rather than simply missing.
+          const attempt =
+            typeof data.attemptId === 'string' && data.attemptId
+              ? await ClassmojiService.quizAttempt.findById(data.attemptId)
+              : null;
 
           return {
             context: {
@@ -316,10 +319,14 @@ export async function action({ request }: Route.ActionArgs) {
             // the pro-tier check all answer for THAT quiz's classroom, so an
             // attempt on any other one would run under gates that never
             // examined it. `findWithMessages` throws when there is no such
-            // attempt, so both cases land on the same 404 below.
+            // attempt, so both cases land on the same 404 below — and only
+            // that error does; anything else the query raises still surfaces.
             const attemptData = await ClassmojiService.quizAttempt
               .findWithMessages(data.attemptId)
-              .catch(() => null);
+              .catch((error: unknown) => {
+                if (error instanceof QuizAttemptNotFoundError) return null;
+                throw error;
+              });
             if (
               !attemptData?.attempt ||
               attemptData.attempt.quiz_id.toString() !== data.quizId.toString()
@@ -915,8 +922,14 @@ export async function action({ request }: Route.ActionArgs) {
           // Cleanup via ai-agent service BEFORE creating new attempt.
           // The attempt created below is the caller's own, so the only session
           // worth ending is the caller's own attempt on this same quiz. An id
-          // that names anything else is skipped rather than refused, which is
-          // what an id naming an already-deleted attempt has always done.
+          // that fails either half is skipped rather than refused: the restart
+          // still proceeds, and a foreign id is answered exactly like one that
+          // names nothing, so it reports nothing about what exists.
+          //
+          // The trade-off is that an id whose row is already gone — a preview
+          // attempt deleted between page load and the restart click — no longer
+          // gets its best-effort teardown, so its ai-agent session can outlive
+          // the row until that session's own expiry.
           const previousAttempt = context.attempt;
           const isCallersAttemptOnThisQuiz =
             !!previousAttempt &&

--- a/apps/webapp/app/routes/api.quiz/route.ts
+++ b/apps/webapp/app/routes/api.quiz/route.ts
@@ -7,6 +7,8 @@
  * 3. Attempt Ownership Verification:
  *    - sendMessage: Verifies user owns the attempt before allowing messages
  *    - completeQuiz: Verifies user owns the attempt before marking complete
+ *    - restartQuiz: Ends the prior ai-agent session only when the named attempt
+ *      is the caller's own attempt on the quiz being restarted
  * 4. Audit Logging: All unauthorized access attempts are logged
  * 5. Admin Access: Admins preview quizzes as themselves, creating their own attempts
  *    - This ensures data isolation between admin previews and student attempts
@@ -157,10 +159,19 @@ export async function action({ request }: Route.ActionArgs) {
             return { response: jsonResponse(404, 'Quiz not found') };
           }
 
+          // `attemptId` names the session to tear down and nothing else — the
+          // attempt this branch creates always belongs to the caller. Resolve it
+          // here so the branch below can hold it against this quiz and this
+          // caller before ending anything.
+          const attempt = data.attemptId
+            ? await ClassmojiService.quizAttempt.findById(data.attemptId)
+            : null;
+
           return {
             context: {
               classroomId: quiz.classroom_id,
               quiz,
+              attempt,
               metadata: { quiz_id: data.quizId },
             },
           };
@@ -890,8 +901,18 @@ export async function action({ request }: Route.ActionArgs) {
 
       case 'restartQuiz': {
         try {
-          // Cleanup via ai-agent service BEFORE creating new attempt
-          if (data.attemptId) {
+          // Cleanup via ai-agent service BEFORE creating new attempt.
+          // The attempt created below is the caller's own, so the only session
+          // worth ending is the caller's own attempt on this same quiz. An id
+          // that names anything else is skipped rather than refused, which is
+          // what an id naming an already-deleted attempt has always done.
+          const previousAttempt = context.attempt;
+          const isCallersAttemptOnThisQuiz =
+            !!previousAttempt &&
+            previousAttempt.quiz_id.toString() === data.quizId.toString() &&
+            (previousAttempt.user_id.toString() === userId.toString() || isImpersonating);
+
+          if (isCallersAttemptOnThisQuiz) {
             await endQuizSession(data.attemptId);
           }
 

--- a/apps/webapp/app/routes/api.quiz/route.ts
+++ b/apps/webapp/app/routes/api.quiz/route.ts
@@ -310,9 +310,20 @@ export async function action({ request }: Route.ActionArgs) {
           let attempt;
 
           if (data.attemptId) {
-            // Resume specific attempt (e.g., admin preview with pre-created attempt)
-            const attemptData = await ClassmojiService.quizAttempt.findWithMessages(data.attemptId);
-            if (!attemptData?.attempt) {
+            // Resume specific attempt (e.g., admin preview with pre-created attempt).
+            // Bound to `quizId`, because that is the quiz every gate above was
+            // resolved from: the classroom membership, the mutation check and
+            // the pro-tier check all answer for THAT quiz's classroom, so an
+            // attempt on any other one would run under gates that never
+            // examined it. `findWithMessages` throws when there is no such
+            // attempt, so both cases land on the same 404 below.
+            const attemptData = await ClassmojiService.quizAttempt
+              .findWithMessages(data.attemptId)
+              .catch(() => null);
+            if (
+              !attemptData?.attempt ||
+              attemptData.attempt.quiz_id.toString() !== data.quizId.toString()
+            ) {
               return new Response(JSON.stringify({ error: 'Attempt not found' }), {
                 status: 404,
                 headers: { 'Content-Type': 'application/json' },

--- a/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
+++ b/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The attempt view under the /student prefix — reads stay inside the
+ * authorized classroom.
+ *
+ * This loader serves two audiences from one body: a student reading their own
+ * attempt, and staff reading a student's. That second audience is why the
+ * ownership check exempts OWNER/TEACHER/ASSISTANT — and why the attempt has to
+ * be held against the quiz. `quizAttempt.findWithMessages` resolves an attempt
+ * by id alone, so an exemption from ownership is an exemption from the only
+ * thing that was scoping the read at all.
+ *
+ * The quiz is already bound to the classroom `params.class` authorized, so
+ * binding the attempt to that quiz is what keeps the staff view inside it. The
+ * binding is checked ahead of ownership, so an attempt from elsewhere is never
+ * confirmed to exist by a 403.
+ */
+
+const quizFindByIdMock = vi.fn();
+const findWithMessagesMock = vi.fn();
+const assertAccessMock = vi.fn();
+const assertProTierMock = vi.fn();
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
+    quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => assertAccessMock(...a),
+  assertProTier: (...a: unknown[]) => assertProTierMock(...a),
+}));
+
+// The loader is what is under test; the view layer only needs to import.
+vi.mock('~/hooks', () => ({
+  useRouteDrawer: () => ({ opened: true }),
+  useDarkMode: () => ({ isDarkMode: false }),
+}));
+vi.mock('~/components', () => ({ QuizAttemptInterface: () => null }));
+vi.mock('react-router', () => ({
+  useLocation: () => ({ pathname: '/student/cs52-26f/quizzes/quiz-1/attempt/attempt-1' }),
+  useNavigate: () => () => {},
+  useParams: () => ({}),
+}));
+vi.mock('antd', () => ({
+  Drawer: () => null,
+  ConfigProvider: () => null,
+  Modal: () => null,
+  theme: { darkAlgorithm: {}, defaultAlgorithm: {} },
+}));
+
+const route = await import('../route.tsx');
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
+const QUIZ_ID = 'quiz-1';
+const QUIZ = { id: QUIZ_ID, name: 'Recursion', classroom_id: 'class-1' };
+
+/** The signed-in student's own attempt on this classroom's quiz. */
+const OWN_ATTEMPT = {
+  id: 'attempt-1',
+  quiz_id: QUIZ_ID,
+  user_id: 'student-1',
+  completed_at: null,
+  total_duration_ms: 1000,
+  unfocused_duration_ms: 250,
+  agent_config: { anthropic_api_key: 'sk-must-not-leak' },
+  user: { id: 'student-1', name: 'Ada Lovelace', login: 'ada' },
+  quiz: { id: QUIZ_ID, classroom: { id: 'class-1', settings: { anthropic_api_key: 'sk-nope' } } },
+};
+
+/** The same shape, sat by someone else on a quiz in another classroom. */
+const FOREIGN_ATTEMPT = {
+  ...OWN_ATTEMPT,
+  id: 'attempt-elsewhere',
+  quiz_id: 'quiz-elsewhere',
+  user_id: 'student-9',
+  quiz: { id: 'quiz-elsewhere', classroom: { id: 'class-2', settings: {} } },
+};
+
+const asStaff = () =>
+  assertAccessMock.mockResolvedValue({
+    userId: 'owner-1',
+    classroom: CLASSROOM,
+    membership: { role: 'OWNER' },
+  });
+
+const loaderArgs = (attemptId: string) =>
+  ({
+    params: { class: CLASS_SLUG, quizId: QUIZ_ID, attemptId },
+    request: new Request(
+      `http://localhost/student/${CLASS_SLUG}/quizzes/${QUIZ_ID}/attempt/${attemptId}`
+    ),
+  }) as unknown as Parameters<typeof route.loader>[0];
+
+const load = (attemptId = 'attempt-1') => route.loader(loaderArgs(attemptId));
+
+describe('student quiz attempt loader — reads stay inside the authorized classroom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    assertAccessMock.mockResolvedValue({
+      userId: 'student-1',
+      classroom: CLASSROOM,
+      membership: { role: 'STUDENT' },
+    });
+    assertProTierMock.mockResolvedValue(undefined);
+    quizFindByIdMock.mockResolvedValue(QUIZ);
+    findWithMessagesMock.mockResolvedValue({
+      attempt: OWN_ATTEMPT,
+      messages: [{ id: 'm1', role: 'assistant', content: 'Question 1' }],
+    });
+  });
+
+  it("serves a student their own attempt on this classroom's quiz", async () => {
+    const data = await load();
+
+    expect(data.quiz).toEqual(QUIZ);
+    expect(data.attempt.id).toBe('attempt-1');
+    expect(data.messages).toHaveLength(1);
+    expect(data.isAdmin).toBe(false);
+    expect(data.focusMetrics).toEqual({ totalMs: 1000, focusedMs: 750, percentage: 75 });
+    // Nothing carrying a key reaches the browser.
+    expect(data.attempt).not.toHaveProperty('agent_config');
+    expect(data.attempt.quiz.classroom).toEqual({ id: 'class-1', settings: undefined });
+  });
+
+  it("serves staff a student's attempt on this quiz without owning it", async () => {
+    // The ownership exemption staff have here is the point of the route.
+    asStaff();
+
+    const data = await load();
+
+    expect(data.attempt.id).toBe('attempt-1');
+    expect(data.isAdmin).toBe(true);
+  });
+
+  it("refuses staff an attempt sat on another classroom's quiz", async () => {
+    // Exempt from ownership, so the quiz binding is the only thing left holding
+    // this read inside the classroom `params.class` authorized.
+    asStaff();
+    findWithMessagesMock.mockResolvedValue({ attempt: FOREIGN_ATTEMPT, messages: [] });
+
+    const thrown = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown.status).toBe(404);
+    expect(await thrown.text()).toBe('Attempt not found');
+  });
+
+  it("refuses a student an attempt sat on another classroom's quiz", async () => {
+    findWithMessagesMock.mockResolvedValue({ attempt: FOREIGN_ATTEMPT, messages: [] });
+
+    const thrown = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    // 404 from the binding, not 403 from ownership: the id is never confirmed.
+    expect(thrown.status).toBe(404);
+    expect(await thrown.text()).toBe('Attempt not found');
+  });
+
+  it('answers an out-of-scope attempt id exactly as it answers one that names nothing', async () => {
+    asStaff();
+    findWithMessagesMock.mockResolvedValue({ attempt: FOREIGN_ATTEMPT, messages: [] });
+    const foreign = (await load('attempt-elsewhere').catch(e => e)) as Response;
+
+    // `findWithMessages` throws rather than returning null when there is no
+    // such attempt; both paths have to end at the same answer.
+    findWithMessagesMock.mockRejectedValue(new Error('Attempt not found'));
+    const missing = (await load('attempt-missing').catch(e => e)) as Response;
+
+    expect(missing).toBeInstanceOf(Response);
+    expect(missing.status).toBe(foreign.status);
+    expect(await missing.text()).toBe(await foreign.text());
+  });
+
+  it("keeps refusing a student another student's attempt on this same quiz", async () => {
+    findWithMessagesMock.mockResolvedValue({
+      attempt: { ...OWN_ATTEMPT, id: 'attempt-peer', user_id: 'student-2' },
+      messages: [],
+    });
+
+    const thrown = (await load('attempt-peer').catch(e => e)) as Response;
+
+    expect(thrown.status).toBe(403);
+  });
+
+  it('refuses a quiz belonging to another classroom before it looks at the attempt', async () => {
+    quizFindByIdMock.mockResolvedValue({ ...QUIZ, classroom_id: 'class-2' });
+
+    const thrown = (await load().catch(e => e)) as Response;
+
+    expect(thrown.status).toBe(404);
+    expect(await thrown.text()).toBe('Quiz not found');
+    expect(findWithMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it('reads nothing when the authorization gate throws', async () => {
+    assertAccessMock.mockRejectedValue(new Response('Forbidden', { status: 403 }));
+
+    await expect(load()).rejects.toBeInstanceOf(Response);
+    expect(quizFindByIdMock).not.toHaveBeenCalled();
+    expect(findWithMessagesMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
+++ b/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/__tests__/attemptScope.test.ts
@@ -27,6 +27,7 @@ vi.mock('@classmoji/services', () => ({
     quiz: { findById: (...a: unknown[]) => quizFindByIdMock(...a) },
     quizAttempt: { findWithMessages: (...a: unknown[]) => findWithMessagesMock(...a) },
   },
+  QuizAttemptNotFoundError: class QuizAttemptNotFoundError extends Error {},
 }));
 
 vi.mock('~/utils/helpers', () => ({
@@ -53,6 +54,11 @@ vi.mock('antd', () => ({
 }));
 
 const route = await import('../route.tsx');
+// The service's own "no such attempt" signal, taken from the mocked module so
+// the route's instanceof check sees the same class it does in production.
+const { QuizAttemptNotFoundError } = (await import('@classmoji/services')) as unknown as {
+  QuizAttemptNotFoundError: new (message?: string) => Error;
+};
 
 const CLASS_SLUG = 'cs52-26f';
 const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE' };
@@ -168,12 +174,24 @@ describe('student quiz attempt loader — reads stay inside the authorized class
 
     // `findWithMessages` throws rather than returning null when there is no
     // such attempt; both paths have to end at the same answer.
-    findWithMessagesMock.mockRejectedValue(new Error('Attempt not found'));
+    findWithMessagesMock.mockRejectedValue(new QuizAttemptNotFoundError('Attempt not found'));
     const missing = (await load('attempt-missing').catch(e => e)) as Response;
 
     expect(missing).toBeInstanceOf(Response);
     expect(missing.status).toBe(foreign.status);
     expect(await missing.text()).toBe(await foreign.text());
+  });
+
+  it('lets a query failure surface instead of reporting the attempt as absent', async () => {
+    // Only the service's "no such attempt" becomes a 404. A student reloading
+    // mid-quiz through a dropped connection must not be told their attempt is
+    // gone, with nothing in the logs to contradict it.
+    findWithMessagesMock.mockRejectedValue(new Error('connection pool timeout'));
+
+    const thrown = (await load().catch(e => e)) as Error;
+
+    expect(thrown).not.toBeInstanceOf(Response);
+    expect(thrown.message).toBe('connection pool timeout');
   });
 
   it("keeps refusing a student another student's attempt on this same quiz", async () => {

--- a/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/route.tsx
+++ b/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/route.tsx
@@ -7,7 +7,7 @@ import { QuizAttemptInterface } from '~/components';
 import { assertClassroomAccess, assertProTier } from '~/utils/helpers';
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { ClassmojiService } = await import('@classmoji/services');
+  const { ClassmojiService, QuizAttemptNotFoundError } = await import('@classmoji/services');
   const classSlug = params.class!;
   const quizId = params.quizId!;
   const attemptId = params.attemptId!;
@@ -33,10 +33,15 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   // `findWithMessages` resolves an attempt by id alone and throws when there is
   // none, so both an id naming nothing and an id naming another quiz's attempt
   // land on the same 404 — checked before ownership, so a foreign id is never
-  // confirmed to exist by a 403.
+  // confirmed to exist by a 403. Only that one error becomes a 404; anything
+  // else the query raises still surfaces, rather than telling a student their
+  // attempt is gone because the database was briefly unreachable.
   const attemptData = await ClassmojiService.quizAttempt
     .findWithMessages(attemptId)
-    .catch(() => null);
+    .catch((error: unknown) => {
+      if (error instanceof QuizAttemptNotFoundError) return null;
+      throw error;
+    });
   if (!attemptData?.attempt || attemptData.attempt.quiz_id.toString() !== quiz.id.toString()) {
     throw new Response('Attempt not found', { status: 404 });
   }

--- a/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/route.tsx
+++ b/apps/webapp/app/routes/student.$class.quizzes.$quizId.attempt.$attemptId/route.tsx
@@ -29,13 +29,22 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw new Response('Quiz not found', { status: 404 });
   }
 
-  // 3. Fetch attempt with messages
-  const attemptData = await ClassmojiService.quizAttempt.findWithMessages(attemptId);
-  if (!attemptData?.attempt) {
+  // 3. Fetch attempt with messages, bound to the quiz resolved above.
+  // `findWithMessages` resolves an attempt by id alone and throws when there is
+  // none, so both an id naming nothing and an id naming another quiz's attempt
+  // land on the same 404 — checked before ownership, so a foreign id is never
+  // confirmed to exist by a 403.
+  const attemptData = await ClassmojiService.quizAttempt
+    .findWithMessages(attemptId)
+    .catch(() => null);
+  if (!attemptData?.attempt || attemptData.attempt.quiz_id.toString() !== quiz.id.toString()) {
     throw new Response('Attempt not found', { status: 404 });
   }
 
-  // 4. Verify ownership (students can only view their own attempts)
+  // 4. Verify ownership (students can only view their own attempts). Staff read
+  // any attempt OF THIS QUIZ without owning it, which is only inside the
+  // authorized classroom because step 2 binds the quiz to it and step 3 binds
+  // the attempt to that quiz.
   const isInstructor = membership
     ? ['OWNER', 'ASSISTANT', 'TEACHER'].includes(membership.role)
     : false;

--- a/packages/services/src/classmoji/quizAttempt.service.ts
+++ b/packages/services/src/classmoji/quizAttempt.service.ts
@@ -2,6 +2,21 @@ import getPrisma from '@classmoji/database';
 import type { MessageRole, Prisma } from '@prisma/client';
 import { checkForCompletion, DEFAULT_EMOJI_GRADE_MAPPINGS } from '@classmoji/utils';
 
+/**
+ * Thrown when an attempt id names no row.
+ *
+ * Typed so a caller can tell "there is no such attempt" apart from a query that
+ * failed for some other reason. Both arrive as a rejection, and a route that
+ * treats them alike answers 404 to a database outage — telling a student their
+ * in-progress attempt does not exist, and logging nothing.
+ */
+export class QuizAttemptNotFoundError extends Error {
+  constructor(message: string = 'Attempt not found') {
+    super(message);
+    this.name = 'QuizAttemptNotFoundError';
+  }
+}
+
 interface QuizAttemptDurationMetrics {
   totalDurationMs?: number | string | null;
   total_duration_ms?: number | string | null;
@@ -533,7 +548,7 @@ export const recordModalClosed = async (
     `;
 
     if (!current || current.length === 0) {
-      throw new Error('Attempt not found');
+      throw new QuizAttemptNotFoundError();
     }
 
     const row = current[0];
@@ -623,7 +638,7 @@ export const calculateAndApplyModalGap = async (attemptId: string) => {
     `;
 
     if (!current || current.length === 0) {
-      throw new Error('Attempt not found');
+      throw new QuizAttemptNotFoundError();
     }
 
     const row = current[0];
@@ -819,7 +834,7 @@ export const getUserAttemptForQuiz = async (quizId: string, userId: string) => {
 export const findWithMessages = async (attemptId: string) => {
   const attempt = await findById(attemptId);
   if (!attempt) {
-    throw new Error('Attempt not found');
+    throw new QuizAttemptNotFoundError();
   }
 
   // All messages are stored in AIConversation (ai-agent owns persistence)

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -56,6 +56,9 @@ export { StaffServiceError } from './classmoji/staff.service.ts';
 export type { AddStaffResult, RemoveStaffResult, StaffRole } from './classmoji/staff.service.ts';
 // Quiz authorization refusal, so routes can answer 403 instead of 500.
 export { QuizAccessError, QUIZ_STAFF_ROLES } from './classmoji/quiz.service.ts';
+// "No such attempt", so routes can answer 404 for that and only that — a query
+// that failed for any other reason has to keep its 500 and its log line.
+export { QuizAttemptNotFoundError } from './classmoji/quizAttempt.service.ts';
 // One builder for the remove_user_from_organization payload, so every caller
 // sends the same fields.
 export { buildRemoveUserPayload } from './classmoji/removeUserPayload.ts';


### PR DESCRIPTION
## Summary

Binds quiz-attempt lookups to the quiz they belong to, everywhere an attempt id arrives from a request.

Several quiz routes resolved the quiz against the authorized classroom correctly, then fetched the attempt by an id from the URL or request body with nothing tying it to that quiz. The gates were right; the second lookup simply wasn't held to them. This applies the same rule in all five places.

### The rule

**An attempt must belong to the quiz the gates were resolved from, checked before ownership.** The quiz is already classroom-bound, so binding the attempt to the quiz is what makes "this classroom's attempts" true. Putting the check ahead of the ownership test means an out-of-scope id answers exactly like a missing one, rather than a 403 confirming it exists.

Policies are unchanged:

- Staff still read any attempt of a quiz without owning it — that's the point of the instructor transcript view.
- Students still must own theirs.
- The restart path still ends the caller's own prior session, with the same impersonation allowance its sibling branches carry.

### Where

- The instructor transcript and preview views, and their teacher and assistant re-exports.
- The student-prefix attempt view, whose own gate lists staff roles and so must be correct standing alone — a parent layout gate is not a boundary for a child loader's read, since loaders run independently and a parent throw discards the child's data rather than preventing the query.
- The restart and resume paths in the quiz API.

### Two related repairs

**Missing attempts returned 500, not 404.** The service throws rather than returning null, so the null-check guarding it was unreachable. There's now a typed `QuizAttemptNotFoundError`, and the routes catch that specific type and let everything else through — so a database timeout surfaces as a real error instead of quietly claiming the attempt doesn't exist. That distinction matters on serverless Postgres, where a dropped connection during a cold start would otherwise tell a student mid-quiz that their work is gone, with nothing in the logs to contradict them.

**A non-string attempt id** reached Prisma and left as a 500 carrying a validation message; it's now treated as naming nothing, consistent with an absent id.

### Tests

`apps/webapp` 729 (36 new across 5 files) · `packages/services` 1216 · `packages/auth` 93 · `apps/mcp` 496. Typecheck carries only the two known pre-existing errors.

Every new test file was verified to fail against the previous code, with one honest exception: the test naming the original threat directly — a student pointing at a peer's attempt on the same quiz — passes both before and after, because the binding it exercises landed in an earlier commit on this branch. It documents the case rather than demonstrating the fix.

### Follow-up

The binding is applied after the lookup in all five places. Moving it into the query itself would remove the possibility of forgetting it, and would make the not-found path fall out naturally instead of needing a typed error. Deliberately left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
