### PR TITLE
fix(askmoji): wrap the composer, and fix the assignments query

### DIFF
--- a/apps/webapp/app/components/features/syllabus-bot/styles.css
+++ b/apps/webapp/app/components/features/syllabus-bot/styles.css
@@ -437,7 +437,10 @@
 /* ── Input bar ── */
 .askmoji-input-bar {
   display: flex;
-  align-items: center;
+  /* flex-start, not center: the composer grows downward as the text wraps,
+     and the prompt chevron should stay on the first line rather than drift
+     to the vertical middle of a five-line block. */
+  align-items: flex-start;
   gap: 8px;
   padding: 12px 16px;
   background: var(--am-header-bg);
@@ -445,13 +448,17 @@
   flex-shrink: 0;
 }
 
-
 .askmoji-input-wrap {
   flex: 1;
+  /* Flex items default to min-width:auto, which floors them at their content
+     width -- long text pushes the box wider instead of wrapping inside it.
+     This is what let the line run off sideways. */
+  min-width: 0;
   position: relative;
   min-height: 20px;
-  display: flex;
-  align-items: center;
+  /* Grow with the text, but stop before the composer eats the transcript. */
+  max-height: 96px;
+  overflow-y: auto;
   cursor: text;
 }
 
@@ -464,13 +471,19 @@
   cursor: text;
 }
 
+/* The real <input> above is invisible and only holds the value; this span is
+   what the user actually sees, so wrapping is decided here, not on the input.
+   It stays inline so the blinking cursor flows after the last character
+   instead of being pinned beside a flex line box. */
 .askmoji-input-display {
   font-size: 14px;
+  line-height: 20px;
   color: var(--am-text-moji);
-  white-space: pre;
+  /* pre-wrap keeps typed runs of spaces but allows line breaks; anywhere
+     breaks an unbroken token (a pasted URL) rather than overflowing. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   pointer-events: none;
-  display: flex;
-  align-items: center;
 }
 
 .askmoji-input-display--empty {


### PR DESCRIPTION
Two Ask Moji fixes, both surfaced while verifying the clock-skew fix (#248) in production.

## 1. The composer ran off sideways instead of wrapping

Typing a long question pushed text out past the panel edge.

`white-space: pre` was only half the story. The composer is a flex item, and flex items default to `min-width: auto` — so the **content set the box width** rather than the box constraining the content. Measured against the real stylesheet in an isolated harness:

| | text width | box width | height | result |
|---|---|---|---|---|
| before | 534px | **534px** | 20px | box outgrew the 420px panel, clipped |
| after | 370px | 373px | **37px** | wraps to two lines inside the panel |

A pasted URL was worse: 1235px on one line. After, it breaks mid-token across four lines.

```css
min-width: 0;             /* let the box shrink, which is what forces wrapping */
white-space: pre-wrap;    /* wrap, but keep typed runs of spaces */
overflow-wrap: anywhere;  /* break an unbroken token rather than overflow */
max-height: 96px;         /* grow with the text, stop before it eats the transcript */
align-items: flex-start;  /* chevron stays on the first line as the box grows */
```

The visible text is a mirror span layered under an invisible `<input>`, so wrapping belongs to the span. The input deliberately stays single-line — that is what keeps Enter meaning *send* rather than inserting a newline.

## 2. `query_course_content` has never worked (submodule bump, classmoji/ai-agent#4)

Found in the prod logs during the browser verification of #248:

```
Unknown field `weight` for select statement on model `Module`.
```

The tool read assignments off `prisma.module`. Module has no `weight` and no `assignments` relation — it holds `ModuleItem[]`. `Assignment` hangs off `Repository`, which carries every field the block already asked for. So the shape was right and only the model was wrong; Prisma reports the first bad field, so `weight` masked the bogus relation behind it.

**Broken since the initial commit.** The syllabus bot has never been able to answer *"when is X due?"* from the database — it threw, returned `isError`, and Claude fell back to reading content-repo files. Verified against a live database: the old query raises the production error, the new one returns repositories with their assignments and deadlines.

Nothing caught it: the existing tests mock Prisma with plain stubs, so a wrong model name is indistinguishable from a right one, and ai-agent is JS so there is no typecheck. The new test runs the real handler against a Prisma stand-in that validates every `select`/`where` key against `Prisma.dmmf`, nested relation selects included. Reverting the fix fails 4 of its 5 cases.

## Test steps

- `cd apps/webapp && npx vitest run` — 757 pass
- `cd apps/ai-agent && npx vitest run --config vitest.unit.config.js` — 15 pass
- Composer wrapping was verified in Chrome against the real stylesheet (long question + pasted URL), since this is a pure CSS change and the dev stack was not running.

## Notes

- No schema change, no migration, no lockfile change.
- Pre-existing and untouched: `styles.css` does not satisfy prettier (true before this change — reformatting it would bury the diff); ai-agent's `handlers.unit.test.js` does not collect; `sessionId` is an unused parameter in `databaseTools.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hnzySrj9w9zUJZBtfDADd