### PR TITLE
refactor(forms): one clock, one email, one step

### DIFF
--- a/apps/pages/app/forms/admin/responsesData.server.ts
+++ b/apps/pages/app/forms/admin/responsesData.server.ts
@@ -171,12 +171,10 @@ export function toResponseRow(row: {
     userId: row.user_id,
     submittedAt: row.submitted_at.toISOString(),
     verifiedAt: row.verified_at ? row.verified_at.toISOString() : null,
-    // The sweep measures from `created_at`, and a labelled row is exempt — so
-    // the date is only offered for a row that will actually go.
-    expiresAt:
-      row.submission_state === 'PENDING_VERIFICATION' && row.created_at && !row.staff_status
-        ? ClassmojiService.formResponse.pendingExpiresAt(row.created_at).toISOString()
-        : null,
+    // Always null now. Unverified rows are kept for the life of the form, so
+    // there is no date to warn anybody about. The field stays on the shape
+    // because the staff table renders it, and "never" is the answer it wants.
+    expiresAt: null as string | null,
     updatedAt: row.updated_at.toISOString(),
     submissionState: row.submission_state,
     staffStatus: row.staff_status,

--- a/apps/pages/app/forms/fill/verify.tsx
+++ b/apps/pages/app/forms/fill/verify.tsx
@@ -7,7 +7,10 @@ import { checkOrigin, readCappedBody } from '~/utils/originCheck.server.ts';
 import { FormCanvas, FormHeader, FormNotice } from '~/components/forms/FormCanvas.tsx';
 import FormRenderer, { clearDraftsForForm } from '~/components/forms/FormRenderer.tsx';
 import AnswerView from '~/components/forms/AnswerView.tsx';
-import { formLinkCookie } from '~/utils/formLinkCookie.server.ts';
+import {
+  EDIT_LINK_COOKIE_MAX_AGE_SECONDS,
+  formLinkCookie,
+} from '~/utils/formLinkCookie.server.ts';
 import { themeFor, type CanvasTheme } from './publicForm.server.ts';
 
 /**
@@ -76,18 +79,28 @@ export type VerifyLoad =
       form: { id: string; title: string; description: string | null };
       identity: { email: string; name: string | null };
     }
+  /**
+   * The response is IN — recorded by the loader on this very request, or on an
+   * earlier one. There is no pending state to show and nothing to agree to.
+   */
   | {
-      view: 'review';
+      view: 'recorded';
       theme: CanvasTheme;
       classroomName: string;
       fillPath: string;
       form: { id: string; title: string; description: string | null };
-      /** Already confirmed once — this link is an EDIT link, not a first confirm. */
-      alreadyVerified: boolean;
       identity: { email: string; name: string | null };
       fields: unknown[];
       answers: Record<string, unknown>;
       resolvedContext: unknown;
+    }
+  /** Their answers are safe; a place is not available. */
+  | {
+      view: 'blocked';
+      reason: 'cap' | 'closed';
+      theme: CanvasTheme;
+      classroomName: string;
+      fillPath: string;
     };
 
 /** Map a service error code to the state the page renders. */
@@ -195,9 +208,65 @@ export const loader = async ({
     );
   }
 
+  /**
+   * ── Clicking the link IS the confirmation ────────────────────────────────
+   *
+   * There used to be a Confirm button here, so a person who had already filled
+   * the form in and pressed Submit was asked to agree to their own answers a
+   * second time. The click on the link is the only thing that was ever missing
+   * — it is what proves the address — so doing it here removes a step without
+   * removing a check.
+   *
+   * Recording on a GET is deliberate and safe in this one direction: a mail
+   * scanner that pre-fetches the link finalises a submission the person had
+   * already made, which is the outcome they asked for. Nothing is created by
+   * the fetch — a row with no answers takes the "go and finish" branch above.
+   *
+   * Idempotent: a row that is already SUBMITTED is left alone, so a reload, a
+   * scanner and the person all land on the same page.
+   */
+  let recorded = resolved.response;
+  if (resolved.response.submission_state !== 'SUBMITTED') {
+    try {
+      const outcome = await ClassmojiService.formResponse.confirmSubmission(token);
+      recorded = outcome.response;
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      // Their answers are safe either way; what they cannot have is a place.
+      if (code === 'FORM_CAP_REACHED' || code === 'FORM_NOT_OPEN' || code === 'FORM_CLOSED') {
+        return data(
+          {
+            view: 'blocked' as const,
+            reason: code === 'FORM_CAP_REACHED' ? ('cap' as const) : ('closed' as const),
+            theme,
+            classroomName,
+            fillPath,
+          },
+          { headers: NO_STORE }
+        );
+      }
+      if (code && code.startsWith('MAGIC_LINK_')) return problem(problemFor(code));
+      throw error;
+    }
+  }
+
+  // This browser keeps the link, so coming back on this machine needs no trip
+  // through the inbox.
+  const headers = new Headers(NO_STORE);
+  headers.append(
+    'Set-Cookie',
+    formLinkCookie({
+      request,
+      classroomSlug,
+      formSlug,
+      rawToken: token,
+      maxAgeSeconds: EDIT_LINK_COOKIE_MAX_AGE_SECONDS,
+    })
+  );
+
   return data(
     {
-      view: 'review' as const,
+      view: 'recorded' as const,
       theme,
       classroomName,
       fillPath,
@@ -206,13 +275,12 @@ export const loader = async ({
         title: resolved.form.title,
         description: resolved.form.description,
       },
-      alreadyVerified: resolved.response.verified_at !== null,
-      identity: { email: resolved.response.email, name: resolved.response.name },
+      identity: { email: recorded.email, name: recorded.name },
       fields: ClassmojiService.form.fieldsOf(resolved.revision.fields),
-      answers: (resolved.response.answers ?? {}) as Record<string, unknown>,
-      resolvedContext: resolved.response.resolved_context,
+      answers: (recorded.answers ?? {}) as Record<string, unknown>,
+      resolvedContext: recorded.resolved_context,
     },
-    { headers: NO_STORE }
+    { headers }
   );
 };
 
@@ -374,12 +442,21 @@ export default function FormVerify() {
   const [editing, setEditing] = useState(false);
 
   /**
-   * The confirmed response is the moment the browser draft has served its
-   * purpose. Clearing it HERE rather than on the fill page's check-email state
-   * is deliberate: the fill page cannot know whether a submission was a first
-   * one or an edit (telling it would be the membership oracle), and an edit
-   * whose link is never clicked should still find its draft waiting.
+   * A recorded response is the moment the browser draft has served its purpose.
+   *
+   * Clearing it HERE rather than on the fill page's check-email state is
+   * deliberate: the fill page cannot know whether a submission was a first one
+   * or an edit (telling it would be the membership oracle), and an edit whose
+   * link is never clicked should still find its draft waiting.
+   *
+   * Driven by the LOADER now, not by a confirm action. Opening the link is what
+   * records the response, so the recorded view is where the draft becomes
+   * spent — and an edit saved from this page lands here too, via `result`.
    */
+  const recordedFormId = loaded.view === 'recorded' ? loaded.form.id : null;
+  useEffect(() => {
+    if (recordedFormId) clearDraftsForForm(recordedFormId);
+  }, [recordedFormId]);
   useEffect(() => {
     if (result?.state === 'confirmed') clearDraftsForForm(result.formId);
   }, [result]);
@@ -518,6 +595,31 @@ export default function FormVerify() {
     );
   }
 
+  /**
+   * They clicked in good faith and there is no place for them — the form filled
+   * up, or closed, between submitting and clicking. Their answers are still on
+   * file; what they cannot have is a spot, and saying so plainly beats a
+   * cheerful screen that implies otherwise.
+   */
+  if (loaded.view === 'blocked') {
+    return (
+      <FormCanvas theme={loaded.theme} classroomName={loaded.classroomName}>
+        <FormNotice
+          icon={loaded.reason === 'cap' ? '🚦' : '🔒'}
+          title={loaded.reason === 'cap' ? 'This form is full' : 'This form has closed'}
+        >
+          <p>
+            Your answers were saved, but{' '}
+            {loaded.reason === 'cap'
+              ? 'every place had been taken by the time you confirmed'
+              : 'the form closed before you confirmed'}
+            , so they are not counted. The teaching team can still see that you tried.
+          </p>
+        </FormNotice>
+      </FormCanvas>
+    );
+  }
+
   const fields = loaded.fields as FormField[];
 
   return (
@@ -568,10 +670,11 @@ export default function FormVerify() {
         </>
       ) : (
         <>
+          {/* Already recorded by the time this renders — the loader did it.
+              So this states the outcome rather than asking for it. */}
           <div className="mb-2 text-sm text-gray-600 dark:text-gray-300">
-            {loaded.alreadyVerified
-              ? 'This is the response we already have for you. Confirm it as it stands, or change it first.'
-              : 'Here is what you sent. Confirm it and your response is recorded.'}
+            You&rsquo;re in. This is what {loaded.form.title} has for you — change it any time
+            while the form is open, using the same link.
           </div>
 
           <div className="mb-7 border-t border-gray-200 pt-5 dark:border-gray-700">
@@ -591,28 +694,13 @@ export default function FormVerify() {
             </div>
           ) : null}
 
-          <div className="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              disabled={fetcher.state !== 'idle'}
-              onClick={() =>
-                fetcher.submit(
-                  { token: tokenFromLocation() },
-                  { method: 'post', encType: 'application/json' }
-                )
-              }
-              className="rounded-md bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-gray-700 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
-            >
-              {fetcher.state !== 'idle' ? 'Confirming…' : 'Confirm'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setEditing(true)}
-              className="rounded-md border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 dark:border-gray-600 dark:text-gray-200"
-            >
-              Edit answers
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded-md border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 dark:border-gray-600 dark:text-gray-200"
+          >
+            Edit answers
+          </button>
         </>
       )}
     </FormCanvas>

--- a/apps/pages/tests/e2e/forms-early-verify.spec.ts
+++ b/apps/pages/tests/e2e/forms-early-verify.spec.ts
@@ -371,11 +371,10 @@ test.describe('the link, opened before the form is finished', () => {
     await page.waitForTimeout(750);
     expect(linksFor(email)).toHaveLength(1);
 
-    // And the original link still verifies and completes the submission.
+    // And the original link still completes the submission — by being opened,
+    // which is the only step there is now.
     await page.goto(linkTarget(link));
-    await expect(page.getByRole('button', { name: 'Confirm' })).toBeVisible();
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
 
     const rows = await responsesOf(formId!);
     expect(rows).toHaveLength(1);
@@ -426,8 +425,7 @@ test.describe('a submit that has nothing to reuse still mails', () => {
     expect(linksFor(email)).toHaveLength(1);
 
     await page.goto(linkTarget(links[0]));
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
   });
 
   /**

--- a/apps/pages/tests/e2e/forms-fill.spec.ts
+++ b/apps/pages/tests/e2e/forms-fill.spec.ts
@@ -451,19 +451,18 @@ test.describe('public fill — the happy path', () => {
     const link = await readMagicLink(email);
     await page.goto(linkTarget(link));
 
-    // The review page shows what they sent, read-only, with their identity.
+    // Opening the link IS the confirmation — there is no second act. The page
+    // reports the outcome and shows what is on file, read-only.
     // `.first()` throughout: the name and the address appear both in the
     // identity block and as the answers they were given as — which is correct,
     // and is why these are not unique locators.
-    await expect(page.getByRole('button', { name: 'Confirm' })).toBeVisible();
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Confirm' })).toHaveCount(0);
     await expect(page.getByText('Maya Chen').first()).toBeVisible();
     await expect(page.getByText(email).first()).toBeVisible();
     await expect(page.getByText('Everything, ideally.')).toBeVisible();
-    // Read-only: a review page that offered inputs would be an edit page.
+    // Read-only until they ask to edit.
     await expect(page.locator('form input[type="text"], form textarea')).toHaveCount(0);
-
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
 
     rows = await responsesOf(formId!);
     expect(rows).toHaveLength(1);
@@ -496,7 +495,7 @@ test.describe('public fill — the happy path', () => {
     expect(rows[0].name).toBe('Attempt 1');
   });
 
-  test('a fresh link on a verified response opens it for editing', async ({ page }) => {
+  test('the same link opens the response for editing, later', async ({ page }) => {
     const email = 'zz-e2e-edit@example.edu';
 
     await page.goto(fillPath);
@@ -504,20 +503,21 @@ test.describe('public fill — the happy path', () => {
     await page.getByRole('button', { name: 'Submit' }).click();
     await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
 
-    await page.goto(linkTarget(await readMagicLink(email)));
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
+    const link = await readMagicLink(email);
+    await page.goto(linkTarget(link));
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
 
     const verifiedAt = (await responsesOf(formId!))[0].verified_at;
 
-    // Submitting again with the same address mails a link to the response that
-    // already exists — the edit path.
-    await page.goto(fillPath);
-    await fillWaitlist(page, email, 'Ignored');
-    await page.getByRole('button', { name: 'Submit' }).click();
-    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
-
-    await page.goto(linkTarget(await readMagicLink(email)));
+    /**
+     * Coming back to edit is the SAME link, not a new one.
+     *
+     * This used to submit the form a second time to have a fresh link mailed,
+     * because the first one was spent on confirming. Nothing is spent now, so
+     * the round trip through the inbox is gone — and so is the second mail it
+     * used to cost.
+     */
+    await page.goto(linkTarget(link));
     await page.getByRole('button', { name: 'Edit answers' }).click();
     await page.getByLabel(LONG_LABEL, { exact: true }).fill('Actually, just the basics.');
     await page.getByRole('button', { name: 'Save and confirm' }).click();
@@ -1085,8 +1085,8 @@ test.describe('magic link', () => {
 
     const link = await readMagicLink(email);
     await page.goto(linkTarget(link));
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
+    expect((await responsesOf(formId!))[0].submission_state).toBe('SUBMITTED');
 
     /**
      * Reopening it lands back on the response, not on a dead end.
@@ -1098,11 +1098,8 @@ test.describe('magic link', () => {
      * whoever came back.
      */
     await page.goto(linkTarget(link));
-    await expect(page.getByText('This is the response we already have for you.')).toBeVisible();
-
-    // And re-confirming edits the one row rather than filing a second.
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
+    await expect(page.getByText('Twice').first()).toBeVisible();
 
     expect(await responsesOf(formId!)).toHaveLength(1);
   });
@@ -1195,8 +1192,7 @@ test.describe('localStorage draft', () => {
     ).toBe(true);
 
     await page.goto(linkTarget(await readMagicLink(email)));
-    await page.getByRole('button', { name: 'Confirm' }).click();
-    await expect(page.getByRole('heading', { name: "You're in" })).toBeVisible();
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
 
     await expect
       .poll(async () =>

--- a/packages/services/src/classmoji/__tests__/forms.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/forms.integration.test.ts
@@ -703,44 +703,6 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         }
       });
 
-      /**
-       * THE SAFETY NET for somebody who loses the one mail.
-       *
-       * The reminder sweep is idempotent through the token table — a stage is
-       * due when no token was created AFTER `submitted_at + stage`. A suppressed
-       * submit moves `submitted_at` to now and adds no token, so the reused link
-       * predates the row and the six-hour nudge still fires with a fresh one.
-       */
-      it('a suppressed submit is still nudged six hours later', async () => {
-        const { formId, revisionId } = await makeOpenForm();
-        const fieldId = await nameFieldId(revisionId);
-        const email = `reuse-nudge-${suite}@example.test`;
-
-        await responseService.beginAddressVerification({ formId, email, revisionId });
-        const submitted = await beginFor(formId, revisionId, fieldId, email);
-        expect(submitted.rawToken).toBeNull();
-
-        // Wind the row and its link back, as if the sweep were running later.
-        const shift = responseService.REMINDER_STAGES_MS[0] + 60_000;
-        const back = (at: Date) => new Date(at.getTime() - shift);
-        const row = await rowFor(formId, email);
-        await prisma.formResponse.update({
-          where: { id: row.id },
-          data: { submitted_at: back(row.submitted_at) },
-        });
-        for (const token of await prisma.formMagicToken.findMany({
-          where: { response_id: row.id },
-        })) {
-          await prisma.formMagicToken.update({
-            where: { id: token.id },
-            data: { created_at: back(token.created_at) },
-          });
-        }
-
-        const swept = await responseService.remindUnverified();
-        expect(swept.emails.some(mail => mail.payload.to === email)).toBe(true);
-        expect(await prisma.formMagicToken.count({ where: { response_id: row.id } })).toBe(2);
-      });
     });
 
     /**
@@ -1452,21 +1414,18 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         select: { id: true },
       });
       const ids = survivors.map(row => row.id);
-      expect(ids).not.toContain(stale.responseId);
+
+      // Anonymous drafts still go: half-typed answers nobody ever saw, kept
+      // only because somebody started filling a form in.
       expect(ids).not.toContain(orphanDraft.id);
+
+      // Everything a person actually submitted stays, however old and however
+      // unverified. An abandoned entry is a real applicant, and staff being
+      // able to see that somebody tried is worth more than a tidy table.
+      expect(ids).toContain(stale.responseId);
       expect(ids).toContain(fresh.responseId);
       expect(ids).toContain(verified.responseId);
       expect(ids).toContain(memberDraft.id);
-
-      // The freed slot lets the same address start over.
-      await expect(
-        responseService.beginPublicSubmission({
-          formId,
-          email: `stale-pending-${suite}@example.test`,
-          answers: { [fieldId]: 'Maya' },
-          revisionId,
-        })
-      ).resolves.toMatchObject({ mode: 'new' });
     });
   });
 
@@ -1658,16 +1617,22 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         expect(response.verified_at).not.toBeNull();
         expect(response.answers).toEqual({ [fieldId]: 'Maya' });
 
-        // The link SURVIVES its own submission, and its life is now the form's
-        // rather than the 48-hour verification window it was minted with. This
-        // is what makes "keep this email" true.
+        // The link survives its own submission — and it was MINTED with the
+        // form's life already on it. One clock, set once, never adjusted.
         const token = await prisma.formMagicToken.findUniqueOrThrow({
           where: { token_hash: responseService.hashToken(rawToken) },
         });
         expect(token.used_at).toBeNull();
-        expect(token.expires_at.getTime()).toBeGreaterThan(
-          Date.now() + responseService.MAGIC_TOKEN_TTL_MS
-        );
+        const form = await prisma.form.findUniqueOrThrow({ where: { id: formId } });
+        if (form.closes_at) {
+          expect(token.expires_at.getTime()).toBe(form.closes_at.getTime());
+        } else {
+          // No close date, so the long backstop — and emphatically not a
+          // two-day TTL, which is the regression this pins.
+          expect(token.expires_at.getTime()).toBeGreaterThan(
+            Date.now() + 300 * 24 * 60 * 60 * 1000
+          );
+        }
       });
 
       /**
@@ -1968,7 +1933,19 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
      * person the form had filled up, which made a waitlist a race between mail
      * servers rather than a queue.
      */
-    it('the earlier submission holds the slot even when the later one verifies first', async () => {
+    /**
+     * A place is taken when the link is CLICKED, not when the form is
+     * submitted.
+     *
+     * This used to assert the opposite: an unverified submission held a
+     * reservation, so the earlier submitter won even if the later one clicked
+     * first. That fairness was real and it cost a second clock — a reservation
+     * has to expire, which is where the forty-eight hours came from, and the
+     * reminders that chased it, and the copy on four screens trying to explain
+     * a deadline nobody could see. The rule is now the one a person would
+     * guess, and the loser can still confirm the moment a place frees up.
+     */
+    it('the place goes to whoever confirms first, not whoever submitted first', async () => {
       const { formId, revisionId } = await makeOpenForm({ response_cap: 1 });
       const fieldId = await nameFieldId(revisionId);
 
@@ -1986,20 +1963,21 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         revisionId,
       });
 
-      // The LATER submission gets to the link first, and is turned away —
-      // somebody who submitted before them is still inside the window.
-      expect(await codeOf(responseService.confirmSubmission(tokenOf(late)))).toBe(
+      // The LATER submission gets to the link first, and takes the place.
+      const { response } = await responseService.confirmSubmission(tokenOf(late));
+      expect(response.submission_state).toBe('SUBMITTED');
+
+      // The earlier one now finds the form full — their answers are kept, and
+      // their link stays live, so a freed place is still theirs to take.
+      expect(await codeOf(responseService.confirmSubmission(tokenOf(early)))).toBe(
         'FORM_CAP_REACHED'
       );
-
-      const { response } = await responseService.confirmSubmission(tokenOf(early));
-      expect(response.submission_state).toBe('SUBMITTED');
 
       const submitted = await prisma.formResponse.findMany({
         where: { form_id: formId, submission_state: 'SUBMITTED' },
       });
       expect(submitted).toHaveLength(1);
-      expect(submitted[0].email).toBe(`fifo-early-${suite}@example.test`);
+      expect(submitted[0].email).toBe(`fifo-late-${suite}@example.test`);
     });
 
     it('an unverified row stops holding a place once its window closes', async () => {
@@ -2085,153 +2063,6 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
       expect(response.submission_state).toBe('SUBMITTED');
     });
   });
-
-  // ── Reminders ────────────────────────────────────────────────────────────
-
-  describe('unverified reminders', () => {
-    /**
-     * Move a response and everything that has happened to it `ms` further into
-     * the past, as if the sweep were running that much later.
-     *
-     * RELATIVE, not absolute, and that is the whole point: the idempotence rule
-     * compares a token's age against the response's, so stamping them all with
-     * one timestamp would collapse "the reminder we already sent" onto "the
-     * moment they submitted" and make every stage look unserved again. Time
-     * passing moves everything together.
-     */
-    const age = async (responseId: string, ms: number) => {
-      const row = await prisma.formResponse.findUniqueOrThrow({ where: { id: responseId } });
-      await prisma.formResponse.update({
-        where: { id: responseId },
-        data: {
-          submitted_at: new Date(row.submitted_at.getTime() - ms),
-          created_at: new Date(row.created_at.getTime() - ms),
-        },
-      });
-      for (const token of await prisma.formMagicToken.findMany({
-        where: { response_id: responseId },
-      })) {
-        await prisma.formMagicToken.update({
-          where: { id: token.id },
-          data: {
-            created_at: new Date(token.created_at.getTime() - ms),
-            expires_at: new Date(token.expires_at.getTime() - ms),
-          },
-        });
-      }
-    };
-
-    const SIX_HOURS = 6 * 60 * 60 * 1000;
-    const ONE_DAY = 24 * 60 * 60 * 1000;
-
-    /** Only this suite's rows — the sweep is global by design. */
-    const mine = (result: {
-      emails: Array<{ payload: { to: string; template: { id: string } } }>;
-    }) => result.emails.filter(email => email.payload.to.includes(suite));
-
-    it('nudges a six-hour-old unverified submission exactly once', async () => {
-      const { formId, revisionId } = await makeOpenForm();
-      const fieldId = await nameFieldId(revisionId);
-      const begun = await responseService.beginPublicSubmission({
-        formId,
-        email: `remind-six-${suite}@example.test`,
-        answers: { [fieldId]: 'Maya' },
-        revisionId,
-      });
-      await age(begun.responseId, SIX_HOURS + 60_000);
-
-      const first = mine(await responseService.remindUnverified());
-      expect(first).toHaveLength(1);
-      expect(first[0].payload.template.id).toBe('form-verify-reminder');
-      expect(first[0].payload.to).toBe(`remind-six-${suite}@example.test`);
-
-      // IDEMPOTENT. The token the first pass minted is dated after the stage
-      // boundary, which IS the record that the stage has been served — so a
-      // second run finds nothing due, with no column tracking it.
-      expect(mine(await responseService.remindUnverified())).toHaveLength(0);
-    });
-
-    it('nudges again at twenty-four hours, and then stops', async () => {
-      const { formId, revisionId } = await makeOpenForm();
-      const fieldId = await nameFieldId(revisionId);
-      const begun = await responseService.beginPublicSubmission({
-        formId,
-        email: `remind-day-${suite}@example.test`,
-        answers: { [fieldId]: 'Maya' },
-        revisionId,
-      });
-
-      await age(begun.responseId, SIX_HOURS + 60_000);
-      expect(mine(await responseService.remindUnverified())).toHaveLength(1);
-
-      // Another day goes by. The six-hour nudge ages with everything else, so
-      // it no longer sits after the twenty-four-hour boundary — which is what
-      // makes the second stage due exactly once.
-      await age(begun.responseId, ONE_DAY);
-      expect(mine(await responseService.remindUnverified())).toHaveLength(1);
-      expect(mine(await responseService.remindUnverified())).toHaveLength(0);
-
-      // No third stage. Somebody who has ignored two mails has answered.
-      await age(begun.responseId, 3 * ONE_DAY);
-      expect(mine(await responseService.remindUnverified())).toHaveLength(0);
-    });
-
-    it('leaves alone what is not waiting on a click', async () => {
-      const { formId, revisionId } = await makeOpenForm();
-      const fieldId = await nameFieldId(revisionId);
-
-      // Too young.
-      await responseService.beginPublicSubmission({
-        formId,
-        email: `remind-fresh-${suite}@example.test`,
-        answers: { [fieldId]: 'Fresh' },
-        revisionId,
-      });
-
-      // Already verified — there is nothing left for them to do.
-      const done = await responseService.beginPublicSubmission({
-        formId,
-        email: `remind-done-${suite}@example.test`,
-        answers: { [fieldId]: 'Done' },
-        revisionId,
-      });
-      await responseService.confirmSubmission(tokenOf(done));
-      await age(done.responseId, 2 * ONE_DAY);
-
-      // An address somebody typed and abandoned. No entry, so "finish your
-      // entry" is not a sentence we get to send — and the address may not even
-      // belong to whoever typed it.
-      const placeholder = await responseService.beginAddressVerification({
-        formId,
-        email: `remind-placeholder-${suite}@example.test`,
-        revisionId,
-      });
-      expect(placeholder.sent).toBe(true);
-      const placeholderRow = await prisma.formResponse.findFirstOrThrow({
-        where: { form_id: formId, email_normalized: `remind-placeholder-${suite}@example.test` },
-      });
-      await age(placeholderRow.id, 2 * ONE_DAY);
-
-      expect(mine(await responseService.remindUnverified())).toHaveLength(0);
-    });
-
-    it('says nothing about a form that has closed', async () => {
-      const { formId, revisionId } = await makeOpenForm();
-      const fieldId = await nameFieldId(revisionId);
-      const begun = await responseService.beginPublicSubmission({
-        formId,
-        email: `remind-closed-${suite}@example.test`,
-        answers: { [fieldId]: 'Maya' },
-        revisionId,
-      });
-      await age(begun.responseId, ONE_DAY + 60_000);
-      await prisma.form.update({ where: { id: formId }, data: { status: 'CLOSED' } });
-
-      expect(mine(await responseService.remindUnverified())).toHaveLength(0);
-    });
-  });
-
-  // ── Retention ────────────────────────────────────────────────────────────
 
   describe('unverified rows are not deleted quietly', () => {
     it('an unverified row outlives its link by weeks, and a staff label keeps it', async () => {

--- a/packages/services/src/classmoji/formResponse.service.ts
+++ b/packages/services/src/classmoji/formResponse.service.ts
@@ -97,8 +97,25 @@ const serviceError = (code: string, message: string) => Object.assign(new Error(
 
 // ─── Magic-link policy ──────────────────────────────────────────────────────
 
-/** How long a verify/edit link stays usable. */
-export const MAGIC_TOKEN_TTL_MS = 48 * 60 * 60 * 1000;
+/**
+ * A link lives as long as its form does. There is no second clock.
+ *
+ * It used to be minted with 48 hours on it, and that number then had to mean
+ * two different things at once — a deadline to verify, and the life of the
+ * handle somebody keeps on their own response. Every surface that tried to
+ * explain it got one of the two wrong, and the flow grew reminders to chase a
+ * deadline that only existed because the number did.
+ *
+ * `assertAccepting` is what actually decides whether a response can still be
+ * written; this only decides how long the link keeps opening it. On a form with
+ * no close date that is a long backstop rather than forever — an unbounded
+ * bearer credential is worth avoiding even when nothing is enforcing it.
+ */
+export const LINK_OPEN_HORIZON_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** When a link minted now should stop working: the form's life, not a TTL. */
+const linkExpiresAt = (form: { closes_at: Date | null }, now: Date): Date =>
+  form.closes_at ?? new Date(now.getTime() + LINK_OPEN_HORIZON_MS);
 /**
  * Links per response inside the rolling window.
  *
@@ -130,19 +147,18 @@ export const MAGIC_TOKEN_WINDOW_MS = 60 * 60 * 1000;
  * stranger can make us send mail. The link is already in their inbox; the right
  * thing to do with it is point at it.
  *
- * ── Why HALF the token's life ──────────────────────────────────────────────
- * A link's usefulness is bounded by its 48-hour life, not by minutes: somebody
- * filling in a long form, or coming back to it after lunch, should be told
- * about the link they already have rather than handed a second one. But a link
- * minted 47 hours ago is about to die, and reusing THAT would strand them. One
- * constant settles both: reuse only inside the first half of the life, and the
- * link handed back always has at least another 24 hours on it.
+ * ── Why a day ──────────────────────────────────────────────────────────────
+ * This used to be half the token's life, back when a token had a life of its
+ * own. A link now lasts as long as its form, so "half of that" would mean a
+ * link minted six months ago still suppressing a fresh send — which is the
+ * opposite of the point. A day is the span over which "you already have it" is
+ * a helpful answer rather than a baffling one.
  *
  * A link is reusable only while it is also unspent and unexpired — see
  * `findLiveLink`. Anything else mints fresh, so nobody is ever left with no
  * live link at all.
  */
-export const MAGIC_TOKEN_REUSE_MS = MAGIC_TOKEN_TTL_MS / 2;
+export const MAGIC_TOKEN_REUSE_MS = 24 * 60 * 60 * 1000;
 /**
  * The `delivery_state` meaning "we never managed to hand this message to the
  * provider at all".
@@ -161,92 +177,9 @@ export const MAGIC_TOKEN_REUSE_MS = MAGIC_TOKEN_TTL_MS / 2;
  * literal, exactly as they already do for 'SENT' and 'BOUNCED'.
  */
 export const MAGIC_LINK_SEND_FAILED = 'FAILED';
-/**
- * How long an edit link lives on a form that never closes.
- *
- * A backstop, not the rule. The rule is the form: `assertAccepting` refuses
- * every write to a form that is not OPEN, so a token outliving its form's
- * usefulness opens a page that can be read and not changed. This exists so that
- * "no close date" does not mean "immortal bearer credential", and it is
- * deliberately long — a waitlist that runs a whole term is the ordinary case,
- * and a link that dies before its form does is the exact failure this rule
- * exists to fix.
- */
-export const EDIT_LINK_OPEN_HORIZON_MS = 365 * 24 * 60 * 60 * 1000;
-
-/**
- * When the link that carried a submission should expire, now that it has.
- *
- * ── Two clocks, deliberately not the same one ──────────────────────────────
- * A token is MINTED with `MAGIC_TOKEN_TTL_MS` (48h), and that number means one
- * thing: how long you have to prove the address before the pending row stops
- * holding its place in the queue. `assertCapAvailable` counts unverified rows
- * by exactly that window and `expireStale` sweeps by it, so it must not move.
- *
- * Once the answers are in, the same token stops being a verification deadline
- * and becomes the handle on the response — the ONE thing the person can come
- * back with, since there is deliberately no "look up my response by email"
- * form anywhere in the product. That job's natural length is the form's own
- * life, not forty-eight hours.
- *
- * So the token is not SPENT at submit, it is EXTENDED here. The verification
- * window keeps its meaning for every row still inside it; the edit window
- * begins only for a row that has actually been submitted.
- *
- * Never shortens. A form closing sooner than the token's current expiry leaves
- * that expiry alone: the form gate already refuses the edit, and being able to
- * READ BACK what you submitted is not something a close date should take away.
- */
-const editLinkExpiresAt = (
-  form: { closes_at: Date | null },
-  currentExpiry: Date,
-  now: Date
-): Date => {
-  const horizon = form.closes_at ?? new Date(now.getTime() + EDIT_LINK_OPEN_HORIZON_MS);
-  return horizon.getTime() > currentExpiry.getTime() ? horizon : currentExpiry;
-};
 /** Abandoned server-side partials are swept after this long. */
 export const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-/**
- * How long an unverified row survives.
- *
- * ── Why this is no longer the link's TTL ───────────────────────────────────
- * It used to be 48h, exactly as long as the link that would verify it, on the
- * reasoning that a row nobody can verify any more is only holding a
- * (form_id, email_normalized) slot hostage. That reasoning had a cost nobody
- * was paying attention to: the instructor never learned that somebody tried.
- * A waitlist that quietly deletes half its applicants is worse than one that
- * shows them as unverified, and "did anybody bounce off the confirmation
- * step?" is a question staff can only answer if the rows are still there.
- *
- * Holding the slot is no longer the problem it was, either: a later submission
- * from the same address REUSES the row and mints a fresh link (see
- * `beginPublicSubmission`), so an abandoned row does not lock anybody out.
- *
- * Thirty days matches the anonymous-draft TTL — one retention story for
- * "personal data typed by someone who never finished", rather than two.
- */
-export const PENDING_TTL_MS = DRAFT_TTL_MS;
 
-/**
- * When a still-unverified response is nudged, measured from its first
- * submission.
- *
- * Six hours catches the overwhelmingly common case — "I meant to click that
- * later" — inside the same day, while a full 42 hours of link life remain.
- * Twenty-four hours is the last honest moment to ask: a fresh link minted then
- * outlives the reminder by another two days, and a third nudge on a form
- * somebody has now ignored twice is spam wearing a helpful hat.
- *
- * IDEMPOTENCE COMES FROM THE TOKEN TABLE, not from a column. A stage is due
- * only when NO token for the response was created after `submitted_at + stage`
- * — and sending mints one, which is precisely the record that the stage has
- * been served. Running the sweep twice in a row therefore mails once, and the
- * property survives a process restart, a re-run by hand, and a schedule that
- * fires late. A resend the person asked for suppresses the next nudge too,
- * which is correct: they have a fresh link in their inbox already.
- */
-export const REMINDER_STAGES_MS = [6 * 60 * 60 * 1000, 24 * 60 * 60 * 1000] as const;
 
 /**
  * The raw token is returned to the caller ONCE and never stored; only its
@@ -318,99 +251,46 @@ const answersAreEmpty = (answers: unknown): boolean =>
   !answers || typeof answers !== 'object' || Object.keys(answers as object).length === 0;
 
 /**
- * Refuse if the cap is already full — with the queue ordered by FIRST
- * SUBMISSION, not by who read their email fastest.
+ * Refuse if the cap is already full. A place is taken when the link is clicked.
  *
- * ── What is counted ────────────────────────────────────────────────────────
- * Two classes of row, and the second is the whole point of this function:
+ * ── What is counted, and why it is only one thing ──────────────────────────
+ * Confirmed responses. Nothing else.
  *
- *  1. VERIFIED submissions. Unconditional: they are in, and they are in
- *     wherever they sit in the order.
- *  2. UNVERIFIED submissions that came in BEFORE this one and can still be
- *     verified — a real answer set (not an address placeholder) holding a
- *     token that is neither spent nor expired.
+ * This used to also count unverified submissions as RESERVATIONS, so that two
+ * people submitting a second apart against the last slot were ranked by
+ * submission time rather than by whose mail server was quicker. That fairness
+ * was real, and it cost a second clock: a reservation has to expire, or one
+ * abandoned submission holds a slot for ever — which is where the forty-eight
+ * hours came from, and the reminders that existed to chase it, and the copy on
+ * four screens trying to explain a deadline nobody could see.
  *
- * Class 2 is a RESERVATION, and it is what stops a slow inbox from costing
- * somebody their place. Before this, the cap counted verified rows only, so
- * two people submitting one second apart against the last slot were ranked by
- * how quickly their mail server delivered: the later submission that verified
- * first took the place, and the earlier one was told the form had filled up.
- *
- * ── Why this does not make an unverified row "close" a form ────────────────
- * The reservation is consulted ONLY here, on the transition into the cap. The
- * fill loader and `beginPublicSubmission` still count verified rows alone, so
- * a pending row never turns a form away at the door — it only loses a tie it
- * was already winning on time. That asymmetry is deliberate: a reservation is
- * a promise to the person who submitted first, not a lock on the form.
+ * The rule is now the one a person would guess: your place is when you click.
+ * A link never expires while its form is open, so nobody is racing a deadline
+ * to claim one — the tie it used to break can only happen on a capped form, at
+ * the exact boundary, between two people who submitted seconds apart, and the
+ * loser can still confirm the moment a place frees up.
  *
  * ── Why it stays exact under concurrency ───────────────────────────────────
  * Every writer holds the form's row lock (see `lockForm`), so these counts are
- * taken in a serialized order. N simultaneous confirmations against a cap of K
- * admit exactly K — and now it is always the K earliest submissions, whatever
- * order the confirmations arrive in, because each one measures itself against
- * everything that came before it rather than against whatever happens to be
- * verified at that instant.
- *
- * `before` is the submitted_at this response WILL HOLD when the transaction
- * commits — for a row whose placeholder timestamp is being bumped to now, that
- * is `now`, not the value on disk. Passing the stale one would let a browser
- * that merely typed an address hours ago jump the queue.
- *
- * Omitting `before` (the classroom path, where a submission verifies in the
- * same transaction) counts verified rows only, which is the behaviour that
- * path has always had.
+ * taken in a serialized order: N simultaneous confirmations against a cap of K
+ * admit exactly K.
  */
 async function assertCapAvailable(
   tx: Prisma.TransactionClient,
   form: LockedFormRow,
-  { excludeResponseId, before, now }: { excludeResponseId?: string; before?: Date; now?: Date } = {}
+  { excludeResponseId }: { excludeResponseId?: string } = {}
 ): Promise<void> {
   if (form.response_cap === null) return;
 
-  // Sentinels rather than nullable casts: no row has an empty-string id, and
-  // nothing was submitted before the epoch, so "absent" is expressed as a
-  // predicate that is simply never true. One query, no dynamic SQL.
-  const exclude = excludeResponseId ?? '';
-  const cutoff = before ?? new Date(0);
-  const at = now ?? new Date();
-  /**
-   * The outer bound on how long a place can be held.
-   *
-   * A live token is the natural test for "can still verify", and on its own it
-   * is not enough: the reminder pass mints a FRESH link at six hours and again
-   * at twenty-four, and the resend button mints one whenever it is pressed, so
-   * "holds a live token" could be renewed indefinitely and a slot held for
-   * weeks by somebody who never verifies. The window is therefore measured from
-   * the SUBMISSION — one link's life, whatever links have been sent since —
-   * which is exactly the promise the design makes: verify within the window and
-   * you keep the place you submitted for.
-   */
-  const windowOpened = new Date(at.getTime() - MAGIC_TOKEN_TTL_MS);
+  const taken = await tx.formResponse.count({
+    where: {
+      form_id: form.id,
+      submission_state: 'SUBMITTED',
+      verified_at: { not: null },
+      ...(excludeResponseId ? { id: { not: excludeResponseId } } : {}),
+    },
+  });
 
-  const rows = await tx.$queryRaw<Array<{ count: bigint }>>`
-    SELECT COUNT(*) AS count
-    FROM form_responses r
-    WHERE r.form_id = ${form.id}
-      AND r.id <> ${exclude}
-      AND (
-        (r.submission_state = 'SUBMITTED' AND r.verified_at IS NOT NULL)
-        OR (
-          r.submission_state = 'PENDING_VERIFICATION'
-          AND r.submitted_at < ${cutoff}
-          AND r.submitted_at > ${windowOpened}
-          AND r.answers <> '{}'::jsonb
-          AND EXISTS (
-            SELECT 1
-            FROM form_magic_tokens t
-            WHERE t.response_id = r.id
-              AND t.used_at IS NULL
-              AND t.expires_at > ${at}
-          )
-        )
-      )
-  `;
-
-  const taken = Number(rows[0]?.count ?? 0);
   if (taken >= form.response_cap) {
     throw serviceError(FORM_CAP_REACHED, 'This form has reached its response limit.');
   }
@@ -616,7 +496,6 @@ function composeLinkEmail({
           FORM_TITLE: formTitle,
           CLASSROOM_NAME: classroomName,
           VERIFY_URL: verifyUrl,
-          EXPIRES_HOURS: MAGIC_TOKEN_TTL_MS / (60 * 60 * 1000),
         }),
       },
     },
@@ -637,6 +516,7 @@ function composeLinkEmail({
 async function mintLinkFor(
   tx: Prisma.TransactionClient,
   responseId: string,
+  form: { closes_at: Date | null },
   now: Date
 ): Promise<{ raw: string; tokenId: string }> {
   const recentTokens = await tx.formMagicToken.count({
@@ -665,7 +545,7 @@ async function mintLinkFor(
     data: {
       response_id: responseId,
       token_hash: hash,
-      expires_at: new Date(now.getTime() + MAGIC_TOKEN_TTL_MS),
+      expires_at: linkExpiresAt(form, now),
     },
     select: { id: true },
   });
@@ -889,7 +769,7 @@ export async function beginPublicSubmission({
       };
     }
 
-    const { raw, tokenId } = await mintLinkFor(tx, responseId, now);
+    const { raw, tokenId } = await mintLinkFor(tx, responseId, form, now);
     const verifyUrl = verifyUrlFor({
       classroomSlug: loadedForm.classroom.slug,
       formSlug: loadedForm.slug,
@@ -1088,7 +968,7 @@ export async function beginAddressVerification({
       if (live) return { emails: [], verifyUrl: null, sent: false, watchTokenId: live.id };
     }
 
-    const { raw, tokenId } = await mintLinkFor(tx, responseId, now);
+    const { raw, tokenId } = await mintLinkFor(tx, responseId, form, now);
     const verifyUrl = verifyUrlFor({
       classroomSlug: loadedForm.classroom.slug,
       formSlug: loadedForm.slug,
@@ -1253,11 +1133,7 @@ export async function confirmSubmission(rawToken: string, { answers }: { answers
     // have taken a slot. See `alreadyCounted`.
     if (!counted) {
       assertAccepting(lockedForm, now);
-      await assertCapAvailable(tx, lockedForm, {
-        excludeResponseId: response.id,
-        before: response.submitted_at,
-        now,
-      });
+      await assertCapAvailable(tx, lockedForm, { excludeResponseId: response.id });
     }
 
     const data: Prisma.FormResponseUncheckedUpdateInput = {
@@ -1289,14 +1165,9 @@ export async function confirmSubmission(rawToken: string, { answers }: { answers
       data.answers = parseAnswers(fields, answers) as unknown as Prisma.InputJsonValue;
     }
 
-    // NOT spent — extended. See `editLinkExpiresAt`: from here the link stops
-    // being a verification deadline and becomes the person's way back to their
-    // own answers, which is the promise the email now makes.
-    await tx.formMagicToken.update({
-      where: { id: token.id },
-      data: { expires_at: editLinkExpiresAt(lockedForm, token.expires_at, now) },
-    });
-
+    // The token is left exactly as it is: not spent, not extended. It was
+    // minted with the form's life already on it, so there is nothing here that
+    // needs to change for it to keep opening this response.
     const updated = await tx.formResponse.update({ where: { id: response.id }, data });
     return { response: updated, firstVerification: !counted };
   });
@@ -1469,23 +1340,10 @@ export async function submitVerifiedPublic({
     const counted = alreadyCounted(response);
     if (!counted) {
       assertAccepting(lockedForm, now);
-      // `before: now` — this row's FIFO position is the submission happening
-      // right now, not the moment its address was typed.
-      await assertCapAvailable(tx, lockedForm, {
-        excludeResponseId: response.id,
-        before: now,
-        now,
-      });
+      await assertCapAvailable(tx, lockedForm, { excludeResponseId: response.id });
     }
 
-    // NOT spent — extended, exactly as in `confirmSubmission`. This is the path
-    // an ordinary submission takes now that verification happens at blur time,
-    // so it is the one that decides whether "keep this email" is true.
-    await tx.formMagicToken.update({
-      where: { id: token.id },
-      data: { expires_at: editLinkExpiresAt(lockedForm, token.expires_at, now) },
-    });
-
+    // Token untouched, exactly as in `confirmSubmission`.
     return tx.formResponse.update({
       where: { id: response.id },
       data: {
@@ -1647,7 +1505,7 @@ export async function submitClassroom({
     // a classroom submission verifies in this same transaction, so there is no
     // unverified queue for it to be ranked against.
     if (!existing || !alreadyCounted(existing)) {
-      await assertCapAvailable(tx, form, { excludeResponseId: existing?.id, now });
+      await assertCapAvailable(tx, form, { excludeResponseId: existing?.id });
     }
 
     const data = {
@@ -2052,17 +1910,23 @@ export async function deleteResponse(responseId: string) {
  * that calls it lives in `packages/tasks/src/workflows/forms.ts`.
  */
 export async function expireStale(now: Date = new Date()) {
-  const pendingBefore = new Date(now.getTime() - PENDING_TTL_MS);
   const draftsBefore = new Date(now.getTime() - DRAFT_TTL_MS);
 
-  const pending = await getPrisma().formResponse.deleteMany({
-    where: {
-      submission_state: 'PENDING_VERIFICATION',
-      created_at: { lt: pendingBefore },
-      staff_status: null,
-    },
-  });
-
+  /**
+   * DRAFTS ONLY. Unverified submissions are kept indefinitely now.
+   *
+   * An abandoned entry is a real applicant: somebody who filled the form in
+   * and did not click. They are visible to staff, and "did anybody bounce off
+   * the confirmation step?" is worth being able to answer for the whole life
+   * of the form. Deleting them was tidying at the cost of information — and
+   * their link never expires while the form is open, so one of them can still
+   * finish months later.
+   *
+   * A draft is a different object: half-typed answers nobody has ever seen,
+   * saved automatically under an on-form promise. Keeping those for ever means
+   * holding somebody's personal data because they started typing, so the
+   * thirty-day sweep stays exactly where it was.
+   */
   const drafts = await getPrisma().formResponse.deleteMany({
     where: {
       submission_state: 'DRAFT',
@@ -2071,144 +1935,6 @@ export async function expireStale(now: Date = new Date()) {
     },
   });
 
-  return { pendingDeleted: pending.count, draftsDeleted: drafts.count };
+  return { draftsDeleted: drafts.count };
 }
 
-/** When an unverified row will be swept, for the staff surface to show. */
-export const pendingExpiresAt = (createdAt: Date): Date =>
-  new Date(createdAt.getTime() + PENDING_TTL_MS);
-
-// ─── Reminders ──────────────────────────────────────────────────────────────
-
-export interface ReminderSweepResult {
-  /** Composed mail for the CALLER to send, in submission order. */
-  emails: FormVerifyEmail[];
-  /** Rows nudged, by stage index. For the task's log line. */
-  remindedByStage: number[];
-  /** Rows that were due but had spent their hourly link budget. */
-  skippedForCooldown: number;
-}
-
-/**
- * Nudge the people who submitted a public response and never clicked the link.
- *
- * ── Who is in scope ────────────────────────────────────────────────────────
- * PENDING_VERIFICATION, `verified_at` still null, and a NON-EMPTY answer set.
- * The last of those matters: a row with `{}` for answers is an address
- * somebody typed into a form and abandoned — possibly somebody else's address,
- * typed by a stranger — and mailing it twice more would turn the early-send
- * convenience into an unsolicited three-message sequence. An entry has to
- * exist before "finish your entry" is a sentence worth sending.
- *
- * ── Idempotence, with no column to track it ────────────────────────────────
- * A stage is due when the response is at least `stage` old AND NO TOKEN for it
- * was created after `submitted_at + stage`. Sending mints a token, which places
- * a token after that boundary — so the same stage can never fire twice, and the
- * property is recomputed from durable state on every run rather than
- * remembered. Running the sweep twice back to back mails once. So does running
- * it after a restart, or by hand, or late.
- *
- * A link the person asked for themselves (the resend button) suppresses the
- * next nudge for the same reason, which is the behaviour you want: they have a
- * fresh link in their inbox already.
- *
- * ── Failure is per row ─────────────────────────────────────────────────────
- * One row that has spent its hourly link budget must not abort the sweep for
- * everybody else, so the cooldown is caught and counted rather than thrown.
- *
- * The caller sends (or logs) the mail — the same "service prepares, route
- * delivers" split `beginPublicSubmission` uses, and the reason this is
- * testable without a mail transport.
- */
-export async function remindUnverified(now: Date = new Date()): Promise<ReminderSweepResult> {
-  const oldest = new Date(now.getTime() - REMINDER_STAGES_MS[0]);
-
-  const candidates = await getPrisma().formResponse.findMany({
-    where: {
-      submission_state: 'PENDING_VERIFICATION',
-      verified_at: null,
-      user_id: null,
-      submitted_at: { lte: oldest },
-      // Only forms that could still take the response. Nudging somebody towards
-      // a form that closed is worse than saying nothing.
-      form: { status: 'OPEN', access: 'PUBLIC' },
-    },
-    select: {
-      id: true,
-      email: true,
-      name: true,
-      answers: true,
-      submitted_at: true,
-      form: {
-        select: {
-          title: true,
-          slug: true,
-          closes_at: true,
-          classroom: { select: { slug: true, name: true } },
-        },
-      },
-    },
-    orderBy: { submitted_at: 'asc' },
-  });
-
-  const emails: FormVerifyEmail[] = [];
-  const remindedByStage = REMINDER_STAGES_MS.map(() => 0);
-  let skippedForCooldown = 0;
-
-  for (const response of candidates) {
-    if (answersAreEmpty(response.answers)) continue;
-    if (response.form.closes_at && response.form.closes_at.getTime() <= now.getTime()) continue;
-
-    const age = now.getTime() - response.submitted_at.getTime();
-
-    // The LATEST stage this row has come of age for. Checking newest-first
-    // means a sweep that missed a run does not send two nudges in a row to
-    // catch up — it sends the one that is actually current.
-    let stageIndex = -1;
-    for (let index = REMINDER_STAGES_MS.length - 1; index >= 0; index--) {
-      if (age >= REMINDER_STAGES_MS[index]) {
-        stageIndex = index;
-        break;
-      }
-    }
-    if (stageIndex < 0) continue;
-
-    const boundary = new Date(response.submitted_at.getTime() + REMINDER_STAGES_MS[stageIndex]);
-    const servedAlready = await getPrisma().formMagicToken.count({
-      where: { response_id: response.id, created_at: { gt: boundary } },
-    });
-    if (servedAlready > 0) continue;
-
-    try {
-      const { raw, tokenId } = await getPrisma().$transaction(tx =>
-        mintLinkFor(tx, response.id, now)
-      );
-      emails.push(
-        composeLinkEmail({
-          to: response.email,
-          name: response.name,
-          formTitle: response.form.title,
-          classroomName: response.form.classroom.name,
-          verifyUrl: verifyUrlFor({
-            classroomSlug: response.form.classroom.slug,
-            formSlug: response.form.slug,
-            rawToken: raw,
-          }),
-          template: 'form-verify-reminder',
-          // A reminder bounces exactly as a first send does, and the staff row
-          // wants to know that too — nobody is on a page to be told.
-          formMagicTokenId: tokenId,
-        })
-      );
-      remindedByStage[stageIndex] += 1;
-    } catch (error) {
-      if ((error as { code?: string }).code === MAGIC_LINK_COOLDOWN) {
-        skippedForCooldown += 1;
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  return { emails, remindedByStage, skippedForCooldown };
-}

--- a/packages/services/src/emails/templates.mjs
+++ b/packages/services/src/emails/templates.mjs
@@ -226,15 +226,6 @@ Need help, email us at hello@classmoji.io`,
       { key: 'FORM_TITLE', type: 'string' },
       { key: 'CLASSROOM_NAME', type: 'string' },
       { key: 'VERIFY_URL', type: 'string' },
-      // Declared but no longer rendered here. ONE builder in
-      // formResponse.service composes the payload for this template and for the
-      // reminder, which still quotes the hours legitimately (a reminder only
-      // ever goes to a row that has NOT verified, so the 48-hour deadline is
-      // still that reader's truth). Keeping the key declared means the shared
-      // payload stays valid for both; dropping it would hand Resend a variable
-      // this template does not know, and a rejected send here is invisible —
-      // see the `escapeVars` comment for how that failure mode already bit us.
-      { key: 'EXPIRES_HOURS', type: 'string', fallbackValue: '48' },
     ],
     html: shell({
       title: 'Verify your email',
@@ -253,77 +244,27 @@ Need help, email us at hello@classmoji.io`,
           color: MUTED,
           pb: 20,
         }),
-        button('{{{VERIFY_URL}}}', 'Verify my email'),
-        // The second job this link does, said plainly. It is the durable handle
-        // on the response — the only one, since there is deliberately no
-        // "look up my response by email" form anywhere in the product.
+        button('{{{VERIFY_URL}}}', 'Confirm my response'),
+        /*
+         * ONE sentence for the link's whole life, because it now has one.
+         *
+         * This block used to be three: a "keep this email", a number of hours,
+         * and an instruction for getting another link. The hours were a
+         * deadline that only existed because the link used to expire; the
+         * instruction ("open the form again with the same address") never
+         * worked for anybody who had already verified, since that address is
+         * deliberately sent nothing. Both are gone along with the deadline
+         * itself — see `LINK_OPEN_HORIZON_MS`.
+         */
         text(
-          '<strong>Keep this email.</strong> This link is your way back to your answers: click it now to carry on filling the form in, and click it again any time after you submit to read or change what you sent.',
+          '<strong>Keep this email.</strong> The same link brings you back to your answers any time while the form is open, so you can read or change what you sent.',
           { size: 14, lh: 22, color: MUTED, pb: 8 }
         ),
-        // No hours, and no "request another one".
-        //
-        // The hours were the VERIFICATION deadline, which stopped being the
-        // link's whole life when a submission started extending it — quoting 48
-        // to somebody whose link now lasts as long as the form would be worse
-        // than saying nothing. And "open the form again with the same address"
-        // was never a way to get a second link: an address that has already
-        // verified is deliberately sent nothing at all, so the instruction sent
-        // people to a blank form and no mail. The resend button on the
-        // check-your-email screen is the real door, and it is only reachable by
-        // the person who asked.
-        text('The link keeps working for as long as this form is open.', {
-          size: 14,
-          lh: 22,
-          color: MUTED,
-          pb: 8,
-        }),
         // A public form is a link anyone can share, so the recipient may
         // genuinely not have submitted anything — that has to be a real option,
         // and "ignore this" has to be the first thing the sentence says.
         text(
           'If you did not use this address on a Classmoji form, ignore this email. Nothing is recorded without the click.',
-          { size: 14, lh: 22, color: MUTED, pb: 24 }
-        ),
-      ],
-    }),
-  },
-
-  {
-    name: 'Form — Verify reminder',
-    alias: 'form-verify-reminder',
-    // A nudge, not a re-announcement. The subject leads with the ask because
-    // this lands in an inbox that already contains the first mail, and the only
-    // useful thing it can add is "this is still outstanding".
-    subject: '[Classmoji] One click to finish your {{{FORM_TITLE}}} entry',
-    variables: [
-      { key: 'RECIPIENT_NAME', type: 'string', fallbackValue: 'there' },
-      { key: 'FORM_TITLE', type: 'string' },
-      { key: 'CLASSROOM_NAME', type: 'string' },
-      { key: 'VERIFY_URL', type: 'string' },
-      { key: 'EXPIRES_HOURS', type: 'string', fallbackValue: '48' },
-    ],
-    html: shell({
-      title: 'One click to finish',
-      preheader: 'Your {{{FORM_TITLE}}} entry is waiting on one click.',
-      rows: [
-        heading('One click to finish'),
-        text(
-          'Hi {{{RECIPIENT_NAME}}}, your answers to <strong>{{{FORM_TITLE}}}</strong> for {{{CLASSROOM_NAME}}} are saved but not recorded — they are waiting on you to verify this address.'
-        ),
-        text('This is the last thing the form needs from you.', {
-          size: 14,
-          lh: 22,
-          color: MUTED,
-          pb: 20,
-        }),
-        button('{{{VERIFY_URL}}}', 'Finish my entry'),
-        text(
-          'This is a fresh link and works for {{{EXPIRES_HOURS}}} hours. It also opens your answers if you want to change anything before you finish.',
-          { size: 14, lh: 22, color: MUTED, pb: 8 }
-        ),
-        text(
-          'If you have changed your mind, do nothing — an entry that is never verified is never recorded.',
           { size: 14, lh: 22, color: MUTED, pb: 24 }
         ),
       ],

--- a/packages/tasks/src/workflows/forms.ts
+++ b/packages/tasks/src/workflows/forms.ts
@@ -1,119 +1,41 @@
 import { logger, schedules } from '@trigger.dev/sdk';
 import { ClassmojiService } from '@classmoji/services';
-import { sendEmailTask } from './email.ts';
 
 /**
- * The forms housekeeping sweep.
+ * The forms housekeeping sweep — anonymous drafts, and nothing else.
  *
- * ── Why a schedule and not a cleanup-on-write ──────────────────────────────
- * A public submission stores a PENDING_VERIFICATION row immediately, so it
- * holds the (form_id, email_normalized) uniqueness slot before anyone has
- * proven they own that address. That is deliberate — it is what stops two
- * people racing for one identity — but nothing on the write path is in a
- * position to clean up after an abandoned one: the person who needs a slot
- * freed is exactly the person who cannot get far enough in to free it.
+ * ── What it does NOT do any more ───────────────────────────────────────────
+ * It used to also delete abandoned unverified submissions after thirty days,
+ * and this file used to carry a second task that chased them with reminder
+ * mail at six and twenty-four hours. Both are gone.
  *
- * So: a sweep, on a clock. It is also the GDPR-shaped half of the design —
- * answers typed by someone who never confirmed are personal data nobody ever
- * asked to keep, and thirty days is how long they are kept so that staff can
- * SEE that somebody tried before the row goes.
+ * They existed to serve a deadline, and the deadline existed because a link
+ * used to expire in forty-eight hours. A link now lives as long as its form,
+ * so there is nothing to chase: somebody who filled the form in and did not
+ * click can still click months later, and their row stays where staff can see
+ * it in the meantime. An abandoned entry is a real applicant, and "did anybody
+ * bounce off the confirmation step?" is worth being able to answer.
  *
- * ── The policy lives in the service ────────────────────────────────────────
- * Which rows are stale is `formResponse.expireStale`'s decision (30 days for
- * unverified rows with no staff label, 30 days for anonymous drafts, classroom
- * drafts kept). This task is scheduling and nothing else, so the same rules
- * apply when the sweep is run by hand from a script or asserted in a unit test.
+ * ── Why a draft is different ───────────────────────────────────────────────
+ * A draft is half-typed answers nobody has ever seen, saved automatically as
+ * somebody types under an on-form promise. Keeping those for ever means
+ * holding personal data because a person started filling something in and
+ * changed their mind, so thirty days still applies. The policy itself lives in
+ * `formResponse.expireStale`, so a hand-run script and a test see the same
+ * rules this schedule does.
  *
  * ── Cadence ────────────────────────────────────────────────────────────────
- * Every six hours. Four runs a day is precision far beyond what a 30-day
- * retention policy is expressing, and it is the cadence the reminder pass in
- * the same file needs — a nudge due at 6h goes out within six hours of being
- * due, which for "you have two days to click this" is close enough.
+ * Every six hours — far more precision than a thirty-day retention policy
+ * needs, and it costs nothing.
  */
 export const expireStaleFormResponsesTask = schedules.task({
   id: 'forms-expire-stale',
   cron: '0 */6 * * *',
   run: async () => {
-    const { pendingDeleted, draftsDeleted } = await ClassmojiService.formResponse.expireStale();
+    const { draftsDeleted } = await ClassmojiService.formResponse.expireStale();
 
-    logger.info('forms: expired stale responses', { pendingDeleted, draftsDeleted });
+    logger.info('forms: expired stale drafts', { draftsDeleted });
 
-    return { pendingDeleted, draftsDeleted };
-  },
-});
-
-/**
- * Should this process actually dispatch mail?
- *
- * The same test `apps/pages/app/utils/tasks.server.ts` makes, and for the same
- * reason: a developer with production secrets in their `.env` must not mail a
- * real applicant every time a sweep runs on a laptop. Requiring production as
- * well as a key means the dangerous direction needs an explicit deployment and
- * the safe direction is what a laptop does.
- */
-const canDispatchEmail = (): boolean =>
-  Boolean(process.env.TRIGGER_SECRET_KEY) && process.env.NODE_ENV === 'production';
-
-/**
- * The reminder pass: one nudge to everybody who submitted a public response and
- * never clicked the link.
- *
- * ── Why this exists ────────────────────────────────────────────────────────
- * The verification click is the single point where a public submission can be
- * lost, and it is lost SILENTLY — for the applicant, who believes they applied,
- * and for the instructor, who never sees them. A form that mails once and gives
- * up is quietly discarding the people whose mail client buried it.
- *
- * ── Where the policy lives ─────────────────────────────────────────────────
- * `formResponse.remindUnverified` decides who is due (6h, then 24h), mints the
- * fresh link, and composes the mail. That includes the idempotence: a stage is
- * due only when no token was minted after it came due, and minting one is what
- * marks it served — so running this twice mails once, with no column tracking
- * it and no state in this task. This function is dispatch and logging.
- *
- * ── The dev escape ─────────────────────────────────────────────────────────
- * Off production the links are written to stdout — the same
- * `[forms:magic-link]` line the fill route logs, so the same reader (and the
- * same e2e helper) finds them. Never both.
- */
-export const remindUnverifiedFormResponsesTask = schedules.task({
-  id: 'forms-remind-unverified',
-  cron: '0 */6 * * *',
-  run: async () => {
-    const { emails, remindedByStage, skippedForCooldown } =
-      await ClassmojiService.formResponse.remindUnverified();
-
-    if (!canDispatchEmail()) {
-      for (const email of emails) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `[forms:magic-link] to=${email.payload.to} ${email.payload.template.variables.VERIFY_URL}`
-        );
-      }
-    } else {
-      for (const email of emails) {
-        try {
-          await sendEmailTask.trigger(email.payload);
-        } catch (error) {
-          // One undeliverable nudge must not abort the pass for everybody else.
-          // The row keeps its token, so the NEXT stage is suppressed rather than
-          // retried — which is the conservative direction: a missed reminder is
-          // better than a duplicate one.
-          logger.error('forms: reminder dispatch failed', {
-            to: email.payload.to,
-            error: (error as Error).message,
-          });
-        }
-      }
-    }
-
-    logger.info('forms: reminded unverified responses', {
-      reminded: emails.length,
-      remindedByStage,
-      skippedForCooldown,
-      dispatched: canDispatchEmail(),
-    });
-
-    return { reminded: emails.length, remindedByStage, skippedForCooldown };
+    return { draftsDeleted };
   },
 });


### PR DESCRIPTION
Tim, on being shown the flow written out:

> "i'm a little frustrated i'm not sure the flow makes sense. you have 48 hours but that doesn't make sense with the deadline. you send a reminder every 6 hours which seems way overboard and then they have multiple links."

All three complaints had one root. A link expired in 48 hours, so that number had to mean two things at once — a deadline to verify, and the life of the handle somebody keeps on their own response. Everything downstream existed to prop up the deadline: reminder mail to chase it, a sweep to delete what it stranded, a cap reservation to be fair to people racing it, and copy on four screens trying to explain a clock nobody could see.

**Removing the deadline removes all of it.**

## The flow now

1. Fill the form; typing your address sends the one link
2. Submit → recorded on the spot if you already clicked, else "check your email"
3. **Clicking the link records it** — no Confirm gate
4. The same link reopens and edits your answers for as long as the form is open

## What changed

- **One clock.** A link is minted with the form's life on it (`closes_at`, else a one-year backstop). `assertAccepting` was always the real gate on editing; this only decides how long the link keeps opening the response.
- **Reminders deleted** — service pass, Trigger task, template, and the 6h/24h stages. Nothing to chase when nothing expires.
- **The Confirm gate is gone.** It asked people to agree a second time to answers they had already submitted. The click was the only thing missing, because it is what proves the address. Recording on a GET is safe in this one direction: a scanner that pre-fetches finalises a submission the person already made, and a row with no answers still takes the "go and finish" branch.
- **The cap counts confirmed responses only.** Your place is when you click — the rule a person would guess. It used to hold reservations for unverified submissions, which is exactly where the second clock came from. Both live forms are uncapped, so this is theory today.
- **Abandoned entries are kept**, at Tim's call. They are real applicants and staff can see them. Anonymous DRAFTS are still swept at thirty days — half-typed answers nobody has ever seen are a different object from a submission somebody made.

## Verified

services **1433** pass (13 pre-existing GitLab-provider failures untouched — those tests reference methods that don't exist and fail identically on staging), tasks **97**, pages **597**, **0** type errors.

Six suites pinned the old flow and were rewritten to the new one rather than deleted — including the security property that survives: a link binding more than once still binds to exactly one address.

Net **−500 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW