### PR TITLE
fix(webapp): filter pages consistently with slides in student loaders

### DIFF
--- a/apps/webapp/app/routes/__tests__/pageDraftFilter.test.ts
+++ b/apps/webapp/app/routes/__tests__/pageDraftFilter.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests pinning the repository query sent by two loaders: the student
+ * repositories view (`student.$class.repos`) and the student dashboard
+ * (`student.$class.dashboard`). Nothing else is covered here.
+ *
+ * Attached pages and attached slides are the same kind of resource to those
+ * views: both render as a leaf under a repository or an assignment, and both
+ * carry an `is_draft` flag the author flips when the resource is ready. The
+ * slide side has always been narrowed in the query; the page side is narrowed
+ * so the two relations stay in step.
+ *
+ * Pinning the query rather than the rendered output is deliberate. The tree
+ * components take whatever the loader hands them, so the only place the
+ * distinction lives is the include — and an include is easy to copy between
+ * routes without noticing which filters came along. Each assertion covers the
+ * whole relation node, so a dropped `include` or `orderBy` fails too.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertClassroomAccess: vi.fn(),
+  repositoryFindMany: vi.fn(),
+  gitRepoFindMany: vi.fn(),
+  classroomFindUnique: vi.fn(),
+  findAllAssignmentsForStudent: vi.fn(),
+  findLatestByGitRepoIds: vi.fn(),
+  getClassroomCalendar: vi.fn(),
+  regradeRequestFindMany: vi.fn(),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    repository: { findMany: (...a: unknown[]) => mocks.repositoryFindMany(...a) },
+    gitRepo: { findMany: (...a: unknown[]) => mocks.gitRepoFindMany(...a) },
+    classroom: { findUnique: (...a: unknown[]) => mocks.classroomFindUnique(...a) },
+  }),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    helper: {
+      findAllAssignmentsForStudent: (...a: unknown[]) => mocks.findAllAssignmentsForStudent(...a),
+    },
+    autogradingResult: {
+      findLatestByGitRepoIds: (...a: unknown[]) => mocks.findLatestByGitRepoIds(...a),
+    },
+    calendar: { getClassroomCalendar: (...a: unknown[]) => mocks.getClassroomCalendar(...a) },
+    regradeRequest: { findMany: (...a: unknown[]) => mocks.regradeRequestFindMany(...a) },
+    organizationTag: { findByClassroomIdAndName: vi.fn() },
+    team: { findUserTeamByTag: vi.fn() },
+    token: { updateExtension: vi.fn() },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => mocks.assertClassroomAccess(...a),
+  assertClassroomMutationAllowed: vi.fn(),
+  addAuditLog: vi.fn(),
+  addClassroomAuditLog: vi.fn(),
+}));
+
+// `~` is not aliased in vitest.config.ts, so every aliased specifier these
+// routes pull has to be stubbed for the import to resolve at all. The view
+// layer is irrelevant here — only the loader's query is under test.
+vi.mock('~/components/features/modules/ReadOnlyModulesTree', () => ({ default: () => null }));
+vi.mock('~/components/features/modules/studentTree', () => ({
+  buildRepositoryNode: () => ({}),
+}));
+vi.mock('../student.$class.dashboard/WeeklyCalendarCard', () => ({ default: () => null }));
+vi.mock('../student.$class.dashboard/ModuleSpotlightCard', () => ({ default: () => null }));
+vi.mock('../student.$class.dashboard/RetroTabsCard', () => ({ default: () => null }));
+
+const CLASS_SLUG = 'cs52-26f';
+
+const loaderArgs = (pathname: string) =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost${pathname}`),
+  }) as never;
+
+/** The `include` the loader handed to `repository.findMany`. */
+const repositoryInclude = () => mocks.repositoryFindMany.mock.calls[0][0].include;
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.assertClassroomAccess.mockResolvedValue({
+    userId: 'student-1',
+    classroom: { id: 'class-1', slug: CLASS_SLUG, settings: {}, git_organization: null },
+    membership: { role: 'STUDENT' },
+  });
+  mocks.repositoryFindMany.mockResolvedValue([]);
+  mocks.gitRepoFindMany.mockResolvedValue([]);
+  mocks.classroomFindUnique.mockResolvedValue({ git_organization: { login: 'cs52' } });
+  mocks.findAllAssignmentsForStudent.mockResolvedValue([]);
+  mocks.findLatestByGitRepoIds.mockResolvedValue(new Map());
+  mocks.getClassroomCalendar.mockResolvedValue([]);
+  mocks.regradeRequestFindMany.mockResolvedValue([]);
+});
+
+/**
+ * The whole relation node a loader should send. `include` varies by route —
+ * the repositories view takes the full row, the dashboard selects two columns
+ * — so it is supplied per call while the filter and ordering stay fixed.
+ */
+const publishedPages = (include: unknown) => ({
+  where: { page: { is_draft: false } },
+  include,
+  orderBy: { order: 'asc' },
+});
+const publishedSlides = (include: unknown) => ({
+  where: { slide: { is_draft: false } },
+  include,
+  orderBy: { order: 'asc' },
+});
+
+describe('the repositories view asks for published pages and slides alike', () => {
+  beforeEach(async () => {
+    const { loader } = await import('../student.$class.repos/route.tsx');
+    await loader(loaderArgs(`/student/${CLASS_SLUG}/repos`));
+  });
+
+  it('narrows the pages attached to a repository', () => {
+    expect(repositoryInclude().pages).toEqual(publishedPages({ page: true }));
+  });
+
+  it('narrows the pages attached to an assignment', () => {
+    expect(repositoryInclude().assignments.include.pages).toEqual(publishedPages({ page: true }));
+  });
+
+  it('leaves the slide relations narrowed exactly as before', () => {
+    expect(repositoryInclude().slides).toEqual(publishedSlides({ slide: true }));
+    expect(repositoryInclude().assignments.include.slides).toEqual(
+      publishedSlides({ slide: true })
+    );
+  });
+});
+
+describe('the dashboard spotlight counts the same set', () => {
+  beforeEach(async () => {
+    const { loader } = await import('../student.$class.dashboard/route.tsx');
+    // The loader returns its query behind a deferred `data` promise, so the
+    // query only runs once that promise is awaited.
+    const { data } = await loader(loaderArgs(`/student/${CLASS_SLUG}/dashboard`));
+    await data;
+  });
+
+  it('narrows the pages attached to a repository', () => {
+    expect(repositoryInclude().pages).toEqual(
+      publishedPages({ page: { select: { id: true, title: true } } })
+    );
+  });
+});

--- a/apps/webapp/app/routes/student.$class.dashboard/route.tsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/route.tsx
@@ -60,7 +60,10 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
             },
             orderBy: { student_deadline: 'asc' },
           },
+          // Pages and slides are both filtered to published content here, so
+          // the spotlight counts the same set whichever resource type it lists.
           pages: {
+            where: { page: { is_draft: false } },
             include: { page: { select: { id: true, title: true } } },
             orderBy: { order: 'asc' },
           },

--- a/apps/webapp/app/routes/student.$class.repos/route.tsx
+++ b/apps/webapp/app/routes/student.$class.repos/route.tsx
@@ -28,7 +28,11 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
       assignments: {
         where: { is_published: true },
         include: {
-          pages: { include: { page: true }, orderBy: { order: 'asc' } },
+          pages: {
+            where: { page: { is_draft: false } },
+            include: { page: true },
+            orderBy: { order: 'asc' },
+          },
           slides: {
             where: { slide: { is_draft: false } },
             include: { slide: true },
@@ -37,7 +41,13 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
         },
         orderBy: { student_deadline: 'asc' },
       },
-      pages: { include: { page: true }, orderBy: { order: 'asc' } },
+      // Attached pages and slides are both filtered to published content here,
+      // so the tree lists the same set whichever resource type it renders.
+      pages: {
+        where: { page: { is_draft: false } },
+        include: { page: true },
+        orderBy: { order: 'asc' },
+      },
       slides: {
         where: { slide: { is_draft: false } },
         include: { slide: true },

--- a/packages/services/src/classmoji/__tests__/calendar.deadlinePages.test.ts
+++ b/packages/services/src/classmoji/__tests__/calendar.deadlinePages.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Pins the page/slide narrowing on the deadline leg of the calendar.
+ *
+ * `getDeadlinesForRange` attaches the pages and slides linked to an
+ * assignment. Both are the same kind of resource here and both carry an
+ * `is_draft` flag, so both relations key their filter off the same
+ * `includeUnpublished` argument: the default (false) asks for published
+ * content only, and the staff calendars, which pass true, keep the whole set.
+ *
+ * The event-link leg goes through `mapLinksToDisplayFormat` instead, which
+ * does its own draft filtering, and is not covered here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const assignmentFindMany = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    assignment: { findMany: assignmentFindMany },
+  }),
+}));
+
+const { getDeadlinesForRange } = await import('../calendar.service.ts');
+
+const START = new Date('2026-09-01T00:00:00Z');
+const END = new Date('2026-09-30T00:00:00Z');
+
+/** The relation nodes the query asked for. */
+const include = () => assignmentFindMany.mock.calls[0][0].include;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  assignmentFindMany.mockResolvedValue([]);
+});
+
+describe('getDeadlinesForRange', () => {
+  it('asks for published pages and slides alike by default', async () => {
+    await getDeadlinesForRange('class-1', START, END);
+
+    expect(include().pages.where).toEqual({ page: { is_draft: false } });
+    expect(include().slides.where).toEqual({ slide: { is_draft: false } });
+  });
+
+  it('keeps the ordering and the linked row alongside the filter', async () => {
+    await getDeadlinesForRange('class-1', START, END);
+
+    expect(include().pages).toEqual({
+      where: { page: { is_draft: false } },
+      include: { page: { select: { id: true, title: true } } },
+      orderBy: { order: 'asc' },
+    });
+  });
+
+  it('leaves both relations unfiltered when unpublished content is requested', async () => {
+    // The admin and assistant calendars pass this; their view is unchanged.
+    await getDeadlinesForRange('class-1', START, END, null, true);
+
+    expect(include().pages.where).toBeUndefined();
+    expect(include().slides.where).toBeUndefined();
+  });
+});

--- a/packages/services/src/classmoji/calendar.service.ts
+++ b/packages/services/src/classmoji/calendar.service.ts
@@ -757,6 +757,16 @@ export const getDeadlinesForRange = async (
         },
       },
       pages: {
+        // Only filter out drafts if not including unpublished content
+        ...(includeUnpublished
+          ? {}
+          : {
+              where: {
+                page: {
+                  is_draft: false,
+                },
+              },
+            }),
         include: {
           page: {
             select: {


### PR DESCRIPTION
## Context
Student-facing list loaders narrowed attached slides by draft status but left the sibling pages relations unnarrowed, so the two resource types followed different rules on the same screens.

## What changed
- `student.$class.repos` (both page legs), `student.$class.dashboard`, and the calendar deadline query in `calendar.service` now filter the pages relation the same way the slides relation next to each of them already did. Staff calendars pass `includeUnpublished: true` and are unchanged; the staff repos/modules surfaces are owned by #256.
- Tests pin every site (whole relation node, not just the where clause) — each assertion was mutation-verified to fail when its filter or its orderBy/include keys are removed.

## Testing
- Webapp suite 764/765, services suite 1311 passed (+3 new) — the only failures are the known pre-existing ones (`navRoles`, GitLabProvider tests), reproduced at HEAD.
- Browser-verified on a devport with a seeded published+draft page pair on one repo: student sees only the published page on repos and dashboard; teacher view unchanged.
- Reviewed by a focused local review pass; all suggestions applied.

Merge note: no file overlap with #256; either merge order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6WM8vAi9PWd6gU35ZZ3r2