### PR TITLE
🚀 Promote staging to main

### DIFF
--- a/apps/mcp/src/tools/settings.ts
+++ b/apps/mcp/src/tools/settings.ts
@@ -22,7 +22,11 @@
  * return, which carries the raw settings row (API keys included).
  */
 
-import { ClassmojiService, getGitProvider } from '@classmoji/services';
+import {
+  ClassmojiService,
+  ClassroomSettingsEntitlementError,
+  getGitProvider,
+} from '@classmoji/services';
 import { z } from 'zod';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolDefinition } from '../mcp/registry.ts';
@@ -159,14 +163,25 @@ export const classroomSettingsUpdateTool: ToolDefinition<ClassroomSettingsUpdate
       throw new ToolError('invalid_params', 'Provide at least one setting to update');
     }
 
+    // Settings BEFORE the classroom row: `updateSettings` refuses a Pro-only
+    // field on an unentitled classroom, and doing it first means that refusal
+    // cannot leave a committed `name` change behind with no audit entry.
+    if (Object.keys(settings).length > 0) {
+      try {
+        await ClassmojiService.classroom.updateSettings(classroom.classroomId, settings);
+      } catch (error: unknown) {
+        if (error instanceof ClassroomSettingsEntitlementError) {
+          throw new ToolError('forbidden', error.message, 'PRO_REQUIRED');
+        }
+        throw error;
+      }
+    }
+
     // The Classroom row itself: `name` ONLY, mirroring the web route's
     // PROFILE_FIELDS whitelist (slug is the key in every URL and two HMAC
     // credentials; git_org_id would move the classroom to another org).
     if (args.name !== undefined) {
       await ClassmojiService.classroom.update(classroom.classroomId, { name: args.name });
-    }
-    if (Object.keys(settings).length > 0) {
-      await ClassmojiService.classroom.updateSettings(classroom.classroomId, settings);
     }
 
     await writeAudit(ctx, {

--- a/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.content/route.tsx
@@ -4,7 +4,7 @@ import { IconInfoCircle, IconExternalLink } from '@tabler/icons-react';
 
 import { namedAction } from 'remix-utils/named-action';
 
-import { ClassmojiService } from '@classmoji/services';
+import { ClassmojiService, ClassroomSettingsEntitlementError } from '@classmoji/services';
 import { getContentRepoName } from '@classmoji/utils';
 import { SettingSection } from '~/components';
 import { ActionTypes } from '~/constants';
@@ -25,12 +25,20 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     attemptedAction: 'view',
   });
 
+  // The syllabus bot is Pro-only; the toggle is disabled (not hidden) on Free
+  // so owners can see the feature exists and why it is unavailable.
+  const syllabusBotEntitlement = await ClassmojiService.entitlement.canUseSyllabusBot(classroom.id);
+
   // Return classroom with settings for display (API keys stripped by assertClassroomAccess)
-  return { organization: classroom, aiAgentAvailable: isAIAgentConfigured() };
+  return {
+    organization: classroom,
+    aiAgentAvailable: isAIAgentConfigured(),
+    syllabusBotProRequired: !syllabusBotEntitlement.allowed,
+  };
 };
 
 const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
-  const { organization, aiAgentAvailable } = loaderData;
+  const { organization, aiAgentAvailable, syllabusBotProRequired } = loaderData;
   const { class: classSlug } = useParams();
 
   const { fetcher } = useGlobalFetcher();
@@ -191,11 +199,36 @@ const SettingsContent = ({ loaderData }: Route.ComponentProps) => {
             <Switch
               checked={settings.syllabus_bot_enabled ?? false}
               onChange={handleSyllabusBotToggle}
-              disabled={!aiAgentAvailable}
+              // The feature predates the Pro gate, so Free classrooms with a
+              // stale `true` exist. Turning it OFF stays allowed (the server
+              // gates only the `true` direction) — otherwise those owners are
+              // stuck with a flag they cannot clear.
+              disabled={
+                !aiAgentAvailable || (syllabusBotProRequired && !settings.syllabus_bot_enabled)
+              }
             />
           </Form.Item>
 
-          {settings.syllabus_bot_enabled && (
+          {syllabusBotProRequired && (
+            <div className="flex items-start gap-2 rounded-lg bg-stone-50 p-3 text-sm text-gray-600 dark:bg-neutral-800 dark:text-gray-400">
+              <IconInfoCircle size={16} className="mt-0.5 shrink-0" />
+              <span>
+                The Syllabus Bot is available on the Pro plan.{' '}
+                <a
+                  href="/settings/billing"
+                  className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  Upgrade to enable it
+                </a>
+                .
+              </span>
+            </div>
+          )}
+
+          {/* Hidden when Pro is required: on a grandfathered Free classroom the
+              flag can still read `true`, but the runtime gate means students do
+              NOT see the Course Assistant button, so this panel would be lying. */}
+          {settings.syllabus_bot_enabled && !syllabusBotProRequired && (
             <div className="mt-4 p-4 bg-nav-hover rounded-lg border border-gray-200 dark:border-neutral-700">
               <div className="flex items-center gap-2 mb-3">
                 <IconInfoCircle size={16} className="text-ink-3" />
@@ -267,7 +300,19 @@ export const action = async ({ params, request }: Route.ActionArgs) => {
 
     async saveContentSettings() {
       const { _action, ...updateData } = data;
-      await ClassmojiService.classroom.updateSettings(classroom.id, updateData);
+      // updateSettings is the hard gate; catching here only turns the refusal
+      // into a readable message instead of a 500.
+      try {
+        await ClassmojiService.classroom.updateSettings(classroom.id, updateData);
+      } catch (error: unknown) {
+        if (error instanceof ClassroomSettingsEntitlementError) {
+          return {
+            error: error.message,
+            action: ActionTypes.SAVE_CONTENT_SETTINGS,
+          };
+        }
+        throw error;
+      }
       return {
         success: 'Content settings updated',
         action: ActionTypes.SAVE_CONTENT_SETTINGS,

--- a/apps/webapp/app/routes/api.syllabus-bot.$class/__tests__/pro-gating.test.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.$class/__tests__/pro-gating.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Pro gating for the syllabus bot.
+ *
+ * The bot is Pro-only, matching quizzes. Bring-your-own-key is deliberately NOT
+ * an access path — see entitlement.service.ts. These tests pin the three
+ * properties that matter:
+ *
+ *   1. The loader reports the bot as disabled for an unentitled classroom, and
+ *      only staff are told why.
+ *   2. Mutations 403 rather than reaching the agent.
+ *   3. Entitlement is checked AFTER the access check, so a non-member can never
+ *      probe a classroom's plan.
+ *
+ * Mirrors api.quiz/__tests__/ai-gating.test.ts in shape.
+ */
+
+const isAIAgentConfiguredMock = vi.fn();
+const assertClassroomAccessMock = vi.fn();
+const assertClassroomMutationAllowedMock = vi.fn();
+const canUseSyllabusBotMock = vi.fn();
+const getClassroomSettingsForServerMock = vi.fn();
+const sendRequestMock = vi.fn();
+
+vi.mock('~/utils/aiFeatures.server', () => ({
+  isAIAgentConfigured: () => isAIAgentConfiguredMock(),
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => assertClassroomAccessMock(...a),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  assertClassroomMutationAllowed: (...a: unknown[]) => assertClassroomMutationAllowedMock(...a),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    entitlement: { canUseSyllabusBot: (...a: unknown[]) => canUseSyllabusBotMock(...a) },
+    classroom: {
+      getClassroomSettingsForServer: (...a: unknown[]) => getClassroomSettingsForServerMock(...a),
+    },
+  },
+}));
+
+vi.mock('~/services/aiAgentConnection.server', () => ({
+  sendRequest: (...a: unknown[]) => sendRequestMock(...a),
+}));
+
+vi.mock('~/utils/agentStreamManager', () => ({ default: { publish: vi.fn() } }));
+vi.mock('@classmoji/utils', () => ({ getContentRepoName: () => 'content-x' }));
+vi.mock('~/routes/student.$class.quizzes/helpers.server', () => ({
+  getInstallationToken: vi.fn(),
+}));
+
+const CLASS = 'some-class';
+const CLASSROOM_ID = 'c1';
+
+const classroomAccess = (role = 'STUDENT') => ({
+  userId: 'user-1',
+  classroom: { id: 'c1', name: 'Some Class', status: 'ACTIVE', git_organization: { login: 'org' } },
+  membership: { role },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isAIAgentConfiguredMock.mockReturnValue(true);
+  assertClassroomAccessMock.mockResolvedValue(classroomAccess());
+  assertClassroomMutationAllowedMock.mockReturnValue(undefined);
+  getClassroomSettingsForServerMock.mockResolvedValue({ syllabus_bot_enabled: true });
+});
+
+describe('syllabus bot Pro gating — loader', () => {
+  it('reports disabled for an unentitled classroom even when the flag is on', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+    const { loader } = await import('../route');
+
+    const res = await loader({
+      params: { class: CLASS },
+      request: new Request('http://x/api/syllabus-bot/some-class'),
+    } as never);
+    const body = await (res as Response).json();
+
+    expect(body.enabled).toBe(false);
+  });
+
+  it('tells staff why but never students, so only the UI that can upsell learns it', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+    const { loader } = await import('../route');
+
+    const read = async (role: string) => {
+      assertClassroomAccessMock.mockResolvedValue(classroomAccess(role));
+      const res = await loader({
+        params: { class: CLASS },
+        request: new Request('http://x/api/syllabus-bot/some-class'),
+      } as never);
+      return (res as Response).json();
+    };
+
+    expect((await read('OWNER')).reason).toBe('pro_required');
+    expect((await read('TEACHER')).reason).toBe('pro_required');
+    expect((await read('STUDENT')).reason).toBeUndefined();
+    expect((await read('ASSISTANT')).reason).toBeUndefined();
+  });
+
+  it('serves the bot for an entitled classroom', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: true });
+    const { loader } = await import('../route');
+
+    const res = await loader({
+      params: { class: CLASS },
+      request: new Request('http://x/api/syllabus-bot/some-class'),
+    } as never);
+    const body = await (res as Response).json();
+
+    expect(body.enabled).toBe(true);
+    // Without this, a refactor that stops passing the classroom id sails through.
+    expect(canUseSyllabusBotMock).toHaveBeenCalledWith(CLASSROOM_ID);
+  });
+});
+
+describe('syllabus bot Pro gating — action', () => {
+  const post = async (fields: Record<string, string>) => {
+    const { action } = await import('../route');
+    const formData = new FormData();
+    Object.entries(fields).forEach(([k, v]) => formData.append(k, v));
+    return action({
+      params: { class: CLASS },
+      request: new Request('http://x/api/syllabus-bot/some-class', {
+        method: 'POST',
+        body: formData,
+      }),
+    } as never);
+  };
+
+  it('403s initConversation for an unentitled classroom', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+
+    const res = (await post({ _action: 'initConversation' })) as Response;
+
+    expect(res.status).toBe(403);
+    expect(sendRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('403s sendMessage for an unentitled classroom, buying no inference', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+
+    const res = (await post({
+      _action: 'sendMessage',
+      conversationId: 'conv-1',
+      content: 'hello',
+    })) as Response;
+
+    expect(res.status).toBe(403);
+    expect(sendRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('checks access before entitlement, so plan status cannot be probed', async () => {
+    const denied = new Response('Forbidden', { status: 403 });
+    assertClassroomAccessMock.mockRejectedValue(denied);
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: true });
+
+    await expect(post({ _action: 'initConversation' })).rejects.toBe(denied);
+    expect(canUseSyllabusBotMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.$class/route.ts
@@ -59,6 +59,23 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     });
   }
 
+  // Pro-gated, same as quizzes. Entitlement is checked on every request rather
+  // than baked into settings, so a lapsed plan stops serving the bot without
+  // anyone rewriting syllabus_bot_enabled.
+  const entitlement = await ClassmojiService.entitlement.canUseSyllabusBot(classroom.id);
+  if (!entitlement.allowed) {
+    const staff = ['OWNER', 'TEACHER'].includes(membership!.role);
+    return jsonResponse({
+      enabled: false,
+      hasContentRepo: false,
+      userRole: membership!.role,
+      isInstructor: staff,
+      orgName: classroom.name,
+      // Staff get a reason so the UI can explain/upsell; students just see it off.
+      ...(staff ? { reason: entitlement.reason } : {}),
+    });
+  }
+
   const settings = await ClassmojiService.classroom.getClassroomSettingsForServer(classroom.id);
   const isInstructor = ['OWNER', 'TEACHER'].includes(membership!.role);
 
@@ -116,6 +133,12 @@ async function handleInitConversation(request: Request, classSlug: string, formD
     attemptedAction: 'init_conversation',
   });
   assertClassroomMutationAllowed({ status: classroom.status, role: membership!.role });
+
+  // After the access check, so this never reveals a classroom's plan to a non-member.
+  const entitlement = await ClassmojiService.entitlement.canUseSyllabusBot(classroom.id);
+  if (!entitlement.allowed) {
+    return jsonResponse({ error: 'The syllabus assistant requires a Pro subscription' }, 403);
+  }
 
   const settings = await ClassmojiService.classroom.getClassroomSettingsForServer(classroom.id);
 
@@ -225,6 +248,14 @@ async function handleSendMessage(request: Request, classSlug: string, formData: 
     attemptedAction: 'send_message',
   });
   assertClassroomMutationAllowed({ status: smClassroom.status, role: smMembership!.role });
+
+  // Gate the expensive path too — a session created before the plan lapsed must
+  // not keep buying inference. endConversation is deliberately NOT gated, so an
+  // already-open session can still be cleaned up.
+  const smEntitlement = await ClassmojiService.entitlement.canUseSyllabusBot(smClassroom.id);
+  if (!smEntitlement.allowed) {
+    return jsonResponse({ error: 'The syllabus assistant requires a Pro subscription' }, 403);
+  }
 
   if (!conversationId || !content) {
     return jsonResponse({ error: 'Missing conversationId or content' }, 400);

--- a/apps/webapp/app/routes/api.syllabus-bot.stream.$conversationId.ts
+++ b/apps/webapp/app/routes/api.syllabus-bot.stream.$conversationId.ts
@@ -15,6 +15,7 @@ import type { LoaderFunctionArgs } from 'react-router';
 import { getAuthSession } from '@classmoji/auth/server';
 import { verifySessionOwnership, AgentType } from '~/utils/agentVerification.server';
 import agentStreamManager from '~/utils/agentStreamManager';
+import { ClassmojiService } from '@classmoji/services';
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const conversationId = params.conversationId!;
@@ -42,6 +43,20 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     if (!(verification as { valid: boolean }).valid) {
       console.warn(
         `[syllabus-bot-stream] Forbidden access: User ${authData.userId} tried to access conversation ${conversationId}`
+      );
+      return new Response('Forbidden', {
+        status: 403,
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    }
+
+    // 2b. Pro gate. Ownership alone isn't enough — a conversation opened while
+    // the classroom was Pro must not keep streaming after the plan lapses.
+    const entitlement =
+      await ClassmojiService.entitlement.canUseSyllabusBotForConversation(conversationId);
+    if (!entitlement.allowed) {
+      console.warn(
+        `[syllabus-bot-stream] Pro required for conversation ${conversationId} (user ${authData.userId})`
       );
       return new Response('Forbidden', {
         status: 403,

--- a/packages/services/src/classmoji/__tests__/classroomSettingsGate.test.ts
+++ b/packages/services/src/classmoji/__tests__/classroomSettingsGate.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * `updateSettings` is the shared write path behind the web settings actions and
+ * the MCP classroom_settings_update tool, so the Pro gate on
+ * `syllabus_bot_enabled` lives there rather than in each caller.
+ *
+ * Three properties, all of which have bitten before:
+ *   - enabling on a non-Pro classroom is refused, and nothing is written;
+ *   - DISABLING is always allowed (the feature predates the gate, so Free
+ *     classrooms hold stale `true`s their owners must be able to clear);
+ *   - a non-boolean truthy value cannot slip past a strict `=== true`.
+ */
+
+const upsertMock = vi.fn();
+const canUseSyllabusBotMock = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({ classroomSettings: { upsert: (...a: unknown[]) => upsertMock(...a) } }),
+}));
+
+vi.mock('../entitlement.service.ts', () => ({
+  canUseSyllabusBot: (...a: unknown[]) => canUseSyllabusBotMock(...a),
+}));
+
+vi.mock('../../git/index.ts', () => ({ GitHubProvider: class {} }));
+
+const CLASSROOM_ID = 'classroom-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  upsertMock.mockResolvedValue({});
+});
+
+describe('updateSettings — syllabus bot Pro gate', () => {
+  it('refuses to enable it on a classroom without Pro, and writes nothing', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+    const { updateSettings, ClassroomSettingsEntitlementError } =
+      await import('../classroom.service.ts');
+
+    await expect(
+      updateSettings(CLASSROOM_ID, { syllabus_bot_enabled: true })
+    ).rejects.toBeInstanceOf(ClassroomSettingsEntitlementError);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('allows enabling it on a Pro classroom', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: true });
+    const { updateSettings } = await import('../classroom.service.ts');
+
+    await updateSettings(CLASSROOM_ID, { syllabus_bot_enabled: true });
+
+    expect(canUseSyllabusBotMock).toHaveBeenCalledWith(CLASSROOM_ID);
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('always allows turning it OFF, even with no entitlement', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+    const { updateSettings } = await import('../classroom.service.ts');
+
+    await updateSettings(CLASSROOM_ID, { syllabus_bot_enabled: false });
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(canUseSyllabusBotMock).not.toHaveBeenCalled();
+  });
+
+  it('does not consult entitlement for unrelated settings writes', async () => {
+    const { updateSettings } = await import('../classroom.service.ts');
+
+    await updateSettings(CLASSROOM_ID, { theme: 'stone' });
+
+    expect(canUseSyllabusBotMock).not.toHaveBeenCalled();
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a non-boolean truthy value rather than passing it through', async () => {
+    canUseSyllabusBotMock.mockResolvedValue({ allowed: false, reason: 'pro_required' });
+    const { updateSettings, ClassroomSettingsEntitlementError } =
+      await import('../classroom.service.ts');
+
+    await expect(
+      // A JSON body can carry the string "true"; a strict === true check would
+      // have waved this straight through to Prisma.
+      updateSettings(CLASSROOM_ID, { syllabus_bot_enabled: 'true' as unknown as boolean })
+    ).rejects.toBeInstanceOf(ClassroomSettingsEntitlementError);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/entitlement.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/entitlement.service.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The syllabus bot's tier decision.
+ *
+ * The property that matters is NOT "does it say Pro sometimes" — it is that it
+ * delegates to `getProStateForClassroomId`, the one function that owns what
+ * "Pro" means. An earlier revision of this module reimplemented the rules on
+ * top of the superseded `getByClassroom`, which picks an arbitrary owner and
+ * skips the accepted-invite filter. That made the bot disagree with quizzes on
+ * multi-owner classrooms. These tests pin the delegation so it cannot come
+ * back.
+ */
+
+const getProStateForClassroomIdMock = vi.fn();
+const findUniqueConversationMock = vi.fn();
+
+vi.mock('../subscription.service.ts', () => ({
+  getProStateForClassroomId: (...a: unknown[]) => getProStateForClassroomIdMock(...a),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    aIConversation: { findUnique: (...a: unknown[]) => findUniqueConversationMock(...a) },
+  }),
+}));
+
+const CLASSROOM_ID = 'classroom-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('canUseSyllabusBot', () => {
+  it('allows when the canonical resolver says the classroom is Pro', async () => {
+    getProStateForClassroomIdMock.mockResolvedValue({ isPro: true, tier: 'PRO', isActive: true });
+    const { canUseSyllabusBot } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBot(CLASSROOM_ID)).toEqual({ allowed: true });
+  });
+
+  it('denies with pro_required when the resolver says it is not Pro', async () => {
+    getProStateForClassroomIdMock.mockResolvedValue({ isPro: false, tier: 'FREE', isActive: true });
+    const { canUseSyllabusBot } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBot(CLASSROOM_ID)).toEqual({
+      allowed: false,
+      reason: 'pro_required',
+    });
+  });
+
+  it('delegates rather than reimplementing — asks the canonical resolver, by id', async () => {
+    getProStateForClassroomIdMock.mockResolvedValue({ isPro: true });
+    const { canUseSyllabusBot } = await import('../entitlement.service.ts');
+
+    await canUseSyllabusBot(CLASSROOM_ID);
+
+    expect(getProStateForClassroomIdMock).toHaveBeenCalledTimes(1);
+    expect(getProStateForClassroomIdMock).toHaveBeenCalledWith(CLASSROOM_ID);
+  });
+
+  it("trusts isPro alone — a lapsed PRO row is the resolver's call, not ours", async () => {
+    // tier says PRO but the plan has ended. The resolver already folded ends_at
+    // into isPro; re-deriving it here is exactly the drift this guards against.
+    getProStateForClassroomIdMock.mockResolvedValue({
+      isPro: false,
+      tier: 'PRO',
+      isActive: false,
+    });
+    const { canUseSyllabusBot } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBot(CLASSROOM_ID)).toEqual({
+      allowed: false,
+      reason: 'pro_required',
+    });
+  });
+
+  it('allows a multi-owner classroom the resolver rules Pro', async () => {
+    // The regression case: getByClassroom would ask memberships[0] and could
+    // answer FREE here while quizzes answered PRO.
+    getProStateForClassroomIdMock.mockResolvedValue({ isPro: true, tier: 'PRO', isActive: true });
+    const { canUseSyllabusBot } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBot(CLASSROOM_ID)).toEqual({ allowed: true });
+  });
+});
+
+describe('canUseSyllabusBotForConversation', () => {
+  it('resolves the conversation to its classroom and gates on that', async () => {
+    findUniqueConversationMock.mockResolvedValue({ classroom_id: CLASSROOM_ID });
+    getProStateForClassroomIdMock.mockResolvedValue({ isPro: true });
+    const { canUseSyllabusBotForConversation } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBotForConversation('conv-1')).toEqual({ allowed: true });
+    expect(getProStateForClassroomIdMock).toHaveBeenCalledWith(CLASSROOM_ID);
+  });
+
+  it('denies an unknown conversation as not_found, never as pro_required', async () => {
+    findUniqueConversationMock.mockResolvedValue(null);
+    const { canUseSyllabusBotForConversation } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBotForConversation('nope')).toEqual({
+      allowed: false,
+      reason: 'not_found',
+    });
+    expect(getProStateForClassroomIdMock).not.toHaveBeenCalled();
+  });
+
+  it('denies when the conversation resolves to a non-Pro classroom', async () => {
+    findUniqueConversationMock.mockResolvedValue({ classroom_id: CLASSROOM_ID });
+    getProStateForClassroomIdMock.mockResolvedValue({ isPro: false });
+    const { canUseSyllabusBotForConversation } = await import('../entitlement.service.ts');
+
+    expect(await canUseSyllabusBotForConversation('conv-1')).toEqual({
+      allowed: false,
+      reason: 'pro_required',
+    });
+  });
+});

--- a/packages/services/src/classmoji/classroom.service.ts
+++ b/packages/services/src/classmoji/classroom.service.ts
@@ -1,6 +1,23 @@
 import getPrisma from '@classmoji/database';
 import { GitHubProvider } from '../git/index.ts';
+import * as entitlementService from './entitlement.service.ts';
 import type { Prisma, Role } from '@prisma/client';
+
+/**
+ * Thrown when a settings write is refused on plan grounds. A distinct class so
+ * callers can map it to a 403 rather than letting it surface as a 500 — see
+ * `admin.$class.settings.content` and `apps/mcp/src/tools/settings.ts`, both of
+ * which catch it. A caller that does not catch it gets a 500, which is the safe
+ * direction: the write is refused either way.
+ */
+export class ClassroomSettingsEntitlementError extends Error {
+  readonly reason = 'pro_required';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClassroomSettingsEntitlementError';
+  }
+}
 
 /**
  * Whitelist of setting fields that are SAFE to expose to the client.
@@ -691,6 +708,29 @@ export const updateSettings = async (
   classroomId: string,
   updates: Prisma.ClassroomSettingsUncheckedCreateWithoutClassroomInput
 ) => {
+  // Turning the syllabus bot ON is Pro-only. Enforced here rather than in the
+  // callers because this upsert is the write path shared by the web settings
+  // actions and the MCP classroom_settings_update tool. Turning it OFF is
+  // always allowed — the feature predates the gate, so Free classrooms with a
+  // stale `true` exist and their owners must be able to clear it.
+  //
+  // NOT the only writer: `classroomConfigImport` and the classroom-creation
+  // paths write `classroomSettings` directly. Those are handled at their own
+  // sites (config import gates the field in; creation paths default it false).
+  // Any NEW raw writer has to account for this itself.
+  //
+  // Tested against anything other than `false`/absent rather than `=== true`,
+  // so a JSON body carrying the string "true" cannot slip past a strict
+  // comparison into Prisma.
+  if (updates.syllabus_bot_enabled !== undefined && updates.syllabus_bot_enabled !== false) {
+    const entitlement = await entitlementService.canUseSyllabusBot(classroomId);
+    if (!entitlement.allowed) {
+      throw new ClassroomSettingsEntitlementError(
+        'The syllabus assistant requires a Pro subscription'
+      );
+    }
+  }
+
   return getPrisma().classroomSettings.upsert({
     where: { classroom_id: classroomId },
     create: {

--- a/packages/services/src/classmoji/classroomConfigImport.service.ts
+++ b/packages/services/src/classmoji/classroomConfigImport.service.ts
@@ -1,6 +1,7 @@
 import getPrisma from '@classmoji/database';
 import type { Prisma } from '@prisma/client';
 import { ModuleItemType } from '@prisma/client';
+import * as entitlementService from './entitlement.service.ts';
 
 type RepositoryImportClient = Prisma.TransactionClient | ReturnType<typeof getPrisma>;
 
@@ -17,9 +18,9 @@ export interface ConfigImportSelections {
   /** default_tokens_per_hour */
   tokens?: boolean;
   /**
-   * quizzes_enabled, slides_enabled, syllabus_bot_enabled,
-   * recent_viewers_enabled, show_modules, show_pages, show_repos,
-   * default_student_page, theme
+   * quizzes_enabled, slides_enabled, syllabus_bot_enabled, recent_viewers_enabled,
+   * show_modules, show_pages, show_repos, default_student_page, theme.
+   * syllabus_bot_enabled only lands on a Pro target — see importClassroomConfig.
    */
   features?: boolean;
   /** llm_provider, llm_model, llm_temperature, llm_max_tokens, code_aware_model, syllabus_bot_model */
@@ -36,6 +37,13 @@ export interface ConfigImportSelections {
 export interface ConfigImportSummary {
   /** Which ClassroomSettings fields were written (post null/undefined filtering). */
   settings_fields: string[];
+  /**
+   * Fields deliberately NOT written because the target classroom is not
+   * entitled to them (today: syllabus_bot_enabled on a non-Pro target). Present
+   * only when something was skipped, so the caller can say so rather than
+   * letting the setting vanish silently.
+   */
+  settings_fields_skipped?: string[];
   /** Number of EmojiMapping rows inserted (skipDuplicates applied). */
   emoji_mappings: number;
   /** Number of LetterGradeMapping rows inserted (skipDuplicates applied). */
@@ -60,6 +68,10 @@ export const SETTINGS_FIELD_GROUPS: Record<
   features: [
     'quizzes_enabled',
     'slides_enabled',
+    // Pro-gated. This writer bypasses `updateSettings`, so the entitlement of
+    // the TARGET classroom is checked in importClassroomConfig below and the
+    // field dropped from the patch when it is not allowed. Listed here so a
+    // Pro -> Pro clone still carries it.
     'syllabus_bot_enabled',
     'recent_viewers_enabled',
     'show_modules',
@@ -161,10 +173,26 @@ export const importClassroomConfig = async (
     const sourceRecord = source as unknown as Record<string, unknown>;
     const patch: Record<string, unknown> = {};
     const written: string[] = [];
+    const skipped: string[] = [];
+
+    // This writer does not go through `updateSettings`, so the Pro gate on
+    // syllabus_bot_enabled has to be applied here. Only ENABLING is gated —
+    // copying a `false` is always fine — and the check runs once, only when the
+    // source actually has it on.
+    const copyingBotOn =
+      fields.includes('syllabus_bot_enabled') && sourceRecord.syllabus_bot_enabled === true;
+    const botAllowedOnTarget = copyingBotOn
+      ? (await entitlementService.canUseSyllabusBot(targetClassroomId)).allowed
+      : false;
+
     for (const field of fields) {
       const value = sourceRecord[field];
       // Skip null/undefined; false/0 are not null/undefined so they copy verbatim.
       if (value === null || value === undefined) continue;
+      if (field === 'syllabus_bot_enabled' && value === true && !botAllowedOnTarget) {
+        skipped.push(field);
+        continue;
+      }
       patch[field] = value;
       written.push(field);
     }
@@ -176,6 +204,7 @@ export const importClassroomConfig = async (
       });
     }
     summary.settings_fields = written;
+    if (skipped.length > 0) summary.settings_fields_skipped = skipped;
   }
 
   // --- Grade scales (emoji + letter grade mappings) ----------------------

--- a/packages/services/src/classmoji/entitlement.service.ts
+++ b/packages/services/src/classmoji/entitlement.service.ts
@@ -1,0 +1,72 @@
+import getPrisma from '@classmoji/database';
+import * as subscriptionService from './subscription.service.ts';
+
+/**
+ * Plan entitlement for AI features, shared by every app.
+ *
+ * This module does NOT decide what "Pro" means — `getProStateForClassroomId`
+ * does, and every gate delegates to it so they cannot disagree. Quizzes reach
+ * it through the webapp's `assertProTier` and the MCP's copy in
+ * `apps/mcp/src/resources/content.ts`; the syllabus bot reaches it through
+ * here. Reimplementing the tier rules (owner resolution, `ends_at`) in this
+ * file would recreate the drift those call sites were consolidated to avoid.
+ *
+ * Entitlement is evaluated at SERVE time, never stored. A feature flag such as
+ * `syllabus_bot_enabled` is necessary but not sufficient: a classroom whose
+ * plan lapses stops being served without anyone rewriting its settings, and
+ * re-upgrading restores the previous state untouched.
+ *
+ * Addressed by classroom ID rather than slug, matching
+ * `getProStateForClassroomId` — every caller already holds a classroom from its
+ * access check, an id cannot be re-pointed by a rename, and it keeps this off
+ * the extra lookup that the config loader (hit on every classroom navigation,
+ * by every user) would otherwise pay.
+ */
+
+export type EntitlementDenialReason = 'pro_required' | 'not_found';
+
+export type EntitlementResult =
+  | { allowed: true }
+  | { allowed: false; reason: EntitlementDenialReason };
+
+const ALLOWED: EntitlementResult = { allowed: true };
+const PRO_REQUIRED: EntitlementResult = { allowed: false, reason: 'pro_required' };
+const NOT_FOUND: EntitlementResult = { allowed: false, reason: 'not_found' };
+
+/**
+ * Whether the syllabus bot may be served for this classroom.
+ *
+ * Pro-only, matching quizzes. Bring-your-own-key is intentionally NOT an access
+ * path: `apps/ai-agent/src/llm/services/syllabusBot.js` falls back to the
+ * platform key when the classroom key is empty, so "has a key" is not a safe
+ * entitlement signal, and a non-empty key is not necessarily a working one. If
+ * BYOK ever becomes a deliberate tier it should be designed once across every
+ * AI feature — changing it starts here.
+ */
+export const canUseSyllabusBot = async (classroomId: string): Promise<EntitlementResult> => {
+  const { isPro } = await subscriptionService.getProStateForClassroomId(classroomId);
+  return isPro ? ALLOWED : PRO_REQUIRED;
+};
+
+/**
+ * Same check, addressed by conversation — for the SSE stream route, which only
+ * knows a conversation id.
+ *
+ * An unknown conversation is denied: the stream has no legitimate use for one
+ * that does not exist. Reported as 'not_found' rather than 'pro_required' so a
+ * data-integrity problem never renders to an owner as "buy Pro".
+ */
+export const canUseSyllabusBotForConversation = async (
+  conversationId: string
+): Promise<EntitlementResult> => {
+  const conversation = await getPrisma().aIConversation.findUnique({
+    where: { id: conversationId },
+    select: { classroom_id: true },
+  });
+
+  if (!conversation) {
+    return NOT_FOUND;
+  }
+
+  return canUseSyllabusBot(conversation.classroom_id);
+};

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -29,6 +29,8 @@ import * as organizationTagService from './organizationTag.service.ts';
 import * as regradeRequestService from './regradeRequest.service.ts';
 import * as gitRepoService from './gitRepo.service.ts';
 import * as subscriptionService from './subscription.service.ts';
+import * as entitlementService from './entitlement.service.ts';
+export { ClassroomSettingsEntitlementError } from './classroom.service.ts';
 import * as teamMembershipService from './teamMembership.service.ts';
 import * as teamService from './team.service.ts';
 import * as teamTagService from './teamTag.service.ts';
@@ -80,6 +82,7 @@ const ClassmojiService = {
   regradeRequest: regradeRequestService,
   gitRepo: gitRepoService,
   subscription: subscriptionService,
+  entitlement: entitlementService,
   teamMembership: teamMembershipService,
   team: teamService,
   teamAdmin: teamAdminService,
@@ -139,6 +142,7 @@ export {
   regradeRequestService,
   gitRepoService,
   subscriptionService,
+  entitlementService,
   teamMembershipService,
   teamService,
   teamAdminService,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -47,6 +47,7 @@ export {
   assignmentService,
   gitRepoAssignmentService,
   notificationService,
+  ClassroomSettingsEntitlementError,
 } from './classmoji/index.ts';
 
 export { ClassmojiService, HelperService, StripeService, FlyCertService, MarkdownImporter };


### PR DESCRIPTION
Promotes #244 — gates the syllabus bot behind the Pro plan.

**Scope:** 2 commits, 12 files, **no schema change and no migrations**. Nothing else has accumulated on staging.

**Verified on staging** (webapp v98, full deploy green after re-running an unrelated Fly builder flake on slides): 753 webapp / 801 services / 496 MCP tests passing; typecheck and lint clean on every touched file.

**Production impact.** Three classrooms have `syllabus_bot_enabled = true` out of 1,303 active:

| Classroom | Owner tier | Students | After this ships |
|---|---|---|---|
| `dartmouth-cs52/dartmouth-cs52-26f` | PRO | 0 | unchanged |
| `dartmouth-cs98/dartmouth-cs98-27w` | PRO | 0 | unchanged |
| `FIAP-MOBILE/2026-2tdsa` | PRO (complimentary) | 27 | unchanged |

FIAP was Free with their own API key and is the only real user of the feature. They were granted complimentary Pro ahead of this merge (subscription `ca72903a…`, no end date, verified resolving PRO/active), so the gate is a no-op for every classroom currently using the bot.

**Merged as a true merge commit**, never squash — `main` carries 30 commits staging lacks, including the prod-only task guards.
