### PR TITLE
fix(syllabus-bot): stop a clock-skew auth failure from posing as an outage

### DIFF
--- a/apps/webapp/app/components/features/syllabus-bot/SyllabusBotChat.tsx
+++ b/apps/webapp/app/components/features/syllabus-bot/SyllabusBotChat.tsx
@@ -298,7 +298,14 @@ const SyllabusBotChat = ({
             onBlur={() => setInputFocused(false)}
             disabled={isStreaming || isInitializing}
           />
-          {inputValue || inputFocused ? (
+          {isInitializing ? (
+            // The composer is genuinely disabled while the course content is
+            // being fetched, which can take a while on a cold start. Saying so
+            // is the difference between "waiting" and "broken".
+            <span className="askmoji-input-display askmoji-input-display--empty">
+              Reading the course materials&hellip;
+            </span>
+          ) : inputValue || inputFocused ? (
             <span className="askmoji-input-display">
               {inputValue}
               {!isStreaming && !isInitializing && <span className="askmoji-cursor" />}

--- a/apps/webapp/app/hooks/useSyllabusBot.ts
+++ b/apps/webapp/app/hooks/useSyllabusBot.ts
@@ -40,6 +40,10 @@ export function useSyllabusBot({ classroomSlug, userRole }: UseSyllabusBotOption
   const [hasContentRepo, setHasContentRepo] = useState(false);
 
   const eventSourceRef = useRef<EventSource | null>(null);
+  // Answers only ever arrive over SSE, so "is the stream up?" is a precondition
+  // for sending, not a cosmetic detail. Tracked in a ref because sendMessage
+  // must read it at call time without re-subscribing on every change.
+  const streamAliveRef = useRef(false);
 
   /**
    * Initialize a new syllabus bot conversation
@@ -104,7 +108,11 @@ export function useSyllabusBot({ classroomSlug, userRole }: UseSyllabusBotOption
 
       const eventSource = new EventSource(`/api/syllabus-bot/stream/${convId}`);
       eventSourceRef.current = eventSource;
-      eventSource.addEventListener('connected', () => {});
+      streamAliveRef.current = false;
+
+      eventSource.addEventListener('connected', () => {
+        streamAliveRef.current = true;
+      });
 
       eventSource.addEventListener('assistant_response', event => {
         const data = JSON.parse(event.data);
@@ -129,18 +137,42 @@ export function useSyllabusBot({ classroomSlug, userRole }: UseSyllabusBotOption
         setMessages(prev => [...prev, newMessage]);
       });
 
+      // Two unrelated failures arrive on this one listener: a server-sent
+      // `event: error` (carries a JSON payload) and a transport failure
+      // (carries nothing). They need different handling.
       eventSource.addEventListener('error', event => {
         const messageEvent = event as MessageEvent;
-        const data = messageEvent.data ? JSON.parse(messageEvent.data) : {};
-        setError(data.error || 'Connection error');
-        setIsStreaming(false);
+
+        if (messageEvent.data) {
+          let payload: { error?: string } = {};
+          try {
+            payload = JSON.parse(messageEvent.data);
+          } catch {
+            // A non-JSON body is still a failure — just don't take the
+            // listener down on the way to reporting it.
+          }
+          setError(payload.error || 'The course assistant hit an error.');
+          setIsStreaming(false);
+          return;
+        }
+
+        // Transport failure. EventSource retries transient drops on its own,
+        // so only CLOSED is terminal — and that is exactly the case where no
+        // answer can ever arrive, so the composer has to be released instead
+        // of sitting disabled forever.
+        if (eventSource.readyState === EventSource.CLOSED) {
+          streamAliveRef.current = false;
+          setError(
+            'Lost the connection to the course assistant. Start a new conversation to retry.'
+          );
+          setIsStreaming(false);
+        }
       });
 
       eventSource.addEventListener('done', () => {
+        streamAliveRef.current = false;
         eventSource.close();
       });
-
-      eventSource.onerror = () => {};
     },
     [classroomSlug]
   );
@@ -151,6 +183,15 @@ export function useSyllabusBot({ classroomSlug, userRole }: UseSyllabusBotOption
   const sendMessage = useCallback(
     async (content: string) => {
       if (!conversationId || !content.trim()) return;
+
+      // The POST only acknowledges receipt; the reply comes back over SSE. If
+      // that stream is down, sending would set isStreaming with nothing left
+      // that could ever clear it — which is what left the input permanently
+      // disabled instead of showing a failure.
+      if (!streamAliveRef.current) {
+        setError('Not connected to the course assistant. Start a new conversation to retry.');
+        return;
+      }
 
       setIsStreaming(true);
       setError(null);
@@ -211,6 +252,7 @@ export function useSyllabusBot({ classroomSlug, userRole }: UseSyllabusBotOption
       eventSourceRef.current.close();
       eventSourceRef.current = null;
     }
+    streamAliveRef.current = false;
 
     try {
       const formData = new FormData();

--- a/apps/webapp/app/utils/__tests__/agentVerification.test.ts
+++ b/apps/webapp/app/utils/__tests__/agentVerification.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * verifySessionOwnership is what gates the syllabus bot's SSE stream.
+ *
+ * The property under test is how it handles a REFUSAL. ai-agent answers a
+ * rejected HMAC signature with `{ type: 'ERROR', code: 'AUTH_FAILED' }`, not
+ * with SESSION_VERIFIED. Listening only for SESSION_VERIFIED meant a refusal
+ * was indistinguishable from silence: the promise hung for the full 5s and
+ * then rejected with "Session verification timeout", which the stream route
+ * maps to a 503 "service unavailable, retry". On 2026-08-28 that turned 4ms of
+ * clock skew into a syllabus bot that looked like a transient outage.
+ */
+
+const emitted: { type: string; requestId?: string; payload?: unknown }[] = [];
+const listeners = new Map<string, ((msg: unknown) => void)[]>();
+
+const socket = {
+  connected: false,
+  on: (evt: string, fn: (msg: unknown) => void) => {
+    listeners.set(evt, [...(listeners.get(evt) ?? []), fn]);
+  },
+  once: (evt: string, fn: (msg: unknown) => void) => {
+    listeners.set(evt, [...(listeners.get(evt) ?? []), fn]);
+  },
+  off: (evt: string, fn: (msg: unknown) => void) => {
+    listeners.set(
+      evt,
+      (listeners.get(evt) ?? []).filter(f => f !== fn)
+    );
+  },
+  emit: (_evt: string, msg: { type: string; requestId?: string; payload?: unknown }) => {
+    emitted.push(msg);
+  },
+  disconnect: () => {},
+};
+
+// The module waits for a 'connect' event before it will send anything, so the
+// fake transport has to complete its handshake the way socket.io would.
+vi.mock('socket.io-client', () => ({
+  io: () => {
+    setTimeout(() => {
+      for (const fn of listeners.get('connect') ?? []) fn(undefined);
+    }, 0);
+    return socket;
+  },
+}));
+vi.mock('../agentAuth.server', () => ({
+  signPayload: (p: Record<string, unknown>) => ({ ...p, _auth: { timestamp: 1, signature: 'x' } }),
+}));
+
+// Deliver a reply as ai-agent would, echoing the requestId the caller sent.
+const reply = (type: string, payload: unknown) => {
+  const requestId = emitted.at(-1)?.requestId;
+  for (const fn of listeners.get('message') ?? []) fn({ type, requestId, payload });
+};
+
+let verifySessionOwnership: typeof import('../agentVerification.server').verifySessionOwnership;
+
+beforeEach(async () => {
+  emitted.length = 0;
+  listeners.clear();
+  vi.resetModules();
+  process.env.AI_AGENT_URL = 'http://ai-agent.test';
+  ({ verifySessionOwnership } = await import('../agentVerification.server'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const call = () =>
+  verifySessionOwnership({ sessionId: 'conv-1', agentType: 'SYLLABUS_BOT', userId: 'user-1' });
+
+describe('verifySessionOwnership', () => {
+  it('resolves with the payload when ai-agent verifies the session', async () => {
+    const promise = call();
+    await vi.waitFor(() => expect(emitted).toHaveLength(1));
+    reply('SESSION_VERIFIED', { valid: true, sessionStatus: 'active' });
+
+    await expect(promise).resolves.toEqual({ valid: true, sessionStatus: 'active' });
+  });
+
+  it('rejects immediately on ERROR instead of hanging until the timeout', async () => {
+    const promise = call();
+    await vi.waitFor(() => expect(emitted).toHaveLength(1));
+    reply('ERROR', { error: 'Authentication failed', code: 'AUTH_FAILED' });
+
+    // The message must NOT read as a timeout — the SSE route turns anything
+    // containing "timeout" into a 503, which is what disguised the auth
+    // failure as a transient outage.
+    await expect(promise).rejects.toThrow(/Authentication failed/);
+    await expect(promise).rejects.toThrow(/AUTH_FAILED/);
+    await promise.catch((e: Error) => {
+      expect(e.message).not.toMatch(/timeout/i);
+      expect(e.message).not.toMatch(/disconnect/i);
+    });
+  });
+
+  it('ignores a reply meant for a different request', async () => {
+    const promise = call();
+    await vi.waitFor(() => expect(emitted).toHaveLength(1));
+
+    for (const fn of listeners.get('message') ?? []) {
+      fn({ type: 'SESSION_VERIFIED', requestId: 'someone-else', payload: { valid: true } });
+    }
+    // Still pending — then the real answer lands.
+    reply('SESSION_VERIFIED', { valid: false, sessionStatus: null });
+
+    await expect(promise).resolves.toEqual({ valid: false, sessionStatus: null });
+  });
+
+  it('rejects when the socket drops mid-verification', async () => {
+    const promise = call();
+    await vi.waitFor(() => expect(emitted).toHaveLength(1));
+    for (const fn of listeners.get('disconnect') ?? []) fn(undefined);
+
+    await expect(promise).rejects.toThrow(/disconnect/i);
+  });
+});

--- a/apps/webapp/app/utils/agentVerification.server.ts
+++ b/apps/webapp/app/utils/agentVerification.server.ts
@@ -130,12 +130,30 @@ export async function verifySessionOwnership({
     const handler = (message: {
       type: string;
       requestId?: string;
-      payload: VerificationResult;
+      payload: VerificationResult & { error?: string; code?: string };
     }) => {
       // Filter by requestId for proper correlation
-      if (message.type === 'SESSION_VERIFIED' && message.requestId === requestId) {
+      if (message.requestId !== requestId) return;
+
+      if (message.type === 'SESSION_VERIFIED') {
         cleanup();
         resolve(message.payload);
+        return;
+      }
+
+      // ai-agent answers a rejected signature with ERROR, not SESSION_VERIFIED.
+      // Listening only for SESSION_VERIFIED meant a hard auth failure looked
+      // exactly like silence: the promise hung for the full 5s and the caller
+      // then reported a *timeout*, which the SSE route maps to 503 "try again".
+      // That is how a clock-skew auth rejection surfaced as a transient outage.
+      if (message.type === 'ERROR') {
+        cleanup();
+        reject(
+          new Error(
+            `ai-agent rejected verification: ${message.payload?.error || 'unknown error'}` +
+              (message.payload?.code ? ` (${message.payload.code})` : '')
+          )
+        );
       }
     };
 


### PR DESCRIPTION
## What

Ask Moji would initialise and then never answer. Three defects sat in a line, each one hiding the one before it. This fixes all three.

Not the Pro gate — that is exonerated below.

## The failure, from production

```
20:35:24  ai-agent  SYLLABUS_BOT_INIT  → auth OK, cloning content repo
20:35:58  webapp    POST /api/syllabus-bot/dartmouth-cs98-27w   200  35366 ms
20:35:58  ai-agent  VERIFY_SESSION → WARN: Message from the future: -4ms
20:35:58  ai-agent  WARN: [auth] Authentication failed
20:36:03  webapp    GET  /api/syllabus-bot/stream/7ef36ee1-...  503   5103 ms
```

**1. Root cause — clock skew (fixed in the ai-agent submodule, classmoji/ai-agent#3).**
The HMAC freshness check allowed 30,000ms of tolerance in the past and zero in the future. That is only satisfiable if signer and verifier share a clock; webapp and ai-agent are separate Fly machines. 4ms of ordinary NTP drift failed `VERIFY_SESSION`, which guards the SSE stream. The check runs in front of every message type, so quizzes and the prompt assistant were exposed to the same hazard.

**2. The refusal was reported as the wrong kind of failure.**
`verifySessionOwnership` listened only for `SESSION_VERIFIED`. ai-agent answers a rejected signature with `ERROR`, so an explicit refusal was indistinguishable from silence: the promise hung the full 5s and rejected with `"Session verification timeout"` — and the stream route maps anything containing *timeout* to **503 Service Unavailable, retry**. A permanent, deterministic auth failure was therefore served as a transient blip. The `5103ms` above is that 5000ms timer, not real work. Its sibling service (`aiAgentConnection.server.ts:218`) has handled `ERROR` all along; these two had drifted apart.

**3. The client swallowed what was left.**
`eventSource.onerror` was an empty function. Worse, replies only ever arrive over SSE — the `POST` just acknowledges receipt — so sending into a dead stream set `isStreaming` with nothing left that could ever clear it. The composer locked permanently with no explanation.

## How

- **Skew tolerance of 5s.** Replay is still bounded by `MAX_AGE_MS` and the timestamp is inside the HMAC, so a captured message cannot be restamped to refresh it. The accepted window goes 30s → 35s; nothing else moves. Drift beyond 1s logs, so real problems stay visible without a log line for the few ms that are normal.
- **Reject on `ERROR`**, carrying ai-agent's own code (`AUTH_FAILED`) rather than inventing a timeout. This alone would have made the original incident self-diagnosing.
- **Surface terminal stream failure** and release the composer. Transient drops are left to EventSource's own retry — only `readyState === CLOSED` counts as terminal — and sending is refused outright when the stream is down rather than locking the input.
- **Label the composer while content loads.** A cold content-repo clone takes ~35s with the input disabled, which is indistinguishable from broken. This does not make it faster, only honest.

## The Pro gate is not involved

Worth stating explicitly since this landed right after #244. The init returned `200` — it passed both the entitlement check and `syllabus_bot_enabled` on the way through. The message that failed died in HMAC verification, which runs before any gate code. The syllabus bot is simply where a service-wide hazard happened to surface.

## Test steps

- `apps/ai-agent`: `npx vitest run --config vitest.unit.config.js` — 10 new tests on both edges of the freshness window, including the exact -4ms case and the replay cases that must keep failing
- `apps/webapp`: `npx vitest run` — **757 pass**, 4 new covering the `ERROR` path
- `npm run typecheck` — clean (needs `npm run db:generate` first; a stale Prisma client reports phantom errors in `site.service.ts`)

**Both new suites were mutation-tested.** Restoring `age < 0` fails 2 tests; removing the `ERROR` branch makes the verification test hang **5003ms** — reproducing the production symptom (5103ms) in a unit test.

The client-side changes have no unit tests by design; they want browser verification, which is planned on staging and prod after this lands.

## Notes

- No schema change, no migration, no lockfile change.
- Known minor: there is a ~1 RTT window after init where the composer is enabled but the stream's `connected` event has not landed, so a very fast click gets "Not connected…" and succeeds on retry. Self-healing; not worth engineering around.
- Pre-existing and untouched: ai-agent's `handlers.unit.test.js` fails to collect; `RequireGitProvider.tsx` has a stale `useGitProvider` import (both verified failing on `staging` without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hnzySrj9w9zUJZBtfDADd