### PR TITLE
fix(forms): let the verification link outlive the submission it carries

### DIFF
--- a/apps/pages/app/forms/fill/fill.tsx
+++ b/apps/pages/app/forms/fill/fill.tsx
@@ -10,7 +10,8 @@ import {
   recordSubmissionAttempt,
 } from '~/utils/submissionRate.server.ts';
 import {
-  clearFormLinkCookie,
+  EDIT_LINK_COOKIE_MAX_AGE_SECONDS,
+  formLinkCookie,
   formWatchCookie,
   readFormLinkCookie,
 } from '~/utils/formLinkCookie.server.ts';
@@ -881,15 +882,28 @@ export const action = async ({
         revisionId,
       });
 
+      /**
+       * The cookie STAYS, and is re-issued with a fresh lifetime.
+       *
+       * It used to be cleared here, because submitting spent the token and a
+       * dead credential left in the jar only looked like breakage. The token
+       * now outlives the submission (see `editLinkExpiresAt`), so the cookie is
+       * no longer a spent receipt — it is this browser's copy of the edit link,
+       * and keeping it is what lets somebody come straight back to their own
+       * answers on the machine they used, without going to their inbox at all.
+       *
+       * Re-issued rather than simply left alone so the browser's expiry tracks
+       * the token's: it was written with the 48-hour verification window, which
+       * is now much the shorter of the two clocks.
+       */
       return data({ state: 'recorded-public' } satisfies ActionResult, {
-        // The token is spent. Leaving the cookie behind would make the next
-        // submit offer a dead credential — harmless, since it falls back, but
-        // it would look like the shortcut had broken.
         headers: {
-          'Set-Cookie': clearFormLinkCookie({
+          'Set-Cookie': formLinkCookie({
             request,
             classroomSlug: params.classroomSlug!,
             formSlug: params.formSlug!,
+            rawToken: linkToken,
+            maxAgeSeconds: EDIT_LINK_COOKIE_MAX_AGE_SECONDS,
           }),
         },
       });

--- a/apps/pages/app/utils/formLinkCookie.server.ts
+++ b/apps/pages/app/utils/formLinkCookie.server.ts
@@ -102,6 +102,17 @@ export function readFormLinkCookie(request: Request, formSlug: string): string |
   return found;
 }
 
+/**
+ * How long this browser keeps its copy of the edit link after a submission.
+ *
+ * The token behind it now lives as long as the form does, so the cookie is the
+ * shorter promise of the two and that is the right way round — a stale cookie
+ * costs one round trip through the inbox, never access. Two hundred days sits
+ * under the 400-day ceiling browsers cap `Max-Age` at, so the number the server
+ * asks for is the number the browser actually keeps.
+ */
+export const EDIT_LINK_COOKIE_MAX_AGE_SECONDS = 200 * 24 * 60 * 60;
+
 /** `Set-Cookie` that hands this browser the verified link for one form. */
 export function formLinkCookie({
   request,
@@ -127,31 +138,14 @@ export function formLinkCookie({
   return attributes.join('; ');
 }
 
-/**
- * `Set-Cookie` that takes it away again — sent the moment the token is spent.
- *
- * The attributes must match the ones it was set with (name, path) or the
- * browser keeps the original and the next submit offers a token the server has
- * already burned. Harmless (it would fall back), but it would look like the
- * feature was broken.
+/*
+ * `clearFormLinkCookie` used to live here, sent "the moment the token is
+ * spent". A submission extends its token now instead of spending it, so that
+ * moment no longer exists and the cookie is deliberately kept — see the submit
+ * branch in `forms/fill/fill.tsx`. Removed rather than left unused, because a
+ * helper whose whole rationale has stopped being true is a trap for whoever
+ * reaches for it next.
  */
-export function clearFormLinkCookie({
-  request,
-  classroomSlug,
-  formSlug,
-}: {
-  request: Request;
-  classroomSlug: string;
-  formSlug: string;
-}): string {
-  return formLinkCookie({
-    request,
-    classroomSlug,
-    formSlug,
-    rawToken: '',
-    maxAgeSeconds: 0,
-  });
-}
 
 // ─── The WATCH cookie ───────────────────────────────────────────────────────
 

--- a/apps/pages/tests/e2e/forms-early-verify.spec.ts
+++ b/apps/pages/tests/e2e/forms-early-verify.spec.ts
@@ -431,17 +431,22 @@ test.describe('a submit that has nothing to reuse still mails', () => {
   });
 
   /**
-   * NOBODY IS STRANDED. Reuse only ever stands in for a link that still works,
-   * so a spent one puts the mail back — which is the difference between "you
-   * already have it" and "you have nothing".
+   * NOBODY IS STRANDED — and after this change, nobody is sent back to their
+   * inbox either.
+   *
+   * This used to assert that a second pass MAILED AGAIN, because submitting
+   * spent the link and left the browser holding a dead credential. Both halves
+   * of that are gone: the token outlives its submission, and the cookie
+   * carrying it is kept rather than cleared. So the second pass is simply an
+   * edit, recorded on the spot, with no new mail — the outcome the old
+   * behaviour was making up for.
    */
-  test('a spent earlier link makes the submit mail again', async ({ page }) => {
+  test('a second pass on the same browser edits in place and mails nothing', async ({ page }) => {
     const email = freshEmail('respend');
     await page.goto(fillPath);
     await typeEmailAndLeave(page, email);
     const [first] = await waitForLinks(email, 1);
 
-    // Open and spend it — this browser now holds a verified, USED token.
     await page.goto(linkTarget(first));
     await page.getByTestId('forms-go-finish').click();
     await page.getByLabel(EMAIL_LABEL, { exact: true }).fill(email);
@@ -449,17 +454,17 @@ test.describe('a submit that has nothing to reuse still mails', () => {
     await page.getByRole('button', { name: 'Submit' }).click();
     await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
-    // A second pass has no live link to lean on, so it mails a fresh edit link
-    // rather than leaving somebody looking at "check your email" for nothing.
+    // Straight through on the shortcut: no "check your email" in sight.
     await page.goto(fillPath);
     await page.getByLabel(EMAIL_LABEL, { exact: true }).fill(email);
     await fillTheRest(page, 'Second Pass');
     await page.getByRole('button', { name: 'Submit' }).click();
-    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
-    const links = await waitForLinks(email, 2);
-    expect(links).toHaveLength(2);
-    expect(links[1]).not.toBe(first);
+    // Still exactly one link, and it is still the first one.
+    await page.waitForTimeout(750);
+    expect(linksFor(email)).toHaveLength(1);
+    expect(linksFor(email)[0]).toBe(first);
   });
 });
 
@@ -513,7 +518,7 @@ test.describe('the binding between a verified link and an address', () => {
     ).toHaveLength(0);
   });
 
-  test('a spent link does not let the same browser submit twice', async ({ page }) => {
+  test('the browser that verified stays verified, and its edit lands', async ({ page }) => {
     const email = freshEmail('spent');
     await page.goto(fillPath);
     await typeEmailAndLeave(page, email);
@@ -526,20 +531,27 @@ test.describe('the binding between a verified link and an address', () => {
     await page.getByRole('button', { name: 'Submit' }).click();
     await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
-    // The token is spent and the cookie cleared, so a second pass is an
-    // ordinary edit request: a link to the mailbox, not a silent overwrite.
+    /**
+     * The cookie SURVIVES the submission now, so coming back still says "your
+     * address is verified in this browser" — and it is true, because the token
+     * behind it outlives the submission too.
+     *
+     * This used to assert the opposite of both lines: no verified banner, and a
+     * second trip to the mailbox to change an answer. That was the cost of
+     * spending the link, paid by the person least able to understand it — the
+     * one sitting at the machine that had already proved who they were.
+     */
     await page.goto(fillPath);
-    await expect(page.getByTestId('forms-verified-here')).toHaveCount(0);
+    await expect(page.getByTestId('forms-verified-here')).toHaveCount(1);
     await page.getByLabel(EMAIL_LABEL, { exact: true }).fill(email);
     await fillTheRest(page, 'Second Go');
     await page.getByRole('button', { name: 'Submit' }).click();
-    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
     const rows = await responsesOf(formId!);
     expect(rows).toHaveLength(1);
-    // The stored answers are still the confirmed ones — an unconfirmed edit
-    // request does not change what is on file.
-    expect(Object.values(rows[0].answers as Record<string, unknown>)).toContain('First Go');
+    // The edit replaced the answers rather than filing a second response.
+    expect(Object.values(rows[0].answers as Record<string, unknown>)).toContain('Second Go');
   });
 });
 

--- a/apps/pages/tests/e2e/forms-fill.spec.ts
+++ b/apps/pages/tests/e2e/forms-fill.spec.ts
@@ -1076,7 +1076,7 @@ test.describe('magic link', () => {
     await expect(page.getByRole('link', { name: 'Request a new link' })).toBeVisible();
   });
 
-  test('a link is single-use, and the spent link is neutral about why', async ({ page }) => {
+  test('the link still opens the response after it has been confirmed', async ({ page }) => {
     const email = 'zz-e2e-twice@example.edu';
     await page.goto(fillPath);
     await fillWaitlist(page, email, 'Twice');
@@ -1088,14 +1088,21 @@ test.describe('magic link', () => {
     await page.getByRole('button', { name: 'Confirm' }).click();
     await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
-    // Reopening the spent link says the LINK is used, never that the response
-    // exists — whoever holds a stale link is not necessarily the person who
-    // owns the mailbox.
+    /**
+     * Reopening it lands back on the response, not on a dead end.
+     *
+     * This used to assert "This link has already been used" — the behaviour the
+     * email contradicted in the same breath by telling people to keep it. The
+     * link is the ONLY handle on a public response, since there is deliberately
+     * no look-up-by-email anywhere in the product, so spending it stranded
+     * whoever came back.
+     */
     await page.goto(linkTarget(link));
-    await expect(
-      page.getByRole('heading', { name: 'This link has already been used' })
-    ).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Request a new link' })).toBeVisible();
+    await expect(page.getByText('This is the response we already have for you.')).toBeVisible();
+
+    // And re-confirming edits the one row rather than filing a second.
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
     expect(await responsesOf(formId!)).toHaveLength(1);
   });

--- a/packages/services/src/classmoji/__tests__/forms.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/forms.integration.test.ts
@@ -432,14 +432,27 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         responseService.MAGIC_LINK_EXPIRED
       );
 
-      const used = await responseService.beginPublicSubmission({
+      /**
+       * A link that HAS been spent is still refused — but nothing spends one
+       * any more, so the only way to reach this state is a row written before
+       * submissions started extending their token instead of consuming it.
+       * Set by hand here for exactly that reason: the rejection has to keep
+       * working for rows already in the database, and no live path produces it.
+       */
+      const legacy = await responseService.beginPublicSubmission({
         formId,
-        email: `used-${suite}@example.test`,
+        email: `legacy-spent-${suite}@example.test`,
         answers: { [fieldId]: 'Maya' },
         revisionId,
       });
-      await responseService.confirmSubmission(tokenOf(used));
-      expect(await codeOf(responseService.confirmSubmission(tokenOf(used)))).toBe(
+      await prisma.formMagicToken.updateMany({
+        where: { response_id: legacy.responseId },
+        data: { used_at: new Date() },
+      });
+      expect(await codeOf(responseService.verifyMagicToken(tokenOf(legacy)))).toBe(
+        responseService.MAGIC_LINK_USED
+      );
+      expect(await codeOf(responseService.confirmSubmission(tokenOf(legacy)))).toBe(
         responseService.MAGIC_LINK_USED
       );
     });
@@ -504,21 +517,18 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
       });
 
       /**
-       * The three ways a link stops being worth pointing at. Each one has to
-       * put the mint back — the one outcome that must never happen is somebody
+       * The two ways a link stops being worth pointing at. Each one has to put
+       * the mint back — the one outcome that must never happen is somebody
        * submitting, getting no mail, and holding no live link.
+       *
+       * "Spent" used to be a third way and is not one any more: confirming
+       * EXTENDS a link rather than consuming it, so the person is left holding
+       * the most useful link they have ever had. That case is covered just
+       * below, because "no new mail" is only correct while the old link works.
        */
-      it('mints afresh once the previous link is spent, expired, or old', async () => {
+      it('mints afresh once the previous link is expired or old', async () => {
         const { formId, revisionId } = await makeOpenForm();
         const fieldId = await nameFieldId(revisionId);
-
-        // SPENT.
-        const spentEmail = `reuse-spent-${suite}@example.test`;
-        const spent = await beginFor(formId, revisionId, fieldId, spentEmail);
-        await responseService.confirmSubmission(tokenOf(spent));
-        const afterSpent = await beginFor(formId, revisionId, fieldId, spentEmail);
-        expect(afterSpent.rawToken).not.toBeNull();
-        expect(afterSpent.emails).toHaveLength(1);
 
         // EXPIRED.
         const deadEmail = `reuse-expired-${suite}@example.test`;
@@ -542,6 +552,32 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         const renewed = await beginFor(formId, revisionId, fieldId, oldEmail);
         expect(renewed.rawToken).not.toBeNull();
         expect(renewed.emails).toHaveLength(1);
+      });
+
+      /**
+       * Confirming does NOT put the mint back, and that is the point.
+       *
+       * Silence here is only defensible because the link they already hold
+       * still works — so this asserts both halves together. Assert the "no
+       * second mail" half alone and you have written the exact bug this change
+       * fixed: a person confirmed, got nothing, and held a dead link.
+       */
+      it('sends nothing more after a confirm, because the first link still works', async () => {
+        const { formId, revisionId } = await makeOpenForm();
+        const fieldId = await nameFieldId(revisionId);
+        const email = `reuse-confirmed-${suite}@example.test`;
+
+        const first = await beginFor(formId, revisionId, fieldId, email);
+        const rawToken = tokenOf(first);
+        await responseService.confirmSubmission(rawToken);
+
+        const after = await beginFor(formId, revisionId, fieldId, email);
+        expect(after.rawToken).toBeNull();
+        expect(after.emails).toHaveLength(0);
+
+        // The half that makes the silence honest.
+        const reopened = await responseService.verifyMagicToken(rawToken);
+        expect(reopened.response.submission_state).toBe('SUBMITTED');
       });
 
       /**
@@ -790,18 +826,16 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         answers: { [fieldId]: 'Maya Chen' },
         revisionId,
       });
-      const confirmed = await responseService.confirmSubmission(tokenOf(first));
+      const rawToken = tokenOf(first);
+      const confirmed = await responseService.confirmSubmission(rawToken);
       const originalVerifiedAt = confirmed.response.verified_at;
 
       await new Promise(resolve => setTimeout(resolve, 20));
 
-      const again = await responseService.beginPublicSubmission({
-        formId,
-        email,
-        answers: { [fieldId]: 'Maya Chen' },
-        revisionId,
-      });
-      const edited = await responseService.confirmSubmission(tokenOf(again), {
+      // The SAME link does the edit. This used to need a second round trip
+      // through the inbox to mint a replacement, because confirming spent the
+      // first one; the link outliving its own submission is what removed it.
+      const edited = await responseService.confirmSubmission(rawToken, {
         answers: { [fieldId]: 'Maya R. Chen' },
       });
 
@@ -1608,7 +1642,7 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         return { formId, revisionId, fieldId, email, rawToken };
       };
 
-      it('records the response and spends the link', async () => {
+      it('records the response and keeps the link alive', async () => {
         const { formId, revisionId, fieldId, email, rawToken } = await verifiedSetup('ok');
 
         const response = await responseService.submitVerifiedPublic({
@@ -1624,10 +1658,69 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         expect(response.verified_at).not.toBeNull();
         expect(response.answers).toEqual({ [fieldId]: 'Maya' });
 
+        // The link SURVIVES its own submission, and its life is now the form's
+        // rather than the 48-hour verification window it was minted with. This
+        // is what makes "keep this email" true.
         const token = await prisma.formMagicToken.findUniqueOrThrow({
           where: { token_hash: responseService.hashToken(rawToken) },
         });
-        expect(token.used_at).not.toBeNull();
+        expect(token.used_at).toBeNull();
+        expect(token.expires_at.getTime()).toBeGreaterThan(
+          Date.now() + responseService.MAGIC_TOKEN_TTL_MS
+        );
+      });
+
+      /**
+       * ── The promise the email makes ─────────────────────────────────────
+       *
+       * "Keep this email — click it again any time after you submit to read or
+       * change what you sent." That sentence was false for the whole of the
+       * blur-time flow: the link was spent at submit, so the one handle on the
+       * response died at the exact moment the response became worth returning
+       * to. This is the test that would have caught it.
+       */
+      it('reopens the answers after submitting, and edits them', async () => {
+        const { formId, revisionId, fieldId, email, rawToken } = await verifiedSetup('durable');
+
+        await responseService.submitVerifiedPublic({
+          rawToken,
+          formId,
+          email,
+          name: 'Maya',
+          answers: { [fieldId]: 'Maya' },
+          revisionId,
+        });
+
+        // Reading it back is the first half of the promise.
+        const reopened = await responseService.verifyMagicToken(rawToken);
+        expect(reopened.response.submission_state).toBe('SUBMITTED');
+        expect(reopened.response.answers).toEqual({ [fieldId]: 'Maya' });
+
+        // Changing it is the second, and the edit must not take a new cap slot.
+        await responseService.submitVerifiedPublic({
+          rawToken,
+          formId,
+          email,
+          name: 'Maya',
+          answers: { [fieldId]: 'Maya Fixed' },
+          revisionId,
+        });
+
+        expect((await rowFor(formId, email)).answers).toEqual({ [fieldId]: 'Maya Fixed' });
+        expect(
+          await prisma.formResponse.count({
+            where: { form_id: formId, submission_state: 'SUBMITTED' },
+          })
+        ).toBe(1);
+
+        // And it is STILL live — durable means durable, not "one more go".
+        expect(
+          (
+            await prisma.formMagicToken.findUniqueOrThrow({
+              where: { token_hash: responseService.hashToken(rawToken) },
+            })
+          ).used_at
+        ).toBeNull();
       });
 
       /**
@@ -1753,14 +1846,14 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
             where: { form_id: formId, submission_state: 'SUBMITTED', verified_at: { not: null } },
           })
         ).toBe(1);
-        // And the link it rode in on is spent.
+        // And the link it rode in on still opens the response it created.
         expect(
           (
             await prisma.formMagicToken.findUniqueOrThrow({
               where: { token_hash: responseService.hashToken(rawToken) },
             })
           ).used_at
-        ).not.toBeNull();
+        ).toBeNull();
       });
 
       it('a link that was never opened does not bind', async () => {
@@ -1784,8 +1877,18 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         ).toBe('MAGIC_LINK_NOT_BOUND');
       });
 
-      it('a spent link does not bind a second time', async () => {
-        const { formId, revisionId, fieldId, email, rawToken } = await verifiedSetup('spent');
+      /**
+       * A link that binds more than once is still bound to ONE address.
+       *
+       * This used to assert that a second bind failed outright, which the
+       * durable link makes wrong — editing your own response is the feature.
+       * What must survive is the binding itself: the row is found FROM the
+       * token, so re-using it to submit under a different address has to fail
+       * exactly as it did on the first use. Repeated use widens what the holder
+       * can do to their OWN response and nothing else.
+       */
+      it('binds again after submitting, but never to a different address', async () => {
+        const { formId, revisionId, fieldId, email, rawToken } = await verifiedSetup('rebind');
         await responseService.submitVerifiedPublic({
           rawToken,
           formId,
@@ -1794,13 +1897,24 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
           revisionId,
         });
 
+        // Their own address: allowed, and it edits.
+        const edited = await responseService.submitVerifiedPublic({
+          rawToken,
+          formId,
+          email,
+          answers: { [fieldId]: 'Changed' },
+          revisionId,
+        });
+        expect((edited.answers as Record<string, string>)[fieldId]).toBe('Changed');
+
+        // Somebody else's: refused, on the second use as on the first.
         expect(
           await codeOf(
             responseService.submitVerifiedPublic({
               rawToken,
               formId,
-              email,
-              answers: { [fieldId]: 'Changed' },
+              email: `someone-else-${suite}@example.test`,
+              answers: { [fieldId]: 'Not mine' },
               revisionId,
             })
           )

--- a/packages/services/src/classmoji/formResponse.service.ts
+++ b/packages/services/src/classmoji/formResponse.service.ts
@@ -161,6 +161,50 @@ export const MAGIC_TOKEN_REUSE_MS = MAGIC_TOKEN_TTL_MS / 2;
  * literal, exactly as they already do for 'SENT' and 'BOUNCED'.
  */
 export const MAGIC_LINK_SEND_FAILED = 'FAILED';
+/**
+ * How long an edit link lives on a form that never closes.
+ *
+ * A backstop, not the rule. The rule is the form: `assertAccepting` refuses
+ * every write to a form that is not OPEN, so a token outliving its form's
+ * usefulness opens a page that can be read and not changed. This exists so that
+ * "no close date" does not mean "immortal bearer credential", and it is
+ * deliberately long — a waitlist that runs a whole term is the ordinary case,
+ * and a link that dies before its form does is the exact failure this rule
+ * exists to fix.
+ */
+export const EDIT_LINK_OPEN_HORIZON_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * When the link that carried a submission should expire, now that it has.
+ *
+ * ── Two clocks, deliberately not the same one ──────────────────────────────
+ * A token is MINTED with `MAGIC_TOKEN_TTL_MS` (48h), and that number means one
+ * thing: how long you have to prove the address before the pending row stops
+ * holding its place in the queue. `assertCapAvailable` counts unverified rows
+ * by exactly that window and `expireStale` sweeps by it, so it must not move.
+ *
+ * Once the answers are in, the same token stops being a verification deadline
+ * and becomes the handle on the response — the ONE thing the person can come
+ * back with, since there is deliberately no "look up my response by email"
+ * form anywhere in the product. That job's natural length is the form's own
+ * life, not forty-eight hours.
+ *
+ * So the token is not SPENT at submit, it is EXTENDED here. The verification
+ * window keeps its meaning for every row still inside it; the edit window
+ * begins only for a row that has actually been submitted.
+ *
+ * Never shortens. A form closing sooner than the token's current expiry leaves
+ * that expiry alone: the form gate already refuses the edit, and being able to
+ * READ BACK what you submitted is not something a close date should take away.
+ */
+const editLinkExpiresAt = (
+  form: { closes_at: Date | null },
+  currentExpiry: Date,
+  now: Date
+): Date => {
+  const horizon = form.closes_at ?? new Date(now.getTime() + EDIT_LINK_OPEN_HORIZON_MS);
+  return horizon.getTime() > currentExpiry.getTime() ? horizon : currentExpiry;
+};
 /** Abandoned server-side partials are swept after this long. */
 export const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 /**
@@ -634,7 +678,9 @@ async function mintLinkFor(
  * Four conditions, and each one is a way the reuse could otherwise strand
  * somebody with a dead link and no mail:
  *
- *  - unspent (`used_at` null) — a link that has been clicked opens nothing;
+ *  - unspent (`used_at` null) — nothing sets this column any more, since a
+ *    submission now EXTENDS its link rather than spending it, but rows written
+ *    before that change still carry it and a spent link opens nothing;
  *  - unexpired — the obvious one;
  *  - minted inside `MAGIC_TOKEN_REUSE_MS` — so what is handed back has real
  *    life left, not the last twenty minutes of it;
@@ -1243,7 +1289,13 @@ export async function confirmSubmission(rawToken: string, { answers }: { answers
       data.answers = parseAnswers(fields, answers) as unknown as Prisma.InputJsonValue;
     }
 
-    await tx.formMagicToken.update({ where: { id: token.id }, data: { used_at: now } });
+    // NOT spent — extended. See `editLinkExpiresAt`: from here the link stops
+    // being a verification deadline and becomes the person's way back to their
+    // own answers, which is the promise the email now makes.
+    await tx.formMagicToken.update({
+      where: { id: token.id },
+      data: { expires_at: editLinkExpiresAt(lockedForm, token.expires_at, now) },
+    });
 
     const updated = await tx.formResponse.update({ where: { id: response.id }, data });
     return { response: updated, firstVerification: !counted };
@@ -1329,8 +1381,15 @@ export async function verifyAddressByToken(rawToken: string, now: Date = new Dat
  * treats as "no shortcut available" rather than as an error. A stale cookie
  * must never be able to make a legitimate submission fail.
  *
- * The token is CONSUMED here: it was single-use before this feature and it is
- * single-use now. A later edit takes a fresh link, exactly as it always did.
+ * The token SURVIVES here, and its life is extended to the form's — see
+ * `editLinkExpiresAt`. It used to be spent at this line, inherited from the
+ * flow where the link's only job was confirming one submission. Verification
+ * moved to blur time, which quietly gave the link a second job — being the
+ * handle on the response — and spending it cut that job off at the exact
+ * moment the response became worth returning to. Nothing was protected by the
+ * spend that the pre-submit behaviour did not already allow: the link is
+ * openable as many times as you like while you are still filling the form in,
+ * so "whoever holds this mail can open this response" was always the model.
  *
  * @throws MAGIC_LINK_NOT_BOUND, FORM_CAP_REACHED, FORM_NOT_OPEN, FORM_CLOSED,
  *   FORM_REVISION_STALE, FORM_ACCESS_MISMATCH, and the contract's
@@ -1419,7 +1478,13 @@ export async function submitVerifiedPublic({
       });
     }
 
-    await tx.formMagicToken.update({ where: { id: token.id }, data: { used_at: now } });
+    // NOT spent — extended, exactly as in `confirmSubmission`. This is the path
+    // an ordinary submission takes now that verification happens at blur time,
+    // so it is the one that decides whether "keep this email" is true.
+    await tx.formMagicToken.update({
+      where: { id: token.id },
+      data: { expires_at: editLinkExpiresAt(lockedForm, token.expires_at, now) },
+    });
 
     return tx.formResponse.update({
       where: { id: response.id },

--- a/packages/services/src/emails/templates.mjs
+++ b/packages/services/src/emails/templates.mjs
@@ -226,6 +226,14 @@ Need help, email us at hello@classmoji.io`,
       { key: 'FORM_TITLE', type: 'string' },
       { key: 'CLASSROOM_NAME', type: 'string' },
       { key: 'VERIFY_URL', type: 'string' },
+      // Declared but no longer rendered here. ONE builder in
+      // formResponse.service composes the payload for this template and for the
+      // reminder, which still quotes the hours legitimately (a reminder only
+      // ever goes to a row that has NOT verified, so the 48-hour deadline is
+      // still that reader's truth). Keeping the key declared means the shared
+      // payload stays valid for both; dropping it would hand Resend a variable
+      // this template does not know, and a rejected send here is invisible —
+      // see the `escapeVars` comment for how that failure mode already bit us.
       { key: 'EXPIRES_HOURS', type: 'string', fallbackValue: '48' },
     ],
     html: shell({
@@ -250,13 +258,26 @@ Need help, email us at hello@classmoji.io`,
         // on the response — the only one, since there is deliberately no
         // "look up my response by email" form anywhere in the product.
         text(
-          '<strong>Keep this email.</strong> The same link opens your answers again later if you want to change them — and if you are still filling the form in, you can click it now and go straight back to finish.',
+          '<strong>Keep this email.</strong> This link is your way back to your answers: click it now to carry on filling the form in, and click it again any time after you submit to read or change what you sent.',
           { size: 14, lh: 22, color: MUTED, pb: 8 }
         ),
-        text(
-          'The link works for {{{EXPIRES_HOURS}}} hours. If you need a new one, open the form again with the same address.',
-          { size: 14, lh: 22, color: MUTED, pb: 8 }
-        ),
+        // No hours, and no "request another one".
+        //
+        // The hours were the VERIFICATION deadline, which stopped being the
+        // link's whole life when a submission started extending it — quoting 48
+        // to somebody whose link now lasts as long as the form would be worse
+        // than saying nothing. And "open the form again with the same address"
+        // was never a way to get a second link: an address that has already
+        // verified is deliberately sent nothing at all, so the instruction sent
+        // people to a blank form and no mail. The resend button on the
+        // check-your-email screen is the real door, and it is only reachable by
+        // the person who asked.
+        text('The link keeps working for as long as this form is open.', {
+          size: 14,
+          lh: 22,
+          color: MUTED,
+          pb: 8,
+        }),
         // A public form is a link anyone can share, so the recipient may
         // genuinely not have submitted anything — that has to be a real option,
         // and "ignore this" has to be the first thing the sentence says.


### PR DESCRIPTION
## The bug Tim hit

The verification email said **"Keep this email. The same link opens your answers again later if you want to change them"** — and that was false. Submitting spent the token, so the only handle on a public response died at the exact moment the response became worth coming back to.

The next line couldn't help either: *"If you need a new one, open the form again with the same address"* — an address that has already verified is **deliberately** sent nothing (oracle resistance), so that instruction led to a blank form and no mail.

## Why

Both lines were written for the original flow, where the mail arrived *after* submitting and confirming it was the link's whole job. Moving verification to blur time gave the link a second job — being the durable handle — without the copy being re-read or the single-use rule re-derived. The service comment still said so outright: *"it was single-use before this feature and it is single-use now."*

Nothing was protected by the spend that the pre-submit behaviour didn't already allow: the link is openable as many times as you like while the form is being filled in, so "whoever holds this mail can open this response" was always the model.

## The change

A submission now **extends** its token instead of consuming it, to the form's own life (`closes_at`, else a one-year backstop; `assertAccepting` stays the real gate on editing).

**Two clocks, kept apart deliberately.** The 48-hour mint TTL still means "how long you have to verify before your pending row stops holding its place in the queue" — what `assertCapAvailable` counts by and `expireStale` sweeps by. It does not move. The edit window begins only once there is something to edit.

The browser cookie is kept and re-issued rather than cleared, so the machine that verified returns to its own answers without touching the inbox — and the "verified in this browser" banner it drives is now true when it says so.

## Verified

- Local round trip: after confirm, `used_at` null and expiry = the form's close date (88.8 days from mint, was 2.0). Reopening the link shows *"This is the response we already have for you"* with an Edit button, where it used to say *"This link has already been used."*
- services **1435 pass** (13 pre-existing GitLab-provider failures untouched — those tests reference methods that don't exist on `GitLabProvider` and fail identically on staging)
- pages **597 pass**

Six places pinned the old contract; each was rewritten to the new one rather than deleted, including the security property that does survive — a link binding more than once still binds to exactly one address.

## Deploy note

`form-verify-link` must be synced to Resend **after** this deploys, not before: the new copy promises durability the currently-deployed code doesn't provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW