### PR TITLE
feat(webapp): show the teaching team draft repos and assignments

### DIFF
--- a/apps/webapp/app/components/features/modules/ReadOnlyModulesTree.tsx
+++ b/apps/webapp/app/components/features/modules/ReadOnlyModulesTree.tsx
@@ -83,9 +83,9 @@ export const isFormClosed = (form: { status: string; closes_at: Date | string | 
 // read-only resource leaf nodes (each opens the relevant app in a new tab).
 export const buildResourceLeaves = (
   input: {
-    pages?: Array<{ page: { id: string; title: string } }>;
-    slides?: Array<{ slide: { id: string; title: string } }>;
-    quizzes?: Array<{ id: string; name: string }>;
+    pages?: Array<{ page: { id: string; title: string; is_draft?: boolean } }>;
+    slides?: Array<{ slide: { id: string; title: string; is_draft?: boolean } }>;
+    quizzes?: Array<{ id: string; name: string; status?: string }>;
     forms?: Array<{
       id: string;
       title: string;
@@ -97,8 +97,18 @@ export const buildResourceLeaves = (
   },
   level: number,
   keyPrefix: string,
-  ctx: { classSlug: string; slidesUrl: string; pagesUrl: string; quizzesHref: string }
+  // `isStaff` comes from the route's gate, never from the URL prefix. Only staff
+  // loaders fetch draft slides and non-live quizzes; it defaults to false so a
+  // caller that omits it cannot label anything.
+  ctx: {
+    classSlug: string;
+    slidesUrl: string;
+    pagesUrl: string;
+    quizzesHref: string;
+    isStaff?: boolean;
+  }
 ): ModuleTreeNode[] => {
+  const isStaff = ctx.isStaff === true;
   const out: ModuleTreeNode[] = [];
   (input.pages ?? []).forEach(({ page }) =>
     out.push({
@@ -108,6 +118,7 @@ export const buildResourceLeaves = (
       resourceIcon: 'page',
       name: page.title,
       pageId: page.id,
+      statusNode: isStaff && page.is_draft === true ? <Tag color="orange">Draft</Tag> : null,
       href: `${ctx.pagesUrl}/${ctx.classSlug}/${page.id}`,
     })
   );
@@ -118,9 +129,13 @@ export const buildResourceLeaves = (
       level,
       resourceIcon: 'slide',
       name: slide.title,
+      statusNode: isStaff && slide.is_draft === true ? <Tag color="orange">Draft</Tag> : null,
       href: `${ctx.slidesUrl}/${slide.id}`,
     })
   );
+  // A quiz reaches here unpublished only in the staff preview. DRAFT is content
+  // students have never seen; CLOSED is content they can no longer attempt —
+  // both read wrong sitting unlabelled next to the live ones.
   (input.quizzes ?? []).forEach(q =>
     out.push({
       key: `${keyPrefix}-quiz-${q.id}`,
@@ -128,6 +143,12 @@ export const buildResourceLeaves = (
       level,
       resourceIcon: 'quiz',
       name: q.name,
+      statusNode:
+        isStaff && q.status === 'DRAFT' ? (
+          <Tag color="orange">Draft</Tag>
+        ) : isStaff && q.status === 'CLOSED' ? (
+          <Tag>Closed</Tag>
+        ) : null,
       href: ctx.quizzesHref,
     })
   );

--- a/apps/webapp/app/components/features/modules/studentTree.tsx
+++ b/apps/webapp/app/components/features/modules/studentTree.tsx
@@ -41,7 +41,21 @@ export interface StudentTreeCtx {
   studentRepoByRepositoryId?: Record<string, { name: string }>;
   /** The viewer's latest autograding result per repository unit, keyed by id. */
   autogradingByRepositoryId?: Record<string, AutogradingResultData>;
+  /**
+   * Whether the viewer is teaching staff, taken from the membership the route's
+   * gate returned — never inferred from `rolePrefix`, which is only the URL the
+   * viewer happened to arrive on.
+   *
+   * Staff loaders fetch unpublished content; student loaders filter it out. This
+   * flag decides only whether a "Draft" chip is drawn, and it defaults to false
+   * so a caller that never sets it cannot label anything. It is presentation —
+   * WHAT a viewer receives is settled in the loader, not here.
+   */
+  isStaff?: boolean;
 }
+
+/** Marks content students cannot see yet. Matches the module row's own chip. */
+const DRAFT_TAG = <Tag color="orange">Draft</Tag>;
 
 export const submittedPill = (status?: string) => {
   const submitted = status === 'CLOSED';
@@ -65,9 +79,9 @@ export const submittedPill = (status?: string) => {
  */
 export const resourceLeaves = (
   input: {
-    pages?: Array<{ page: { id: string; title: string } }>;
-    slides?: Array<{ slide: { id: string; title: string } }>;
-    quizzes?: Array<{ id: string; name: string }>;
+    pages?: Array<{ page: { id: string; title: string; is_draft?: boolean } }>;
+    slides?: Array<{ slide: { id: string; title: string; is_draft?: boolean } }>;
+    quizzes?: Array<{ id: string; name: string; status?: string }>;
     forms?: Array<{
       id: string;
       title: string;
@@ -121,6 +135,10 @@ export const buildRepositoryNode = (
       weightText: a.weight != null ? `${a.weight}%` : undefined,
       statusNode: (
         <div className="flex items-center gap-2 flex-wrap">
+          {/* Staff-only, and gated on the flag rather than on the data: a
+              student payload carries is_published too (always true, the loader
+              filtered on it), so the flag is what keeps this off their tree. */}
+          {ctx.isStaff === true && a.is_published === false && DRAFT_TAG}
           {submittedPill(ra?.status)}
           {showGrades && (
             <span className="inline-flex items-center gap-1 whitespace-nowrap">

--- a/apps/webapp/app/routes/__tests__/repoDraftPolicy.test.ts
+++ b/apps/webapp/app/routes/__tests__/repoDraftPolicy.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests pinning WHO sees unpublished repositories, assignments and
+ * attached resources.
+ *
+ * There are two repos loaders whose Prisma calls look almost identical:
+ *
+ *   - student.$class.repos  — filters `is_published: true` at the repository
+ *     AND assignment level. This is what keeps drafts off the student surface.
+ *   - assistant.$class_.repos — filters NOTHING. The teaching team is meant to
+ *     see the classroom as it actually is (a teacher prepping next term has
+ *     nothing but drafts), with drafts badged in the view instead of hidden.
+ *     It is re-exported by /teacher, so this one loader serves both staff roles.
+ *
+ * Because the two `where` clauses are a copy-paste apart, the failure mode is
+ * silent in both directions: paste the student filter into the staff loader and
+ * the teacher's page goes blank again; paste the staff one into the student
+ * loader and every student sees unreleased coursework. These tests assert the
+ * ABSENCE of a filter as carefully as its presence, so either direction fails.
+ *
+ * student.$class.modules serves BOTH audiences from one loader, so its
+ * repository include is a function of that route's own `isStaff` — derived from
+ * the membership its gate returned, never from the URL prefix. The last test
+ * here pins that specifically: role decides, prefix does not.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertClassroomAccess: vi.fn(),
+  requireClassroomTeachingTeam: vi.fn(),
+  repositoryFindMany: vi.fn(),
+  classroomFindUnique: vi.fn(),
+  gitRepoFindMany: vi.fn(),
+  listForClassroom: vi.fn(),
+  findAllAssignmentsForStudent: vi.fn(),
+  findLatestByGitRepoIds: vi.fn(),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    repository: { findMany: mocks.repositoryFindMany },
+    classroom: { findUnique: mocks.classroomFindUnique },
+    gitRepo: { findMany: mocks.gitRepoFindMany },
+  }),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    helper: { findAllAssignmentsForStudent: mocks.findAllAssignmentsForStudent },
+    autogradingResult: { findLatestByGitRepoIds: mocks.findLatestByGitRepoIds },
+    module: { listForClassroom: mocks.listForClassroom },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => mocks.assertClassroomAccess(...a),
+  addAuditLog: vi.fn(),
+  addClassroomAuditLog: vi.fn(),
+  assertClassroomMutationAllowed: vi.fn(),
+  assertProTier: vi.fn(),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  requireClassroomTeachingTeam: (...a: unknown[]) => mocks.requireClassroomTeachingTeam(...a),
+  assertClassroomMutationAllowed: vi.fn(),
+}));
+
+// `~` is not aliased in vitest.config.ts, so every aliased specifier these route
+// modules pull has to be stubbed for the import to resolve at all. The view
+// layers only need to import; none of them runs in a loader test.
+vi.mock('~/components/features/modules/ReadOnlyModulesTree', () => ({ default: () => null }));
+vi.mock('~/components/features/modules/studentTree', () => ({
+  buildRepositoryNode: () => ({}),
+  resourceLeaves: () => [],
+}));
+vi.mock('../student.$class.repos/ModuleAccordion', () => ({ default: () => null }));
+
+const CLASS_SLUG = 'cs52-26f';
+const CLASSROOM = { id: 'class-1', slug: CLASS_SLUG, status: 'ACTIVE', settings: {} };
+
+const loaderArgs = (pathname: string) =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost${pathname}`),
+  }) as never;
+
+const runLoader = async (routePath: string, pathname: string) => {
+  const { loader } = await import(`../${routePath}/route.tsx`);
+  await Promise.resolve(loader(loaderArgs(pathname)));
+};
+
+/** The `findMany` options the loader handed Prisma for the repository fetch. */
+const repositoryQuery = (callIndex = 0) =>
+  mocks.repositoryFindMany.mock.calls[callIndex][0] as {
+    where: Record<string, unknown>;
+    include: {
+      assignments: {
+        where?: unknown;
+        include: { slides: { where?: unknown }; pages: { where?: unknown } };
+      };
+      slides: { where?: unknown };
+      pages: { where?: unknown };
+      quizzes: { where?: unknown };
+    };
+  };
+
+/**
+ * Every draft-filterable leg of the modules route's repository include, as
+ * `{ leg: whereClause | undefined }`. Named so a failure says WHICH leg drifted,
+ * and enumerated so a newly added leg that nobody made conditional shows up as a
+ * missing key rather than passing silently.
+ */
+const includeLegs = () => {
+  const { include } = repositoryQuery();
+  return {
+    assignments: include.assignments.where,
+    assignmentPages: include.assignments.include.pages.where,
+    assignmentSlides: include.assignments.include.slides.where,
+    pages: include.pages.where,
+    slides: include.slides.where,
+    quizzes: include.quizzes.where,
+  };
+};
+
+const STUDENT_LEGS = {
+  assignments: { is_published: true },
+  assignmentPages: { page: { is_draft: false } },
+  assignmentSlides: { slide: { is_draft: false } },
+  pages: { page: { is_draft: false } },
+  slides: { slide: { is_draft: false } },
+  quizzes: { status: 'PUBLISHED' },
+};
+
+const STAFF_LEGS = {
+  assignments: undefined,
+  assignmentPages: undefined,
+  assignmentSlides: undefined,
+  pages: undefined,
+  slides: undefined,
+  quizzes: undefined,
+};
+
+const asTeacher = () =>
+  mocks.assertClassroomAccess.mockResolvedValue({
+    userId: 'teacher-1',
+    classroom: CLASSROOM,
+    membership: { role: 'TEACHER' },
+  });
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+
+  mocks.requireClassroomTeachingTeam.mockResolvedValue({
+    userId: 'ta-1',
+    classroom: CLASSROOM,
+    membership: { role: 'ASSISTANT' },
+  });
+  mocks.assertClassroomAccess.mockResolvedValue({
+    userId: 'student-1',
+    classroom: CLASSROOM,
+    membership: { role: 'STUDENT' },
+  });
+
+  mocks.repositoryFindMany.mockResolvedValue([]);
+  mocks.classroomFindUnique.mockResolvedValue(null);
+  mocks.gitRepoFindMany.mockResolvedValue([]);
+  mocks.findAllAssignmentsForStudent.mockResolvedValue([]);
+  mocks.findLatestByGitRepoIds.mockResolvedValue(new Map());
+  // One module holding one repository item — without it the modules loader
+  // short-circuits the rich repository fetch and there is nothing to inspect.
+  mocks.listForClassroom.mockResolvedValue([
+    { id: 'm1', title: 'Week 1', is_published: true, items: [] },
+    {
+      id: 'm2',
+      title: 'Week 2',
+      is_published: true,
+      items: [{ id: 'i1', item_type: 'REPOSITORY', repository_id: 'r1' }],
+    },
+  ]);
+});
+
+describe('the student repos loader hides everything unpublished', () => {
+  it('filters is_published at BOTH the repository and the assignment level', async () => {
+    await runLoader('student.$class.repos', `/student/${CLASS_SLUG}/repos`);
+
+    const query = repositoryQuery();
+    expect(query.where.is_published).toBe(true);
+    expect(query.include.assignments.where).toEqual({ is_published: true });
+  });
+});
+
+describe('the staff repos loader hides nothing', () => {
+  // Asserting ABSENCE, not just a different value: a copy-paste of the student
+  // filter must fail here, and `toBeUndefined` is what catches that.
+  it('does not filter is_published at the repository level', async () => {
+    await runLoader('assistant.$class_.repos', `/assistant/${CLASS_SLUG}/repos`);
+
+    const query = repositoryQuery();
+    expect(query.where).toEqual({ classroom_id: CLASSROOM.id });
+    expect('is_published' in query.where).toBe(false);
+  });
+
+  it('does not filter is_published on the nested assignments', async () => {
+    await runLoader('assistant.$class_.repos', `/assistant/${CLASS_SLUG}/repos`);
+
+    expect(repositoryQuery().include.assignments.where).toBeUndefined();
+  });
+
+  it('does not filter draft slides, pages or quizzes either', async () => {
+    await runLoader('assistant.$class_.repos', `/assistant/${CLASS_SLUG}/repos`);
+
+    const { include } = repositoryQuery();
+    expect(include.slides.where).toBeUndefined();
+    expect(include.pages.where).toBeUndefined();
+    expect(include.quizzes.where).toBeUndefined();
+    expect(include.assignments.include.slides.where).toBeUndefined();
+    expect(include.assignments.include.pages.where).toBeUndefined();
+  });
+
+  it('serves /teacher from the very same loader', async () => {
+    const staff = await import('../teacher.$class_.repos/route');
+    const assistant = await import('../assistant.$class_.repos/route');
+
+    expect(staff.loader).toBe(assistant.loader);
+  });
+});
+
+describe('the shared modules loader filters by ROLE, not by URL prefix', () => {
+  // Asserted as a whole object rather than leg by leg: every draft-filterable
+  // leg has to move together, and a leg someone adds later without making it
+  // conditional fails this as a missing key instead of slipping through.
+  it('gives a student every filter', async () => {
+    await runLoader('student.$class.modules', `/student/${CLASS_SLUG}/modules`);
+
+    expect(includeLegs()).toEqual(STUDENT_LEGS);
+  });
+
+  it('gives staff none of them', async () => {
+    asTeacher();
+
+    await runLoader('student.$class.modules', `/teacher/${CLASS_SLUG}/modules`);
+
+    expect(includeLegs()).toEqual(STAFF_LEGS);
+  });
+
+  // If `isStaff` were ever sniffed from the pathname rather than taken from the
+  // membership the gate returned, the prefix alone would change what comes back.
+  // These two pin that it cannot.
+  it('gives a STUDENT the filtered include even under a staff prefix', async () => {
+    await runLoader('student.$class.modules', `/teacher/${CLASS_SLUG}/modules`);
+
+    expect(includeLegs()).toEqual(STUDENT_LEGS);
+  });
+
+  it('gives a TEACHER the unfiltered include even under the student prefix', async () => {
+    asTeacher();
+
+    await runLoader('student.$class.modules', `/student/${CLASS_SLUG}/modules`);
+
+    expect(includeLegs()).toEqual(STAFF_LEGS);
+  });
+});

--- a/apps/webapp/app/routes/__tests__/staffGateIdentity.test.ts
+++ b/apps/webapp/app/routes/__tests__/staffGateIdentity.test.ts
@@ -76,7 +76,6 @@ vi.mock('~/components/features/dashboard', () => ({
 vi.mock('~/components/features/modules/studentTree', () => ({ buildStudentTree: () => [] }));
 vi.mock('~/components/features/modules/ReadOnlyModulesTree', () => ({ default: () => null }));
 vi.mock('../student.$class.repos/ModuleAccordion', () => ({ default: () => null }));
-vi.mock('../assistant.$class_.repos/RepositoryAssignmentsTable', () => ({ default: () => null }));
 vi.mock('../assistant.$class_.grading/RepositoryAssignmentsTable', () => ({
   default: () => null,
 }));

--- a/apps/webapp/app/routes/assistant.$class_.repos/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.repos/route.tsx
@@ -13,31 +13,32 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     action: 'view_repos',
   });
 
+  // The teaching team sees EVERY repository, assignment and attached resource,
+  // published or not — a teacher prepping next term has nothing but drafts, and
+  // filtering them out left this page empty for the people who are meant to be
+  // building it. This is the same policy the MCP repo tools already apply to
+  // staff; drafts are marked as such in the view rather than hidden, so the list
+  // is never silently narrower than the classroom itself.
+  //
+  // Deliberately NO publish/draft `where` anywhere below. The student loader is
+  // left alone: its identical-looking filters are what keep drafts off the
+  // student surface, and repoDraftPolicy.test.ts fails if either loader is ever
+  // copy-pasted onto the other.
   const repositories = await getPrisma().repository.findMany({
-    where: { classroom_id: classroom.id, is_published: true },
+    where: { classroom_id: classroom.id },
     include: {
       assignments: {
-        where: { is_published: true },
         include: {
           pages: { include: { page: true }, orderBy: { order: 'asc' } },
-          slides: {
-            where: { slide: { is_draft: false } },
-            include: { slide: true },
-            orderBy: { order: 'asc' },
-          },
+          slides: { include: { slide: true }, orderBy: { order: 'asc' } },
         },
         orderBy: { student_deadline: 'asc' },
       },
       pages: { include: { page: true }, orderBy: { order: 'asc' } },
-      slides: {
-        where: { slide: { is_draft: false } },
-        include: { slide: true },
-        orderBy: { order: 'asc' },
-      },
-      quizzes: {
-        where: { status: 'PUBLISHED' },
-        select: { id: true, name: true },
-      },
+      slides: { include: { slide: true }, orderBy: { order: 'asc' } },
+      // `status` is rendered, not just fetched: a DRAFT quiz is annotated in the
+      // summary line, the only place this view surfaces quizzes at all.
+      quizzes: { select: { id: true, name: true, status: true } },
     },
     orderBy: { created_at: 'asc' },
   });
@@ -61,12 +62,12 @@ const AssistantModules = ({ loaderData }: Route.ComponentProps) => {
       </h1>
 
       {repositories.length === 0 ? (
+        // Staff see drafts too, so an empty list here means the classroom has no
+        // repositories at all — never "none published yet".
         <div className="rounded-2xl bg-panel ring-1 ring-line p-8 text-center">
-          <h3 className="text-lg font-semibold text-ink-1">
-            No published repositories yet
-          </h3>
+          <h3 className="text-lg font-semibold text-ink-1">No repositories yet</h3>
           <p className="text-sm text-ink-3 mt-1">
-            Repositories will appear here once your instructor publishes them.
+            Drafts appear here too — this classroom has no repositories at all yet.
           </p>
         </div>
       ) : (

--- a/apps/webapp/app/routes/student.$class.modules/route.tsx
+++ b/apps/webapp/app/routes/student.$class.modules/route.tsx
@@ -18,27 +18,53 @@ import {
 // Rich repository include matching the standalone repositories view, so a
 // repository placed in a module renders identically (assignments, git repos,
 // submission state, attached resources).
-const REPO_INCLUDE = {
+//
+// `isStaff` MUST be this route's own flag, derived from the membership its gate
+// returned — never a prefix sniff or a client-supplied value. It is the single
+// thing standing between a student and another student's unpublished work here,
+// and repoDraftPolicy.test.ts pins that every filter below flips with the role.
+//
+// EVERY draft-filterable leg below is conditional on the same flag —
+// assignments, both slides legs, both pages legs, and quizzes. Students get the
+// published view of all six; staff get all six unfiltered, and anything
+// unpublished that reaches the tree is chipped there rather than hidden. Keeping
+// them uniform is the point: a leg that is filtered for one role and not the
+// other is how the two surfaces drifted apart in the first place.
+const repoInclude = (isStaff: boolean) => ({
   assignments: {
-    where: { is_published: true },
+    // Staff preview drafts; students only ever get published assignments.
+    ...(isStaff ? {} : { where: { is_published: true } }),
     include: {
-      pages: { include: { page: true }, orderBy: { order: 'asc' as const } },
+      pages: {
+        ...(isStaff ? {} : { where: { page: { is_draft: false } } }),
+        include: { page: true },
+        orderBy: { order: 'asc' as const },
+      },
       slides: {
-        where: { slide: { is_draft: false } },
+        ...(isStaff ? {} : { where: { slide: { is_draft: false } } }),
         include: { slide: true },
         orderBy: { order: 'asc' as const },
       },
     },
     orderBy: { student_deadline: 'asc' as const },
   },
-  pages: { include: { page: true }, orderBy: { order: 'asc' as const } },
+  pages: {
+    ...(isStaff ? {} : { where: { page: { is_draft: false } } }),
+    include: { page: true },
+    orderBy: { order: 'asc' as const },
+  },
   slides: {
-    where: { slide: { is_draft: false } },
+    ...(isStaff ? {} : { where: { slide: { is_draft: false } } }),
     include: { slide: true },
     orderBy: { order: 'asc' as const },
   },
-  quizzes: { where: { status: 'PUBLISHED' as const }, select: { id: true, name: true } },
-};
+  // `status` is selected because the tree renders it: a DRAFT or CLOSED quiz is
+  // chipped for staff rather than silently listed alongside the live ones.
+  quizzes: {
+    ...(isStaff ? {} : { where: { status: 'PUBLISHED' as const } }),
+    select: { id: true, name: true, status: true },
+  },
+});
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const classSlug = params.class!;
@@ -91,7 +117,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   const richRepos = repoIds.length
     ? await getPrisma().repository.findMany({
         where: { id: { in: repoIds } },
-        include: REPO_INCLUDE,
+        include: repoInclude(isStaff),
       })
     : [];
   const repoById = Object.fromEntries(richRepos.map(r => [r.id, r]));
@@ -225,8 +251,11 @@ const StudentModules = ({ loaderData }: Route.ComponentProps) => {
   const { modules, repoById, raByAssignmentId, slidesUrl, pagesUrl, classSlug, isStaff } =
     loaderData;
   // Served under every prefix this route's gate allows, so resource links stay
-  // on the prefix the viewer arrived on.
-  const ctx: StudentTreeCtx = { classSlug, slidesUrl, pagesUrl, rolePrefix };
+  // on the prefix the viewer arrived on. `isStaff` is the loader's own flag —
+  // note it travels SEPARATELY from rolePrefix, which is only the URL: a student
+  // under /teacher is still a student, and gets no draft chips because the
+  // loader gave them no drafts to chip.
+  const ctx: StudentTreeCtx = { classSlug, slidesUrl, pagesUrl, rolePrefix, isStaff };
   const nodes = buildModuleNodes(
     modules,
     repoById as Record<string, AnyRepository>,

--- a/apps/webapp/app/routes/student.$class.repos/AssignmentCard.tsx
+++ b/apps/webapp/app/routes/student.$class.repos/AssignmentCard.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { Tag } from 'antd';
 import { motion, useReducedMotion } from 'framer-motion';
 import { IconBrandGithub, IconCheck } from '@tabler/icons-react';
 import { EmojisDisplay } from '~/components';
@@ -9,6 +10,8 @@ interface AssignmentCardAssignment {
   title: string;
   grades_released?: boolean;
   student_deadline?: string | Date | null;
+  // Only ever false on the teaching-team view, which fetches drafts too.
+  is_published?: boolean;
   pages?: Array<{ page: { id: string; title: string } }>;
   slides?: Array<{ slide: { id: string; title: string } }>;
 }
@@ -81,6 +84,14 @@ const AssignmentCard = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <h4 className="font-medium text-ink-0">{assignment.title}</h4>
+            {/* Staff-only: the loader that feeds this view fetches drafts, so
+                say which rows students cannot see yet. `!me-0` drops antd's own
+                8px marginInlineEnd, which would stack on the row's gap-2. */}
+            {assignment.is_published === false && (
+              <Tag color="orange" className="!me-0">
+                Draft
+              </Tag>
+            )}
             {statusPill &&
               (statusPill.tone === 'submitted' ? (
                 <motion.span

--- a/apps/webapp/app/routes/student.$class.repos/ModuleAccordion.tsx
+++ b/apps/webapp/app/routes/student.$class.repos/ModuleAccordion.tsx
@@ -5,17 +5,20 @@ import { IconChevronDown, IconCheck, IconUsers } from '@tabler/icons-react';
 import ResourceLinks from './ResourceLinks';
 import AssignmentCard from './AssignmentCard';
 
+// The `is_draft` / `status` flags below are only ever set to a draft value on
+// the teaching-team view, whose loader fetches unpublished content too.
 interface LinkedPage {
-  page: { id: string; title: string };
+  page: { id: string; title: string; is_draft?: boolean };
 }
 
 interface LinkedSlide {
-  slide: { id: string; title: string };
+  slide: { id: string; title: string; is_draft?: boolean };
 }
 
 interface LinkedQuiz {
   id: string;
   name: string;
+  status?: string;
 }
 
 interface Assignment {
@@ -23,6 +26,8 @@ interface Assignment {
   title: string;
   grades_released?: boolean;
   student_deadline?: string | Date | null;
+  // Only ever false on the teaching-team view, which fetches drafts too.
+  is_published?: boolean;
   [key: string]: unknown;
 }
 
@@ -35,6 +40,8 @@ interface Repository {
   team_formation_mode?: string | null;
   team_formation_deadline?: string | Date | null;
   max_team_size?: number | null;
+  // Only ever false on the teaching-team view, which fetches drafts too.
+  is_published?: boolean;
   assignments?: Assignment[];
   pages?: LinkedPage[];
   slides?: LinkedSlide[];
@@ -146,7 +153,8 @@ const TeamFormationBanner = ({ repository, userTeam, classSlug }: TeamFormationB
 
 interface ModuleCardProps {
   repository: Repository;
-  ordinal: number;
+  /** Position among PUBLISHED repositories; null for a draft, which has none. */
+  ordinal: number | null;
   repoAssignmentsByAssignmentId: Record<string, RepoAssignment>;
   userTeam?: UserTeam;
   classSlug: string | undefined;
@@ -157,12 +165,27 @@ interface ModuleCardProps {
 }
 
 const buildSummary = (repository: Repository) => {
-  const qCount = repository.quizzes?.length ?? 0;
+  const quizzes = repository.quizzes ?? [];
+  const qCount = quizzes.length;
   const sCount = repository.slides?.length ?? 0;
   const pCount = repository.pages?.length ?? 0;
   const aCount = repository.assignments?.length ?? 0;
+  // Pages, slides and assignments each carry their own Draft chip one row away,
+  // so their totals stand alone. Quizzes are counted here and nowhere else, so
+  // an unannotated total would read as more LIVE quizzes than the repository
+  // actually has — a draft was never released, a closed one can no longer be
+  // attempted. `status` is undefined on student payloads, so this annotates
+  // nothing there.
+  const qDrafts = quizzes.filter(q => q.status === 'DRAFT').length;
+  const qClosed = quizzes.filter(q => q.status === 'CLOSED').length;
   const parts: string[] = [];
-  if (qCount) parts.push(`${qCount} ${qCount === 1 ? 'quiz' : 'quizzes'}`);
+  if (qCount) {
+    const quizLabel = `${qCount} ${qCount === 1 ? 'quiz' : 'quizzes'}`;
+    const notes: string[] = [];
+    if (qDrafts) notes.push(`${qDrafts} draft${qDrafts === 1 ? '' : 's'}`);
+    if (qClosed) notes.push(`${qClosed} closed`);
+    parts.push(notes.length ? `${quizLabel} (${notes.join(', ')})` : quizLabel);
+  }
   if (sCount) parts.push(`${sCount} slide ${sCount === 1 ? 'deck' : 'decks'}`);
   if (pCount) parts.push(`${pCount} ${pCount === 1 ? 'page' : 'pages'}`);
   if (aCount) parts.push(`${aCount} ${aCount === 1 ? 'assignment' : 'assignments'}`);
@@ -188,7 +211,13 @@ const ModuleCard = ({
     const ra = repoAssignmentsByAssignmentId[String(a.id)];
     return ra?.status === 'CLOSED';
   }).length;
-  const pct = total > 0 ? Math.round((done / total) * 100) : null;
+  // Submission progress is a viewer's OWN progress, so it needs their own
+  // repo-assignments. The staff loader passes `{}`, which would otherwise render
+  // every bar at a meaningless 0% — a wall of them in an all-drafts classroom.
+  // Keyed off the data rather than the URL prefix: whoever has no submissions to
+  // show gets no bar, whichever prefix they arrived on.
+  const hasOwnSubmissions = Object.keys(repoAssignmentsByAssignmentId).length > 0;
+  const pct = hasOwnSubmissions && total > 0 ? Math.round((done / total) * 100) : null;
   const summary = buildSummary(repository);
 
   const hasExpandableContent =
@@ -216,12 +245,25 @@ const ModuleCard = ({
       >
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
-            <div className="text-xs font-semibold tracking-[0.18em] text-ink-4">
-              MODULE #{ordinal}
+            {/* Drafts hold no place in the published sequence, so they get no
+                number rather than one that shifts every other module's. */}
+            {ordinal !== null && (
+              <div className="text-xs font-semibold tracking-[0.18em] text-ink-4">
+                MODULE #{ordinal}
+              </div>
+            )}
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <h3 className="text-lg sm:text-xl font-semibold text-ink-0 tracking-tight">
+                {repository.title}
+              </h3>
+              {/* Staff-only: the loader that feeds this view fetches drafts, so
+                  say which rows students cannot see yet. */}
+              {repository.is_published === false && (
+                <Tag color="orange" className="shrink-0">
+                  Draft
+                </Tag>
+              )}
             </div>
-            <h3 className="mt-1 text-lg sm:text-xl font-semibold text-ink-0 tracking-tight">
-              {repository.title}
-            </h3>
             {summary && <p className="text-sm text-ink-3 mt-1">{summary}</p>}
           </div>
           {hasExpandableContent && (
@@ -319,6 +361,17 @@ const ModuleAccordion = ({
   pagesUrl,
   rolePrefix = 'student',
 }: ModuleAccordionProps) => {
+  // MODULE #N counts PUBLISHED repositories only, so a staff viewer sees the
+  // same numbers their students do — the student dashboard computes the ordinal
+  // the same way, as an index into the published list. Drafts sit in place but
+  // take no number, rather than pushing every later module's number up by one.
+  let publishedSoFar = 0;
+  const ordinals = repositories.map(r => (r.is_published === false ? null : ++publishedSoFar));
+  // Auto-expand surfaces a viewer's own unfinished work, so it needs their own
+  // repo-assignments. The staff loader passes `{}`, where every card would
+  // qualify and an all-drafts classroom would open fully expanded.
+  const hasOwnSubmissions = Object.keys(repoAssignmentsByAssignmentId).length > 0;
+
   return (
     <div className="space-y-4 lg:space-y-5">
       {repositories.map((repository, idx) => {
@@ -330,14 +383,14 @@ const ModuleAccordion = ({
           <ModuleCard
             key={repository.id}
             repository={repository}
-            ordinal={idx + 1}
+            ordinal={ordinals[idx]}
             repoAssignmentsByAssignmentId={repoAssignmentsByAssignmentId}
             userTeam={repository.slug ? userTeamsByModuleSlug[repository.slug] : undefined}
             classSlug={classSlug}
             slidesUrl={slidesUrl}
             pagesUrl={pagesUrl}
             rolePrefix={rolePrefix}
-            defaultOpen={hasOpenAssignment}
+            defaultOpen={hasOwnSubmissions && hasOpenAssignment}
           />
         );
       })}

--- a/apps/webapp/app/routes/student.$class.repos/ResourceLinks.tsx
+++ b/apps/webapp/app/routes/student.$class.repos/ResourceLinks.tsx
@@ -1,13 +1,26 @@
+import { Tag } from 'antd';
 import { IconFileText, IconPresentation } from '@tabler/icons-react';
 import { PageLink } from '~/components/features/pages';
 
+// Draft resources are chipped where they are listed, the way `resourceLeaves`
+// already chips a DRAFT form. For slides, `is_draft` is only ever true on the
+// teaching-team view, whose loader fetches drafts; a page is chipped by the same
+// rule wherever a caller lists one that is draft.
 interface LinkedPage {
-  page: { id: string; title: string };
+  page: { id: string; title: string; is_draft?: boolean };
 }
 
 interface LinkedSlide {
-  slide: { id: string; title: string };
+  slide: { id: string; title: string; is_draft?: boolean };
 }
+
+// Rendered inside the link so the chip travels with the item it labels, rather
+// than floating loose in the surrounding `gap-4` row.
+const DraftTag = () => (
+  <Tag color="orange" className="!ms-1 !me-0">
+    Draft
+  </Tag>
+);
 
 interface ResourceLinksProps {
   pages?: LinkedPage[];
@@ -34,7 +47,7 @@ const ResourceLinks = ({
   return (
     <div className="flex flex-wrap gap-4 mt-2">
       {hasPages &&
-        pages!.map(({ page }: { page: { id: string; title: string } }) => (
+        pages!.map(({ page }: LinkedPage) => (
           <PageLink
             key={page.id}
             pageId={page.id}
@@ -44,10 +57,11 @@ const ResourceLinks = ({
           >
             <IconFileText size={16} className="text-ink-3" />
             {page.title}
+            {page.is_draft === true && <DraftTag />}
           </PageLink>
         ))}
       {hasSlides &&
-        slides!.map(({ slide }: { slide: { id: string; title: string } }) => (
+        slides!.map(({ slide }: LinkedSlide) => (
           <a
             key={slide.id}
             href={`${slidesUrl}/${slide.id}`}
@@ -57,6 +71,7 @@ const ResourceLinks = ({
           >
             <IconPresentation size={16} className="text-ink-3" />
             {slide.title}
+            {slide.is_draft === true && <DraftTag />}
           </a>
         ))}
     </div>


### PR DESCRIPTION
## Context
A teacher or assistant in a classroom being prepped for next term saw an empty repositories list ("No published repositories yet") while the owner saw everything — the staff repos/modules surfaces reused a published-only data filter even though their page gate already admits the full teaching team. Real case: a new TEACHER in a brand-new classroom where every repo is still a draft.

## What changed
- **Staff see drafts, clearly marked.** The teaching-team repos view (`/teacher` + `/assistant`, one shared loader) and the staff modules view now return all repositories, assignments, pages, slides, and quizzes. Draft items carry the same orange `Draft` chip used elsewhere; quiz summary counts annotate drafts and closed ("3 quizzes (1 draft, 1 closed)").
- **Students are unchanged** — their loaders keep the published-only filters, and the modules loader now filters draft pages the same way it already filtered draft slides (the two relations were inconsistently handled).
- **Ordinals stay in sync**: `MODULE #N` counts published repos only (matching the student dashboard computation), so a draft repo never shifts the numbering staff and students discuss.
- **Policy pinned by tests**: `repoDraftPolicy.test.ts` asserts the student loaders keep their filters and the staff loaders keep none, in both directions (role decides, URL prefix does not), and that `/teacher` re-exports the identical loader. Every assertion was mutation-verified (flip the filter, watch the test fail).
- Empty state on the staff view now reads "No repositories yet" and only renders when the classroom truly has none.

## Testing
- Browser-verified on a devport with a seeded draft+published mix: teacher sees both repos (draft chipped, unnumbered), draft assignment/page chips render in both the repos accordion and the modules tree; student login sees no draft repo and no draft pages on repos, modules, or dashboard.
- Unit suite 769/770 (the one failure is the pre-existing `navRoles` forms-route case, reproduced at HEAD); typecheck has only the pre-existing `RequireGitProvider` error; prettier/eslint at the exact pre-existing baseline.
- Reviewed by two independent local review passes plus a focused delta review (student-path first); all findings fixed.

Follow-up candidate (not in this PR): staff have no dedicated Assignments surface — assignments appear only nested inside repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6WM8vAi9PWd6gU35ZZ3r2