### PR TITLE
fix(forms): stop two screens quoting a 48-hour link life

### DIFF
--- a/apps/pages/app/forms/fill/fill.tsx
+++ b/apps/pages/app/forms/fill/fill.tsx
@@ -1736,8 +1736,8 @@ export default function FormFill() {
               </>
             ) : (
               <>
-                Nothing is recorded until you click it. The link works for 48 hours, and the same
-                link lets you change your answers later.
+                Nothing is recorded until you click it. The same link brings you back to your
+                answers for as long as the form is open.
               </>
             )}
           </p>

--- a/apps/pages/app/forms/fill/verify.tsx
+++ b/apps/pages/app/forms/fill/verify.tsx
@@ -396,7 +396,7 @@ const PROBLEM_COPY: Record<LinkProblem, { icon: string; title: string; body: str
   expired: {
     icon: '⏳',
     title: 'This link has expired',
-    body: 'Links last 48 hours. Fill the form in again and we will send you a new one — if you already had a response saved, the new link will open it.',
+    body: 'Fill the form in again and we will send you a new one — if you already had a response saved, the new link will open it.',
   },
   // Deliberately NEUTRAL. A used token means the response was confirmed — but
   // saying so to whoever holds a spent link would confirm that the address


### PR DESCRIPTION
Two user-facing strings in the public form flow still promised a 48-hour magic link. That model is gone — a link now lives as long as its form (`LINK_OPEN_HORIZON_MS`, or the form's own `closes_at`), there are no reminders and no confirm step — so both lines were written for a system that no longer exists. The product owner hit the first one on staging.

**`apps/pages/app/forms/fill/fill.tsx`** — the check-your-email screen

- before: `Nothing is recorded until you click it. The link works for 48 hours, and the same link lets you change your answers later.`
- after: `Nothing is recorded until you click it. The same link brings you back to your answers for as long as the form is open.`

Two sentences, naming the one clock that actually exists, and the same promise the verification email already makes — so the screen and the mail now say the same thing.

**`apps/pages/app/forms/fill/verify.tsx`** — the expired-link screen

- before: `Links last 48 hours. Fill the form in again and we will send you a new one — if you already had a response saved, the new link will open it.`
- after: `Fill the form in again and we will send you a new one — if you already had a response saved, the new link will open it.`

The sentence is dropped rather than renumbered. A link can only reach this screen because its form has closed, so any duration there would be wrong whatever number it named.

### Swept and deliberately left

- `verify.tsx` "Each link works once." — `used_at` is no longer set, but rows written before that change still carry it, so that screen is reachable and accurate for exactly those legacy links.
- `admin/responses.tsx` retention hover ("Kept until … then deleted") — unreachable: `expiresAt` is hardcoded `null` in `responsesData.server.ts`. Stale but never rendered.
- Code comments only, not rewritten here: `verify.tsx`'s header ("single-use, and 48-hour-lived"), `fill.tsx:939`, and `tests/e2e/forms-fill.spec.ts` ("rather than waiting 48 hours for it").

No test asserted on either old string, so no spec changes were needed.

### Testing

- `npx tsc --noEmit -p apps/pages/tsconfig.json` — 0 errors
- `forms-fill.spec.ts` + `forms-early-verify.spec.ts` — 45 passed

PR #260 carried this same fix and was closed unmerged by mistake; this reopens it against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW
