### PR TITLE
fix(forms): verification email never sent — template variables must be strings

### DIFF
--- a/apps/pages/app/forms/admin/responses.tsx
+++ b/apps/pages/app/forms/admin/responses.tsx
@@ -211,11 +211,32 @@ const STATE_CHIP: Record<string, { label: string; title: string }> = {
  */
 const DELIVERY_LABEL: Record<string, string> = {
   BOUNCED: 'Bounced — we could not deliver',
+  /**
+   * NOT a bounce, and the difference is the whole point of the row.
+   *
+   * A bounce means the message left and the recipient's mail system refused it,
+   * so the address is the thing to question. FAILED means it never left us at
+   * all — so the address may be perfectly good and this person is waiting for a
+   * link that was never sent. Chasing them about their email would be the wrong
+   * move; the resend button is the right one.
+   */
+  FAILED: 'Never sent — the message failed on our side',
   DELAYED: 'Delayed — still trying',
   COMPLAINED: 'Marked as spam by the recipient',
   DELIVERED: 'Delivered',
   SENT: 'Sent',
 };
+
+/**
+ * The states that mean "this person was never reached", as opposed to "this
+ * person has not got round to clicking yet".
+ *
+ * That is the distinction the whole surface exists to draw: an Unverified chip
+ * alone leaves an instructor chasing somebody who never received mail. All
+ * three are terminal and all three are red; a DELAYED or a DELIVERED is not,
+ * and stays out of the table scan.
+ */
+const UNREACHED = new Set(['BOUNCED', 'COMPLAINED', 'FAILED']);
 
 const absolute = (iso: string) => dayjs(iso).format('MMM D, YYYY h:mm A');
 
@@ -1044,19 +1065,31 @@ function ResponseTableRow({
               {chip.label}
             </span>
           ) : null}
-          {/* The bounce, ON THE ROW.
+          {/* WE NEVER REACHED THEM, ON THE ROW.
               An Unverified chip says somebody did not finish; this says we were
               never able to reach them, which is the difference between a person
-              to chase and a mailbox that does not exist. Only a hard failure
+              to chase and a person who is owed an apology. Only a hard failure
               earns a place here — a delay or a delivery belongs in the drawer,
-              not in a scan of the table. */}
-          {row.delivery?.state === 'BOUNCED' || row.delivery?.state === 'COMPLAINED' ? (
+              not in a scan of the table.
+
+              THREE WORDS, NOT ONE, because the follow-up differs. "Bounced" and
+              "Spam" are facts about the recipient's mail system and point at the
+              address. "Not sent" is a fact about OURS — the dispatch failed and
+              no message ever left — so the address may be fine and the person is
+              simply waiting for something that never went. Collapsing it into
+              "Bounced" would send staff to correct an address that was never
+              wrong. */}
+          {row.delivery && UNREACHED.has(row.delivery.state) ? (
             <span
               title={row.delivery.detail ?? DELIVERY_LABEL[row.delivery.state]}
               data-testid={`forms-bounce-chip-${row.id}`}
               className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-red-700 dark:bg-red-950 dark:text-red-300"
             >
-              {row.delivery.state === 'BOUNCED' ? 'Bounced' : 'Spam'}
+              {row.delivery.state === 'BOUNCED'
+                ? 'Bounced'
+                : row.delivery.state === 'FAILED'
+                  ? 'Not sent'
+                  : 'Spam'}
             </span>
           ) : null}
         </div>
@@ -1181,17 +1214,20 @@ function ResponseDrawer({
                 </dd>
               </>
             ) : null}
-            {/* WHY it never verified, when the provider has said.
-                Shown only when there is something to say: silence here means no
-                report, which is NOT the same as "delivered fine" and must not
-                be rendered as though it were. */}
+            {/* WHY it never verified, when anything is known.
+                Usually the provider's report; sometimes our own — a dispatch
+                that failed before the message ever reached Resend says FAILED
+                here, with the reason it gave. Shown only when there is
+                something to say: silence means no report at all, which is NOT
+                the same as "delivered fine" and must not be rendered as though
+                it were. */}
             {row.delivery ? (
               <>
                 <dt className="text-gray-500 dark:text-gray-400">Email delivery</dt>
                 <dd
                   data-testid="forms-response-delivery"
                   className={
-                    row.delivery.state === 'BOUNCED' || row.delivery.state === 'COMPLAINED'
+                    UNREACHED.has(row.delivery.state)
                       ? 'text-red-700 dark:text-red-300'
                       : 'text-gray-800 dark:text-gray-100'
                   }

--- a/apps/pages/app/forms/fill/delivery.ts
+++ b/apps/pages/app/forms/fill/delivery.ts
@@ -29,14 +29,25 @@ export type { DeliveryState, DeliveryStatus };
  *  2. Asking about somebody else's send requires their cookie, which is their
  *     browser — at which point the attacker has the browser and this endpoint is
  *     the least of it.
- *  3. THE ANSWER IS ASYMMETRIC ON PURPOSE. Only bounced and delayed are ever
- *     reported. `DELIVERED` is deliberately flattened into `pending`, so a
- *     successful delivery is INDISTINGUISHABLE from a message still in flight,
- *     from a webhook that is not configured, and from an id that names nothing.
- *     Reporting delivery would turn this into an address-validity probe: type an
- *     address, watch for `delivered`, learn the mailbox exists. Bounced is safe
- *     to report for the same reason it is useful — it is the failure of the
- *     asker's own action, and it is what the person needs to be told.
+ *  3. THE ANSWER IS ASYMMETRIC ON PURPOSE. Only failure is ever reported —
+ *     bounced, delayed, and failed. `DELIVERED` is deliberately flattened into
+ *     `pending`, so a successful delivery is INDISTINGUISHABLE from a message
+ *     still in flight, from a webhook that is not configured, and from an id
+ *     that names nothing. Reporting delivery would turn this into an
+ *     address-validity probe: type an address, watch for `delivered`, learn the
+ *     mailbox exists. Bounced is safe to report for the same reason it is
+ *     useful — it is the failure of the asker's own action, and it is what the
+ *     person needs to be told.
+ *
+ *     `failed` — the dispatch never reached the provider — WIDENS NOTHING, and
+ *     it is worth being precise about why. It is a fact about OUR infrastructure
+ *     (a template not yet synced, a rate limit, an outage), not about the
+ *     address: it is written before anything is asked of the recipient's mail
+ *     system, so it can be reported for a perfectly valid mailbox and for a
+ *     nonexistent one with equal probability. It therefore carries no
+ *     information about whether a mailbox exists, which is the only thing this
+ *     endpoint must never disclose. It is still cookie-scoped, still failure-
+ *     only, and still counted against the distinct-address ceiling.
  *  4. AN UNKNOWN ID IS `pending`, NEVER 404. The fill action always sets a watch
  *     cookie, substituting an opaque id when there was no real send (an address
  *     that has already responded is mailed nothing — see
@@ -164,6 +175,13 @@ export const loader = async ({
   }
 
   if (token.delivery_state === 'BOUNCED') return answer('bounced');
+  /**
+   * The send that never left. Written by `sendEmailTask`'s `onFailure` hook once
+   * its retries are exhausted, so it means "this message is not coming" rather
+   * than "an attempt went badly" — which is the same thing a bounce means to the
+   * person waiting, and is reported for the same reason.
+   */
+  if (token.delivery_state === 'FAILED') return answer('failed');
   if (token.delivery_state === 'DELAYED') return answer('delayed');
 
   // SENT, DELIVERED, COMPLAINED, null, or a state this build has never heard

--- a/apps/pages/app/forms/fill/deliveryState.ts
+++ b/apps/pages/app/forms/fill/deliveryState.ts
@@ -29,6 +29,17 @@ export type DeliveryState =
   | 'pending'
   /** The provider could not deliver it. The one thing worth interrupting for. */
   | 'bounced'
+  /**
+   * WE never managed to send it — the dispatch failed outright, so no message
+   * reached the provider at all.
+   *
+   * Kept separate from `bounced` because the copy must not lie about whose
+   * fault it was and the recovery differs: a bounce says "that address did not
+   * accept mail" and is usually a typo to fix; this says "we did not get it
+   * out" and is usually worth simply asking again. The same weight, though —
+   * from where the respondent sits, both mean the link is not coming.
+   */
+  | 'failed'
   /** Delayed, and still trying. Worth a softer word, not an alarm. */
   | 'delayed';
 

--- a/apps/pages/app/forms/fill/fill.tsx
+++ b/apps/pages/app/forms/fill/fill.tsx
@@ -136,15 +136,17 @@ const DELIVERY_POLL_WINDOW_MS = 3 * 60_000;
 /**
  * Watch for a bounce on the send this browser just caused.
  *
- * Keyed on `token` — a value that changes each time a send happens — so
- * re-typing an address restarts the watch rather than leaving it pinned to the
- * previous one. Passing `null` means "nothing outstanding" and the effect does
- * nothing at all.
+ * Keyed on `token` — a value that changes every time the server re-points the
+ * watch cookie, which is every blur send, every resend, and every submit — so
+ * each new send restarts the watch rather than leaving it pinned to the
+ * previous one's answer. That is what stops a warning about a dead send
+ * outliving the fresh send that replaced it. Passing `null` means "nothing
+ * outstanding" and the effect does nothing at all.
  *
  * The endpoint takes NO address and is keyed only on an HttpOnly cookie this
  * server set; see `delivery.ts` for why that is what keeps it from being a
- * mailbox oracle. It reports `bounced` and `delayed` and flattens everything
- * else — delivered included — into `pending`.
+ * mailbox oracle. It reports `bounced`, `failed` and `delayed` and flattens
+ * everything else — delivered included — into `pending`.
  */
 function useDeliveryWatch(deliveryPath: string, token: string | number | null): DeliveryState {
   const [state, setState] = useState<DeliveryState>('pending');
@@ -187,7 +189,7 @@ function useDeliveryWatch(deliveryPath: string, token: string | number | null): 
         });
         if (response.ok) {
           const body = (await response.json()) as { state?: DeliveryState };
-          if (body.state === 'bounced' || body.state === 'delayed') {
+          if (body.state === 'bounced' || body.state === 'failed' || body.state === 'delayed') {
             // Answered. Stop asking — the answer will not improve.
             setState(body.state);
             return;
@@ -660,7 +662,10 @@ export const action = async ({
         null
       );
     }
-    return { state: 'check-email', email: identity.email } satisfies ActionResult;
+    // The submit reply carries a watch cookie too, and a trapped bot must get
+    // the same one for the same reason: a reply whose SHAPE differed is how a
+    // bot learns the trap sprang.
+    return withWatch({ state: 'check-email', email: identity.email } satisfies ActionResult, null);
   }
 
   if (!identity.email) {
@@ -916,12 +921,40 @@ export const action = async ({
      */
     await dispatchVerifyEmail(result.emails, result.verifyUrl ?? '');
 
-    return { state: 'check-email', email: identity.email } satisfies ActionResult;
+    /**
+     * ── The watch follows the NEWEST send, submit included ────────────────
+     *
+     * The submit used to answer without a watch cookie, which left the browser
+     * pointed at whatever the blur had set — or, for somebody whose autofill
+     * filled the address without ever firing a blur send, at nothing at all. So
+     * a bounce on the check-email screen, the one surface where the person is
+     * sitting and waiting for the mail, could go unreported entirely.
+     *
+     * It matters more now that a failed dispatch is reported. The submit is the
+     * path that RECOVERS from one — a token marked FAILED no longer satisfies
+     * reuse, so this call mints and dispatches a fresh link — and without this
+     * cookie the page would keep answering for the dead send and go on telling
+     * somebody "we couldn't send it" seconds after we successfully did.
+     *
+     * `watchTokenId` is the reused live token when nothing was sent, and the
+     * fresh one when something was, so it always names the send that is
+     * genuinely outstanding.
+     */
+    return withWatch(
+      { state: 'check-email', email: identity.email } satisfies ActionResult,
+      result.watchTokenId
+    );
   } catch (error) {
     // The same view as success. A visible cooldown would answer "has this
-    // address submitted recently?" — the same oracle by another name.
+    // address submitted recently?" — the same oracle by another name, and the
+    // cookie has to match: a reply without one would say "nothing was sent" out
+    // loud. The stand-in id answers `pending`, exactly as an in-flight send
+    // does.
     if ((error as { code?: string }).code === 'MAGIC_LINK_COOLDOWN') {
-      return { state: 'check-email', email: identity.email } satisfies ActionResult;
+      return withWatch(
+        { state: 'check-email', email: identity.email } satisfies ActionResult,
+        null
+      );
     }
     return publicFailure(error);
   }
@@ -1344,22 +1377,52 @@ export default function FormFill() {
   }, [linkResult]);
 
   /**
-   * ── Did the message bounce? ──────────────────────────────────────────────
+   * ── Which send is being watched ──────────────────────────────────────────
    *
-   * Started by the send itself and keyed on WHEN it happened, so each new
-   * address restarts the watch instead of inheriting the previous answer. The
-   * server is asked over a cookie it set on that very response — there is no
-   * address in the request and none could be put there.
+   * One counter, bumped by every server reply that re-pointed the watch cookie:
+   * the blur send and the resend (`link-sent`), and the submit (`check-email`).
+   * Zero means nothing has been sent yet in this page's life, which is what
+   * `null` tells the hook to do — nothing.
    *
-   * The answer only ever moves in the alarming direction: `bounced` and
-   * `delayed` are reported, everything else stays `pending`. A successful
-   * delivery is therefore indistinguishable from a message still in flight,
-   * which is exactly what stops this being a way to test whether an address
-   * exists.
+   * It has to include the SUBMIT, and that is the whole reason it is a counter
+   * rather than the send timestamp it used to be. The submit is the path that
+   * recovers from a failed dispatch — a token marked FAILED no longer satisfies
+   * reuse, so submitting mints and dispatches a fresh link — and the server has
+   * just re-pointed the cookie at that new send. Left keyed on the blur alone,
+   * the page would hold the previous answer and go on saying "we couldn't send
+   * it" seconds after a link successfully went out. Restarting resets the state
+   * to `pending` and asks about the new send, so if THAT one fails too the
+   * warning honestly comes back.
+   *
+   * The server is asked over a cookie it set on that very reply — there is no
+   * address in the request and none could be put there. The answer only ever
+   * moves in the alarming direction: `bounced`, `failed` and `delayed` are
+   * reported, everything else stays `pending`. A successful delivery is
+   * therefore indistinguishable from a message still in flight, which is what
+   * stops this being a way to test whether an address exists.
    */
+  const [watchGeneration, setWatchGeneration] = useState(0);
+  useEffect(() => {
+    if (linkResult?.state === 'link-sent') setWatchGeneration(generation => generation + 1);
+  }, [linkResult]);
+  useEffect(() => {
+    if (result?.state === 'check-email') setWatchGeneration(generation => generation + 1);
+  }, [result]);
+
   const deliveryPath = `/${params.classroomSlug}/forms/${params.formSlug}/delivery`;
-  const delivery = useDeliveryWatch(deliveryPath, linkSentFor?.at ?? null);
+  const delivery = useDeliveryWatch(deliveryPath, watchGeneration === 0 ? null : watchGeneration);
   const bounced = delivery === 'bounced';
+  /**
+   * The mail never left us — the dispatch failed after its retries were spent.
+   *
+   * Held apart from `bounced` because the sentence differs, but it must reach
+   * every place `bounced` reaches: `undelivered` is what "the link is not
+   * coming, whatever the reason" is called below, and it is what suppresses the
+   * reassuring "check your inbox" line. Anything that branches on `bounced`
+   * alone would leave somebody staring at an inbox that was never mailed.
+   */
+  const sendFailed = delivery === 'failed';
+  const undelivered = bounced || sendFailed;
 
   if (data.view === 'signin') {
     return (
@@ -1450,29 +1513,54 @@ export default function FormFill() {
     const resent = linkResult?.state === 'link-sent' && linkResult.resent;
 
     /**
-     * IT BOUNCED, AND THEY ARE STILL HERE.
+     * IT NEVER ARRIVED, AND THEY ARE STILL HERE.
      *
      * The reassuring copy is replaced rather than added to. "We sent a link —
      * check your inbox" is now known to be false, and leaving it on screen
      * beside a warning would send somebody off to search a mailbox that never
      * received anything. Both existing doors — resend, and change the address —
      * are kept, because they are exactly the two things that can help.
+     *
+     * ── Two ways the link fails to arrive, two different sentences ─────────
+     * A BOUNCE is the recipient's mail system refusing a message that left us:
+     * usually a typo, so the address is what to look at. A FAILED DISPATCH is
+     * ours — the send never reached the mail provider at all — and telling
+     * somebody to check an address we never actually tried would send them
+     * hunting for a mistake they did not make. So the failure is owned plainly
+     * and the offer is to try again, with the change-address door still there
+     * for anyone who wants it. Both keep the same shape, the same two buttons
+     * and the same `forms-bounced` hook, because the page's job is identical:
+     * the link is not coming, nothing is lost, here is what to do.
      */
-    if (bounced) {
+    if (undelivered) {
       return (
         <FormCanvas theme={data.theme} classroomName={data.classroomName}>
-          <FormNotice icon="⚠️" title="That email did not go through">
+          <FormNotice
+            icon="⚠️"
+            title={sendFailed ? 'We could not send that email' : 'That email did not go through'}
+          >
             {/* The outcome, not the cause — see the note on the in-form banner.
                 Naming WHY delivery failed would tell anyone who typed an
                 address more about that mailbox than they should learn, and it
                 changes nothing about what this person should do next. */}
             <p data-testid="forms-bounced">
-              We could not deliver to <strong className="font-semibold">{checkEmail}</strong>.
-              Nothing is recorded yet, and your answers are still here.
+              {sendFailed ? (
+                <>
+                  Something went wrong on our side and the link to{' '}
+                  <strong className="font-semibold">{checkEmail}</strong> never went out. Nothing is
+                  recorded yet, and your answers are still here.
+                </>
+              ) : (
+                <>
+                  We could not deliver to <strong className="font-semibold">{checkEmail}</strong>.
+                  Nothing is recorded yet, and your answers are still here.
+                </>
+              )}
             </p>
             <p className="mt-3 text-gray-500 dark:text-gray-400">
-              The usual cause is a typo in the address. Change it below and we will send a new link
-              straight away.
+              {sendFailed
+                ? 'This is usually temporary. Try that address again below — or use a different one if you would rather.'
+                : 'The usual cause is a typo in the address. Change it below and we will send a new link straight away.'}
             </p>
 
             <div className="mt-6 flex flex-wrap items-center gap-3">
@@ -1665,13 +1753,25 @@ export default function FormFill() {
           link, a link for an address that already responded, a send the
           cooldown swallowed. Any difference between them answers "has this
           person already applied?" for anybody who can type an address. */}
-      {/* THE BOUNCE, WHILE THEY ARE STILL TYPING.
+      {/* THE FAILURE, WHILE THEY ARE STILL TYPING.
           This is the whole point of sending on blur: the message has already
           failed and they have not finished the form, so the correction costs
           them nothing. It REPLACES the reassuring line rather than sitting
-          under it — telling somebody to check an inbox that rejected the mail
-          is worse than saying nothing. */}
-      {!verifiedHere && bounced && linkSent ? (
+          under it — telling somebody to check an inbox that never received the
+          mail is worse than saying nothing.
+
+          A BOUNCE points at the address; a FAILED DISPATCH points at us. The
+          two sentences differ because the action does: one is "check what you
+          typed", the other is "that was our fault, we will try again". Sending
+          somebody hunting for a typo in an address we never actually mailed
+          would be a small lie with a real cost.
+
+          "Press Submit and we will try again" is a promise the reuse rule now
+          keeps: a token whose send failed no longer satisfies `findLiveLink`,
+          so the submit mints and dispatches a fresh link instead of concluding
+          one is already in their inbox. Before that fix this banner would have
+          been telling them to do the one thing guaranteed to send nothing. */}
+      {!verifiedHere && undelivered && linkSent ? (
         <div
           role="alert"
           data-testid="forms-bounced"
@@ -1683,13 +1783,27 @@ export default function FormFill() {
               any of that here would widen the very oracle the rate limits are
               holding shut, in exchange for nothing the person can act on. The
               action is the same in every case: check the address. */}
-          <strong className="font-semibold">We couldn&rsquo;t deliver to {linkSent.email}.</strong>{' '}
-          Check the address above — fix it and we will send a new link. Nothing you have typed is
-          lost.
+          {sendFailed ? (
+            <>
+              <strong className="font-semibold">
+                We couldn&rsquo;t send the link to {linkSent.email}.
+              </strong>{' '}
+              That one is on us, not on your address. Finish your answers and press Submit — we will
+              try again then. Nothing you have typed is lost.
+            </>
+          ) : (
+            <>
+              <strong className="font-semibold">
+                We couldn&rsquo;t deliver to {linkSent.email}.
+              </strong>{' '}
+              Check the address above — fix it and we will send a new link. Nothing you have typed
+              is lost.
+            </>
+          )}
         </div>
       ) : null}
 
-      {!verifiedHere && !bounced && linkSent ? (
+      {!verifiedHere && !undelivered && linkSent ? (
         <div
           role="status"
           data-testid="forms-link-sent"

--- a/apps/pages/tests/e2e/forms-bounce.spec.ts
+++ b/apps/pages/tests/e2e/forms-bounce.spec.ts
@@ -149,6 +149,85 @@ test.describe('the respondent is told, while they are still on the form', () => 
 
     await expect(page.getByText('Check your email')).toBeVisible();
   });
+
+  /**
+   * ── THE MAIL THAT NEVER LEFT ─────────────────────────────────────────────
+   *
+   * A dispatch that fails after its retries are spent (an unsynced template, a
+   * rate limit, an outage) is written onto the token as FAILED by
+   * `sendEmailTask`'s `onFailure`. From where the respondent sits it is the
+   * same fact a bounce is — the link is not coming — so it is surfaced the same
+   * way and on the same schedule.
+   *
+   * The SENTENCE differs on purpose. A bounce points at the address they typed;
+   * this points at us. Telling somebody to go hunting for a typo in an address
+   * we never actually mailed is a small lie with a real cost, so the copy owns
+   * the failure and offers the recovery instead.
+   */
+  test('a send that never left is reported too, and owns the failure', async ({ page }) => {
+    const email = freshEmail('nosend');
+    await page.goto(fillPath);
+    await typeEmailAndLeave(page, email);
+    await expect(page.getByTestId('forms-link-sent')).toBeVisible();
+
+    await markDelivery(email, 'FAILED', 'Resend send failed: Template not found');
+
+    const failed = page.getByTestId('forms-bounced');
+    await expect(failed).toBeVisible({ timeout: 20_000 });
+    await expect(failed).toContainText(email);
+    // Ours, not theirs — and a way forward.
+    await expect(failed).toContainText(/couldn’t send/i);
+    await expect(failed).toContainText(/on us/i);
+
+    // The reassuring line is REPLACED, exactly as it is for a bounce.
+    await expect(page.getByTestId('forms-link-sent')).toHaveCount(0);
+  });
+
+  /**
+   * THE POINT OF THE WHOLE FIX, end to end.
+   *
+   * The bug was not that nobody was told; it was that the system had decided a
+   * live link already covered the address and would never send another. So the
+   * assertion that matters is not the banner — it is that pressing Submit after
+   * a failed send actually mints and dispatches a NEW link, which is exactly
+   * what the banner promises.
+   */
+  test('submitting after a failed send mints a fresh link rather than standing down', async ({
+    page,
+  }) => {
+    const prisma = await getTestPrisma();
+    const email = freshEmail('retry');
+    await page.goto(fillPath);
+    await typeEmailAndLeave(page, email);
+    await expect(page.getByTestId('forms-link-sent')).toBeVisible();
+
+    await markDelivery(email, 'FAILED', 'Resend send failed: Template not found');
+    await expect(page.getByTestId('forms-bounced')).toBeVisible({ timeout: 20_000 });
+
+    const response = await prisma.formResponse.findFirstOrThrow({
+      where: { form_id: formId!, email_normalized: email.toLowerCase() },
+      select: { id: true },
+    });
+    expect(await prisma.formMagicToken.count({ where: { response_id: response.id } })).toBe(1);
+
+    await page.getByLabel(NAME_LABEL, { exact: true }).fill('Second Try');
+    await page.getByRole('radio', { name: '7', exact: true }).click();
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(page.getByText('Check your email')).toBeVisible();
+
+    /**
+     * TWO tokens, and the new one is clean. Before the fix this was one — the
+     * submit found the failed token unspent, unexpired and young, concluded a
+     * live link already covered the address, and sent nothing at all.
+     */
+    const tokens = await prisma.formMagicToken.findMany({
+      where: { response_id: response.id },
+      orderBy: { created_at: 'desc' },
+      select: { delivery_state: true },
+    });
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0].delivery_state).toBeNull();
+  });
 });
 
 test.describe('the status endpoint is not a mailbox oracle', () => {
@@ -250,6 +329,79 @@ test.describe('the status endpoint is not a mailbox oracle', () => {
 
     const response = await page.request.get(deliveryPath);
     expect(await response.json()).toEqual({ state: 'bounced' });
+  });
+
+  /**
+   * A DISPATCH FAILURE WIDENS NOTHING, and it is worth pinning why rather than
+   * only that.
+   *
+   * `failed` is a fact about OUR infrastructure — a template not yet synced, a
+   * rate limit, an outage — recorded before anything is asked of the
+   * recipient's mail system. It is therefore equally likely for a real mailbox
+   * and for one that does not exist, and carries no information about which. It
+   * is still cookie-scoped, still only ever a failure, and still counted
+   * against the distinct-address ceiling.
+   */
+  test('reports a failed send to the browser that caused it, and to nobody else', async ({
+    page,
+  }) => {
+    const email = freshEmail('nosend-api');
+    await page.goto(fillPath);
+    await typeEmailAndLeave(page, email);
+    await expect(page.getByTestId('forms-link-sent')).toBeVisible();
+
+    await markDelivery(email, 'FAILED', 'Resend send failed: Template not found');
+
+    const owner = await page.request.get(deliveryPath);
+    expect(await owner.json()).toEqual({ state: 'failed' });
+
+    // A browser that caused no send holds no cookie and learns nothing — and
+    // naming the address does not help, because there is no parameter for one.
+    const clean = await page.context().browser()!.newContext();
+    try {
+      const blind = await clean.request.get(deliveryPath);
+      expect(await blind.json()).toEqual({ state: 'pending' });
+      const named = await clean.request.get(
+        `${deliveryPath}?email=${encodeURIComponent(email)}`
+      );
+      expect(await named.json()).toEqual({ state: 'pending' });
+    } finally {
+      await clean.close();
+    }
+  });
+
+  /**
+   * A watch id that is not this browser's is answered exactly as one in flight.
+   *
+   * `failed` must not become the state that finally distinguishes "no such
+   * send" from "send outstanding" — that sameness is what keeps the substituted
+   * stand-in id (set whenever there was no real send) from leaking back out.
+   */
+  test('answers a foreign watch id `pending`, even while a real send has failed', async ({
+    page,
+    browser,
+  }) => {
+    const email = freshEmail('nosend-foreign');
+    await page.goto(fillPath);
+    await typeEmailAndLeave(page, email);
+    await expect(page.getByTestId('forms-link-sent')).toBeVisible();
+    await markDelivery(email, 'FAILED');
+
+    const context = await browser.newContext();
+    try {
+      await context.addCookies([
+        {
+          name: `forms_watch_${FORM_SLUG}`,
+          value: randomUUID(),
+          domain: 'localhost',
+          path: `/${CLASS}/forms`,
+        },
+      ]);
+      const response = await context.request.get(deliveryPath);
+      expect(await response.json()).toEqual({ state: 'pending' });
+    } finally {
+      await context.close();
+    }
   });
 
   test('is never cached', async ({ page }) => {

--- a/apps/pages/tests/e2e/forms-responses.spec.ts
+++ b/apps/pages/tests/e2e/forms-responses.spec.ts
@@ -306,6 +306,71 @@ test.describe('forms responses — owner', () => {
     await expect(drawer.locator('input[type="text"], textarea, select')).toHaveCount(0);
   });
 
+  /**
+   * ── "Unverified" is three different situations wearing one chip ──────────
+   *
+   * Somebody who has not got round to clicking, somebody whose mail bounced,
+   * and somebody whose mail NEVER LEFT US all show as Unverified, and a course
+   * would chase all three the same way. The third is the one this row exists
+   * for: the address may be perfectly good, the person is waiting for something
+   * that was never sent, and telling an instructor to go and check their email
+   * address would send them after a mistake nobody made.
+   *
+   * Its own words, therefore — "Not sent" on the row, and the reason the
+   * dispatch gave in the drawer — rather than being folded into "Bounced".
+   */
+  test('a response whose verification mail never went out says so, in its own words', async ({
+    page,
+  }) => {
+    const prisma = await getTestPrisma();
+    const revision = await prisma.formRevision.findFirstOrThrow({
+      where: { form_id: formId! },
+      select: { id: true },
+    });
+
+    const email = 'zz-e2e-neversent@example.edu';
+    const response = await prisma.formResponse.create({
+      data: {
+        form_id: formId!,
+        revision_id: revision.id,
+        email,
+        email_normalized: email,
+        name: 'Never Sent',
+        answers: { [NAME_FIELD]: 'Never Sent', [SCALE_FIELD]: 3 },
+        submission_state: 'PENDING_VERIFICATION',
+        submitted_at: new Date(),
+      },
+    });
+    await prisma.formMagicToken.create({
+      data: {
+        response_id: response.id,
+        token_hash: `zz-e2e-neversent-${response.id}`,
+        expires_at: new Date(Date.now() + 3_600_000),
+        delivery_state: 'FAILED',
+        delivery_detail: 'Resend send failed: Template not found',
+      },
+    });
+
+    try {
+      await loginAs(page, 'owner');
+      await page.goto(responsesPath);
+
+      const chip = page.getByTestId(`forms-bounce-chip-${response.id}`);
+      await expect(chip).toBeVisible();
+      // NOT "Bounced" — the address was never tried.
+      await expect(chip).toHaveText('Not sent');
+
+      await page.getByText(email).first().click();
+      const drawer = page.getByRole('dialog', { name: 'Response details' });
+      const delivery = drawer.getByTestId('forms-response-delivery');
+      await expect(delivery).toContainText('Never sent');
+      // The reason, for whoever has to work out why.
+      await expect(delivery).toContainText('Template not found');
+    } finally {
+      await prisma.formResponse.delete({ where: { id: response.id } }).catch(() => {});
+    }
+  });
+
   test('inline status editing writes through and suggests labels already in use', async ({
     page,
   }) => {

--- a/packages/services/src/classmoji/__tests__/forms.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/forms.integration.test.ts
@@ -545,6 +545,129 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
       });
 
       /**
+       * ── THE FOURTH WAY, and the one that stranded somebody ────────────────
+       *
+       * A token is not a delivery. The three conditions above all describe the
+       * TOKEN — unspent, unexpired, young — and every one of them is satisfied
+       * by a link whose mail never went out at all. That is not hypothetical:
+       * a Trigger run failed with "Template not found", the page had already
+       * answered the browser successfully, and four hours later the submit
+       * found a pristine token, concluded a live link covered the address, and
+       * sent nothing. The applicant could not be sent a link BECAUSE the
+       * system believed it already had.
+       *
+       * Marked by `sendEmailTask`'s `onFailure`, so FAILED means the retries
+       * are spent and the message is genuinely never going out.
+       */
+      it('mints afresh when the previous send is known to have failed', async () => {
+        const { formId, revisionId } = await makeOpenForm();
+        const fieldId = await nameFieldId(revisionId);
+        const email = `reuse-failed-${suite}@example.test`;
+
+        // Blur: the link is minted and dispatched.
+        const blur = await responseService.beginAddressVerification({ formId, email, revisionId });
+        expect(blur.sent).toBe(true);
+
+        // The dispatch fails, asynchronously, long after the page answered.
+        await prisma.formMagicToken.updateMany({
+          where: { id: blur.watchTokenId! },
+          data: {
+            delivery_state: responseService.MAGIC_LINK_SEND_FAILED,
+            delivery_detail: 'Resend send failed: Template not found',
+          },
+        });
+
+        // BOTH paths back in must mint. Re-typing the address is the first
+        // chance to recover, and submitting is the one the form's own copy
+        // promises ("press Submit — we will try again then").
+        const retyped = await responseService.beginAddressVerification({
+          formId,
+          email,
+          revisionId,
+        });
+        expect(retyped.sent).toBe(true);
+        expect(retyped.emails).toHaveLength(1);
+        expect(retyped.watchTokenId).not.toBe(blur.watchTokenId);
+
+        // And that fresh token is dispatched with its OWN id, so its own
+        // outcome can be written back rather than the dead one's.
+        expect(retyped.emails[0].payload.formMagicTokenId).toBe(retyped.watchTokenId);
+
+        // Now fail that one too, and submit.
+        await prisma.formMagicToken.updateMany({
+          where: { id: retyped.watchTokenId! },
+          data: { delivery_state: responseService.MAGIC_LINK_SEND_FAILED },
+        });
+        const submitted = await beginFor(formId, revisionId, fieldId, email);
+        expect(submitted.rawToken).not.toBeNull();
+        expect(submitted.emails).toHaveLength(1);
+        expect(submitted.linkAlreadySentAt).toBeNull();
+
+        // The link it hands over is real — a fresh mint, not a resurrection of
+        // a dead one.
+        const review = await responseService.verifyMagicToken(tokenOf(submitted));
+        expect(review.response.answers).toEqual({ [fieldId]: 'Maya' });
+      });
+
+      /**
+       * THE OTHER HALF OF THAT RULE, and the regression it guards.
+       *
+       * A send dispatched seconds ago has NO delivery state — nothing has been
+       * reported about it yet, and nothing will be for a while. If "not known
+       * to have succeeded" disqualified reuse, every fresh token would be
+       * unreusable and the double-send this whole rule exists to prevent would
+       * be back: two mails for one action, seconds apart. Only a KNOWN failure
+       * disqualifies.
+       */
+      it('still reuses a send nothing has been reported about yet', async () => {
+        const { formId, revisionId } = await makeOpenForm();
+        const fieldId = await nameFieldId(revisionId);
+        const email = `reuse-inflight-${suite}@example.test`;
+
+        const blur = await responseService.beginAddressVerification({ formId, email, revisionId });
+        const row = await rowFor(formId, email);
+        expect(
+          await prisma.formMagicToken.findFirstOrThrow({ where: { id: blur.watchTokenId! } })
+        ).toMatchObject({ delivery_state: null });
+
+        const submitted = await beginFor(formId, revisionId, fieldId, email);
+        expect(submitted.emails).toHaveLength(0);
+        expect(submitted.linkAlreadySentAt).not.toBeNull();
+        expect(await prisma.formMagicToken.count({ where: { response_id: row.id } })).toBe(1);
+      });
+
+      /**
+       * A state that is not FAILED is not a failure.
+       *
+       * The filter is written as "null, or not FAILED" rather than as a list of
+       * acceptable states, so a value this build has never heard of — a future
+       * provider event, a state added by a later migration — keeps a live link
+       * reusable rather than quietly doubling everybody's mail. 'SENT' is the
+       * ordinary case and the one that must never regress: it is written by the
+       * task on every successful dispatch.
+       */
+      it('reuses a link the provider accepted, and one in a state it does not know', async () => {
+        const { formId, revisionId } = await makeOpenForm();
+        const fieldId = await nameFieldId(revisionId);
+
+        for (const state of ['SENT', 'DELIVERED', 'SOMETHING_NEW']) {
+          const email = `reuse-${state.toLowerCase()}-${suite}@example.test`;
+          const blur = await responseService.beginAddressVerification({
+            formId,
+            email,
+            revisionId,
+          });
+          await prisma.formMagicToken.updateMany({
+            where: { id: blur.watchTokenId! },
+            data: { delivery_state: state },
+          });
+
+          const submitted = await beginFor(formId, revisionId, fieldId, email);
+          expect(submitted.emails, `${state} must stay reusable`).toHaveLength(0);
+        }
+      });
+
+      /**
        * THE SAFETY NET for somebody who loses the one mail.
        *
        * The reminder sweep is idempotent through the token table — a stage is

--- a/packages/services/src/classmoji/formResponse.service.ts
+++ b/packages/services/src/classmoji/formResponse.service.ts
@@ -143,6 +143,24 @@ export const MAGIC_TOKEN_WINDOW_MS = 60 * 60 * 1000;
  * live link at all.
  */
 export const MAGIC_TOKEN_REUSE_MS = MAGIC_TOKEN_TTL_MS / 2;
+/**
+ * The `delivery_state` meaning "we never managed to hand this message to the
+ * provider at all".
+ *
+ * Not one of the provider's own states — those are reported by the Resend
+ * webhook ('SENT', 'DELIVERED', 'BOUNCED', 'DELAYED', 'COMPLAINED') and all
+ * describe a message that at least left. This one is written by
+ * `sendEmailTask`'s `onFailure` hook, after its retries are exhausted, and
+ * describes the opposite: nothing was sent, so there is nothing to bounce.
+ *
+ * It shares the column because it answers the same question every other value
+ * there answers — "did the mail carrying this link reach them?" — and because
+ * the column is deliberately a plain string so a new value costs no migration.
+ * Named here because the reuse rule turns on it; the writer (packages/tasks)
+ * and the readers (the `/delivery` endpoint, the staff row) spell the same
+ * literal, exactly as they already do for 'SENT' and 'BOUNCED'.
+ */
+export const MAGIC_LINK_SEND_FAILED = 'FAILED';
 /** Abandoned server-side partials are swept after this long. */
 export const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 /**
@@ -613,17 +631,44 @@ async function mintLinkFor(
 /**
  * When this response last got a link that is STILL WORTH POINTING AT, or null.
  *
- * Three conditions, and each one is a way the reuse could otherwise strand
+ * Four conditions, and each one is a way the reuse could otherwise strand
  * somebody with a dead link and no mail:
  *
  *  - unspent (`used_at` null) — a link that has been clicked opens nothing;
  *  - unexpired — the obvious one;
  *  - minted inside `MAGIC_TOKEN_REUSE_MS` — so what is handed back has real
- *    life left, not the last twenty minutes of it.
+ *    life left, not the last twenty minutes of it;
+ *  - NOT KNOWN TO HAVE FAILED TO SEND — see below.
  *
  * The RAW token is not recoverable (only its digest is stored), which is
  * exactly right: reuse means "send nothing", never "send the old link again".
  * The one already in their inbox is the copy.
+ *
+ * ── "A token exists" is not "mail reached them" ────────────────────────────
+ * The first three conditions all describe the TOKEN. None of them describes the
+ * MESSAGE, and that gap stranded people: a mail whose Trigger run failed (an
+ * unsynced template, a rate limit, a provider outage) leaves a token that is
+ * unspent, unexpired and freshly minted, so every check above passes and the
+ * next blur or submit concludes a live link already covers the address and
+ * sends nothing. Somebody who never received a link could then never get one —
+ * the failure being asynchronous, the page that asked for the mail had already
+ * answered the browser successfully.
+ *
+ * `delivery_state === 'FAILED'` is written by `sendEmailTask`'s `onFailure`
+ * hook, which fires only once the retries are exhausted. So it means "this
+ * message is never going out", not "an attempt went badly".
+ *
+ * ── Why only a KNOWN failure disqualifies ──────────────────────────────────
+ * A NULL `delivery_state` is "nothing reported yet", and a send dispatched
+ * seconds ago always looks exactly like that. Treating unknown as failed would
+ * make every fresh token unreusable and bring back the double-send this rule
+ * exists to prevent — two mails for one action, seconds apart. So the filter is
+ * written as "null, or anything that is not FAILED" rather than as a whitelist
+ * of good states: an unfamiliar state a future provider event introduces stays
+ * reusable, which is the same conservative direction the column's own comment
+ * takes. Spelled out as an explicit OR rather than a bare `not`, because
+ * `not` against a NULL column is exactly the SQL three-valued-logic trap that
+ * would silently exclude every unreported send.
  *
  * Called inside the form's row lock by every path that would otherwise mint, so
  * two concurrent sends for one address cannot both decide they are the first.
@@ -639,6 +684,7 @@ async function findLiveLink(
       used_at: null,
       expires_at: { gt: now },
       created_at: { gt: new Date(now.getTime() - MAGIC_TOKEN_REUSE_MS) },
+      OR: [{ delivery_state: null }, { delivery_state: { not: MAGIC_LINK_SEND_FAILED } }],
     },
     orderBy: { created_at: 'desc' },
     // The id comes back so a caller who sends NOTHING can still point a browser

--- a/packages/services/src/emails/__tests__/escape.test.ts
+++ b/packages/services/src/emails/__tests__/escape.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeVars } from '../escape.ts';
+
+/**
+ * Resend requires every template variable to be a string, and rejects the whole
+ * send otherwise. That send happens inside a Trigger task, so the rejection is
+ * invisible to both the caller and the person waiting for the mail — the only
+ * symptom is an email that never arrives. A real form verification failed this
+ * way with `Variable "EXPIRES_HOURS" must be a \`string\``, which is why the
+ * coercion lives in `escapeVars` rather than at each call site.
+ */
+describe('escapeVars', () => {
+  it('hands back strings, never numbers', () => {
+    const out = escapeVars({ EXPIRES_HOURS: 48, COUNT: 0 });
+
+    expect(out.EXPIRES_HOURS).toBe('48');
+    expect(out.COUNT).toBe('0');
+    for (const value of Object.values(out)) expect(typeof value).toBe('string');
+  });
+
+  it('escapes markup in string values', () => {
+    const out = escapeVars({ NAME: '<script>alert(1)</script>' });
+
+    expect(out.NAME).not.toContain('<script>');
+    expect(out.NAME).toContain('&lt;');
+  });
+
+  it('leaves a number free of escaping artefacts', () => {
+    expect(escapeVars({ N: 1234 }).N).toBe('1234');
+  });
+
+  it('drops null and undefined rather than sending the words', () => {
+    const out = escapeVars({ A: null, B: undefined, C: 'kept' });
+
+    expect(out).not.toHaveProperty('A');
+    expect(out).not.toHaveProperty('B');
+    expect(out.C).toBe('kept');
+  });
+});

--- a/packages/services/src/emails/escape.ts
+++ b/packages/services/src/emails/escape.ts
@@ -19,14 +19,23 @@ export const escapeHtml = (value: string): string =>
     return replacements[c] ?? c;
   });
 
-/** Escape every value in a variables bag. Numbers pass through untouched. */
+/**
+ * Escape every value in a variables bag, and hand back strings only.
+ *
+ * A number is stringified rather than passed through. Resend rejects the whole
+ * send with `Variable "X" must be a \`string\`` when a variable arrives as a
+ * number, and since the send happens inside a Trigger task, that rejection
+ * surfaces nowhere the caller or the recipient can see — the mail simply never
+ * arrives. Coercing here means no caller can reintroduce it. A number needs no
+ * HTML escaping, so String() is the whole of the work.
+ */
 export const escapeVars = <T extends Record<string, string | number | null | undefined>>(
   vars: T
-): Record<string, string | number> => {
-  const out: Record<string, string | number> = {};
+): Record<string, string> => {
+  const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(vars)) {
     if (value === null || value === undefined) continue;
-    out[key] = typeof value === 'number' ? value : escapeHtml(String(value));
+    out[key] = typeof value === 'number' ? String(value) : escapeHtml(String(value));
   }
   return out;
 };

--- a/packages/services/src/emails/sync-templates.mjs
+++ b/packages/services/src/emails/sync-templates.mjs
@@ -6,9 +6,16 @@
  *
  *   RESEND_API_KEY=re_... node packages/services/src/emails/sync-templates.mjs
  *   RESEND_API_KEY=re_... node .../sync-templates.mjs --dry   # print, send nothing
+ *   RESEND_API_KEY=re_... node .../sync-templates.mjs --only form-verify-link
  *
  * NOTE: this overwrites dashboard edits. If someone tweaks copy in the Resend
  * UI, mirror it back into templates.mjs or the next sync discards it.
+ *
+ * `--only` narrows that blast radius to the aliases you name (repeat the flag,
+ * or pass one comma-separated list). Reach for it when you are adding a single
+ * template and do not want to answer for every other one in the file. An alias
+ * that matches nothing is an error rather than a silent no-op — a typo must not
+ * look like a successful run that pushed nothing.
  *
  * The key here must be FULL ACCESS. The app's own RESEND_API_KEY is send-only
  * (correct for runtime least-privilege) and returns 401 restricted_api_key on
@@ -20,10 +27,33 @@ import { templates } from './templates.mjs';
 const dry = process.argv.includes('--dry');
 const apiKey = process.env.RESEND_API_KEY;
 
+/** Aliases named by `--only a --only b` and/or `--only a,b`. Empty means all. */
+const only = new Set(
+  process.argv
+    .flatMap((arg, i) => (arg === '--only' ? [process.argv[i + 1]] : []))
+    .filter(Boolean)
+    .flatMap(value => value.split(','))
+    .map(value => value.trim())
+    .filter(Boolean)
+);
+
+const selected = only.size ? templates.filter(t => only.has(t.alias)) : templates;
+
+// A typo must not read as "synced everything you asked for" when it pushed
+// nothing at all.
+const unknown = [...only].filter(alias => !templates.some(t => t.alias === alias));
+if (unknown.length) {
+  console.error(`Unknown template alias: ${unknown.join(', ')}`);
+  console.error(`Known aliases: ${templates.map(t => t.alias).join(', ')}`);
+  process.exit(1);
+}
+
 if (!apiKey && !dry) {
   console.error('RESEND_API_KEY is required (or pass --dry).');
   process.exit(1);
 }
+
+if (only.size) console.log(`Syncing ${selected.length} of ${templates.length} templates.`);
 
 // Constructed lazily: the Resend constructor throws on a missing key, which
 // would break --dry.
@@ -38,7 +68,7 @@ const check = (label, { data, error }) => {
 
 let failed = 0;
 
-for (const t of templates) {
+for (const t of selected) {
   if (dry) {
     console.log(`\n─── ${t.alias} ───`);
     console.log(`subject: ${t.subject}`);

--- a/packages/tasks/src/workflows/__tests__/email.test.ts
+++ b/packages/tasks/src/workflows/__tests__/email.test.ts
@@ -14,13 +14,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   send: vi.fn(),
   batchSend: vi.fn(),
+  updateMany: vi.fn(),
+  update: vi.fn(),
+  warn: vi.fn(),
 }));
 
 // `task()` normally returns a wrapped trigger handle; return the config itself
 // so the test can invoke `run` directly.
 vi.mock('@trigger.dev/sdk', () => ({
   task: (config: unknown) => config,
-  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+  logger: { info: vi.fn(), error: vi.fn(), warn: (...a: unknown[]) => mocks.warn(...a) },
 }));
 
 vi.mock('resend', () => ({
@@ -28,6 +31,23 @@ vi.mock('resend', () => ({
     emails = { send: (...a: unknown[]) => mocks.send(...a) };
     batch = { send: (...a: unknown[]) => mocks.batchSend(...a) };
   },
+}));
+
+/**
+ * Prisma, for the two write-backs onto `form_magic_tokens`.
+ *
+ * Mocked rather than run against a database because what is worth pinning here
+ * is the SHAPE of the write — which row, guarded by what — not that Postgres
+ * can store a string. The reuse rule that consumes this column is proved
+ * end-to-end against real Postgres in the services integration suite.
+ */
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    formMagicToken: {
+      updateMany: (...a: unknown[]) => mocks.updateMany(...a),
+      update: (...a: unknown[]) => mocks.update(...a),
+    },
+  }),
 }));
 
 const { sendEmailTask, sendBatchEmailTask } = await import('../email.ts');
@@ -40,6 +60,14 @@ const run = (input: unknown) =>
     input,
     CTX
   );
+
+/** Invoke the task's final-failure hook exactly as Trigger.dev would. */
+const fail = (input: unknown, error: unknown) =>
+  (
+    sendEmailTask as unknown as {
+      onFailure: (a: { payload: unknown; error: unknown }) => Promise<void>;
+    }
+  ).onFailure({ payload: input, error });
 
 describe('sendEmailTask', () => {
   beforeEach(() => {
@@ -160,6 +188,102 @@ describe('sendEmailTask', () => {
     // 429s during a roster import. The per-task override is the guard.
     const { retry } = sendEmailTask as unknown as { retry: { maxAttempts: number } };
     expect(retry.maxAttempts).toBeGreaterThan(1);
+  });
+});
+
+/**
+ * ── The send that never happened ────────────────────────────────────────────
+ *
+ * A verification mail is dispatched fire-and-forget, so the page that asked for
+ * it has already answered the browser by the time Resend refuses. Nothing on
+ * the request path can learn that the send failed — which meant a failed send
+ * left a token looking pristine, and the reuse rule then concluded "a live link
+ * already covers this address" and sent nothing, forever.
+ *
+ * `onFailure` is the hook that closes it, and the hook matters: it fires ONCE,
+ * after the retries are exhausted. Recording the failure inline in `run` would
+ * mark a token dead while attempt two was about to deliver it.
+ */
+describe('sendEmailTask.onFailure', () => {
+  const TOKEN = 'tok_9f3c';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('marks the token FAILED with the reason, so reuse cannot hand it back', async () => {
+    await fail(
+      { ...PAYLOAD, formMagicTokenId: TOKEN },
+      new Error('Resend send failed: Template not found')
+    );
+
+    expect(mocks.updateMany).toHaveBeenCalledTimes(1);
+    const [args] = mocks.updateMany.mock.calls[0];
+    expect(args.where.id).toBe(TOKEN);
+    expect(args.data.delivery_state).toBe('FAILED');
+    expect(args.data.delivery_detail).toContain('Template not found');
+  });
+
+  it('refuses to claim FAILED for a message Resend already accepted', async () => {
+    // The interlock. A token carrying a provider id was accepted, so the mail
+    // is out in the world whatever became of the run afterwards — telling the
+    // person it is not coming would be false, and would spend a fresh link
+    // mailing them a duplicate.
+    await fail({ ...PAYLOAD, formMagicTokenId: TOKEN }, new Error('boom'));
+
+    expect(mocks.updateMany.mock.calls[0][0].where.provider_message_id).toBeNull();
+  });
+
+  it('finds the token id through the wrapped { payload } shape too', async () => {
+    // `batchTrigger` call sites pass the batch-item shape. Reading `payload`
+    // directly here would silently never find `formMagicTokenId` and the whole
+    // fix would be a no-op for those.
+    await fail({ payload: { ...PAYLOAD, formMagicTokenId: TOKEN } }, new Error('boom'));
+
+    expect(mocks.updateMany.mock.calls[0][0].where.id).toBe(TOKEN);
+  });
+
+  it('writes nothing for a send that carries no token', async () => {
+    // Most mail in this system is not a form link. A failure there has no row
+    // to write to and must not invent one.
+    await fail(PAYLOAD, new Error('boom'));
+
+    expect(mocks.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('truncates the reason, which renders in the staff drawer', async () => {
+    await fail({ ...PAYLOAD, formMagicTokenId: TOKEN }, new Error('x'.repeat(5_000)));
+
+    expect(mocks.updateMany.mock.calls[0][0].data.delivery_detail.length).toBeLessThanOrEqual(200);
+  });
+
+  it('records something even when the error is not an Error', async () => {
+    await fail({ ...PAYLOAD, formMagicTokenId: TOKEN }, undefined);
+
+    expect(mocks.updateMany.mock.calls[0][0].data.delivery_detail).toBeTruthy();
+  });
+
+  it('swallows a database fault rather than masking the original failure', async () => {
+    // The run has already failed for a real reason. A bookkeeping error thrown
+    // out of here would replace that reason in the dashboard with a Prisma
+    // complaint, and there is nothing left to retry into.
+    mocks.updateMany.mockRejectedValue(new Error('connection reset'));
+
+    await expect(
+      fail({ ...PAYLOAD, formMagicTokenId: TOKEN }, new Error('boom'))
+    ).resolves.toBeUndefined();
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+
+  it('is registered as a hook, not called from run — so retries are not pre-empted', async () => {
+    // A failing attempt must leave the token untouched: four more attempts may
+    // yet deliver it, and a token marked FAILED in between would mint a second
+    // link for a message that is still going out.
+    mocks.send.mockResolvedValue({ data: null, error: { message: 'rate limited' } });
+
+    await expect(run({ ...PAYLOAD, formMagicTokenId: TOKEN })).rejects.toThrow('rate limited');
+    expect(mocks.updateMany).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/tasks/src/workflows/email.ts
+++ b/packages/tasks/src/workflows/email.ts
@@ -162,7 +162,92 @@ export const sendEmailTask = task({
 
     return data;
   },
+  /**
+   * ── The send that never happened, written down ───────────────────────────
+   *
+   * `run` throwing is not the end of the story: this task retries five times, so
+   * a thrown attempt may still be followed by one that succeeds. `onFailure`
+   * fires ONCE, and only after the retries are exhausted — which is exactly the
+   * moment "this message is never going out" becomes true. Recording the failure
+   * inline in `run` instead would mark a token dead while the next attempt was
+   * about to deliver it, and the reuse rule reads this column.
+   *
+   * WHY THE COLUMN MATTERS. Dispatch is fire-and-forget: the page that asked for
+   * the mail answered the browser long before Resend replied, so nothing on the
+   * request path can ever learn that the send failed. Without this write a
+   * failed send leaves a token that looks pristine — unspent, unexpired, freshly
+   * minted — and `findLiveLink` concludes "a live link already covers this
+   * address" and sends nothing. Somebody who never received a link can then
+   * never be sent one. See `findLiveLink` in formResponse.service.ts for the
+   * other half of the fix.
+   *
+   * KNOWN GAP: `onFailure` does not fire for Crashed, System failure, Canceled,
+   * or a `maxDuration` timeout. Those leave the token in the same "nothing
+   * known" state as an in-flight send, which reuse still treats as reusable —
+   * unchanged from before this hook existed, and the six-hour reminder sweep
+   * remains the backstop for them.
+   */
+  onFailure: async ({ payload, error }: { payload: SendEmailTaskInput; error: unknown }) => {
+    await recordDispatchFailure(extractPayload(payload), error);
+  },
 });
+
+/**
+ * How much of the provider's complaint is kept.
+ *
+ * It renders in the staff drawer, and a stack-trace-length string there is
+ * noise rather than information — the leading sentence is the part that says
+ * what went wrong ('Template not found', a 429, a refused sending domain).
+ */
+const DELIVERY_DETAIL_MAX = 200;
+
+/**
+ * Mark the token whose link this message carried as undeliverable BY US.
+ *
+ * Distinct from a bounce, and the distinction is real: a bounce is the
+ * recipient's mail system refusing a message that left the building; this is a
+ * message that never left at all. The consequence for the person waiting is
+ * identical — no link — which is why both disqualify a token from reuse and
+ * both are reported to the browser that caused the send.
+ *
+ * ── Why `updateMany`, and why the `provider_message_id: null` guard ────────
+ * `updateMany` because the row may legitimately be gone (the response it
+ * belonged to can be deleted between the dispatch and the failure), and no
+ * match must be a no-op rather than a P2025 thrown out of a failure hook.
+ *
+ * The `provider_message_id: null` clause is the interlock. A token that already
+ * carries a provider id was ACCEPTED by Resend, and that message is out in the
+ * world whatever became of the run afterwards. Overwriting that with FAILED
+ * would tell a person their link is not coming while it sits in their inbox,
+ * and would spend a fresh link mailing them a duplicate. FAILED may only ever
+ * be claimed for a send that provably never got that far.
+ *
+ * ── Why every failure here is swallowed ───────────────────────────────────
+ * The same reasoning as `recordProviderMessageId`, pointing the other way: this
+ * is bookkeeping about an error that has already been raised and reported.
+ * Throwing would replace the real cause in the dashboard with a database
+ * complaint, and the run is already finally failed so there is nothing left to
+ * retry into. Losing the note costs a reuse we should not have made; masking
+ * the original error costs whoever has to debug it.
+ */
+async function recordDispatchFailure(payload: SendEmailTaskBody, error: unknown): Promise<void> {
+  if (!payload.formMagicTokenId) return;
+
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const detail = (message || 'The message could not be sent.').slice(0, DELIVERY_DETAIL_MAX);
+
+  try {
+    await getPrisma().formMagicToken.updateMany({
+      where: { id: payload.formMagicTokenId, provider_message_id: null },
+      data: { delivery_state: 'FAILED', delivery_detail: detail },
+    });
+  } catch (writeError) {
+    logger.warn('Could not record dispatch failure', {
+      formMagicTokenId: payload.formMagicTokenId,
+      error: (writeError as Error).message,
+    });
+  }
+}
 
 /**
  * Write the provider's message id onto the row that asked for the send.


### PR DESCRIPTION
A form verification link silently never arrived. Two causes, both fixed here.

**Template variables must be strings.** `escapeVars` passed numbers through untouched, so `EXPIRES_HOURS: 48` reached Resend as a number and it rejected the entire send with `Variable "EXPIRES_HOURS" must be a \`string\``. Because the send runs inside a Trigger task, that rejection surfaced nowhere the caller or the recipient could see it — the page said "check your email" and nothing came. Coerced at the choke point so no call site can reintroduce it, with a regression test.

**Template sync can target one alias.** `sync-templates.mjs --only form-verify-link` narrows the blast radius when adding a single template, instead of pushing all nine and overwriting any dashboard edits. An unknown alias is a hard error rather than a silent no-op.

Verified: 169 forms service tests green, services typecheck clean (pre-existing GitLabProvider failures untouched).

Follow-up already in progress on a separate branch: a magic link whose send failed is still treated as "already sent" by the reuse logic, so a transient provider failure can strand a respondent with no way to get a link. That fix records dispatch failure on the token, refuses to reuse a known-failed link, and surfaces it to both the respondent and staff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)