### PR TITLE
fix(webapp): give prod room to burst, on shared-cpu-2x

### DIFF
--- a/apps/webapp/fly.toml
+++ b/apps/webapp/fly.toml
@@ -34,6 +34,14 @@ primary_region = 'iad'
   HOST = "0.0.0.0"
   PORT = "8080"
 
+# shared-cpu-2x, not 1x. A shared vCPU gets a 6.25% baseline quota plus a
+# 500-second burst credit bucket; the pooled quota scales with vCPU count, so
+# two vCPUs double the baseline to 12.5%. On 2026-08-27 the 1x machine drained
+# its bucket to zero during class hours, went to 75% steal, and served 221x 503
+# over two hours. Mean CPU is only 1-2% of a core — the failure mode is bursts
+# against a too-small baseline, not sustained load, so the fix is headroom in
+# the quota rather than a bigger machine.
 [[vm]]
   memory = '1gb'
-  cpus = 1
+  cpu_kind = 'shared'
+  cpus = 2


### PR DESCRIPTION
## Context

The prod webapp runs a **single `shared-cpu-1x` machine**. A shared vCPU gets a **6.25% baseline quota** plus a **500-second burst credit bucket**, and the pooled quota scales with vCPU count — so two vCPUs double the baseline to 12.5%.

Mean CPU on the webapp is only **1–2% of a core**, so this is not a sustained-load problem. It's a burst problem, and the burst budget has run out in production:

| When | What the metrics show |
|---|---|
| 2026-08-27 17:00–18:00 UTC | `cpu_balance` drained to `1` (of 50000), `steal` hit **75%**, edge served **221× 503** |
| 2026-08-31 12:00 UTC | smaller repeat, **46× 503** |
| 14-day window | 70/509 samples with the credit bucket meaningfully drained |

Doubling the baseline keeps ordinary class-hour bursts inside the quota instead of on credit.

## Change

`apps/webapp/fly.toml` — `cpus = 1` → `cpus = 2`, memory unchanged at 1GB. `cpu_kind` is spelled out because the size is now a deliberate choice rather than a default worth leaving implicit.

List price goes **$5.92 → $6.64/mo**.

## Why not more machines instead

Horizontal scaling is the better long-term answer, but it's blocked today: `agentStreamManager` is a per-process in-memory EventEmitter, and the syllabus-bot SSE subscribe and its `sendMessage` POST are separate requests. With two machines and no proxy affinity, roughly half of Askmoji's replies would publish into a process nobody is listening on. That's being handled separately as part of the ai-agent/Askmoji rebuild. Vertical scaling is the move that's safe right now.

The quiz path is unaffected either way — it's plain request/response with no cross-request in-process state.

## Test steps

- `flyctl config validate -c apps/webapp/fly.toml -a classmoji-webapp` → passes
- `scripts/fly-autostop-config.sh apps/webapp/fly.toml stop` → still emits a valid config with the `[[vm]]` block intact (staging/dev deploys depend on this)
- After deploy: `flyctl machines list -a classmoji-webapp` should report `shared-cpu-2x:1024MB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbtGa8FXWUnRVF6qoybXNA