### PR TITLE
fix(forms): scope link reuse to the browser, not to a clock

### DIFF
--- a/apps/pages/app/forms/fill/fill.tsx
+++ b/apps/pages/app/forms/fill/fill.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { data, useFetcher, useLoaderData, useParams, type SubmitTarget } from 'react-router';
 import { exceedsMaxDepth, type FormField } from '@classmoji/services/form-contract';
 
@@ -14,6 +14,7 @@ import {
   formLinkCookie,
   formWatchCookie,
   readFormLinkCookie,
+  readFormWatchCookie,
 } from '~/utils/formLinkCookie.server.ts';
 import { dispatchVerifyEmail } from '~/utils/tasks.server.ts';
 import { checkMailDomain, domainOf, suggestDomain } from '~/utils/emailDomain.server.ts';
@@ -133,6 +134,16 @@ const normalizeAddress = (email: string): string => email.trim().toLowerCase();
  */
 const DELIVERY_POLL_MS = 4_000;
 const DELIVERY_POLL_WINDOW_MS = 3 * 60_000;
+
+/**
+ * How long the blur send waits to see whether a Submit is following it.
+ *
+ * A quarter of a second: comfortably longer than the gap between `focusout` and
+ * `submit` on a click (one mouseup, plus the form's own validation pass), and
+ * far too short for anybody tabbing on to the next question to notice their
+ * link taking a moment longer to leave. See `cancelPendingLinkSend`.
+ */
+const BLUR_SEND_HOLD_MS = 250;
 
 /**
  * Watch for a bounce on the send this browser just caused.
@@ -595,6 +606,31 @@ export const action = async ({
   const noAdvice = { state: 'domain-checked', advice: null } satisfies ActionResult;
 
   /**
+   * ── The READ half of the watch cookie: "have we already mailed this fill?" ─
+   *
+   * The watch cookie was set on the reply that sent a link, and holds that
+   * send's row id. Presenting it back is how this browser shows it is the one
+   * we mailed — which is the entire basis of the reuse rule now. See
+   * `findLiveLink`; the service checks the id names a live token for the very
+   * response being written, so a cookie left over from a different address, or
+   * the random stand-in a no-send reply sets, resolves to nothing and a fresh
+   * link is minted.
+   *
+   * This replaced a TIME window, which was wrong in both directions at once. A
+   * day of it turned "you already have a link" into a lie for anyone who came
+   * back the next morning; two minutes of it sent two identical mails to anyone
+   * who took longer than two minutes over the form. Neither length was ever
+   * going to work, because the question was never how long ago — it was whether
+   * this is still the same browser, mid-fill.
+   *
+   * A browser that blocks cookies presents nothing and is mailed on both the
+   * blur and the submit. That is the honest fallback: two mails is worse than
+   * one, and better than telling somebody to check an inbox they have no link
+   * in.
+   */
+  const heldTokenId = readFormWatchCookie(request, params.formSlug!);
+
+  /**
    * ── The watch cookie, on EVERY reply an early send can produce ───────────
    *
    * The page polls `/delivery` with this to learn whether the message it just
@@ -602,18 +638,20 @@ export const action = async ({
    * header is IDENTICAL IN SHAPE whatever happened on the server.
    *
    * Four outcomes here send no mail at all: a sprung honeypot, an address that
-   * has already verified, an address a live link already covers, and a send the
-   * per-address cooldown swallowed. Every one of them renders the same line as a
-   * real send, deliberately — that sameness is what stops this endpoint
-   * answering "has this person already applied?", and it is what stops a bot
-   * learning that the trap sprang. A cookie present only when mail actually went
-   * out would put both answers back on the wire, in a response header, for
-   * anybody willing to look.
+   * has already verified, a browser that presented a link it still holds, and a
+   * send the per-address cooldown swallowed. Every one of them renders the same
+   * line as a real send, deliberately — that sameness is what stops this
+   * endpoint answering "has this person already applied?", and it is what stops
+   * a bot learning that the trap sprang. A cookie present only when mail
+   * actually went out would put both answers back on the wire, in a response
+   * header, for anybody willing to look.
    *
    * So there is ALWAYS a cookie, and when there is no real send to point at it
    * carries a fresh random id. `/delivery` answers `pending` for an id it cannot
    * find — the same thing it says for a send in flight and for one that arrived
-   * — so the substitution is not observable from outside.
+   * — so the substitution is not observable from outside. The stand-in is
+   * harmless as a `heldTokenId` too: it names no token, so the next request
+   * mints rather than falling silent.
    */
   const withWatch = (result: ActionResult, watchTokenId: string | null) =>
     data(result, {
@@ -825,6 +863,11 @@ export const action = async ({
         name: identity.name,
         revisionId,
         force: body.intent === 'resend',
+        // NOT on a resend. That is somebody looking at "we sent a link" and
+        // telling us it never came; answering them with the link they are
+        // holding a cookie for is the one reply that helps nobody. `force`
+        // skips the check anyway — passing null says so out loud.
+        heldTokenId: body.intent === 'resend' ? null : heldTokenId,
       });
 
       await dispatchVerifyEmail(result.emails, result.verifyUrl ?? '');
@@ -924,13 +967,19 @@ export const action = async ({
       // The revision the BROWSER rendered against, not the current one — sending
       // the current one would make the staleness check unfalsifiable.
       revisionId,
+      // The link this browser already holds, if it holds one — the blur send
+      // set the cookie naming it. Without this the submit has no way to tell
+      // "I was mailed a minute ago" from "I have never been mailed", and would
+      // have to guess from a clock.
+      heldTokenId,
     });
 
     /**
-     * An EMPTY `emails` means a live link already covers this address — the one
-     * minted when they typed it — and dispatching nothing is the correct
-     * outcome, not a swallowed failure. The service only returns empty when it
-     * has confirmed an unspent, unexpired, young token exists, so "no mail" is
+     * An EMPTY `emails` means this browser already holds a live link for this
+     * response — the one minted when they typed the address — and dispatching
+     * nothing is the correct outcome, not a swallowed failure. The service only
+     * returns empty when the id this browser presented names an unspent,
+     * unexpired token whose send is not known to have failed, so "no mail" is
      * never "no link".
      */
     await dispatchVerifyEmail(result.emails, result.verifyUrl ?? '');
@@ -1295,6 +1344,38 @@ export default function FormFill() {
   const domainFetcher = useFetcher<ActionResult>();
   const domainAdvice =
     domainFetcher.data?.state === 'domain-checked' ? domainFetcher.data.advice : null;
+
+  /**
+   * ── The blur send waits a beat, so the submit can call it off ────────────
+   *
+   * Somebody who types their address LAST and clicks Submit fires both: the
+   * click blurs the email field on its way to the button, so a `verify-email`
+   * request and a `submit` request leave within milliseconds of each other.
+   * Neither carries the watch cookie the other is about to set — no reply has
+   * come back yet — so the server cannot tell they are one action, and mails
+   * twice. On a form whose email input sits at the bottom (every form that
+   * does not ask for an address of its own) that is not an edge case, it is
+   * the ordinary path.
+   *
+   * The server cannot fix this: the two requests are genuinely indistinguish-
+   * able from two browsers, which is exactly what scoping reuse to a browser
+   * means. So the page, which knows they are one action, says so — by holding
+   * the blur send for a moment and dropping it if a submit follows. The submit
+   * mints and mails the link itself, so nothing is lost by not sending twice.
+   *
+   * Long enough to cover the gap between `focusout` and `submit` (one mouseup,
+   * plus the form's own validation), short enough that somebody who tabs on to
+   * the next question never notices. If validation REFUSES the submit, no
+   * cancel happens and the send goes out on schedule — which is right, because
+   * they are still filling the form in.
+   */
+  const pendingLinkSend = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelPendingLinkSend = () => {
+    if (pendingLinkSend.current === null) return;
+    clearTimeout(pendingLinkSend.current);
+    pendingLinkSend.current = null;
+  };
+  useEffect(() => cancelPendingLinkSend, []);
 
   /**
    * Dismissed by domain, not by a bare boolean.
@@ -1916,17 +1997,27 @@ export default function FormFill() {
          * single round trip.
          */
         onIdentityEmail={submission => {
-          linkFetcher.submit(
-            {
-              intent: 'verify-email',
-              identity: { email: submission.email, name: submission.name },
-              revisionId: data.revisionId,
-              trap: submission.trap,
-            } as SubmitTarget,
-            { method: 'post', encType: 'application/json' }
-          );
+          // Held for a beat rather than sent outright — see
+          // `cancelPendingLinkSend`. A Submit arriving in that window is the
+          // same action as this blur, and mails the link itself.
+          cancelPendingLinkSend();
+          pendingLinkSend.current = setTimeout(() => {
+            pendingLinkSend.current = null;
+            linkFetcher.submit(
+              {
+                intent: 'verify-email',
+                identity: { email: submission.email, name: submission.name },
+                revisionId: data.revisionId,
+                trap: submission.trap,
+              } as SubmitTarget,
+              { method: 'post', encType: 'application/json' }
+            );
+          }, BLUR_SEND_HOLD_MS);
           // Fired alongside, never before or after: they are two independent
           // questions about the same address and neither waits on the other.
+          // NOT held back with the send above: it mails nothing, and the
+          // "did you mean gmail.com?" warning is most useful while they are
+          // still looking at the field.
           domainFetcher.submit(
             {
               intent: 'check-domain',
@@ -1951,6 +2042,10 @@ export default function FormFill() {
           )
         }
         onSubmit={submission => {
+          // This submit IS the blur that just fired, finishing. Drop the held
+          // send: it would be a second identical mail, and this request mints
+          // and mails the link anyway.
+          cancelPendingLinkSend();
           // Held BEFORE the request goes out, so "wrong address" has something
           // to come back to even if the round trip never completes.
           setKept({

--- a/apps/pages/app/utils/formLinkCookie.server.ts
+++ b/apps/pages/app/utils/formLinkCookie.server.ts
@@ -150,7 +150,17 @@ export function formLinkCookie({
 // ─── The WATCH cookie ───────────────────────────────────────────────────────
 
 /**
- * "Did the message this browser just caused bounce?" — and nothing else.
+ * "Which send did this browser cause?" — and only ever that.
+ *
+ * ── Two questions, one id ──────────────────────────────────────────────────
+ * It was built for one: did the message this browser just caused bounce? The
+ * fill action now reads it back for a second, and they are the same question
+ * asked from different ends — the page asks `/delivery` how that send went, and
+ * the action asks whether a send exists to point at instead of making another
+ * (see `heldTokenId` in `forms/fill/fill.tsx` and `findLiveLink` in the
+ * service). Both are questions about something the holder themselves caused;
+ * neither is answerable by anyone else's cookie, because the service checks the
+ * id against the response being written.
  *
  * ── This is NOT the cookie above, and the difference is the whole design ───
  * The verified-link cookie holds the RAW MAGIC TOKEN and means "the person here
@@ -162,8 +172,11 @@ export function formLinkCookie({
  *
  * So it holds a `form_magic_tokens` ROW ID. Nothing in this system
  * authenticates with a row id: it opens no link, submits no response and proves
- * no address. The single question it can answer is the one its holder already
- * knows the context for — "the send I just triggered, how did it go?"
+ * no address. The two questions above are the only ones it can answer, and both
+ * are about a send its holder already knows they triggered. Even the reuse one
+ * takes nothing away: the worst a forged or borrowed id achieves is suppressing
+ * a mail to an address, which is precisely what that address's own browser
+ * would have done a moment earlier.
  *
  * A DIFFERENT NAME, deliberately. `readFormLinkCookie` matches on the name, so
  * these two can never be confused for one another by accident; the submit path
@@ -182,13 +195,34 @@ const watchCookieNameFor = (formSlug: string): string =>
   `forms_watch_${formSlug.replace(/[^a-zA-Z0-9-]/g, '')}`;
 
 /**
- * How long a browser may keep asking about one send.
+ * How long this cookie lives — which is now TWO promises, not one.
  *
- * Short: the page polls for a bounce for a bounded window while somebody is
- * actually on the form. A bounce that lands after they have gone is what the
- * STAFF surfacing is for — this cookie is not trying to be a mailbox.
+ * The first is the original: how long a browser may keep asking whether one
+ * send bounced. That is a short question. The page polls for a couple of
+ * minutes while somebody is actually on the form, and a bounce landing after
+ * they have gone is what the STAFF surfacing is for — this cookie has never
+ * been trying to be a mailbox.
+ *
+ * The second is why the number went up. The same id is now the proof a browser
+ * offers that it ALREADY RECEIVED a link for this form (see `findLiveLink` in
+ * `formResponse.service`), so this lifetime IS the boundary between "still
+ * filling the same form in" and "came back later". Both mistakes are visible
+ * from the outside: too short and somebody slow over a long form gets a second
+ * identical mail at Submit; too long and somebody returning tomorrow is told to
+ * check an inbox for a link they can no longer find.
+ *
+ * FOUR HOURS covers any single sitting, interruptions included, and expires
+ * comfortably before tomorrow morning — which is the return visit that must be
+ * mailed. It is not a licence to be vague about the boundary: cookies cleared,
+ * a private window, a different device and a different browser all present
+ * nothing and are mailed immediately, whatever the clock says.
+ *
+ * The longer life costs nothing on the polling side. `/delivery` still answers
+ * only `pending` for an id it cannot find, and `mayLearnDeliveryOutcome` is
+ * what bounds how much a client can learn — neither is a function of how long
+ * the cookie lives.
  */
-export const WATCH_COOKIE_MAX_AGE_SECONDS = 30 * 60;
+export const WATCH_COOKIE_MAX_AGE_SECONDS = 4 * 60 * 60;
 
 /** The watch id this browser holds for one form, or null. */
 export function readFormWatchCookie(request: Request, formSlug: string): string | null {

--- a/apps/pages/tests/e2e/forms-early-verify.spec.ts
+++ b/apps/pages/tests/e2e/forms-early-verify.spec.ts
@@ -4,7 +4,12 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { test, expect, type Page } from '@playwright/test';
 
-import { getClassroomIdBySlug, getTestClassroomSlug, getTestPrisma, getTestServices } from '../helpers';
+import {
+  getClassroomIdBySlug,
+  getTestClassroomSlug,
+  getTestPrisma,
+  getTestServices,
+} from '../helpers';
 import { parseFormDefinition } from '@classmoji/services/form-contract';
 import { presetByKey } from '../../app/components/forms/presets.ts';
 import { SUBMISSION_RATE_LIMIT } from '../../app/utils/submissionRate.server.ts';
@@ -28,10 +33,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  *  2. a link opened before the form is finished says so, and does not render an
  *     empty answer set as if it were a submission;
  *  3. a verified browser submits in one step — and NO second mail is sent;
- *  3b. neither does an UNVERIFIED one: the submit reuses the link already in
- *     the inbox, and the check-email screen says so rather than promising a
- *     message nobody sent. A submit with nothing to reuse still mails, and a
- *     spent link puts the mail back — nobody is left holding no link;
+ *  3b. neither does an UNVERIFIED one: the submit reuses the link this browser
+ *     already holds, and the check-email screen says so rather than promising a
+ *     message nobody sent. It holds it however long the form took — reuse is
+ *     scoped to the browser, not to a clock. A submit with nothing to show
+ *     still mails, and a spent link puts the mail back — nobody is left holding
+ *     no link;
  *  4. THE BINDING: a browser holding a verified link for one address cannot
  *     submit under another;
  *  5. the old two-step flow still works untouched, because the early send is an
@@ -382,17 +389,60 @@ test.describe('the link, opened before the form is finished', () => {
     expect(Object.values(rows[0].answers as Record<string, unknown>)).toContain('Old Way');
   });
 
+  /**
+   * ── THE ADDRESS TYPED LAST, AND THE CLICK THAT BLURS IT ──────────────────
+   *
+   * The one journey where the blur send and the submit are genuinely
+   * simultaneous. Clicking Submit moves focus off the email field on the way to
+   * the button, so `verify-email` and the submit leave within milliseconds of
+   * each other — and neither carries the watch cookie the other is about to
+   * set, because no reply has come back yet.
+   *
+   * The server cannot tell those two requests apart from two browsers. That is
+   * not a bug in the reuse rule, it is what scoping reuse to a browser MEANS —
+   * so the page is what has to know they are one action, by holding the blur
+   * send for a moment and dropping it when a submit follows (see
+   * `BLUR_SEND_HOLD_MS` in `fill.tsx`).
+   *
+   * Measured, not assumed: before that hold this produced TWO identical mails,
+   * seconds apart, on every form whose email input sits at the bottom — which
+   * is every form that does not ask for an address of its own. One mail is the
+   * whole assertion.
+   */
+  test('typing the address last and clicking Submit still mails exactly once', async ({ page }) => {
+    const email = freshEmail('lastfield');
+    await page.goto(fillPath);
+
+    // Everything EXCEPT the address, so the email field is the last one touched
+    // and the click to Submit is what blurs it.
+    await fillTheRest(page, 'Last Field');
+    await page.getByLabel(EMAIL_LABEL, { exact: true }).fill(email);
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+    await waitForLinks(email, 1);
+
+    // Long enough for a suppressed second send to have shown up if there were
+    // one — the hold is a quarter of a second, and the dispatch behind it is
+    // fast.
+    await page.waitForTimeout(1500);
+    expect(linksFor(email)).toHaveLength(1);
+
+    // And the one link that went out finishes the job.
+    await page.goto(linkTarget(linksFor(email)[0]));
+    await expect(page.getByText(/You[’']re in\./)).toBeVisible();
+  });
 });
 
-// ─── One live link per address ──────────────────────────────────────────────
+// ─── One live link per address, per browser ─────────────────────────────────
 
 /**
  * The two ways the reuse could have gone wrong, and neither does.
  *
- * Reuse stands in for a mail only when there is genuinely a working link to
- * stand in for. Everywhere else — nothing sent before, or a link that has been
- * spent — the mail comes back, because the one state nobody may end up in is
- * "submitted, no mail, no link".
+ * Reuse stands in for a mail only when this browser can SHOW a working link to
+ * stand in for. Everywhere else — nothing sent before, a link that has been
+ * spent, a browser that cannot reach the one we mailed — the mail comes back,
+ * because the one state nobody may end up in is "submitted, no mail, no link".
  */
 test.describe('a submit that has nothing to reuse still mails', () => {
   /**
@@ -511,9 +561,7 @@ test.describe('the binding between a verified link and an address', () => {
     const victimRow = rows.find(row => row.email === victim);
     expect(victimRow?.submission_state).toBe('PENDING_VERIFICATION');
     expect(victimRow?.verified_at).toBeNull();
-    expect(
-      rows.filter(row => row.submission_state === 'SUBMITTED')
-    ).toHaveLength(0);
+    expect(rows.filter(row => row.submission_state === 'SUBMITTED')).toHaveLength(0);
   });
 
   test('the browser that verified stays verified, and its edit lands', async ({ page }) => {
@@ -614,7 +662,9 @@ test.describe('resend and wrong-address', () => {
       .getByRole('radiogroup', { name: SCALE_LABEL })
       .getByRole('radio', { name: '7' })
       .click();
-    await page.getByLabel(LONG_LABEL, { exact: true }).fill('A long answer I do not want to retype.');
+    await page
+      .getByLabel(LONG_LABEL, { exact: true })
+      .fill('A long answer I do not want to retype.');
     await page.getByRole('button', { name: 'Submit' }).click();
     await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
 

--- a/packages/services/src/classmoji/__tests__/forms.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/forms.integration.test.ts
@@ -38,12 +38,13 @@ const RUN = Boolean(DATABASE_URL) && isLocal && !isSharedDevDb;
 /**
  * The link a `beginPublicSubmission` MINTED.
  *
- * `rawToken` is nullable now: a submission whose address already holds a live,
- * unspent, young link reuses it and mails nothing (see `MAGIC_TOKEN_REUSE_MS`).
- * Every call site below that asks for a token is one where a fresh token is
- * genuinely expected — a first begin for a new address, or one whose previous
- * link has been spent or aged out — so a null here is a real failure and says
- * so, rather than surfacing three frames later as "cannot read null".
+ * `rawToken` is nullable now: a submission that PRESENTS a live, unspent link
+ * of its own reuses it and mails nothing (see `findLiveLink`). Every call site
+ * below that asks for a token is one where a fresh token is genuinely expected
+ * — a first begin for a new address, or one that presented nothing, or one
+ * whose presented link is spent, expired or undeliverable — so a null here is a
+ * real failure and says so, rather than surfacing three frames later as "cannot
+ * read null".
  */
 const tokenOf = ({ rawToken }: { rawToken: string | null }): string => {
   if (!rawToken) throw new Error('expected a freshly minted link, got a reused one');
@@ -459,37 +460,73 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
     });
 
     /**
-     * ── One live link per address ───────────────────────────────────────────
+     * ── One live link per address, per BROWSER ──────────────────────────────
      *
      * Typing an address mails a link; submitting used to mail a second one
      * seconds later. Two mails for one action reads as broken, and the second
-     * makes the first ambiguous. So a send that finds a live, unspent, young
-     * link stands down — and every way that link could stop being usable puts
-     * the mint back, which is what stops "no mail" from ever meaning "no link".
+     * makes the first ambiguous. So a send that can be shown a live link stands
+     * down — and every way that link could stop being usable, or stop being
+     * reachable by the caller, puts the mint back. That is what stops "no mail"
+     * from ever meaning "no link".
+     *
+     * SHOWN is the word that changed. This used to ask a clock — "was a link
+     * for this address minted recently?" — and no answer to that question is
+     * right: a day of it left a person coming back the next morning waiting for
+     * mail that was suppressed, and two minutes of it double-mails anyone slow
+     * over a long form. The caller now has to NAME the link it holds
+     * (`heldTokenId`, the watch cookie's id in the fill route), which is the
+     * same browser, mid-fill, and nothing else.
      */
-    describe('reusing a link that is already in the inbox', () => {
-      const beginFor = (formId: string, revisionId: string, fieldId: string, email: string) =>
+    describe('reusing a link this browser can show it holds', () => {
+      const beginFor = (
+        formId: string,
+        revisionId: string,
+        fieldId: string,
+        email: string,
+        heldTokenId?: string | null
+      ) =>
         responseService.beginPublicSubmission({
           formId,
           email,
           answers: { [fieldId]: 'Maya' },
           revisionId,
+          heldTokenId,
         });
 
-      it('a submit after the address was typed sends nothing and mints nothing', async () => {
+      it('a submit that presents the blur link sends nothing and mints nothing', async () => {
         const { formId, revisionId } = await makeOpenForm();
         const fieldId = await nameFieldId(revisionId);
         const email = `reuse-blur-${suite}@example.test`;
 
-        // Exactly the uninterrupted path: leave the email field, then submit.
+        // Exactly the uninterrupted path: leave the email field, then submit —
+        // the browser presenting the id the blur reply put in its cookie.
         const blur = await responseService.beginAddressVerification({ formId, email, revisionId });
         expect(blur.sent).toBe(true);
 
-        const submitted = await beginFor(formId, revisionId, fieldId, email);
+        /**
+         * AND THE FORM TOOK THREE HOURS TO FILL IN.
+         *
+         * The whole point of scoping this to the browser rather than to a
+         * clock. A two-minute window would have sent a second identical mail
+         * here; anything shorter than "however long a person takes over a form"
+         * would too, and no such number exists.
+         */
+        const longFill = new Date(Date.now() - 3 * 60 * 60 * 1000);
+        await prisma.formMagicToken.updateMany({
+          where: { id: blur.watchTokenId! },
+          data: { created_at: longFill },
+        });
+
+        const submitted = await beginFor(formId, revisionId, fieldId, email, blur.watchTokenId);
         expect(submitted.rawToken).toBeNull();
         expect(submitted.verifyUrl).toBeNull();
         expect(submitted.emails).toHaveLength(0);
-        expect(submitted.linkAlreadySentAt).not.toBeNull();
+        // And it reports the link's TRUE age — three hours ago, not a
+        // comfortable "just now" from a clock that no longer decides anything.
+        // The fill route drops this field (rendering it would answer "has this
+        // person applied?"), so this assertion is the only thing keeping it
+        // honest.
+        expect(submitted.linkAlreadySentAt?.getTime()).toBe(longFill.getTime());
 
         // One link for the whole journey, and it opens the answers that were
         // just submitted — the placeholder overwrite filled the same row in.
@@ -508,26 +545,74 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         const { formId, revisionId } = await makeOpenForm();
         const email = `reuse-retype-${suite}@example.test`;
 
-        await responseService.beginAddressVerification({ formId, email, revisionId });
-        const again = await responseService.beginAddressVerification({ formId, email, revisionId });
+        const first = await responseService.beginAddressVerification({ formId, email, revisionId });
+        const again = await responseService.beginAddressVerification({
+          formId,
+          email,
+          revisionId,
+          heldTokenId: first.watchTokenId,
+        });
 
         expect(again.sent).toBe(false);
         expect(again.emails).toHaveLength(0);
+        // The same send stays the one worth watching, so a real bounce still
+        // reaches the page.
+        expect(again.watchTokenId).toBe(first.watchTokenId);
         const row = await rowFor(formId, email);
         expect(await prisma.formMagicToken.count({ where: { response_id: row.id } })).toBe(1);
       });
 
       /**
-       * The two ways a link stops being worth pointing at. Each one has to put
-       * the mint back — the one outcome that must never happen is somebody
-       * submitting, getting no mail, and holding no live link.
+       * ── THE CASE THE OLD RULE GOT WRONG ──────────────────────────────────
        *
-       * "Spent" used to be a third way and is not one any more: confirming
-       * EXTENDS a link rather than consuming it, so the person is left holding
-       * the most useful link they have ever had. That case is covered just
-       * below, because "no new mail" is only correct while the old link works.
+       * A caller holding nothing is a browser that cannot reach the link we
+       * mailed: a different device, tomorrow's page load, a cleared cookie jar,
+       * a form republished since. Under the time window it was told to check an
+       * inbox for a link it could not find, and nothing arrived. It is mailed.
+       *
+       * This is the assertion that the address alone is no longer sufficient
+       * grounds for silence — delete `heldTokenId` from the service and this
+       * fails, whatever the clock says.
        */
-      it('mints afresh once the previous link is expired or old', async () => {
+      it('a submit from a browser holding nothing is mailed a link of its own', async () => {
+        const { formId, revisionId } = await makeOpenForm();
+        const fieldId = await nameFieldId(revisionId);
+        const email = `reuse-elsewhere-${suite}@example.test`;
+
+        const blur = await responseService.beginAddressVerification({ formId, email, revisionId });
+        expect(blur.sent).toBe(true);
+
+        // Seconds later — the age is not what decides this.
+        const elsewhere = await beginFor(formId, revisionId, fieldId, email, null);
+        expect(elsewhere.rawToken).not.toBeNull();
+        expect(elsewhere.emails).toHaveLength(1);
+        expect(elsewhere.linkAlreadySentAt).toBeNull();
+
+        const row = await rowFor(formId, email);
+        expect(await prisma.formMagicToken.count({ where: { response_id: row.id } })).toBe(2);
+
+        // And the same for a browser coming back to the FORM rather than the
+        // submit — the blur that fires on tomorrow's page load.
+        const tomorrow = await responseService.beginAddressVerification({
+          formId,
+          email,
+          revisionId,
+        });
+        expect(tomorrow.sent).toBe(true);
+        expect(tomorrow.emails).toHaveLength(1);
+      });
+
+      /**
+       * The ways a link stops being worth pointing at even when the caller CAN
+       * point at it. Each one has to put the mint back — the one outcome that
+       * must never happen is somebody submitting, getting no mail, and holding
+       * no live link.
+       *
+       * A KNOWN-FAILED send is a fifth way and has a test of its own below,
+       * because it is the one that actually stranded somebody and the reasoning
+       * is worth its own space.
+       */
+      it('a presented link that is spent, expired or foreign puts the mint back', async () => {
         const { formId, revisionId } = await makeOpenForm();
         const fieldId = await nameFieldId(revisionId);
 
@@ -538,21 +623,52 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
           where: { response_id: dead.responseId },
           data: { expires_at: new Date(Date.now() - 1000) },
         });
-        expect((await beginFor(formId, revisionId, fieldId, deadEmail)).rawToken).not.toBeNull();
-
-        // OLD: still valid, but past the reuse window — so what it would hand
-        // back has less than half its life left. Mint rather than strand.
-        const oldEmail = `reuse-old-${suite}@example.test`;
-        const old = await beginFor(formId, revisionId, fieldId, oldEmail);
-        await prisma.formMagicToken.updateMany({
-          where: { response_id: old.responseId },
-          data: {
-            created_at: new Date(Date.now() - responseService.MAGIC_TOKEN_REUSE_MS - 60_000),
-          },
+        const deadHeld = await prisma.formMagicToken.findFirstOrThrow({
+          where: { response_id: dead.responseId },
         });
-        const renewed = await beginFor(formId, revisionId, fieldId, oldEmail);
-        expect(renewed.rawToken).not.toBeNull();
-        expect(renewed.emails).toHaveLength(1);
+        expect(
+          (await beginFor(formId, revisionId, fieldId, deadEmail, deadHeld.id)).rawToken
+        ).not.toBeNull();
+
+        // SPENT. Nothing writes `used_at` any more — a submission extends its
+        // link rather than consuming it — but rows written before that change
+        // still carry it, and a spent link opens nothing.
+        const spentEmail = `reuse-spent-${suite}@example.test`;
+        const spent = await beginFor(formId, revisionId, fieldId, spentEmail);
+        const spentHeld = await prisma.formMagicToken.findFirstOrThrow({
+          where: { response_id: spent.responseId },
+        });
+        await prisma.formMagicToken.update({
+          where: { id: spentHeld.id },
+          data: { used_at: new Date() },
+        });
+        const afterSpent = await beginFor(formId, revisionId, fieldId, spentEmail, spentHeld.id);
+        expect(afterSpent.rawToken).not.toBeNull();
+        expect(afterSpent.emails).toHaveLength(1);
+
+        /**
+         * FOREIGN: a live id, but for somebody else's response.
+         *
+         * The realistic version is one person's own browser — they typed one
+         * address, then corrected it to another, and the cookie still names the
+         * first link. It opens the wrong row, so it is no use to them, and
+         * `response_id` is what refuses it. Without that check a cookie could
+         * suppress the mail for an address it has nothing to do with.
+         */
+        const otherEmail = `reuse-foreign-other-${suite}@example.test`;
+        const other = await beginFor(formId, revisionId, fieldId, otherEmail);
+        const otherHeld = await prisma.formMagicToken.findFirstOrThrow({
+          where: { response_id: other.responseId },
+        });
+
+        const correctedEmail = `reuse-foreign-${suite}@example.test`;
+        const corrected = await beginFor(formId, revisionId, fieldId, correctedEmail, otherHeld.id);
+        expect(corrected.rawToken).not.toBeNull();
+        expect(corrected.emails).toHaveLength(1);
+        // And the foreign response was not touched on the way past.
+        expect(
+          await prisma.formMagicToken.count({ where: { response_id: other.responseId } })
+        ).toBe(1);
       });
 
       /**
@@ -572,7 +688,7 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         const rawToken = tokenOf(first);
         await responseService.confirmSubmission(rawToken);
 
-        const after = await beginFor(formId, revisionId, fieldId, email);
+        const after = await beginFor(formId, revisionId, fieldId, email, first.watchTokenId);
         expect(after.rawToken).toBeNull();
         expect(after.emails).toHaveLength(0);
 
@@ -621,6 +737,7 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
           formId,
           email,
           revisionId,
+          heldTokenId: blur.watchTokenId,
         });
         expect(retyped.sent).toBe(true);
         expect(retyped.emails).toHaveLength(1);
@@ -635,7 +752,7 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
           where: { id: retyped.watchTokenId! },
           data: { delivery_state: responseService.MAGIC_LINK_SEND_FAILED },
         });
-        const submitted = await beginFor(formId, revisionId, fieldId, email);
+        const submitted = await beginFor(formId, revisionId, fieldId, email, retyped.watchTokenId);
         expect(submitted.rawToken).not.toBeNull();
         expect(submitted.emails).toHaveLength(1);
         expect(submitted.linkAlreadySentAt).toBeNull();
@@ -667,7 +784,7 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
           await prisma.formMagicToken.findFirstOrThrow({ where: { id: blur.watchTokenId! } })
         ).toMatchObject({ delivery_state: null });
 
-        const submitted = await beginFor(formId, revisionId, fieldId, email);
+        const submitted = await beginFor(formId, revisionId, fieldId, email, blur.watchTokenId);
         expect(submitted.emails).toHaveLength(0);
         expect(submitted.linkAlreadySentAt).not.toBeNull();
         expect(await prisma.formMagicToken.count({ where: { response_id: row.id } })).toBe(1);
@@ -699,42 +816,49 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
             data: { delivery_state: state },
           });
 
-          const submitted = await beginFor(formId, revisionId, fieldId, email);
+          const submitted = await beginFor(formId, revisionId, fieldId, email, blur.watchTokenId);
           expect(submitted.emails, `${state} must stay reusable`).toHaveLength(0);
         }
       });
-
     });
 
     /**
-     * The cooldown is now a limit on ASKING, not on submitting.
+     * The cooldown is a limit on ASKING, not on submitting — for a browser that
+     * can show what it already has.
      *
-     * Repeating the submit no longer spends the budget at all — the second one
-     * reuses the live link — so the only way to reach the ceiling is the resend
-     * button, which force-mints because it is the person on the check-email
-     * screen saying the mail did not arrive. That is the shape worth pinning:
-     * one link for the address, plus `MAX_PER_WINDOW - 1` times of asking
-     * again, and then an hour's wait.
+     * Repeating the submit from the SAME fill costs nothing: it presents the
+     * link it holds and reuses it. So the ordinary way to reach the ceiling is
+     * the resend button, which force-mints because it is the person on the
+     * check-email screen saying the mail did not arrive. That is the shape
+     * worth pinning: one link for the address, plus `MAX_PER_WINDOW - 1` times
+     * of asking again, and then an hour's wait.
+     *
+     * A caller presenting NOTHING each time spends a slot each time instead,
+     * and hits the same ceiling three tries in. That is the ceiling doing its
+     * job — it is what bounds what one mailbox can be sent — and it is why the
+     * per-address budget matters more now than it did under a time window.
      */
     it('allows three link sends per response per hour, then cools down', async () => {
       const { formId, revisionId } = await makeOpenForm();
       const fieldId = await nameFieldId(revisionId);
       const email = `cooldown-${suite}@example.test`;
-      const submit = () =>
+      const submit = (heldTokenId?: string | null) =>
         responseService.beginPublicSubmission({
           formId,
           email,
           answers: { [fieldId]: 'Maya' },
           revisionId,
+          heldTokenId,
         });
       /** The check-email screen's "send it again". */
       const askAgain = () =>
         responseService.beginAddressVerification({ formId, email, revisionId, force: true });
 
       const first = await submit();
-      const second = await submit();
+      const second = await submit(first.watchTokenId);
       expect(second.mode).toBe('existing');
-      // The second submit cost nothing: same row, same link, no mail.
+      // The second submit cost nothing: same row, same link, no mail — because
+      // it could show the link the first one minted.
       expect(second.rawToken).toBeNull();
       expect(second.emails).toHaveLength(0);
 
@@ -745,7 +869,13 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
       expect(await codeOf(askAgain())).toBe(responseService.MAGIC_LINK_COOLDOWN);
       // And a submit in that state is still not an error — it has a live link
       // to point at, which is exactly what the cooldown means.
-      await expect(submit()).resolves.toMatchObject({ rawToken: null, emails: [] });
+      await expect(submit(first.watchTokenId)).resolves.toMatchObject({
+        rawToken: null,
+        emails: [],
+      });
+      // A caller with nothing to show is refused rather than mailed, which is
+      // the ceiling doing the job the reuse rule no longer does.
+      expect(await codeOf(submit())).toBe(responseService.MAGIC_LINK_COOLDOWN);
 
       // The refused send must not have left a token behind.
       expect(first.responseId).toBe(second.responseId);
@@ -951,23 +1081,37 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         )
       );
 
+      /**
+       * ONE ROW. That is what this test is for, and it is the part the row lock
+       * decides: six writers serialized, one select-then-insert that cannot go
+       * stale, one (form_id, email_normalized) slot.
+       *
+       * Six at once, none of them presenting a link, is not a journey anybody
+       * makes — it is the lock under load. Reuse cannot help here and should not
+       * pretend to: each caller has nothing to show, so each is a browser we
+       * have not mailed as far as the service can tell, and the thing that
+       * actually bounds the mailbox is the per-address ceiling. It holds: three
+       * links, then a cooldown, from six simultaneous tries.
+       */
       const rows = await prisma.formResponse.findMany({ where: { form_id: formId } });
       expect(rows).toHaveLength(1);
 
-      /**
-       * The row lock serializes them, and reuse is decided INSIDE it — so the
-       * first one through mints and the other five find that link and stand
-       * down. Nobody is refused (a cooldown for pressing Submit twice would be
-       * a bad way to meet a form) and the mailbox gets exactly one message.
-       */
       const fulfilled = outcomes.filter(outcome => outcome.status === 'fulfilled');
-      expect(fulfilled).toHaveLength(6);
       const minted = fulfilled.filter(
         outcome =>
           (outcome as PromiseFulfilledResult<{ rawToken: string | null }>).value.rawToken !== null
       );
-      expect(minted).toHaveLength(1);
-      expect(await prisma.formMagicToken.count({ where: { response_id: rows[0].id } })).toBe(1);
+      expect(minted).toHaveLength(responseService.MAGIC_TOKEN_MAX_PER_WINDOW);
+      expect(
+        outcomes.filter(
+          outcome =>
+            outcome.status === 'rejected' &&
+            (outcome.reason as { code?: string }).code === responseService.MAGIC_LINK_COOLDOWN
+        )
+      ).toHaveLength(6 - responseService.MAGIC_TOKEN_MAX_PER_WINDOW);
+      expect(await prisma.formMagicToken.count({ where: { response_id: rows[0].id } })).toBe(
+        responseService.MAGIC_TOKEN_MAX_PER_WINDOW
+      );
     });
 
     it('the partial unique index refuses a second row for one classroom user', async () => {
@@ -1725,12 +1869,14 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
         /**
          * The other device: an ordinary submission, and a link of its own.
          *
-         * The submit itself mints nothing — the address already holds the live
-         * link the laptop is sitting on — so the phone gets its second link the
-         * only way a second link is ever handed out: by asking for it on the
-         * check-email screen. Which is exactly how somebody ends up holding two
-         * live links for one response, and therefore the honest way to set this
-         * scenario up.
+         * The phone holds nothing — the live link for this address is in the
+         * laptop's cookie jar, on the other side of the room — so its submit
+         * mints and mails a second one. That is the whole reason reuse is
+         * scoped to a browser: silence here would leave somebody on a phone
+         * told to check an inbox for a link only the laptop can reach.
+         *
+         * And it is how one response comes to have two live links, which is the
+         * scenario this test needs.
          */
         const begun = await responseService.beginPublicSubmission({
           formId,
@@ -1738,14 +1884,8 @@ describe.skipIf(!RUN)('forms services (integration)', () => {
           answers: { [fieldId]: 'From the phone' },
           revisionId,
         });
-        expect(begun.rawToken).toBeNull();
-        const phone = await responseService.beginAddressVerification({
-          formId,
-          email,
-          revisionId,
-          force: true,
-        });
-        await responseService.confirmSubmission(tokenIn(phone));
+        expect(begun.rawToken).not.toBeNull();
+        await responseService.confirmSubmission(tokenOf(begun));
         const counted = await prisma.formResponse.findUniqueOrThrow({
           where: { id: begun.responseId },
         });

--- a/packages/services/src/classmoji/formResponse.service.ts
+++ b/packages/services/src/classmoji/formResponse.service.ts
@@ -124,41 +124,21 @@ const linkExpiresAt = (form: { closes_at: Date | null }, now: Date): Date =>
  * It briefly went to five, when moving the verification mail to blur time made
  * an ordinary journey cost two — typing the address minted one, submitting
  * minted another — and three then refused somebody their second attempt inside
- * the hour. Reuse (see `MAGIC_TOKEN_REUSE_MS`) removed the second link instead
- * of paying for it, so the reason for the loosening is gone and the ceiling on
+ * the hour. Reuse (see `findLiveLink`) removed the second link instead of
+ * paying for it, so the reason for the loosening is gone and the ceiling on
  * what one mailbox can be sent goes back to where it was. Three now buys the
  * link itself plus two resends the person explicitly asked for, which is more
  * headroom than five bought when every step minted.
+ *
+ * It matters MORE than it did. Reuse is scoped to a browser now, so a caller
+ * that cannot show the link it holds is mailed rather than quietly refused —
+ * and this is what bounds how many times that can happen to one mailbox.
  *
  * The per-CLIENT limit in the pages app is the primary defence against a mail
  * relay; this one bounds what can be aimed at a single mailbox.
  */
 export const MAGIC_TOKEN_MAX_PER_WINDOW = 3;
 export const MAGIC_TOKEN_WINDOW_MS = 60 * 60 * 1000;
-/**
- * How recently a link must have been minted for the next send to REUSE it
- * rather than mint a second one.
- *
- * ── Why there is a reuse rule at all ───────────────────────────────────────
- * Typing an address mints a link, and submitting used to mint another. Two
- * mails for one action reads as broken to the person receiving them, and the
- * second makes the first ambiguous: which one do I click? Both worked, so it
- * was never incorrect — just noisy, and noisy on the one surface where a
- * stranger can make us send mail. The link is already in their inbox; the right
- * thing to do with it is point at it.
- *
- * ── Why a day ──────────────────────────────────────────────────────────────
- * This used to be half the token's life, back when a token had a life of its
- * own. A link now lasts as long as its form, so "half of that" would mean a
- * link minted six months ago still suppressing a fresh send — which is the
- * opposite of the point. A day is the span over which "you already have it" is
- * a helpful answer rather than a baffling one.
- *
- * A link is reusable only while it is also unspent and unexpired — see
- * `findLiveLink`. Anything else mints fresh, so nobody is ever left with no
- * live link at all.
- */
-export const MAGIC_TOKEN_REUSE_MS = 24 * 60 * 60 * 1000;
 /**
  * The `delivery_state` meaning "we never managed to hand this message to the
  * provider at all".
@@ -177,7 +157,6 @@ export const MAGIC_TOKEN_REUSE_MS = 24 * 60 * 60 * 1000;
  * literal, exactly as they already do for 'SENT' and 'BOUNCED'.
  */
 export const MAGIC_LINK_SEND_FAILED = 'FAILED';
-
 
 /**
  * The raw token is returned to the caller ONCE and never stored; only its
@@ -551,18 +530,61 @@ async function mintLinkFor(
 }
 
 /**
- * When this response last got a link that is STILL WORTH POINTING AT, or null.
+ * The link THIS BROWSER can prove it already received for this response, or
+ * null.
  *
- * Four conditions, and each one is a way the reuse could otherwise strand
- * somebody with a dead link and no mail:
+ * ── Why there is a reuse rule at all ───────────────────────────────────────
+ * Typing an address mints a link, and submitting would mint another. Two mails
+ * for one action reads as broken to the person receiving them, and the second
+ * makes the first ambiguous: which one do I click? Both work, so it was never
+ * incorrect — just noisy, and noisy on the one surface where a stranger can
+ * make us send mail. The link is already in their inbox; the right thing to do
+ * with it is point at it.
  *
+ * ── Why the caller has to PRESENT the link, and time is not enough ─────────
+ * This used to ask "was a link for this address minted recently?", and the
+ * window was a day. A day silently refused people: somebody who came back the
+ * next morning, or tried from their phone, or filled in a republished version,
+ * typed their address, was told to check their mail, and got nothing — because
+ * reuse had decided a link they could no longer find already covered them.
+ *
+ * Shortening the window does not fix that, it only moves it. Two minutes was
+ * the obvious answer and it is wrong in the other direction: anybody who takes
+ * longer than two minutes to fill a form in gets both mails, which is the exact
+ * noise this rule exists to remove. There is no length that is both long enough
+ * for a slow form and short enough for a return visit, because TIME IS NOT THE
+ * QUESTION. The question is "is this the same browser, still in the middle of
+ * the same fill?" — and a clock is a bad proxy for it in both directions.
+ *
+ * So the caller must NAME the link it holds. `heldTokenId` comes from the watch
+ * cookie the fill page set on the reply that sent it (see `formWatchCookie` in
+ * the pages app), so presenting one is a demonstration that this browser was
+ * the one we mailed. Same browser, same fill — silence, however long they take.
+ * A different device, a new tab after the cookie lapsed, a cleared jar, or
+ * tomorrow — nothing is presented, so a fresh link is minted and sent, which is
+ * what somebody with no link in reach actually needs.
+ *
+ * The id is a bare row handle and nothing authenticates with it, so a forged or
+ * borrowed one buys nothing: the worst it can do is suppress a mail to an
+ * address, which is exactly what its owner's own browser would have done, and
+ * `response_id` below is what stops a cookie from one address suppressing the
+ * mail for another.
+ *
+ * ── The conditions on the link itself ─────────────────────────────────────
+ * Presenting an id is not sufficient — each of these is a way reuse could
+ * otherwise strand somebody with a dead link and no mail:
+ *
+ *  - it names a token for THIS response — a browser that typed one address and
+ *    then another is holding a link that opens the wrong row;
  *  - unspent (`used_at` null) — nothing sets this column any more, since a
  *    submission now EXTENDS its link rather than spending it, but rows written
  *    before that change still carry it and a spent link opens nothing;
  *  - unexpired — the obvious one;
- *  - minted inside `MAGIC_TOKEN_REUSE_MS` — so what is handed back has real
- *    life left, not the last twenty minutes of it;
  *  - NOT KNOWN TO HAVE FAILED TO SEND — see below.
+ *
+ * There is deliberately no condition on AGE. A link a browser can still point
+ * at is one it demonstrably received; how long ago that was tells us nothing
+ * further, and the old age check is what was refusing people.
  *
  * The RAW token is not recoverable (only its digest is stored), which is
  * exactly right: reuse means "send nothing", never "send the old link again".
@@ -600,20 +622,30 @@ async function mintLinkFor(
 async function findLiveLink(
   tx: Prisma.TransactionClient,
   responseId: string,
+  heldTokenId: string | null | undefined,
   now: Date
 ): Promise<{ id: string; created_at: Date } | null> {
+  // Nothing presented, nothing to reuse — and no query worth making. A caller
+  // with no held link is a browser we have never mailed for this response, or
+  // one that can no longer show us we did; either way it needs a link of its
+  // own.
+  if (!heldTokenId) return null;
+
   return tx.formMagicToken.findFirst({
     where: {
+      id: heldTokenId,
       response_id: responseId,
       used_at: null,
       expires_at: { gt: now },
-      created_at: { gt: new Date(now.getTime() - MAGIC_TOKEN_REUSE_MS) },
       OR: [{ delivery_state: null }, { delivery_state: { not: MAGIC_LINK_SEND_FAILED } }],
     },
-    orderBy: { created_at: 'desc' },
     // The id comes back so a caller who sends NOTHING can still point a browser
     // at the send that is already outstanding — otherwise re-typing the same
-    // address would replace a real bounce watch with a dead one.
+    // address would replace a real bounce watch with a dead one. `created_at`
+    // becomes `linkAlreadySentAt`, which the fill route deliberately drops on
+    // the floor (it is a membership oracle if rendered) and the tests assert:
+    // the true age of the link they hold, however old that is, never a
+    // comfortable "just now".
     select: { id: true, created_at: true },
   });
 }
@@ -632,8 +664,8 @@ async function findLiveLink(
  * The caller composes and sends the mail (or logs the link in dev) — the same
  * "service prepares, route delivers" split roster.service uses for invites — so
  * this function stays testable and free of transport concerns. `emails` is
- * EMPTY, and `rawToken` null, when a live link already covers this response;
- * see `MAGIC_TOKEN_REUSE_MS`.
+ * EMPTY, and `rawToken` null, when the caller presents a link this browser
+ * already holds for this response; see `findLiveLink`.
  *
  * @throws MAGIC_LINK_COOLDOWN, FORM_NOT_OPEN, FORM_CLOSED, FORM_REVISION_STALE,
  *   FORM_ACCESS_MISMATCH, and the contract's answer-validation codes.
@@ -644,12 +676,20 @@ export async function beginPublicSubmission({
   name,
   answers,
   revisionId,
+  heldTokenId,
 }: {
   formId: string;
   email: string;
   name?: string | null;
   answers: unknown;
   revisionId: string;
+  /**
+   * The link this browser can show it already received for this response — the
+   * watch cookie's id, forwarded by the fill route. Reuse turns on it and on
+   * nothing else; see `findLiveLink`. Absent means "mint and send", which is
+   * the right answer for a browser that cannot point at a link.
+   */
+  heldTokenId?: string | null;
 }): Promise<BeginPublicSubmissionResult> {
   const emailNormalized = normalizeEmail(email);
   const { form: loadedForm, validated } = await validateAgainstRevision({
@@ -735,7 +775,7 @@ export async function beginPublicSubmission({
     }
 
     /**
-     * ── The second mail that used not to be worth sending ─────────────────
+     * ── The second mail that is not worth sending ─────────────────────────
      *
      * Somebody who typed their address (which mailed a link) and then submitted
      * without opening it used to get a SECOND mail, seconds after the first.
@@ -744,15 +784,18 @@ export async function beginPublicSubmission({
      * placeholder overwrite above has just put the real answers into it — so
      * there is nothing the new link would do that the old one does not.
      *
-     * Nobody is stranded by this. Reuse requires a link that is unspent,
-     * unexpired and young (`findLiveLink`), so the alternative to a mail is
-     * always a working link rather than silence; the check-email screen's
-     * resend button force-mints for the person who cannot find it; and the
-     * unverified-reminder sweep mints a fresh one six hours later on its own,
-     * because `submitted_at` moves to now here and the reused token predates
-     * it.
+     * Only for the browser that HOLDS that link, though. A submit arriving with
+     * no `heldTokenId` is a browser that cannot show us it was mailed — another
+     * device, a lapsed cookie, a submit with no blur send behind it — and the
+     * correct answer for all three is a link it can actually reach.
+     *
+     * Nobody is stranded either way. Reuse requires a link that is unspent,
+     * unexpired and not known to have failed to send (`findLiveLink`), so the
+     * alternative to a mail is always a working link rather than silence, and
+     * the check-email screen's resend button force-mints for the person who
+     * cannot find it.
      */
-    const live = await findLiveLink(tx, responseId, now);
+    const live = await findLiveLink(tx, responseId, heldTokenId, now);
     if (live) {
       return {
         responseId,
@@ -845,11 +888,16 @@ export interface AddressVerificationResult {
  * presses Submit, the link is already in their inbox — and if they clicked it
  * on the way, the submit lands in one round trip instead of two.
  *
- * ── An address that already holds a live link ──────────────────────────────
- * No mail either. One live link per address is the whole policy — see
- * `MAGIC_TOKEN_REUSE_MS` — so re-typing the same address, on this page load or
- * on tomorrow's, points at the link already in the inbox rather than adding to
- * it. `force` is the one way past it.
+ * ── A browser that already holds a live link ───────────────────────────────
+ * No mail either — for THAT BROWSER. One live link per address per fill is the
+ * policy, and `heldTokenId` is how a caller shows this fill is the one we
+ * already mailed: tabbing back past the address field, or submitting after
+ * typing it, points at the link in the inbox rather than adding to it, however
+ * long the form takes. A browser that presents nothing is one that cannot
+ * reach that link — tomorrow's page load, a phone, a cleared cookie jar — and
+ * it is mailed, because being told to check an inbox for a link you can no
+ * longer find is the failure this used to have. See `findLiveLink`. `force` is
+ * the one way past it regardless.
  *
  * ── An address that has already responded ──────────────────────────────────
  * No mail. Somebody typing their address into a form they filled in last week
@@ -872,11 +920,19 @@ export async function beginAddressVerification({
   name,
   revisionId,
   force = false,
+  heldTokenId,
 }: {
   formId: string;
   email: string;
   name?: string | null;
   revisionId: string;
+  /**
+   * The link this browser can show it already received for this response — the
+   * watch cookie's id, forwarded by the fill route. See `findLiveLink`. The
+   * resend button passes none: it is `force` anyway, and a person telling us
+   * the first link did not arrive must never be answered with it.
+   */
+  heldTokenId?: string | null;
   /**
    * Send even for an address that has already responded.
    *
@@ -949,16 +1005,17 @@ export async function beginAddressVerification({
       ).id;
 
     /**
-     * A live link already covers this address — so nothing is sent.
+     * This browser already holds a live link for this response — nothing sent.
      *
-     * The same rule the submit follows, and here it is what keeps the per-
-     * mailbox ceiling meaningful: without it, reloading the form and re-typing
-     * the same address mints a link every time, and three reloads would leave
-     * the resend button refused for an hour. `force` skips it, because a resend
-     * is the person on the screen telling us the first one did not arrive.
+     * The same rule the submit follows, and here it is what keeps one fill down
+     * to one mail: without it, tabbing back through the email field, or the
+     * blur that fires on the way to Submit, would mint a link every time and
+     * three passes would leave the resend button refused for an hour. `force`
+     * skips it, because a resend is the person on the screen telling us the
+     * first one did not arrive.
      */
     if (!force) {
-      const live = await findLiveLink(tx, responseId, now);
+      const live = await findLiveLink(tx, responseId, heldTokenId, now);
       // No mail — but the outstanding send is the one worth watching, so its id
       // goes back rather than nothing. Without this, reloading the form and
       // re-typing the same address would swap a live bounce watch for a dead
@@ -1872,5 +1929,3 @@ export async function deleteResponse(responseId: string) {
 }
 
 // ─── Expiry sweep ───────────────────────────────────────────────────────────
-
-


### PR DESCRIPTION
## The bug, as experienced

Tim, on staging: he came back to a form the next day, typed his email address, was told **"check your email"** — and nothing arrived. Nothing had failed. The reuse rule had decided a link minted the day before still covered him and suppressed the send. That link was in a mailbox he was no longer looking at, which is the same thing as having no link at all.

## Why 24 hours was once right, and is not now

The window was `24h` because it was half a magic token's 48-hour life. Tokens now live as long as their form (`LINK_OPEN_HORIZON_MS`), so that number had nothing left to be half **of** — and a day of silence was buying nothing while quietly refusing anyone who came back.

The obvious fix was to shorten it. I set it to two minutes. Tim asked the question that kills the whole approach:

> "if it takes me 2 minutes to fill out the form and I hit submit, will it send another identical one?"

Yes — and most people take longer than two minutes over a form. A day refuses the person coming back; two minutes double-mails the person filling it in. **There is no length that is both**, because time was never the question. The question is "is this the same browser, still in the middle of the same fill?", and a clock is a bad proxy for that in both directions.

Nothing from the two-minute version was pushed or opened as a PR.

## The change: reuse is scoped to the session, not to time

The caller now has to **present** the link it holds.

- `findLiveLink` takes a `heldTokenId` and reuses **only** when that id names a live token (unspent, unexpired, not delivery-`FAILED`) **for this very response**. No id, or an id naming something else → mint and mail.
- `MAGIC_TOKEN_REUSE_MS` is deleted, along with the `created_at` condition it fed. A link a browser can still point at is one it demonstrably received; how long ago tells us nothing further.
- The id is the **watch cookie** the fill page already sets on every reply that sends a link. It is a bare `form_magic_tokens` row id — it opens no link, submits no response, proves no address — which is why it was safe to hand a browser in the first place.
- The `resend` intent passes none: `force` skips the check anyway, and answering "it never arrived" with the link they hold a cookie for helps nobody.
- Watch cookie `Max-Age`: **30 min → 4 hours**. It is now the session boundary as well as the bounce-watch handle — long enough for any single sitting with interruptions, short enough that tomorrow is a new sitting.

Same browser, same fill → silence, however long they take. A phone, a new day, a cleared cookie jar → a link they can actually reach.

### Cookie scoping — verified, not assumed

- Name carries the form: `forms_watch_<slug>`, sanitised. Two forms in one classroom cannot overwrite each other.
- Path carries the classroom's forms subtree (`/<class>/forms`), which is what makes it present on React Router's `.data` requests — the RFC 6265 trap already documented in `formLinkCookie.server.ts`.
- `response_id` in the query is the **second wall**: a cookie left from a different address, or the random stand-in a no-send reply sets, resolves to nothing and mints. A foreign id can never suppress mail for an address it has nothing to do with.

## One thing the server cannot decide

Typing your address **last** and clicking Submit fires both requests: the click blurs the email field on its way to the button, so `verify-email` and `submit` leave within milliseconds and **neither carries the cookie the other is about to set**. The server sees two browsers and mails twice — which is correct behaviour for two browsers, and exactly wrong here.

On every form whose email input sits at the bottom (every form that does not ask for an email of its own, where `FormRenderer` appends the identity block last) that is the ordinary path, not an edge case. **Measured in a real browser on the e2e fixture: 2 mails.**

The page knows the two requests are one action even though the server cannot, so the blur send is held **250 ms** and dropped if a submit follows. Measured again: **1 mail**. Pinned by a new e2e that types the address last and clicks Submit directly. If client validation refuses the submit, no cancel happens and the send goes out on schedule — right, because they are still filling the form in.

## The spam ceiling is unaffected — and doing more work

`MAGIC_TOKEN_MAX_PER_WINDOW` (3) per `MAGIC_TOKEN_WINDOW_MS` (1h), per `(form, email)`, is untouched. It matters *more* now: a caller that cannot show its link is mailed rather than quietly refused, so three cookie-less attempts in an hour reach the ceiling. That is the ceiling doing the job the reuse rule no longer does, and the concurrency test asserts it explicitly (six simultaneous submits for one address → three links, three cooldowns, still exactly one row).

## Residual behaviours, named rather than hidden

- A browser that **blocks cookies** presents nothing and gets both mails (blur + submit), spending 2 of its 3 hourly slots. Two mails is worse than one and better than being told to check an inbox you have no link in.
- A **press-and-hold click** longer than 250 ms outruns the hold and double-mails. Bounded by the same ceiling.
- Verify on a phone → back on the laptop → edit the email field → the re-blur hits the "already verified" early return, which sets a stand-in watch cookie, so a following submit mints a second link for someone already verified. Noise, not harm; deliberately left alone.

## Verification (all run locally through devport 5 / `classmoji_forms`)

| Suite | Result |
| --- | --- |
| `packages/services` typecheck | **0 errors** outside the 16 pre-existing `GitLabProvider*` test errors |
| `apps/pages` typecheck | **0 errors** |
| `packages/services` full suite | **1434 passed**, 13 failed (all pre-existing GitLab), 12 skipped |
| `forms.integration.test.ts` | **74 passed** |
| `packages/tasks` | **97 passed** |
| `forms-fill.spec.ts` + `forms-early-verify.spec.ts` | **45 passed** (includes the known-flaky resend throttle test) |

Tests reworked to the new contract: blur→submit in one session reuses **even with the token backdated three hours**; a submit presenting nothing mints and mails; a presented link that is spent, expired, `FAILED`, or belongs to another response mints; the cooldown test now distinguishes a caller that can show its link from one that cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW
