### PR TITLE
fix(forms): stop the success screen sending people to a blank form

### DIFF
--- a/apps/pages/app/forms/fill/fill.tsx
+++ b/apps/pages/app/forms/fill/fill.tsx
@@ -1512,9 +1512,13 @@ export default function FormFill() {
             Your response to <strong className="font-semibold">{data.form.title}</strong> is
             recorded. We have your answers and the teaching team can see them.
           </p>
+          {/* Same correction as the verify screen's copy, for the same reason:
+              re-filling the form with an address that has already verified
+              sends nothing at all, so this used to send people to a blank form
+              to wait for mail that would never arrive. */}
           <p className="mt-3 text-gray-500 dark:text-gray-400">
-            Nothing else is needed from you. If you want to change something later, fill the form in
-            again with the same address and we will email you a link to your response.
+            Nothing else is needed from you. Keep the email we sent you — that link brings you back
+            to this response for as long as the form is open.
           </p>
         </FormNotice>
       </FormCanvas>

--- a/apps/pages/app/forms/fill/verify.tsx
+++ b/apps/pages/app/forms/fill/verify.tsx
@@ -407,9 +407,16 @@ export default function FormVerify() {
             recorded{result.edited ? ' with your changes' : ''}. We have your answers and the
             teaching team can see them.
           </p>
+          {/* Points at the link they already have, NOT back at the form.
+              "Fill it in again with the same address and we will email you"
+              was never true for somebody who has verified: that address is
+              deliberately sent nothing, so the instruction led to a blank form
+              and mail that was never coming. The link in their inbox is the way
+              back, and since a submission stopped spending it, saying so is
+              finally honest. */}
           <p className="mt-3 text-gray-500 dark:text-gray-400">
-            Nothing else is needed from you. If you want to change something later, fill the form in
-            again with the same address and we will email you a link to your response.
+            Nothing else is needed from you. Keep the email we sent you — that link brings you back
+            to this response for as long as the form is open.
           </p>
         </FormNotice>
       </FormCanvas>


### PR DESCRIPTION
Found while testing the durable-link fix end to end on staging.

The **"You're in"** screen — the one every successful submitter sees — closed with:

> "If you want to change something later, fill the form in again with the same address and we will email you a link to your response."

That is the same instruction that was wrong in the verification email, in two more places (`fill.tsx` and `verify.tsx`).

It cannot work. An address that has already verified is **deliberately sent nothing** when typed again — the oracle-resistance rule that stops a stranger learning who is on a waitlist, and stops them making someone else's mailbox ring. So the instruction shown to everyone who submits successfully led to a blank form and mail that was never coming.

Both now point at the link the person already holds, which is the thing that actually works — and only works honestly now that submitting extends that link rather than spending it (#258).

The malformed-link copy in `verify.tsx:321` is deliberately left alone: it speaks to somebody whose link is unusable and who may never have verified, and for them the form still is the way in.

**Verified:** pages 597 pass, 0 type errors.

One note: `forms-early-verify.spec.ts > "resend ... throttled honestly"` is flaky under full-suite runs — it trips a shared in-memory per-client rate limit depending on ordering. Observed failing and passing on identical code across consecutive full runs; unrelated to this change, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW