### PR TITLE
feat(webapp): create a team tag inline on the group assignment form

### DIFF
--- a/apps/webapp/app/routes/admin.$class.repos_.form/FormModule.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.form/FormModule.tsx
@@ -587,7 +587,7 @@ const FormModule = ({
                     label="Team Tag"
                     extra={
                       isNewTagOpen ? (
-                        <div className="flex items-center gap-2">
+                        <div className="mt-2 flex items-center gap-2">
                           <Input
                             size="small"
                             autoFocus
@@ -621,6 +621,7 @@ const FormModule = ({
                           <Button
                             type="text"
                             size="small"
+                            className="!text-ink-2 hover:enabled:!text-ink-1"
                             onClick={closeNewTag}
                             disabled={isCreatingTag}
                           >
@@ -631,7 +632,7 @@ const FormModule = ({
                         <button
                           type="button"
                           onClick={() => setIsNewTagOpen(true)}
-                          className="text-xs text-ink-3 hover:text-ink-1 transition-colors"
+                          className="mt-1 text-xs text-ink-3 hover:text-ink-1 transition-colors"
                         >
                           + New tag
                         </button>

--- a/apps/webapp/app/routes/admin.$class.repos_.form/FormModule.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.form/FormModule.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { useRevalidator } from 'react-router';
+import { useFetcher, useRevalidator } from 'react-router';
 import { useCallout } from '@classmoji/ui-components';
 import { useForm, type Control, type FieldValues } from 'react-hook-form';
 import { FormItem } from 'react-hook-form-antd';
@@ -149,6 +149,25 @@ const FormModule = ({
       []
     ).map(test => ({ ...test }))
   );
+  // Inline team-tag creation, so a group assignment doesn't send the instructor
+  // off to Settings → Team mid-form.
+  const tagFetcher = useFetcher<{ tag?: TagRef; error?: string }>();
+  const [isNewTagOpen, setIsNewTagOpen] = useState(false);
+  const [newTagName, setNewTagName] = useState('');
+  const [createdTags, setCreatedTags] = useState<TagRef[]>([]);
+  const isCreatingTag = tagFetcher.state !== 'idle';
+
+  // Loader revalidation lands after the fetcher resolves, so render tags we just
+  // created ourselves too — selecting an id the Select has no option for would
+  // leave the field looking empty.
+  const tagOptions = useMemo(() => {
+    const merged = [...tags];
+    createdTags.forEach(createdTag => {
+      if (!merged.some(existing => existing.id === createdTag.id)) merged.push(createdTag);
+    });
+    return merged;
+  }, [tags, createdTags]);
+
   const [agOpened, { open: openAgModal, close: closeAgModal }] = useDisclosure();
   const [editingTest, setEditingTest] = useState<AutogradingTestData>(emptyAutogradingTest());
   const [editingTestIndex, setEditingTestIndex] = useState<number | null>(null);
@@ -238,14 +257,63 @@ const FormModule = ({
 
   const assignments = watch('assignments');
   const type = watch('type');
+  const teamFormationMode = watch('team_formation_mode');
   const isExtraCredit = watch('is_extra_credit');
 
+  const closeNewTag = () => {
+    setIsNewTagOpen(false);
+    setNewTagName('');
+  };
+
+  const createTag = () => {
+    const name = newTagName.trim();
+    if (!name) {
+      callout.show({ variant: 'error', title: 'Please enter a tag name.' });
+      return;
+    }
+
+    tagFetcher.submit(
+      { name },
+      { action: '?/createTag', method: 'POST', encType: 'application/json' }
+    );
+  };
+
+  // Select the tag once it comes back. The action upserts, so re-entering an
+  // existing name simply selects that tag.
+  useEffect(() => {
+    if (tagFetcher.state !== 'idle' || !tagFetcher.data) return;
+
+    const { tag: createdTag, error } = tagFetcher.data;
+    if (error) {
+      callout.show({ variant: 'error', title: error });
+      return;
+    }
+    if (!createdTag) return;
+
+    setCreatedTags(prev =>
+      prev.some(existing => existing.id === createdTag.id) ? prev : [...prev, createdTag]
+    );
+    // shouldValidate re-runs the resolver, clearing 'Tag is required for
+    // instructor-assigned teams.' if it was already showing.
+    setValue('tag', createdTag.id, { shouldValidate: true, shouldDirty: true });
+    closeNewTag();
+  }, [tagFetcher.state, tagFetcher.data]);
+
+  // Don't leave a half-typed tag behind when the mode that shows the field changes.
+  useEffect(() => {
+    closeNewTag();
+  }, [type, teamFormationMode]);
+
+  // Keyed on the id, not the object: a loader revalidation hands back a new
+  // `repository` for the same record, and re-running this would stomp an unsaved
+  // template pick with the persisted one.
   useEffect(() => {
     if (repository) setValue('template', repository.template);
-    return () => {
-      resetAssignmentsToRemove();
-    };
-  }, [repository]);
+  }, [repository?.id]);
+
+  // Queued assignment deletions live in the store until the form is submitted, so
+  // only drop them when the form itself goes away — never on a re-render.
+  useEffect(() => () => resetAssignmentsToRemove(), []);
 
   // Close drawer after successful submission and revalidate parent route
   useEffect(() => {
@@ -509,10 +577,69 @@ const FormModule = ({
                   <InputNumber min={2} style={{ width: '100%' }} placeholder="e.g., 4" />
                 </FormItem>
 
-                {watch('team_formation_mode') === 'INSTRUCTOR' && (
-                  <FormItem control={control} name="tag" label="Team Tag">
+                {teamFormationMode === 'INSTRUCTOR' && (
+                  // The affordance rides in the item's `extra` slot so antd owns
+                  // the spacing: it sizes the block below the control to fit both
+                  // this and the validation message, in every combination.
+                  <FormItem
+                    control={control}
+                    name="tag"
+                    label="Team Tag"
+                    extra={
+                      isNewTagOpen ? (
+                        <div className="flex items-center gap-2">
+                          <Input
+                            size="small"
+                            autoFocus
+                            aria-label="New team tag name"
+                            value={newTagName}
+                            onChange={e => setNewTagName(e.target.value)}
+                            onKeyDown={e => {
+                              // Enter creates the tag rather than submitting the
+                              // repository form; Escape backs out of the input.
+                              if (e.key === 'Enter') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                createTag();
+                              } else if (e.key === 'Escape') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                closeNewTag();
+                              }
+                            }}
+                            placeholder="New tag name"
+                            disabled={isCreatingTag}
+                          />
+                          <Button
+                            type="primary"
+                            size="small"
+                            onClick={createTag}
+                            loading={isCreatingTag}
+                          >
+                            Create
+                          </Button>
+                          <Button
+                            type="text"
+                            size="small"
+                            onClick={closeNewTag}
+                            disabled={isCreatingTag}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setIsNewTagOpen(true)}
+                          className="text-xs text-ink-3 hover:text-ink-1 transition-colors"
+                        >
+                          + New tag
+                        </button>
+                      )
+                    }
+                  >
                     <Select className="w-full" placeholder="Select a team tag">
-                      {tags.map((tag: TagRef) => (
+                      {tagOptions.map((tag: TagRef) => (
                         <Select.Option key={tag.id} value={tag.id}>
                           #{tag.name}
                         </Select.Option>
@@ -521,7 +648,7 @@ const FormModule = ({
                   </FormItem>
                 )}
 
-                {watch('team_formation_mode') === 'SELF_FORMED' && (
+                {teamFormationMode === 'SELF_FORMED' && (
                   <FormItem
                     control={control}
                     name="team_formation_deadline"

--- a/apps/webapp/app/routes/admin.$class.repos_.form/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.repos_.form/route.tsx
@@ -1,5 +1,6 @@
 import { namedAction } from 'remix-utils/named-action';
 import { useNavigate, useParams } from 'react-router';
+import type { ShouldRevalidateFunctionArgs } from 'react-router';
 import { IconChevronLeft, IconFolder } from '@tabler/icons-react';
 
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
@@ -70,6 +71,23 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     slides,
     hasReposWithProjects,
   };
+};
+
+// Inline tag creation mints one tag the form already renders locally (FormModule
+// merges the action's tag into the Select's options), so re-running this loader
+// buys nothing — and it costs: a fresh `repository` object would disturb edits the
+// instructor hasn't saved yet, and the whole heavy load (GitHub-backed repository,
+// pages, slides) would run behind the Create button. Skip it for that one named
+// action; everything else keeps the default behaviour.
+export const shouldRevalidate = ({
+  formAction,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) => {
+  if (formAction && new URL(formAction, 'http://localhost').searchParams.has('/createTag')) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
 };
 
 const ModuleForm = ({ loaderData }: Route.ComponentProps) => {
@@ -292,6 +310,21 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   };
 
   return namedAction(request, {
+    // Lets an instructor add a team tag from the group-assignment form without
+    // leaving for Settings → Team. Upsert, so re-typing an existing name hands
+    // back that tag instead of tripping the [classroom_id, name] unique index.
+    async createTag() {
+      const name = typeof data.name === 'string' ? data.name.trim() : '';
+      if (!name) return { error: 'Please enter a tag name.' };
+
+      try {
+        const createdTag = await ClassmojiService.organizationTag.upsert(classroom.id, name);
+        return { tag: { id: createdTag.id, name: createdTag.name } };
+      } catch (error: unknown) {
+        console.error('Tag create error:', error);
+        return { error: 'Failed to create tag. Please try again.' };
+      }
+    },
     async create() {
       try {
         const createdModule = await ClassmojiService.repository.create({

--- a/apps/webapp/app/routes/admin.$class.settings.team/TagSection.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.team/TagSection.tsx
@@ -20,13 +20,21 @@ const TagSection = ({ tags }: TagSectionProps) => {
   const callout = useCallout();
 
   const createTag = () => {
-    if (tags.find((tag: Tag) => tag.name === name)) {
+    // Compare and submit the trimmed name — the action trims too, so an untrimmed
+    // check here would wave through a duplicate and then silently create nothing.
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      callout.show({ variant: 'error', title: 'Please enter a tag name' });
+      return;
+    }
+
+    if (tags.find((tag: Tag) => tag.name === trimmedName)) {
       callout.show({ variant: 'error', title: 'Tag already exists' });
       return;
     }
 
     fetcher!.submit(
-      { name },
+      { name: trimmedName },
       { action: '?/createTag', method: 'POST', encType: 'application/json' }
     );
 

--- a/apps/webapp/app/routes/admin.$class.settings.team/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.team/route.tsx
@@ -40,7 +40,13 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
 
   return namedAction(request, {
     async createTag() {
-      return ClassmojiService.organizationTag.create(classroom.id, data.name);
+      // Trim and reject empty, matching the repository form's inline tag creation:
+      // otherwise the two paths can mint 'Section A' and 'Section A ' as separate,
+      // visually identical tags. Upsert so the trimmed name can't collide either.
+      const name = typeof data.name === 'string' ? data.name.trim() : '';
+      if (!name) return { error: 'Please enter a tag name.' };
+
+      return ClassmojiService.organizationTag.upsert(classroom.id, name);
     },
 
     async deleteTag() {


### PR DESCRIPTION
## Context
Creating a group assignment with instructor-assigned teams requires a team tag, but tags could only be created in Settings → Team — forcing a mid-form detour (and losing form state). 

## What changed
- **Inline tag creation**: a `+ New tag` affordance under the Team Tag select (shown for instructor-assigned group assignments) reveals an input + Create/Cancel. Creating auto-selects the tag and clears the "Tag is required" validation error. Enter creates without submitting the outer form; Escape cancels. Works on both create and edit since they share `FormModule`.
- **Server**: new `?/createTag` named action on the assignment form route, behind the same `requireClassroomAdmin` + `assertClassroomMutationAllowed` gate as the existing actions. Uses `organizationTag.upsert`, so re-entering an existing name selects it instead of tripping the `[classroom_id, name]` unique index.
- **Revalidation hardening**: the new mid-form fetcher POST exposed a pre-existing landmine — post-action revalidation handed the form a fresh `repository` object, re-firing an effect whose cleanup wiped queued assignment deletions and reverted unsaved template picks. Fixed both ways: the effect is keyed on `repository?.id` with a mount-only cleanup, and `shouldRevalidate` skips the loader re-run for tag creation.
- **Consistency**: Settings → Team tag creation now trims names and rejects empties the same way, so the two paths can't mint visually identical `"tag"` / `"tag "` duplicates.

## Testing
- Browser-verified on a devport (light + dark): create/select/error-clearing flow, Enter/Escape handling, spacing with the validation error visible (the affordance rides the FormItem's `extra` slot, so antd sizes them together).
- Edit-mode regression test: deleted an assignment, created a tag inline, saved, reloaded — the deletion persists.
- Typecheck/eslint/prettier clean on touched files (one pre-existing unrelated typecheck error on the branch in `RequireGitProvider.tsx`).
- Reviewed by two independent local review passes (correctness/security + React/UI conventions); all findings fixed or deliberately accepted (shared audit-log label across named actions matches the settings route idiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6WM8vAi9PWd6gU35ZZ3r2