### PR TITLE
🚀 Promote staging to main

### DIFF
--- a/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
@@ -68,8 +68,16 @@ const StepImportModules = ({
   };
 
   const handleSourceChange = (classroomId: string) => {
+    const next = importableClassrooms.find(c => c.id === classroomId);
     setSourceClassroomId(classroomId);
     setSelectedModules(new Map());
+    // Switching to a class the user only TEACHES unmounts the API-keys row, so a
+    // selection made against a previously-picked owned class would be stranded:
+    // still set, still summarised on the review step, and impossible to untick
+    // because the checkbox is gone. Clear it with the source that justified it.
+    if (!next?.is_owner && importSelections.apiKeys) {
+      setImportSelections({ ...importSelections, apiKeys: false });
+    }
   };
 
   const handleSelectAll = () => {
@@ -111,7 +119,7 @@ const StepImportModules = ({
         <div>
           <div className="font-medium">Import from existing classroom</div>
           <div className="text-sm text-gray-500">
-            Copy repositories and assignments from another classroom you own
+            Copy repositories and assignments from another classroom you own or teach
           </div>
         </div>
         <Switch checked={importEnabled} onChange={setImportEnabled} />

--- a/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepImportModules.tsx
@@ -7,14 +7,14 @@ import {
   QuestionCircleOutlined,
 } from '@ant-design/icons';
 import ModuleSelectionDrawer from './ModuleSelectionDrawer';
-import type { ClassroomModule, ImportSelections, OwnedClassroom } from './types';
+import type { ClassroomModule, ImportSelections, ImportableClassroom } from './types';
 
 interface ModuleConfig {
   includeQuizzes: boolean;
 }
 
 interface StepImportModulesProps {
-  ownedClassrooms: OwnedClassroom[];
+  importableClassrooms: ImportableClassroom[];
   importEnabled: boolean;
   setImportEnabled: (enabled: boolean) => void;
   sourceClassroomId: string | null;
@@ -35,7 +35,7 @@ interface CopyGroupRow {
 }
 
 const StepImportModules = ({
-  ownedClassrooms,
+  importableClassrooms,
   importEnabled,
   setImportEnabled,
   sourceClassroomId,
@@ -47,7 +47,7 @@ const StepImportModules = ({
 }: StepImportModulesProps) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
-  const sourceClassroom = ownedClassrooms.find(c => c.id === sourceClassroomId);
+  const sourceClassroom = importableClassrooms.find(c => c.id === sourceClassroomId);
   const repositories = sourceClassroom?.repositories || [];
 
   const handleModuleToggle = (moduleId: string, checked: boolean) => {
@@ -119,7 +119,7 @@ const StepImportModules = ({
 
       {importEnabled && (
         <>
-          {ownedClassrooms.length === 0 ? (
+          {importableClassrooms.length === 0 ? (
             <Empty
               description="You don't have any other classrooms to import from"
               className="py-8"
@@ -141,7 +141,7 @@ const StepImportModules = ({
                       .includes(input.toLowerCase())
                   }
                 >
-                  {ownedClassrooms.map(classroom => (
+                  {importableClassrooms.map(classroom => (
                     <Select.Option key={classroom.id} value={classroom.id}>
                       <div className="flex items-center gap-2">
                         {(classroom.git_organization as { avatar_url?: string } | null)
@@ -261,11 +261,18 @@ const StepImportModules = ({
                           label: 'AI & quiz config',
                           sublabel: 'models, temperature, syllabus bot',
                         },
-                        {
-                          key: 'apiKeys',
-                          label: 'AI API keys',
-                          sublabel: 'secrets — copy only if you mean to',
-                        },
+                        // Owners only. A teacher may copy a class they teach but
+                        // not lift its LLM credentials out of it; the server
+                        // strips this regardless of what the form posts.
+                        ...(sourceClassroom?.is_owner
+                          ? [
+                              {
+                                key: 'apiKeys' as const,
+                                label: 'AI API keys',
+                                sublabel: 'secrets — copy only if you mean to',
+                              },
+                            ]
+                          : []),
                         {
                           key: 'pages',
                           label: 'Pages',

--- a/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
@@ -28,11 +28,18 @@ interface StepReviewProps {
 const distinctTemplateCount = (classroom?: ImportableClassroom): number =>
   new Set((classroom?.repositories ?? []).map(m => (m.template ?? '').trim()).filter(Boolean)).size;
 
-/** Human labels for the enabled "Also copy" groups, with counts where known. */
+/**
+ * Human labels for the enabled "Also copy" groups, with counts where known.
+ *
+ * `isSourceOwner` gates the API-keys line rather than trusting the selection:
+ * the server refuses to copy keys out of a class the requester only teaches, so
+ * listing them here would promise something that is about to be stripped.
+ */
 const copySummaryParts = (
   selections: ImportSelections,
   counts?: ImportableClassroom['_count'],
-  templateCount = 0
+  templateCount = 0,
+  isSourceOwner = false
 ): string[] => {
   const parts: string[] = [];
   if (selections.grading) parts.push('grading & late penalty');
@@ -41,7 +48,7 @@ const copySummaryParts = (
   if (selections.tokens) parts.push('tokens');
   if (selections.features) parts.push('features & appearance');
   if (selections.aiConfig) parts.push('AI config');
-  if (selections.apiKeys) parts.push('API keys');
+  if (selections.apiKeys && isSourceOwner) parts.push('API keys');
   if (selections.pages && (counts?.pages ?? 0) > 0) parts.push(`pages (${counts?.pages})`);
   if (selections.slides && (counts?.slides ?? 0) > 0) parts.push(`slide decks (${counts?.slides})`);
   if (selections.modules && (counts?.modules ?? 0) > 0) parts.push(`modules (${counts?.modules})`);
@@ -135,7 +142,8 @@ const StepReview = ({
             const parts = copySummaryParts(
               importSelections,
               sourceClassroom._count,
-              distinctTemplateCount(sourceClassroom)
+              distinctTemplateCount(sourceClassroom),
+              sourceClassroom.is_owner
             );
             return parts.length > 0 ? (
               <div className="text-sm text-gray-700 dark:text-gray-300">

--- a/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/StepReview.tsx
@@ -10,7 +10,7 @@ import type {
   GitOrganizationOption,
   ImportSelections,
   ModuleConfig,
-  OwnedClassroom,
+  ImportableClassroom,
 } from './types';
 
 interface StepReviewProps {
@@ -19,19 +19,19 @@ interface StepReviewProps {
   slugPreview: string;
   contentRepoName?: string | null;
   importEnabled: boolean;
-  sourceClassroom?: OwnedClassroom;
+  sourceClassroom?: ImportableClassroom;
   selectedModules: Map<string, ModuleConfig>;
   importSelections?: ImportSelections;
 }
 
 /** Distinct non-empty template refs across a classroom's repositories. */
-const distinctTemplateCount = (classroom?: OwnedClassroom): number =>
+const distinctTemplateCount = (classroom?: ImportableClassroom): number =>
   new Set((classroom?.repositories ?? []).map(m => (m.template ?? '').trim()).filter(Boolean)).size;
 
 /** Human labels for the enabled "Also copy" groups, with counts where known. */
 const copySummaryParts = (
   selections: ImportSelections,
-  counts?: OwnedClassroom['_count'],
+  counts?: ImportableClassroom['_count'],
   templateCount = 0
 ): string[] => {
   const parts: string[] = [];
@@ -43,10 +43,8 @@ const copySummaryParts = (
   if (selections.aiConfig) parts.push('AI config');
   if (selections.apiKeys) parts.push('API keys');
   if (selections.pages && (counts?.pages ?? 0) > 0) parts.push(`pages (${counts?.pages})`);
-  if (selections.slides && (counts?.slides ?? 0) > 0)
-    parts.push(`slide decks (${counts?.slides})`);
-  if (selections.modules && (counts?.modules ?? 0) > 0)
-    parts.push(`modules (${counts?.modules})`);
+  if (selections.slides && (counts?.slides ?? 0) > 0) parts.push(`slide decks (${counts?.slides})`);
+  if (selections.modules && (counts?.modules ?? 0) > 0) parts.push(`modules (${counts?.modules})`);
   if (selections.duplicateTemplates && templateCount > 0)
     parts.push(`private template copies (${templateCount})`);
   if (selections.calendar && (counts?.calendar_events ?? 0) > 0)

--- a/apps/webapp/app/routes/_user.create-classroom/__tests__/sourceAccess.test.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/__tests__/sourceAccess.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSourceAccess, API_KEYS_STRIPPED_WARNING, SOURCE_ROLES } from '../sourceAccess.ts';
+
+/**
+ * The import source gate. Owners and teachers may copy a class; only owners may
+ * copy its API keys, because those are the source owner's real LLM credentials
+ * and everything else in an import is course material a teacher can already read.
+ */
+describe('resolveSourceAccess', () => {
+  describe('who may import at all', () => {
+    it('admits an owner', () => {
+      expect(resolveSourceAccess(['OWNER']).allowed).toBe(true);
+    });
+
+    it('admits a teacher', () => {
+      expect(resolveSourceAccess(['TEACHER']).allowed).toBe(true);
+    });
+
+    // These two are the denial coverage. They were the ONLY outcome before
+    // teachers were admitted; the teacher case flipped, these did not.
+    it('refuses an assistant', () => {
+      expect(resolveSourceAccess(['ASSISTANT']).allowed).toBe(false);
+    });
+
+    it('refuses a student', () => {
+      expect(resolveSourceAccess(['STUDENT']).allowed).toBe(false);
+    });
+
+    it('refuses someone with no membership at all', () => {
+      expect(resolveSourceAccess([]).allowed).toBe(false);
+    });
+
+    // An assistant who is ALSO a teacher is admitted on the teacher row; the
+    // assistant row neither grants nor blocks anything.
+    it('admits on the usable role when a non-usable role is also held', () => {
+      expect(resolveSourceAccess(['ASSISTANT', 'TEACHER']).allowed).toBe(true);
+    });
+
+    it('does not treat an unknown role as usable', () => {
+      expect(resolveSourceAccess(['SUPERUSER']).allowed).toBe(false);
+    });
+  });
+
+  describe('API keys are owner-only', () => {
+    it('lets an owner copy them', () => {
+      const access = resolveSourceAccess(['OWNER'], { grading: true, apiKeys: true });
+      expect(access).toMatchObject({ allowed: true, isOwner: true });
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.configSelections.apiKeys).toBe(true);
+      expect(access.warnings).toEqual([]);
+    });
+
+    it('strips them from a teacher and says so', () => {
+      const access = resolveSourceAccess(['TEACHER'], { grading: true, apiKeys: true });
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.isOwner).toBe(false);
+      expect(access.configSelections.apiKeys).toBe(false);
+      expect(access.warnings).toEqual([API_KEYS_STRIPPED_WARNING]);
+    });
+
+    it('leaves the teacher’s other selections untouched', () => {
+      const access = resolveSourceAccess(['TEACHER'], {
+        grading: true,
+        gradeScales: true,
+        features: true,
+        apiKeys: true,
+      });
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.configSelections).toEqual({
+        grading: true,
+        gradeScales: true,
+        features: true,
+        apiKeys: false,
+      });
+    });
+
+    // The multi-role trap: memberships are unique per (classroom, user, role),
+    // so an owner who also holds TEACHER has two rows. Deciding from one
+    // arbitrary row would strip keys from a genuine owner.
+    it('treats an OWNER+TEACHER as an owner regardless of row order', () => {
+      for (const roles of [
+        ['OWNER', 'TEACHER'],
+        ['TEACHER', 'OWNER'],
+      ]) {
+        const access = resolveSourceAccess(roles, { apiKeys: true });
+        if (!access.allowed) throw new Error('expected allowed');
+        expect(access.isOwner).toBe(true);
+        expect(access.configSelections.apiKeys).toBe(true);
+        expect(access.warnings).toEqual([]);
+      }
+    });
+
+    it('warns nobody when a teacher never asked for keys', () => {
+      const access = resolveSourceAccess(['TEACHER'], { grading: true });
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.warnings).toEqual([]);
+      expect(access.configSelections).toEqual({ grading: true });
+    });
+
+    it('handles an absent selections object', () => {
+      const access = resolveSourceAccess(['TEACHER']);
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.configSelections).toEqual({});
+      expect(access.warnings).toEqual([]);
+    });
+  });
+
+  describe('the returned selections are what gets persisted', () => {
+    // This is the assertion that protects the job row. The action writes
+    // `access.configSelections` to ImportJob.selections.config, and the retry
+    // path reads that row back. A stripped key must be false ON THE ROW, not
+    // merely skipped at apply time, or wiring config into retry later would
+    // silently resurrect it.
+    it('reports apiKeys:false rather than omitting the key', () => {
+      const access = resolveSourceAccess(['TEACHER'], { apiKeys: true });
+      if (!access.allowed) throw new Error('expected allowed');
+      expect('apiKeys' in access.configSelections).toBe(true);
+      expect(access.configSelections.apiKeys).toBe(false);
+      expect(JSON.stringify(access.configSelections)).toContain('"apiKeys":false');
+    });
+
+    it('does not mutate the caller’s object', () => {
+      const requested = { grading: true, apiKeys: true };
+      resolveSourceAccess(['TEACHER'], requested);
+      expect(requested.apiKeys).toBe(true);
+    });
+  });
+
+  it('exposes exactly the two source roles', () => {
+    expect([...SOURCE_ROLES]).toEqual(['OWNER', 'TEACHER']);
+  });
+});

--- a/apps/webapp/app/routes/_user.create-classroom/__tests__/sourceAccess.test.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/__tests__/sourceAccess.test.ts
@@ -103,6 +103,16 @@ describe('resolveSourceAccess', () => {
       expect(access.configSelections).toEqual({});
       expect(access.warnings).toEqual([]);
     });
+
+    // An explicit `false` is not a request, so it must pass through silently —
+    // warning here would tell a teacher their keys were refused when they never
+    // asked for them.
+    it('passes an explicit apiKeys:false through without a warning', () => {
+      const access = resolveSourceAccess(['TEACHER'], { grading: true, apiKeys: false });
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.configSelections).toEqual({ grading: true, apiKeys: false });
+      expect(access.warnings).toEqual([]);
+    });
   });
 
   describe('the returned selections are what gets persisted', () => {
@@ -123,6 +133,17 @@ describe('resolveSourceAccess', () => {
       const requested = { grading: true, apiKeys: true };
       resolveSourceAccess(['TEACHER'], requested);
       expect(requested.apiKeys).toBe(true);
+    });
+
+    // The owner path returns early, so it is the branch where an alias could
+    // slip back in unnoticed — nothing downstream mutates the object today, and
+    // that is exactly why a regression here would be silent.
+    it('returns a fresh object on the owner path too', () => {
+      const requested = { grading: true, apiKeys: true };
+      const access = resolveSourceAccess(['OWNER'], requested);
+      if (!access.allowed) throw new Error('expected allowed');
+      expect(access.configSelections).not.toBe(requested);
+      expect(access.configSelections).toEqual(requested);
     });
   });
 

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -29,6 +29,7 @@ import {
   suggestContentNamespace,
 } from '@classmoji/utils';
 import { slugify } from './utils';
+import { resolveSourceAccess, SOURCE_ROLES } from './sourceAccess';
 
 /** Background work needs Trigger.dev; without it the async phases can't run. */
 const isTriggerConfigured = () =>
@@ -237,13 +238,15 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   // returning an error after it leaves an orphaned classroom that also blocks
   // a same-slug retry. Source-ownership for imports is part of that gate.
   const sourceClassroomId: string | undefined = importConfig?.sourceClassroomId;
-  const configSelections = importConfig?.config ?? {};
+  // Reassigned below when a non-owner requests the source's API keys — the
+  // sanitized object is what reaches both the inline apply and the job row.
+  let configSelections: Record<string, boolean> = importConfig?.config ?? {};
   // A COPY of the request's content toggles: the GitHub pre-flight below drops
   // the ones this environment cannot honor, and everything downstream (the
   // `wants*` flags, the phase totals, whether a job is created at all, and the
   // selections persisted on the job for a later retry) reads them from here.
   const contentSelections: Record<string, boolean> = { ...(importConfig?.content ?? {}) };
-  const anyConfigSelected = Object.values(configSelections).some(Boolean);
+  let anyConfigSelected = Object.values(configSelections).some(Boolean);
   const anyContentSelected = Object.values(contentSelections).some(Boolean);
   const requestedRepos: Array<{ id: string; includeQuizzes?: boolean }> =
     importConfig?.repositories ?? [];
@@ -258,16 +261,39 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   let githubUnavailableNote: string | null = null;
 
   if (importRequested) {
-    // The picker only OFFERS owned classrooms, but every id here arrives from
-    // the request body — re-verify ownership server-side before copying
-    // anything (settings can carry API keys; content must not be exfiltrated
-    // from classrooms the requester doesn't own).
-    const sourceMembership = await getPrisma().classroomMembership.findFirst({
-      where: { classroom_id: sourceClassroomId, user_id: user.id, role: 'OWNER' },
+    // The picker only OFFERS classrooms the user owns or teaches, but every id
+    // here arrives from the request body — re-verify server-side before copying
+    // anything, so content cannot be lifted out of a classroom the requester has
+    // no standing in.
+    //
+    // findMany, not findFirst: roles are additive (unique per classroom+user+role)
+    // and someone may hold OWNER *and* TEACHER here. An unordered findFirst could
+    // hand back the TEACHER row and strip API keys from a genuine owner.
+    const sourceMemberships = await getPrisma().classroomMembership.findMany({
+      where: {
+        classroom_id: sourceClassroomId,
+        user_id: user.id,
+        role: { in: [...SOURCE_ROLES] },
+      },
+      select: { role: true },
     });
-    if (!sourceMembership) {
-      return { error: 'You must own the source classroom to import from it' };
+
+    const access = resolveSourceAccess(
+      sourceMemberships.map(m => m.role),
+      configSelections
+    );
+    if (!access.allowed) {
+      return { error: 'You must own or teach the source classroom to import from it' };
     }
+
+    // The sanitized selections replace the request's: this is what reaches both
+    // the inline config apply AND the job row, so a future retry path cannot
+    // resurrect a stripped key.
+    configSelections = access.configSelections;
+    importWarnings.push(...access.warnings);
+    // Recomputed: a teacher who selected ONLY apiKeys has an empty config now,
+    // and `importRequested` was decided before the strip.
+    anyConfigSelected = Object.values(configSelections).some(Boolean);
 
     // ── GitHub pre-flight ────────────────────────────────────────────────────
     // Template duplication and the page/deck copy all READ the source org, so

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -29,7 +29,7 @@ import {
   suggestContentNamespace,
 } from '@classmoji/utils';
 import { slugify } from './utils';
-import { resolveSourceAccess, SOURCE_ROLES } from './sourceAccess';
+import { resolveSourceAccess, SOURCE_ROLES, API_KEYS_STRIPPED_WARNING } from './sourceAccess';
 
 /** Background work needs Trigger.dev; without it the async phases can't run. */
 const isTriggerConfigured = () =>
@@ -246,12 +246,20 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   // `wants*` flags, the phase totals, whether a job is created at all, and the
   // selections persisted on the job for a later retry) reads them from here.
   const contentSelections: Record<string, boolean> = { ...(importConfig?.content ?? {}) };
-  let anyConfigSelected = Object.values(configSelections).some(Boolean);
+  // Two DIFFERENT questions, deliberately not one variable:
+  //   `anyConfigRequested` — what the request asked for, used only to decide
+  //     whether an import was attempted at all. Must stay pre-strip, so that a
+  //     request asking ONLY for API keys still runs the membership gate below
+  //     instead of quietly becoming a no-op that skips it.
+  //   `anyConfigSelected` — what will actually be applied, recomputed after the
+  //     strip and read by every downstream branch.
+  const anyConfigRequested = Object.values(configSelections).some(Boolean);
+  let anyConfigSelected = anyConfigRequested;
   const anyContentSelected = Object.values(contentSelections).some(Boolean);
   const requestedRepos: Array<{ id: string; includeQuizzes?: boolean }> =
     importConfig?.repositories ?? [];
   const importRequested =
-    !!sourceClassroomId && (requestedRepos.length > 0 || anyConfigSelected || anyContentSelected);
+    !!sourceClassroomId && (requestedRepos.length > 0 || anyConfigRequested || anyContentSelected);
 
   /** Per-item notes; surfaced on the response and seeded onto the job row. */
   const importWarnings: string[] = [];
@@ -646,11 +654,19 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
   if (githubUnavailableNote) {
     successMessage += ` ${githubUnavailableNote}`;
   }
+  // Same treatment, same reason. The generic counter below points at server logs
+  // and at the job row's warning list, and a config-only import has neither: it
+  // writes no ImportJob, and this note is never logged. Said outright or the
+  // user is told "1 item skipped" with nowhere to find out which.
+  if (importWarnings.includes(API_KEYS_STRIPPED_WARNING)) {
+    successMessage += ` ${API_KEYS_STRIPPED_WARNING}`;
+  }
   if (importJobId) {
     successMessage += ' Import continuing in the background.';
   }
-  if (importWarnings.length > 0) {
-    successMessage += ` (${importWarnings.length} item${importWarnings.length === 1 ? '' : 's'} skipped — see server logs)`;
+  const countedWarnings = importWarnings.filter(w => w !== API_KEYS_STRIPPED_WARNING);
+  if (countedWarnings.length > 0) {
+    successMessage += ` (${countedWarnings.length} item${countedWarnings.length === 1 ? '' : 's'} skipped — see server logs)`;
   }
 
   return {

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -14,6 +14,7 @@ import StepBasicInfo from './StepBasicInfo';
 import StepImportModules from './StepImportModules';
 import StepReview from './StepReview';
 import { slugify, STEPS } from './utils';
+import { SOURCE_ROLES } from './sourceAccess';
 import type { ImportSelections } from './types';
 import type { Route } from './+types/route';
 
@@ -168,7 +169,10 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         memberships: {
           some: {
             user_id: user.id,
-            role: { in: ['OWNER', 'TEACHER'] },
+            // Shared with the action's re-verification. If these two ever drift,
+            // the picker offers a source the action refuses — a dead end reached
+            // only after the whole wizard has been filled in.
+            role: { in: [...SOURCE_ROLES] },
           },
         },
       },

--- a/apps/webapp/app/routes/_user.create-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.create-classroom/route.tsx
@@ -143,8 +143,10 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     useInstalledFilter = true;
   }
 
-  // Fetch the displayable orgs and the user's owned classrooms in parallel.
-  const [gitOrgs, ownedClassrooms] = await Promise.all([
+  // Fetch the displayable orgs and the classrooms this user may import FROM in
+  // parallel. Import sources are OWNER *or* TEACHER — a teacher may copy a class
+  // they teach, minus the API keys (see the strip in action.ts).
+  const [gitOrgs, importableClassrooms] = await Promise.all([
     getPrisma().gitOrganization.findMany({
       where: {
         provider: 'GITHUB',
@@ -166,7 +168,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         memberships: {
           some: {
             user_id: user.id,
-            role: 'OWNER',
+            role: { in: ['OWNER', 'TEACHER'] },
           },
         },
       },
@@ -174,6 +176,13 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         id: true,
         slug: true,
         name: true,
+        // THIS viewer's roles only, and only the role column — enough to derive
+        // `is_owner` below. A wider select would serialize every member's
+        // membership rows into the picker payload.
+        memberships: {
+          where: { user_id: user.id },
+          select: { role: true },
+        },
         git_organization: {
           select: {
             login: true,
@@ -218,16 +227,25 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     avatar_url: avatarByProviderId.get(org.provider_id) ?? null,
   }));
 
+  // Collapse the viewer's membership rows to a single flag and DROP the rows —
+  // the picker needs "may this person copy the API keys too", nothing more.
+  // `some(OWNER)` rather than reading one row's role: roles are additive and a
+  // person may hold both OWNER and TEACHER here, in which case they are an owner.
+  const importSources = importableClassrooms.map(({ memberships, ...classroom }) => ({
+    ...classroom,
+    is_owner: memberships.some(m => m.role === 'OWNER'),
+  }));
+
   return {
     user,
     gitOrgs: gitOrgsWithAvatars,
-    ownedClassrooms,
+    importableClassrooms: importSources,
     githubAppName: process.env.GITHUB_APP_NAME,
   };
 };
 
 const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
-  const { gitOrgs, ownedClassrooms, githubAppName } = loaderData;
+  const { gitOrgs, importableClassrooms, githubAppName } = loaderData;
   const navigate = useNavigate();
   const { fetcher, notify } = useGlobalFetcher();
   const { openInstallPopup, isRefreshing } = useGitHubAppInstallPopup(githubAppName);
@@ -396,8 +414,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
 
     // Build import config if applicable
     let importConfig = null;
-    const anySelection =
-      selectedModules.size > 0 || Object.values(importSelections).some(Boolean);
+    const anySelection = selectedModules.size > 0 || Object.values(importSelections).some(Boolean);
     if (importEnabled && sourceClassroomId && anySelection) {
       const { pages, slides, modules, duplicateTemplates, ...config } = importSelections;
       importConfig = {
@@ -423,7 +440,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
     );
   };
 
-  const sourceClassroom = ownedClassrooms.find(c => c.id === sourceClassroomId);
+  const sourceClassroom = importableClassrooms.find(c => c.id === sourceClassroomId);
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -480,7 +497,7 @@ const CreateClassroom = ({ loaderData }: Route.ComponentProps) => {
 
             {currentStep === 1 && (
               <StepImportModules
-                ownedClassrooms={ownedClassrooms}
+                importableClassrooms={importableClassrooms}
                 importEnabled={importEnabled}
                 setImportEnabled={setImportEnabled}
                 sourceClassroomId={sourceClassroomId}

--- a/apps/webapp/app/routes/_user.create-classroom/sourceAccess.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/sourceAccess.ts
@@ -55,7 +55,9 @@ export const resolveSourceAccess = (
 
   const isOwner = usable.includes('OWNER');
   if (isOwner || !configSelections.apiKeys) {
-    return { allowed: true, isOwner, configSelections, warnings: [] };
+    // Copied on this branch too, so the caller's object is never aliased and the
+    // "returns a fresh object" contract holds regardless of which path ran.
+    return { allowed: true, isOwner, configSelections: { ...configSelections }, warnings: [] };
   }
 
   // Rewritten to `false` rather than deleted: the key is what the review step

--- a/apps/webapp/app/routes/_user.create-classroom/sourceAccess.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/sourceAccess.ts
@@ -1,0 +1,70 @@
+/**
+ * Who may import FROM a classroom, and what they may carry out of it.
+ *
+ * SERVER-SIDE DECISION. The create-classroom picker hides what a viewer cannot
+ * choose, but the source id and the copy selections both arrive in the request
+ * body, so the answer has to be recomputed here from real membership rows.
+ *
+ * The rule: **owners and teachers may import; only owners may copy the API
+ * keys.** Copying a class means copying its `ClassroomSettings`, and the
+ * `apiKeys` group carries `openai_api_key` / `anthropic_api_key` — real
+ * credentials. Letting a teacher take those would move the owner's LLM billing
+ * into a classroom the teacher controls, which is why this gate was originally
+ * owner-only for everything. Everything else in an import is course material a
+ * teacher can already read in the app, so the narrower rule is the accurate one.
+ */
+
+/** Roles that may be used as an import source. Assistants and students cannot. */
+export const SOURCE_ROLES = ['OWNER', 'TEACHER'] as const;
+export type SourceRole = (typeof SOURCE_ROLES)[number];
+
+/** Shown to the user when their key selection was dropped. */
+export const API_KEYS_STRIPPED_WARNING =
+  'AI API keys were not copied — only an owner of the source classroom can copy its keys.';
+
+export type SourceAccess =
+  | { allowed: false }
+  | {
+      allowed: true;
+      isOwner: boolean;
+      /** The selections to actually apply — `apiKeys` removed for non-owners. */
+      configSelections: Record<string, boolean>;
+      /** Non-empty when something was dropped from the request. */
+      warnings: string[];
+    };
+
+/**
+ * Decide access from the requester's membership rows on the SOURCE classroom.
+ *
+ * Takes every matching row rather than one: memberships are unique per
+ * (classroom, user, role) and a person may legitimately hold OWNER *and*
+ * TEACHER in the same classroom. Reading the role off a single arbitrary row
+ * could hand back TEACHER for someone who is also the owner and strip keys they
+ * are entitled to copy.
+ */
+export const resolveSourceAccess = (
+  roles: readonly string[],
+  configSelections: Record<string, boolean> = {}
+): SourceAccess => {
+  const usable = roles.filter((r): r is SourceRole =>
+    (SOURCE_ROLES as readonly string[]).includes(r)
+  );
+  if (usable.length === 0) {
+    return { allowed: false };
+  }
+
+  const isOwner = usable.includes('OWNER');
+  if (isOwner || !configSelections.apiKeys) {
+    return { allowed: true, isOwner, configSelections, warnings: [] };
+  }
+
+  // Rewritten to `false` rather than deleted: the key is what the review step
+  // and the persisted job row read, and an absent key would read as "not asked
+  // for" instead of "asked for and refused".
+  return {
+    allowed: true,
+    isOwner: false,
+    configSelections: { ...configSelections, apiKeys: false },
+    warnings: [API_KEYS_STRIPPED_WARNING],
+  };
+};

--- a/apps/webapp/app/routes/_user.create-classroom/types.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/types.ts
@@ -22,10 +22,18 @@ export interface ClassroomModule {
   };
 }
 
-export interface OwnedClassroom {
+/**
+ * A classroom the viewer may import FROM — one they OWN or TEACH.
+ *
+ * `is_owner` is derived server-side in the loader and decides one thing only:
+ * whether the API-keys option is offered. Teachers may copy everything else.
+ * It is display logic — the server strips the keys regardless (action.ts).
+ */
+export interface ImportableClassroom {
   id: string;
   slug?: string;
   name: string;
+  is_owner: boolean;
   git_organization?: {
     login: string;
     avatar_url?: string | null;

--- a/packages/tasks/src/workflows/__tests__/classroomImport.sourceAccess.test.ts
+++ b/packages/tasks/src/workflows/__tests__/classroomImport.sourceAccess.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The import task's run-time re-check of source access.
+ *
+ * This is the third of three enforcement points (picker query, create-classroom
+ * action, then here) and the only one that runs after the request is over: the
+ * copy happens later, in another process, from data on a row, so the membership
+ * it trusted at request time may since have been revoked.
+ *
+ * Two things are pinned. That it admits OWNER *and* TEACHER — the widening this
+ * file exists to protect, and which lives on the far side of a package boundary
+ * from the webapp's `SOURCE_ROLES`, so nothing but a test keeps the two lists
+ * agreeing. And that it refuses when no row comes back, rather than falling
+ * through to copy anyway.
+ *
+ * `@trigger.dev/sdk` and the service/db modules are mocked — no network, no DB.
+ * Prisma is a hand-written stub so the `where` clause itself can be asserted;
+ * the point is what is ASKED of the database, which a fixture-returning mock
+ * would hide.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@trigger.dev/sdk', () => ({
+  task: (config: unknown) => config,
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+vi.mock('@classmoji/services', () => ({ ClassmojiService: {} }));
+vi.mock('@classmoji/services/import-progress', async importOriginal => importOriginal());
+
+const { assertSourceAccess } = await import('../classroomImport.ts');
+
+const findFirst = vi.fn();
+const prisma = { classroomMembership: { findFirst } } as never;
+
+const job = {
+  id: 'job-1',
+  source_classroom_id: 'source-classroom',
+  requested_by: 'user-1',
+} as never;
+
+beforeEach(() => {
+  findFirst.mockReset();
+});
+
+describe('assertSourceAccess', () => {
+  it('passes when a membership row comes back', async () => {
+    findFirst.mockResolvedValue({ id: 'membership-1' });
+    await expect(assertSourceAccess(prisma, job)).resolves.toBeUndefined();
+  });
+
+  it('refuses when the requester no longer has one', async () => {
+    findFirst.mockResolvedValue(null);
+    await expect(assertSourceAccess(prisma, job)).rejects.toThrow(
+      'Requester no longer has access to the source classroom — import refused'
+    );
+  });
+
+  // The load-bearing assertion. A teacher must still be admitted here, or the
+  // copy dies at run time for exactly the people the widening was for — and the
+  // failure would surface as a failed background job, not a refused request.
+  it('asks for OWNER or TEACHER, scoped to this job’s source and requester', async () => {
+    findFirst.mockResolvedValue({ id: 'membership-1' });
+    await assertSourceAccess(prisma, job);
+
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    const { where } = findFirst.mock.calls[0][0];
+    expect(where.classroom_id).toBe('source-classroom');
+    expect(where.user_id).toBe('user-1');
+    expect([...where.role.in].sort()).toEqual(['OWNER', 'TEACHER']);
+  });
+
+  // Guards the obvious regression in the other direction: quietly re-narrowing
+  // to owners, or widening to the whole teaching team.
+  it('does not admit assistants or students', async () => {
+    findFirst.mockResolvedValue({ id: 'membership-1' });
+    await assertSourceAccess(prisma, job);
+
+    const { where } = findFirst.mock.calls[0][0];
+    expect(where.role.in).not.toContain('ASSISTANT');
+    expect(where.role.in).not.toContain('STUDENT');
+  });
+});

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -251,7 +251,10 @@ function phaseProgress(
  * action.ts). This task never applies `selections.config`; it reads
  * `selections.content` only.
  */
-async function assertSourceAccess(prisma: PrismaClient, job: LoadedImportJob): Promise<void> {
+export async function assertSourceAccess(
+  prisma: PrismaClient,
+  job: LoadedImportJob
+): Promise<void> {
   const membership = await prisma.classroomMembership.findFirst({
     where: {
       classroom_id: job.source_classroom_id,

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -238,25 +238,30 @@ function phaseProgress(
 }
 
 /**
- * Re-verify that the requester still OWNS the source classroom, at the moment
- * the copy actually happens.
+ * Re-verify that the requester still owns or teaches the source classroom, at
+ * the moment the copy actually happens.
  *
  * Defense in depth: the create-classroom action already checked this before
  * creating the row, but the copy now runs later, in a different process, from
- * data on a row. Ownership can be revoked in between, and settings can carry
- * API keys — so the task refuses rather than trusting its own input.
+ * data on a row, and the membership can be revoked in between.
+ *
+ * Membership is all this checks. The owner-only distinction — copying the
+ * source's API keys — is settled in the action, which strips the selection
+ * before it is ever persisted here (see the strip in create-classroom's
+ * action.ts). This task never applies `selections.config`; it reads
+ * `selections.content` only.
  */
-async function assertSourceOwnership(prisma: PrismaClient, job: LoadedImportJob): Promise<void> {
+async function assertSourceAccess(prisma: PrismaClient, job: LoadedImportJob): Promise<void> {
   const membership = await prisma.classroomMembership.findFirst({
     where: {
       classroom_id: job.source_classroom_id,
       user_id: job.requested_by,
-      role: 'OWNER',
+      role: { in: ['OWNER', 'TEACHER'] },
     },
     select: { id: true },
   });
   if (!membership) {
-    throw new Error('Requester no longer owns the source classroom — import refused');
+    throw new Error('Requester no longer has access to the source classroom — import refused');
   }
 }
 
@@ -797,7 +802,7 @@ async function runImport(prisma: PrismaClient, importJobId: string) {
   {
     let job = await loadJob(prisma, importJobId);
 
-    await assertSourceOwnership(prisma, job);
+    await assertSourceAccess(prisma, job);
 
     await prisma.importJob.update({
       where: { id: job.id },


### PR DESCRIPTION
## Summary

Promotes one change from staging: **teachers can import from a class they teach, minus the API keys** (#242).

**No database migrations in this release** — `packages/database/migrations/` is unchanged, so the Fly `release_command` has nothing to apply and no maintenance window is needed.

### What's shipping

The class-to-class copy in the create-classroom wizard required OWNER on the source, so a teacher could not make their own copy of a course they help run.

The reason for that restriction was real but narrower than the restriction itself: the copy includes `ClassroomSettings`, and the `apiKeys` group carries `openai_api_key` / `anthropic_api_key`. Importing could therefore lift the owner's LLM credentials into a classroom the requester controls. Everything else an import copies is course material a teacher already reads in the app.

So the rule is now **owners and teachers may import; only owners may copy the API keys.** Assistants and students are still refused.

Source access widened at all three enforcement points, since each stands alone — the picker query, the action's re-verification of the body-supplied source id, and the background task's re-check at run time. The keys are stripped server-side before the inline config apply and before the selections are written to the `ImportJob` row, so a future retry path that starts honouring `selections.config` cannot resurrect them.

The wizard also no longer offers, or promises, something the server will refuse: switching the source picker from an owned class to a taught one clears a stranded key selection, and the review step gates that line on ownership rather than on the raw selection. The refusal is now stated in the success message rather than counted anonymously as "1 item skipped — see server logs".

### Verification

`apps/webapp` 747 · `packages/tasks` 89 · `packages/services` 1216 (12 pre-existing GitLabProvider failures, unchanged). Typecheck carries only the two known pre-existing errors.

Reviewed by two independent passes — an authorization lens briefed on "what does this make newly reachable that is not on the approved list" (clean across all five checks) and a correctness lens (found the stale-selection defect above, fixed in the second commit).

Verified on staging: webapp v96 → v97, healthy, and `deploy-trigger` succeeded so the run-time gate is deployed alongside it.

### Merge note

**Merge as a true merge commit — not squash, not rebase.** `main` carries merge commits from previous promotions that `staging` never receives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014seDiH7vtqvdhQtnyp6nAw
