### PR TITLE
fix(webapp): stop the student detail drawer crashing, and scope its loader

### DIFF
--- a/apps/webapp/app/routes/admin.$class.students.$login/SingleStudentView.tsx
+++ b/apps/webapp/app/routes/admin.$class.students.$login/SingleStudentView.tsx
@@ -50,9 +50,16 @@ interface StudentRepoAssignment {
   is_late_override: boolean;
   num_late_hours: number;
   extension_hours: number;
-  repository: {
+  // The student's own repo. Named `repository` until 574339e renamed the
+  // relation (module -> repository, repository -> gitRepo) in services; this
+  // interface kept the old name, which is why the compiler never flagged the
+  // two dereferences below it.
+  git_repo: {
     name: string;
-    student_id: string;
+    // Nullable in the schema: a GitRepo belongs to EITHER a student or a team.
+    // Every row here is a student repo — findAllForStudent filters on
+    // git_repo.student_id — but the type must not claim more than the schema.
+    student_id: string | null;
     [key: string]: unknown;
   };
   graders: Array<{ grader: { id: string; login: string; name: string } }>;
@@ -255,9 +262,19 @@ const SingleStudentView = (props: SingleStudentViewProps) => {
               repositoryAssignment={{
                 id: record.id,
                 assignment_id: record.assignment_id,
-                studentId: record.repository.student_id,
+                // Mirrors the same EmojiGrader call in
+                // assistant.$class_.grading/RepositoryAssignmentsTable.tsx,
+                // which was updated when the relation was renamed. This one was
+                // missed, and `record.repository` has been undefined ever since
+                // — `.student_id` on it threw during the initial render of the
+                // auto-expanded assignment table, taking the whole page down for
+                // any student with graded work.
+                studentId: record.git_repo.student_id ?? undefined,
                 grades: record.grades,
-                repository: record.repository,
+                // EmojiGrader reads `repository?.name` to build the repoName it
+                // posts to addGrade, so this being undefined silently submitted
+                // a null repo name once the crash above was out of the way.
+                repository: record.git_repo,
               }}
               emojiMappings={emojiMappings as Record<string, unknown>}
             />

--- a/apps/webapp/app/routes/admin.$class.students.$login/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.students.$login/route.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider, Modal, Button, theme } from 'antd';
+import { ConfigProvider, Modal, theme } from 'antd';
 import { IconUser, IconX } from '@tabler/icons-react';
 
 import { useRouteDrawer, useDarkMode } from '~/hooks';
@@ -18,29 +18,69 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'view_student',
   });
 
-  const student = await ClassmojiService.user.findByLogin(login!);
+  // One classroom-scoped, role-pinned, projected lookup — the same fix
+  // admin.$class.grades.$login already carries.
+  //
+  // This used to resolve the student with the GLOBAL `user.findByLogin`, which
+  // includes every classroom that student belongs to, each one's
+  // git_organization row (carrying `access_token` and `github_installation_id`)
+  // and each one's owner memberships — and returned the whole graph. There is
+  // no entry.server.tsx here, so React Router serialises whatever a loader
+  // returns straight into the page.
+  const enrollment = await ClassmojiService.classroomMembership.findStudentByLoginInClassroom(
+    classroom.id,
+    login!
+  );
+
+  // No such student in THIS classroom. An unknown login and a login belonging
+  // to someone outside the classroom are indistinguishable from here, which is
+  // the intent. Previously this dereferenced a null user (`student!.id`) and
+  // answered with a 500 — including for a correct login in the wrong case,
+  // since the lookup is case-sensitive.
+  if (!enrollment) {
+    throw new Response('Student not found', { status: 404 });
+  }
+
+  const student = {
+    id: enrollment.user.id,
+    name: enrollment.user.name,
+    login: enrollment.user.login,
+    school_id: enrollment.user.school_id,
+    // The view reads `avatar_url`; the User column is `image`.
+    avatar_url: enrollment.user.image,
+    image: enrollment.user.image,
+  };
+
   const repositories = await ClassmojiService.repository.findByClassroomSlug(classSlug!);
   const repositoryAssignments = await ClassmojiService.gitRepoAssignment.findAllForStudent(
-    student!.id,
+    student.id,
     classSlug!
   );
 
   const emojiMappings = await ClassmojiService.emojiMapping.findByClassroomId(classroom.id);
 
-  const settings = await ClassmojiService.classroom.getClassroomSettingsForServer(classroom.id);
+  // Projected, not the raw row. `getClassroomSettingsForServer` is a bare
+  // findUnique on ClassroomSettings, which carries `openai_api_key` and
+  // `anthropic_api_key` — its name says ForServer, and this loader was
+  // returning it to the browser. The grade maths (OrganizationSettings in
+  // @classmoji/utils) wants exactly one field.
+  const settingsRow = await ClassmojiService.classroom.getClassroomSettingsForServer(classroom.id);
+  const settings = {
+    late_penalty_points_per_hour: settingsRow?.late_penalty_points_per_hour ?? 0,
+  };
 
   const letterGradeMappings = await ClassmojiService.letterGradeMapping.findByClassroomId(
     classroom.id
   );
 
-  const tokenBalance = await ClassmojiService.token.getBalance(classroom.id, student!.id);
+  const tokenBalance = await ClassmojiService.token.getBalance(classroom.id, student.id);
 
   addAuditLog({
     request,
     params,
     action: 'VIEW',
     resourceType: 'STUDENT_GRADES_SCREEN',
-    resourceId: String(student!.id),
+    resourceId: String(student.id),
   });
 
   return {
@@ -91,7 +131,13 @@ const StudentView = ({ loaderData }: Route.ComponentProps) => {
         maskClosable
         destroyOnClose
         styles={{
-          content: { padding: 0, borderRadius: 16, overflow: 'hidden', maxWidth: 1100, margin: '0 auto' },
+          content: {
+            padding: 0,
+            borderRadius: 16,
+            overflow: 'hidden',
+            maxWidth: 1100,
+            margin: '0 auto',
+          },
           body: { padding: 0 },
           header: { display: 'none' },
           footer: { display: 'none' },
@@ -103,7 +149,7 @@ const StudentView = ({ loaderData }: Route.ComponentProps) => {
             <IconUser size={18} strokeWidth={1.75} className="shrink-0 text-ink-3" />
             <div className="min-w-0">
               <div className="text-sm font-semibold text-ink-0 truncate">
-                @{student!.login} &mdash; {student!.name}
+                @{student.login} &mdash; {student.name}
               </div>
             </div>
           </div>

--- a/packages/services/src/classmoji/classroomMembership.service.ts
+++ b/packages/services/src/classmoji/classroomMembership.service.ts
@@ -110,7 +110,11 @@ export const findStudentByLoginInClassroom = async (classroomId: string, login: 
       comment: true,
       letter_grade: true,
       user: {
-        select: { id: true, name: true, login: true, image: true },
+        // `school_id` is owner-only contact info (see
+        // apps/webapp/app/utils/studentFields.server.ts). Selected here because
+        // the student detail drawer shows it, but callers still choose what to
+        // return — the grades drawer projects it away.
+        select: { id: true, name: true, login: true, image: true, school_id: true },
       },
     },
   });


### PR DESCRIPTION
Fixes the blank page reported at `/admin/hg2051-2026-sem1/students/alishaanwarr` — clicking the eye icon on the students roster.

## The crash

`SingleStudentView.tsx:258` read `record.repository.student_id`. Commit `574339e` renamed that Prisma relation on `GitRepoAssignment` (`repository` → `git_repo`) in services, and `d8ef1ea` did the same for webapp server code, but **neither touched this file**. `record.repository` has been `undefined` ever since, so the Actions column's `render` threw

```
TypeError: Cannot read properties of undefined (reading 'student_id')
```

during the initial paint of the **auto-expanded** assignment sub-table (`defaultExpandedRowKeys`, `:375-377`), blanking the page for any student with graded work. A student with no assignments renders no such cell, which is why it looked student-specific.

**It is client-only.** Fly logs show the loader returning `200` in 201ms for `…/alishaanwarr.data`, with zero 5xx — the page's own server render never reaches that column.

**Why the compiler stayed quiet:** the local `StudentRepoAssignment` interface declared a `repository` member the row does not have, and `route.tsx:171-173` casts the loader value into that shape. Correcting the interface is the load-bearing edit here; the two dereferences are what it then exposes.

The fix matches `assistant.$class_.grading/RepositoryAssignmentsTable.tsx:433-435`, the same `EmojiGrader` call against the same query, which *was* updated in the rename.

## A second bug in the same block

`repository: record.repository` passed `undefined`. `EmojiGrader` reads `repository?.name` to build the `repoName` it posts to `addGrade`, so grading from this screen would have submitted a null repo name even once the crash was gone.

## Loader defects — the ones #240 fixed next door and missed here

`admin.$class.grades.$login` got both of these in #240; this route did not.

- **Global lookup, unscoped.** `user.findByLogin` returns every classroom the student belongs to, each one's `git_organization` (carrying `access_token`) and each one's owner memberships — and this loader returned the whole graph. There is no `entry.server.tsx`, so a loader's return is serialised straight into the page. Now uses the classroom-scoped, role-pinned, projected `findStudentByLoginInClassroom` and throws 404 instead of dereferencing a null user.
- **Raw settings row.** `getClassroomSettingsForServer` is a bare `findUnique` on `ClassroomSettings`, which carries `openai_api_key` and `anthropic_api_key`. Its name says *ForServer*; the loader shipped it to the browser. Now projected to `late_penalty_points_per_hour`, the single field `OrganizationSettings` in `@classmoji/utils` uses.

`school_id` is added to `findStudentByLoginInClassroom`'s select because this drawer displays it; the grades drawer projects it away.

## Verification

Against the local seed, as an owner of `example-pape98`:

| Case | Before | After |
|---|---|---|
| valid student | blank page | **200** |
| unknown login | 500 | **404** |
| correct login, wrong case | 500 | **404** |
| student from another classroom | 200, rendered | **404** |
| teacher's login (not a student here) | 200 | **404** |

`openai_api_key` / `anthropic_api_key` confirmed absent from the serialised payload; other classrooms' slugs absent.

Typecheck and lint at the `staging` baseline (webapp 1 pre-existing TS error in `RequireGitProvider.tsx`; services 16 pre-existing in `GitLabProvider` tests). Both touched webapp files are lint-clean — a pre-existing unused `Button` import went with them.

**Not verified end-to-end:** I could not render the crashing cell. It lives in an auto-expanded sub-table that neither SSR nor `renderToStaticMarkup` produces, so no HTTP or Node-side check reaches it. The data shape was proven directly against the database — `record.repository` is `undefined` and throws that exact `TypeError`, while `record.git_repo` carries `name` and `student_id`. **Please confirm in a browser.**

## Known, not fixed here

`classroom.git_organization` still reaches the browser via the shared record from `assertClassroomAccess`, so `github_installation_id` ships from **every** admin route (and `access_token` would, for GitLab/Gitea orgs — it is null on GitHub App installs). That is platform-wide and wants its own change rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)