### PR TITLE
fix(forms): serve the short form link on a class-site host, and a way back to the app

### DIFF
--- a/apps/pages/app/components/forms/BackToClassroom.tsx
+++ b/apps/pages/app/components/forms/BackToClassroom.tsx
@@ -1,0 +1,24 @@
+/**
+ * The way out of the forms admin and back into Classmoji.
+ *
+ * The forms screens are served by the pages app on a different origin from the
+ * webapp, so there is no nav shell around them and no in-app link that could
+ * lead anywhere but deeper into forms. Staff arriving from the classroom's
+ * Forms nav entry had nothing to click to get back.
+ *
+ * A plain `<a>`, not a `<Link>`: the target is another origin, and a client-side
+ * navigation to it would only be a 404 inside this router.
+ */
+export function BackToClassroom({ href, name }: { href: string; name: string }) {
+  return (
+    <a
+      href={href}
+      title="Back to this classroom in Classmoji"
+      className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+    >
+      ← {name}
+    </a>
+  );
+}
+
+export default BackToClassroom;

--- a/apps/pages/app/components/forms/useCopyLink.ts
+++ b/apps/pages/app/components/forms/useCopyLink.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * "Copy link", with the brief inline confirmation the forms list already uses.
+ *
+ * Shared rather than duplicated because the builder and the list copy the SAME
+ * URL and must agree about it — including the flash of feedback, which is the
+ * only thing that tells anyone the click did something.
+ *
+ * `copiedKey` rather than a boolean: the list copies one of many rows and has to
+ * put the confirmation on the row that was clicked. A single-button caller can
+ * ignore the key and compare against its own.
+ */
+export function useCopyLink(resetMs = 1500): {
+  copiedKey: string | null;
+  copy: (text: string, key?: string) => Promise<void>;
+} {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // The timeout outlives the component otherwise, and fires setState on an
+  // unmounted tree — which the builder can reach by navigating to Responses
+  // within the flash window.
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const copy = useCallback(
+    async (text: string, key = 'link') => {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        // Clipboard is permission-gated and blocked outright in some embedded
+        // contexts. The link is visible on the row's View action either way, so
+        // a refusal is a non-event rather than an error to shout about.
+        return;
+      }
+      setCopiedKey(key);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(
+        () => setCopiedKey(current => (current === key ? null : current)),
+        resetMs
+      );
+    },
+    [resetMs]
+  );
+
+  return { copiedKey, copy };
+}

--- a/apps/pages/app/forms/admin/adminLinks.server.ts
+++ b/apps/pages/app/forms/admin/adminLinks.server.ts
@@ -50,12 +50,18 @@ export function classroomHomeUrl(role: string, classroomSlug: string): string {
  * with the site feature off keeps the canonical link with no branch of its own.
  */
 export async function publicFormOrigin(
-  classroomId: string,
+  classroom: { id: string; status?: string },
   requestOrigin: string
 ): Promise<string> {
-  const site = await ClassmojiService.site.getSiteForClassroom(classroomId);
-  // A site switched off does not serve `/forms/…` either — the bridge resolves
-  // through the same lookup — so a disabled site keeps the canonical link.
+  // A classroom that has never been opened does not serve its site at all —
+  // `getSiteBySubdomain` calls that `unavailable` — so a short link built here
+  // would 404 until the instructor publishes. The canonical one works today,
+  // and a link that works is worth more than a link that is shorter.
+  if (classroom.status === 'UNPUBLISHED') return requestOrigin;
+
+  const site = await ClassmojiService.site.getSiteForClassroom(classroom.id);
+  // Same reasoning for a site switched off: the bridge resolves through the
+  // same lookup and would refuse it.
   if (!site || !site.is_enabled) return requestOrigin;
   return siteOrigin(site.subdomain) ?? requestOrigin;
 }

--- a/apps/pages/app/forms/admin/adminLinks.server.ts
+++ b/apps/pages/app/forms/admin/adminLinks.server.ts
@@ -50,18 +50,20 @@ export function classroomHomeUrl(role: string, classroomSlug: string): string {
  * with the site feature off keeps the canonical link with no branch of its own.
  */
 export async function publicFormOrigin(
-  classroom: { id: string; status?: string },
+  classroom: { id: string; status?: string; is_archived?: boolean },
   requestOrigin: string
 ): Promise<string> {
-  // A classroom that has never been opened does not serve its site at all —
-  // `getSiteBySubdomain` calls that `unavailable` — so a short link built here
-  // would 404 until the instructor publishes. The canonical one works today,
-  // and a link that works is worth more than a link that is shorter.
-  if (classroom.status === 'UNPUBLISHED') return requestOrigin;
+  // The three conditions under which the site does not serve, mirroring
+  // `getSiteBySubdomain` — which is what the bridge resolves through, so a
+  // short link built past any of them would 404 while the canonical one works.
+  // A link that works beats a link that is shorter.
+  //
+  // BOTH classroom conditions, not just the status one: `is_archived` is a
+  // separate boolean from ClassroomStatus, and the staff gate does not consider
+  // it, so staff of an archived classroom do reach this screen.
+  if (classroom.is_archived || classroom.status === 'UNPUBLISHED') return requestOrigin;
 
   const site = await ClassmojiService.site.getSiteForClassroom(classroom.id);
-  // Same reasoning for a site switched off: the bridge resolves through the
-  // same lookup and would refuse it.
   if (!site || !site.is_enabled) return requestOrigin;
   return siteOrigin(site.subdomain) ?? requestOrigin;
 }

--- a/apps/pages/app/forms/admin/adminLinks.server.ts
+++ b/apps/pages/app/forms/admin/adminLinks.server.ts
@@ -1,0 +1,61 @@
+import { ClassmojiService } from '~/utils/db.server.ts';
+// The app's one place for these reads. `app/site/env.server.ts` was written for
+// the class-site routes, but `webappUrl` and `siteOrigin` are the same two
+// answers the forms admin needs, complete with their dev fallbacks — a second
+// copy here would be a second set of defaults to keep in step.
+import { siteOrigin, webappUrl } from '~/site/env.server.ts';
+import { rolePrefix } from '~/site/tenant.server.ts';
+
+/**
+ * The two links the forms admin screens need that point OUTSIDE the pages app.
+ *
+ * Both are computed on the server because both depend on things the browser
+ * cannot see: which webapp origin this deployment talks to, and whether the
+ * classroom has a course site at all.
+ */
+
+/**
+ * Where "back to the classroom" goes, for the role that got through
+ * `assertFormAdmin`.
+ *
+ * The role prefix matters. `/admin/:class/**` carries an owner-only loader, so
+ * sending a TEACHER there would bounce them off a screen they are entitled to —
+ * they belong under `/teacher`. `rolePrefix` is the site bridge's answer to the
+ * same question and is reused rather than restated; forms admin is OWNER or
+ * TEACHER today (`requireClassroomStaff`), and the other branches cost nothing
+ * and stop being wrong the day that widens.
+ */
+export function classroomHomeUrl(role: string, classroomSlug: string): string {
+  const prefix = rolePrefix(role as Parameters<typeof rolePrefix>[0]);
+  // A role the prefix map does not know is not a reason to render a dead link:
+  // the app's front door resolves the classroom for whoever arrives.
+  if (!prefix) return `${webappUrl()}/`;
+  return `${webappUrl()}/${prefix}/${classroomSlug}/dashboard`;
+}
+
+/**
+ * The origin a form's public link should be shared on.
+ *
+ * The SHORT class-site link when the classroom has a site — `cs52.classmoji.io`
+ * — because that is the address of the course, and a link that fits on a slide
+ * is the whole point of the bridge in `app/site/forms.ts`. Both hostnames serve
+ * the same form; the site one just 302s across.
+ *
+ * Falls back to the origin that served THIS request (not `pagesUrl()`): that is
+ * what the list has always copied, and it is what keeps the link right on a
+ * devport, in a tunnel, and anywhere else the configured URL is not the one the
+ * instructor is actually looking at.
+ *
+ * `siteOrigin` returns null when SITE_BASE_DOMAIN is unset, so an environment
+ * with the site feature off keeps the canonical link with no branch of its own.
+ */
+export async function publicFormOrigin(
+  classroomId: string,
+  requestOrigin: string
+): Promise<string> {
+  const site = await ClassmojiService.site.getSiteForClassroom(classroomId);
+  // A site switched off does not serve `/forms/…` either — the bridge resolves
+  // through the same lookup — so a disabled site keeps the canonical link.
+  if (!site || !site.is_enabled) return requestOrigin;
+  return siteOrigin(site.subdomain) ?? requestOrigin;
+}

--- a/apps/pages/app/forms/admin/builder.tsx
+++ b/apps/pages/app/forms/admin/builder.tsx
@@ -110,7 +110,7 @@ export const loader = async ({
     ClassmojiService.repository.findByClassroomId(classroom.id),
     // The same origin the list copies, resolved the same way, so the two
     // surfaces can never hand out two different addresses for one form.
-    publicFormOrigin(classroom.id, new URL(request.url).origin),
+    publicFormOrigin(classroom, new URL(request.url).origin),
   ]);
 
   const revisions = (form as { revisions?: Array<{ version: number }> }).revisions ?? [];

--- a/apps/pages/app/forms/admin/builder.tsx
+++ b/apps/pages/app/forms/admin/builder.tsx
@@ -15,7 +15,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { IconListDetails, IconLock, IconPlus } from '@tabler/icons-react';
+import { IconCopy, IconListDetails, IconLock, IconPlus } from '@tabler/icons-react';
 import type { FormField } from '@classmoji/services/form-contract';
 
 import { ClassmojiService } from '~/utils/db.server.ts';
@@ -23,6 +23,9 @@ import { assertFormAdmin, formMutationBlocked } from '~/utils/formAuth.server.ts
 import FormPreview from '~/components/forms/FormPreview.tsx';
 import { ConfirmDialog } from '~/components/forms/ConfirmDialog.tsx';
 import FieldCard from '~/components/forms/builder/FieldCard.tsx';
+import { BackToClassroom } from '~/components/forms/BackToClassroom.tsx';
+import { useCopyLink } from '~/components/forms/useCopyLink.ts';
+import { classroomHomeUrl, publicFormOrigin } from './adminLinks.server.ts';
 import type { ScopeChoices } from '~/components/forms/builder/FieldConfig.tsx';
 import { FIELD_TYPE_META, makeField } from '~/components/forms/fieldTypes.ts';
 
@@ -90,7 +93,9 @@ export const loader = async ({
   request: Request;
 }) => {
   const classroomSlug = params.classroomSlug!;
-  const { classroom } = await assertFormAdmin(classroomSlug, request, { action: 'edit_form' });
+  const { classroom, membership } = await assertFormAdmin(classroomSlug, request, {
+    action: 'edit_form',
+  });
 
   const form = await ClassmojiService.form.findBySlug(classroom.id, params.formSlug!, {
     includeCurrentRevision: true,
@@ -100,15 +105,23 @@ export const loader = async ({
   // Team-review scopes. Read here rather than in the component because both
   // lists are classroom-scoped data and the picker must never be able to name a
   // tag or an assignment from another classroom.
-  const [tags, repositories] = await Promise.all([
+  const [tags, repositories, shareOrigin] = await Promise.all([
     ClassmojiService.organizationTag.findByClassroomId(classroom.id),
     ClassmojiService.repository.findByClassroomId(classroom.id),
+    // The same origin the list copies, resolved the same way, so the two
+    // surfaces can never hand out two different addresses for one form.
+    publicFormOrigin(classroom.id, new URL(request.url).origin),
   ]);
 
   const revisions = (form as { revisions?: Array<{ version: number }> }).revisions ?? [];
 
   return {
     classroomSlug,
+    classroomName: (classroom as { name?: string | null }).name ?? classroomSlug,
+    classroomHome: classroomHomeUrl(membership.role, classroomSlug),
+    // Built on the server because only the server knows whether this classroom
+    // has a course site to shorten the link onto.
+    publicUrl: `${shareOrigin}/${classroomSlug}/forms/${form.slug}`,
     form: {
       id: form.id,
       title: form.title,
@@ -254,6 +267,7 @@ export const action = async ({
 
 export default function FormBuilder() {
   const data = useLoaderData<typeof loader>();
+  const { copiedKey, copy } = useCopyLink();
   const fetcher = useFetcher<{
     error?: string;
     ok?: boolean;
@@ -371,12 +385,16 @@ export default function FormBuilder() {
     <div className="mx-auto max-w-7xl px-6 py-8">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0">
-          <Link
-            to={`/${data.classroomSlug}/forms`}
-            className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          >
-            ← Forms
-          </Link>
+          <div className="flex items-center gap-1.5 text-xs text-gray-400">
+            <BackToClassroom href={data.classroomHome} name={data.classroomName} />
+            <span className="text-gray-300 dark:text-gray-600">·</span>
+            <Link
+              to={`/${data.classroomSlug}/forms`}
+              className="hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              Forms
+            </Link>
+          </div>
           <input
             value={title}
             onChange={event => setTitle(event.target.value)}
@@ -398,6 +416,19 @@ export default function FormBuilder() {
               responses page owns its own empty state — gating this on a count
               would hide the link in precisely the case where someone is
               wondering whether anything has come in. */}
+          {/* The link a respondent gets — the SHORT one on a classroom that has
+              a course site. The builder is where a form is finished, and the
+              instructor's next move after publishing it is to send it to
+              someone; until now that meant going back to the list to find the
+              copy button. */}
+          <button
+            type="button"
+            onClick={() => copy(data.publicUrl)}
+            title={`Copy the public link to this form (${data.publicUrl})`}
+            className="flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:border-gray-400 hover:text-gray-900 dark:border-gray-600 dark:text-gray-200 dark:hover:border-gray-500 dark:hover:text-white"
+          >
+            <IconCopy size={16} /> {copiedKey ? 'Copied' : 'Copy link'}
+          </button>
           <Link
             to={`/${data.classroomSlug}/forms/${data.form.slug}/responses`}
             title="See the responses collected by this form"

--- a/apps/pages/app/forms/admin/list.tsx
+++ b/apps/pages/app/forms/admin/list.tsx
@@ -64,7 +64,7 @@ export const loader = async ({
     ClassmojiService.form.findByClassroomId(classroom.id),
     // The classroom's own site host when it has one, so what staff copy is the
     // short link they would put on a slide. See publicFormOrigin.
-    publicFormOrigin(classroom.id, new URL(request.url).origin),
+    publicFormOrigin(classroom, new URL(request.url).origin),
   ]);
 
   const classroomName = (classroom as { name?: string | null }).name ?? classroomSlug;

--- a/apps/pages/app/forms/admin/list.tsx
+++ b/apps/pages/app/forms/admin/list.tsx
@@ -15,6 +15,9 @@ import {
 import { ClassmojiService, prisma } from '~/utils/db.server.ts';
 import { assertFormAdmin, formMutationBlocked } from '~/utils/formAuth.server.ts';
 import { ConfirmDialog } from '~/components/forms/ConfirmDialog.tsx';
+import { BackToClassroom } from '~/components/forms/BackToClassroom.tsx';
+import { useCopyLink } from '~/components/forms/useCopyLink.ts';
+import { classroomHomeUrl, publicFormOrigin } from './adminLinks.server.ts';
 
 dayjs.extend(relativeTime);
 
@@ -53,16 +56,24 @@ export const loader = async ({
   request: Request;
 }) => {
   const classroomSlug = params.classroomSlug!;
-  const { classroom } = await assertFormAdmin(classroomSlug, request, { action: 'list_forms' });
+  const { classroom, membership } = await assertFormAdmin(classroomSlug, request, {
+    action: 'list_forms',
+  });
 
-  const forms = await ClassmojiService.form.findByClassroomId(classroom.id);
+  const [forms, shareOrigin] = await Promise.all([
+    ClassmojiService.form.findByClassroomId(classroom.id),
+    // The classroom's own site host when it has one, so what staff copy is the
+    // short link they would put on a slide. See publicFormOrigin.
+    publicFormOrigin(classroom.id, new URL(request.url).origin),
+  ]);
+
+  const classroomName = (classroom as { name?: string | null }).name ?? classroomSlug;
 
   return {
     classroomSlug,
-    classroomName: (classroom as { name?: string | null }).name ?? classroomSlug,
-    // The share link is built from the host that served this request, so it is
-    // right in dev, on the devport, and in production without a second env var.
-    origin: new URL(request.url).origin,
+    classroomName,
+    classroomHome: classroomHomeUrl(membership.role, classroomSlug),
+    shareOrigin,
     forms: forms.map(
       (form): FormRow => ({
         id: form.id,
@@ -177,10 +188,11 @@ const STATUS_CHIP: Record<FormStatus, string> = {
 };
 
 export default function FormsList() {
-  const { forms, classroomSlug, origin } = useLoaderData<typeof loader>();
+  const { forms, classroomSlug, classroomName, classroomHome, shareOrigin } =
+    useLoaderData<typeof loader>();
   const fetcher = useFetcher<{ error?: string; ok?: boolean }>();
   const [query, setQuery] = useState('');
-  const [copied, setCopied] = useState<string | null>(null);
+  const { copiedKey, copy } = useCopyLink();
   // The form a delete has been REQUESTED for and not yet confirmed. Holding the
   // row (not a boolean) is what lets the dialog name the form being deleted.
   const [pendingDelete, setPendingDelete] = useState<FormRow | null>(null);
@@ -193,19 +205,7 @@ export default function FormsList() {
     );
   }, [forms, query]);
 
-  const linkFor = (form: FormRow) => `${origin}/${classroomSlug}/forms/${form.slug}`;
-
-  const copyLink = async (form: FormRow) => {
-    try {
-      await navigator.clipboard.writeText(linkFor(form));
-      setCopied(form.id);
-      setTimeout(() => setCopied(current => (current === form.id ? null : current)), 1500);
-    } catch {
-      // Clipboard is permission-gated and blocked outright in some embedded
-      // contexts. The link is visible on the row's View action either way, so a
-      // refusal is a non-event rather than an error to shout about.
-    }
-  };
+  const linkFor = (form: FormRow) => `${shareOrigin}/${classroomSlug}/forms/${form.slug}`;
 
   const setStatus = (form: FormRow, status: FormStatus) => {
     fetcher.submit(
@@ -229,7 +229,10 @@ export default function FormsList() {
       <Outlet />
 
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Forms</h1>
+        <div className="min-w-0">
+          <BackToClassroom href={classroomHome} name={classroomName} />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Forms</h1>
+        </div>
         <div className="flex items-center gap-2">
           <div className="relative">
             <IconSearch
@@ -365,7 +368,7 @@ export default function FormsList() {
                       </Link>
                       <button
                         type="button"
-                        onClick={() => copyLink(form)}
+                        onClick={() => copy(linkFor(form), form.id)}
                         title="Copy the link to this form"
                         aria-label={`Copy link to ${form.title}`}
                         className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
@@ -399,7 +402,7 @@ export default function FormsList() {
                       >
                         <IconTrash size={16} />
                       </button>
-                      {copied === form.id ? (
+                      {copiedKey === form.id ? (
                         <span className="text-xs text-emerald-600 dark:text-emerald-400">
                           copied
                         </span>

--- a/apps/pages/app/forms/admin/responses.tsx
+++ b/apps/pages/app/forms/admin/responses.tsx
@@ -7,11 +7,13 @@ import { IconDownload, IconSearch, IconTrash, IconX } from '@tabler/icons-react'
 import type { FormField } from '@classmoji/services/form-contract';
 
 import AnswerView from '~/components/forms/AnswerView.tsx';
+import { BackToClassroom } from '~/components/forms/BackToClassroom.tsx';
 import { ConfirmDialog } from '~/components/forms/ConfirmDialog.tsx';
 import { answerColumnFields, formatAnswer } from '~/components/forms/answerFormat.ts';
 import { ClassmojiService } from '~/utils/db.server.ts';
 import { formMutationBlocked } from '~/utils/formAuth.server.ts';
 import { hasRepeatGroup } from './responsesCsv.server.ts';
+import { classroomHomeUrl } from './adminLinks.server.ts';
 import {
   NO_STORE,
   auditResponses,
@@ -101,9 +103,13 @@ export const loader = async ({
     data: { count: rows.length },
   });
 
+  const classroom = context.classroom as { name?: string | null; slug: string };
+
   return data(
     {
       classroomSlug: params.classroomSlug!,
+      classroomName: classroom.name ?? params.classroomSlug!,
+      classroomHome: classroomHomeUrl(context.membership.role, params.classroomSlug!),
       form: context.form,
       rows,
       suggestions,
@@ -263,6 +269,8 @@ const chipTitle = (
 export default function FormResponses() {
   const {
     classroomSlug,
+    classroomName,
+    classroomHome,
     form,
     rows,
     suggestions,
@@ -372,23 +380,26 @@ export default function FormResponses() {
   return (
     <div className="mx-auto max-w-[96rem] px-6 py-8">
       <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-base font-semibold text-gray-600 dark:text-gray-400">
-          <Link
-            to={`/${classroomSlug}/forms`}
-            className="hover:text-gray-900 dark:hover:text-white"
-          >
-            Forms
-          </Link>
-          <span className="mx-1.5 text-gray-300 dark:text-gray-600">/</span>
-          <Link
-            to={`/${classroomSlug}/forms/${form.slug}/edit`}
-            className="text-gray-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
-          >
-            {form.title}
-          </Link>
-          <span className="mx-1.5 text-gray-300 dark:text-gray-600">/</span>
-          Responses
-        </h1>
+        <div className="min-w-0">
+          <BackToClassroom href={classroomHome} name={classroomName} />
+          <h1 className="text-base font-semibold text-gray-600 dark:text-gray-400">
+            <Link
+              to={`/${classroomSlug}/forms`}
+              className="hover:text-gray-900 dark:hover:text-white"
+            >
+              Forms
+            </Link>
+            <span className="mx-1.5 text-gray-300 dark:text-gray-600">/</span>
+            <Link
+              to={`/${classroomSlug}/forms/${form.slug}/edit`}
+              className="text-gray-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
+            >
+              {form.title}
+            </Link>
+            <span className="mx-1.5 text-gray-300 dark:text-gray-600">/</span>
+            Responses
+          </h1>
+        </div>
 
         <div className="flex items-center gap-2">
           <div className="relative">

--- a/apps/pages/app/routes.ts
+++ b/apps/pages/app/routes.ts
@@ -17,8 +17,8 @@ import { flatRoutes } from '@react-router/fs-routes';
  *
  * Static segments outrank `:pageSlug` in React Router's ranking regardless of
  * declaration order, which is what keeps `RESERVED_PAGE_SLUGS`
- * (app / classmoji / sign-in / schedule / robots.txt) from being shadowed by a
- * page that claims one as its slug.
+ * (app / classmoji / sign-in / schedule / forms / robots.txt) from being
+ * shadowed by a page that claims one as its slug.
  *
  * The `/:classroomSlug/forms` subtree is declared here too, with its modules
  * under `app/forms/**`, for the same reason the site tree is: it must NOT
@@ -64,6 +64,15 @@ export default [
     // A resource route (no component): it answers with text/plain and has no
     // business rendering the site shell.
     route('robots.txt', 'site/robots.ts'),
+
+    // The short-link bridge: `cs52.classmoji.io/forms/waitlist` 302s to the
+    // canonical host's `/{classroomSlug}/forms/waitlist`. A resource route for
+    // the same reason robots.txt is one — it answers with a `Location` header,
+    // so there is nothing for the site layout to wrap. Outside the layout it
+    // also skips that loader's page-index query on a response nobody renders.
+    // Static `forms` outranks `:pageSlug`, and `forms` is in
+    // RESERVED_PAGE_SLUGS so no page can hold the segment either.
+    route('forms/*', 'site/forms.ts'),
 
     layout('site/layout.tsx', [
       index('site/home.tsx'),

--- a/apps/pages/app/site/forms.ts
+++ b/apps/pages/app/site/forms.ts
@@ -1,0 +1,60 @@
+import { redirect } from 'react-router';
+import type { LoaderFunctionArgs } from 'react-router';
+
+import { siteFormsBridgePath } from '~/utils/formsPaths.ts';
+import { siteHeaders } from './headers.server.ts';
+import { resolveSiteContext } from './tenant.server.ts';
+import { pagesUrl } from './env.server.ts';
+
+/**
+ * `/forms/…` on a class-site host — the short-link bridge.
+ *
+ * An instructor shares `cs52.classmoji.io/forms/cs52-waitlist`, because that is
+ * the address of the course and nobody wants to paste a pages-host URL onto a
+ * slide. The form itself is served from the canonical pages host at
+ * `/{classroomSlug}/forms/{formSlug}`, and this route is the 302 between them.
+ *
+ * ── Why a redirect and not the form ────────────────────────────────────────
+ * The `_site` tree is script-less SSR by design: a course site ships no
+ * hydration payload, and its Content-Security-Policy says so. A form is the
+ * opposite — a hydrated React route with client validation, a fetcher, and a
+ * delivery poll. Serving it here would mean either lifting the site's script
+ * rules for every tenant hostname, or maintaining a second, non-interactive
+ * renderer for the same form. One hop to the surface that already exists is
+ * cheaper than both, and it puts every submission on ONE origin, which is what
+ * the submission origin check and the magic-link cookie both assume.
+ *
+ * Modelled on `site/app.tsx`, the other one-domain bridge, and like it never
+ * cacheable and never indexed: the destination is derived per request and the
+ * canonical URL of a form is the one it redirects to.
+ *
+ * A RESOURCE route (no component), like `robots.ts`: it has nothing to render
+ * and no reason to run the site layout's loader for a response that is a
+ * `Location` header.
+ *
+ * The bridge lives exactly as long as the site does. A disabled, archived or
+ * unpublished site 404s here, because `resolveSiteContext` refuses it — a short
+ * link is part of the site, not a second door around it.
+ */
+export const loader = async (args: LoaderFunctionArgs) => {
+  const { request, params } = args;
+  // Resolved before the shape check, and re-read from the database rather than
+  // trusted from the routing snapshot, for the same reason every other site
+  // loader does it: a hostname re-pointed at another classroom must never send
+  // a visitor to the previous tenant's form.
+  const { site } = await resolveSiteContext(args);
+  const headers = siteHeaders({ request, cacheable: false, noindex: true });
+
+  const path = siteFormsBridgePath(params['*'] ?? '');
+  if (!path) return new Response('Not found', { status: 404, headers });
+
+  // The query string is carried VERBATIM. `/verify?token=…` is the magic link
+  // itself: a bridge that dropped the search would turn every emailed link on a
+  // class-site host into an expired-link page.
+  const { search } = new URL(request.url);
+
+  return redirect(`${pagesUrl()}/${site.classroom.slug}/forms/${path}${search}`, {
+    status: 302,
+    headers,
+  });
+};

--- a/apps/pages/app/utils/formsPaths.ts
+++ b/apps/pages/app/utils/formsPaths.ts
@@ -117,3 +117,65 @@ export function isPublicFormsPath(pathname: string): boolean {
 export function isFormsPath(pathname: string): boolean {
   return classifyFormsPath(pathname) !== null;
 }
+
+/**
+ * A form slug as `titleToIdentifier` (and therefore the create path) can
+ * produce one: lowercase alphanumerics with interior hyphens.
+ *
+ * The bridge below validates against it rather than forwarding whatever
+ * arrived, because its output goes into a `Location` header. Everything the
+ * check accepts is byte-identical decoded and raw, which is what lets the
+ * bridge read React Router's already-decoded splat param instead of doing raw
+ * path surgery on the request URL.
+ */
+const FORM_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Second-level paths under a form that the class-site bridge forwards.
+ *
+ * A superset of `PUBLIC_FORM_SUBPATHS`, and deliberately so. `delivery` is a
+ * RESOURCE route — the fill page polls it for a bounce — so `root.tsx` never
+ * runs for it and `classifyFormsPath` has no reason to exempt it from a login
+ * redirect it will never meet. The bridge asks a different question: "does this
+ * path belong to the public fill flow", and delivery does. Widening the gate's
+ * set to match would exempt a path the gate does not guard, which is a change
+ * with no upside; two sets, each answering its own question, is the honest
+ * shape.
+ */
+const BRIDGED_FORM_SUBPATHS: ReadonlySet<string> = new Set([...PUBLIC_FORM_SUBPATHS, 'delivery']);
+
+/**
+ * The canonical-host path suffix a class-site request for `/forms/{rest}`
+ * should be redirected to, or `null` when this shape is not bridged.
+ *
+ * `rest` is the splat under `_site/{subdomain}/forms/`. The answer is appended
+ * to `/{classroomSlug}/forms/` on the canonical pages host — see
+ * `app/site/forms.ts` for why a class site redirects instead of rendering.
+ *
+ * ADMIN SURFACES ARE NOT BRIDGED. `/forms` (the list), `/forms/new`, and
+ * everything under a form that is not a fill surface answer 404 on a site host:
+ * a course website is an anonymous, script-less reading surface, and a staff
+ * screen reached from it could only bounce the visitor to a login. The
+ * one-segment case is passed through `classifyFormsPath` rather than compared
+ * against a second copy of the admin names, so an admin path invented later is
+ * refused here the moment it is refused there.
+ */
+export function siteFormsBridgePath(rest: string): string | null {
+  const segments = rest.split('/').filter(Boolean);
+  // `{slug}` or `{slug}/{subpath}`. `responses/export` is the only deeper shape
+  // that exists, and it is an admin one.
+  if (segments.length === 0 || segments.length > 2) return null;
+
+  const slug = segments[0];
+  if (!FORM_SLUG.test(slug)) return null;
+  // Catches `new`; every other RESERVED_FORM_SLUGS entry is refused at create,
+  // so a bridged link to one simply finds no form on the far side.
+  if (classifyFormsPath(`/_/forms/${slug}`) !== 'public') return null;
+
+  if (segments.length === 1) return slug;
+
+  // Folded for the same reason the gate folds these: a mail client that
+  // upper-cased `/verify` must not turn a magic link into a 404.
+  const subpath = segments[1].toLowerCase();
+  return BRIDGED_FORM_SUBPATHS.has(subpath) ? `${slug}/${subpath}` : null;
+}

--- a/apps/pages/tests/e2e/forms-admin-chrome.spec.ts
+++ b/apps/pages/tests/e2e/forms-admin-chrome.spec.ts
@@ -98,6 +98,19 @@ test.describe('the way back to Classmoji', () => {
     );
   });
 
+  test('and a teacher at their own tree, which is the whole point', async ({ page }) => {
+    // `/admin/:class/**` carries an owner-only loader, so a teacher sent there
+    // would be turned away from a screen they are entitled to. This is the
+    // branch the role mapping exists for; asserting only the owner case would
+    // pass against a hardcoded `/admin`.
+    await loginAs(page, 'teacher', `/${CLASS}/forms`);
+
+    await expect(page.locator(BACK_LINK)).toHaveAttribute(
+      'href',
+      `${WEBAPP}/teacher/${CLASS}/dashboard`
+    );
+  });
+
   test('so do the builder and the responses view', async ({ page }) => {
     await loginAs(page, 'owner', `/${CLASS}/forms/${FORM_SLUG}/edit`);
     await expect(page.locator(BACK_LINK)).toHaveAttribute(

--- a/apps/pages/tests/e2e/forms-admin-chrome.spec.ts
+++ b/apps/pages/tests/e2e/forms-admin-chrome.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+
+import {
+  getClassroomIdBySlug,
+  getDevPort,
+  getPagesBaseURL,
+  getTestClassroomSlug,
+  getTestPrisma,
+  loginAs,
+} from '../helpers';
+
+/**
+ * The two ways out of the forms admin: back to Classmoji, and out to the form.
+ *
+ * ── Why these are worth a spec ─────────────────────────────────────────────
+ * The forms screens are served by the PAGES app on a different origin from the
+ * webapp, so there is no nav shell around them. Every link on them led further
+ * into forms; an instructor who followed the classroom's Forms nav entry had
+ * nothing to click to get back and used the browser's Back button or retyped
+ * the URL. The back link is the fix, and its target is not a constant — it is
+ * the viewer's ROLE prefix, because `/admin/:class/**` is owner-only and a
+ * teacher sent there would be turned away from a screen they are entitled to.
+ *
+ * The copy control is the other half: the builder is where a form is finished,
+ * and the next move after publishing is to send the link to someone. Until now
+ * that meant navigating back to the list to find the copy button.
+ *
+ * What is NOT asserted here is the SHORT link. `publicFormOrigin` resolves the
+ * classroom's site host when it has one, and the dev stack deliberately runs
+ * with SITE_BASE_DOMAIN unset (see `forms-site-link.spec.ts`), so on this
+ * server the origin resolves to the request's own — which is what these
+ * assertions expect.
+ */
+
+const CLASS = getTestClassroomSlug();
+const FORM_SLUG = 'zz-e2e-chrome';
+const WEBAPP = getDevPort('webapp') || 'http://localhost:3000';
+const PAGES = getPagesBaseURL();
+
+const BACK_LINK = 'a[title="Back to this classroom in Classmoji"]';
+
+let formId: string | null = null;
+
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+test.beforeAll(async () => {
+  const prisma = await getTestPrisma();
+  const classroomId = await getClassroomIdBySlug(CLASS);
+
+  const owner = await prisma.classroomMembership.findFirst({
+    where: { classroom_id: classroomId, role: 'OWNER' },
+    select: { user_id: true },
+  });
+  if (!owner) throw new Error('no OWNER membership — is the dev database seeded?');
+
+  // Left over from an interrupted run.
+  await prisma.form.deleteMany({ where: { classroom_id: classroomId, slug: FORM_SLUG } });
+
+  const form = await prisma.form.create({
+    data: {
+      classroom_id: classroomId,
+      title: 'ZZ E2E Chrome',
+      slug: FORM_SLUG,
+      access: 'PUBLIC',
+      status: 'DRAFT',
+      created_by: owner.user_id,
+      draft_fields: {
+        definition_version: 1,
+        fields: [
+          {
+            id: '44444444-4444-4444-8444-444444444444',
+            type: 'short_text',
+            label: 'Anything',
+            required: false,
+          },
+        ],
+      },
+    },
+  });
+  formId = form.id;
+});
+
+test.afterAll(async () => {
+  if (!formId) return;
+  const prisma = await getTestPrisma();
+  await prisma.form.delete({ where: { id: formId } }).catch(() => {});
+});
+
+test.describe('the way back to Classmoji', () => {
+  test('the list links an owner at the admin tree', async ({ page }) => {
+    await loginAs(page, 'owner', `/${CLASS}/forms`);
+
+    // The full absolute URL, not a path: the webapp is another origin, and a
+    // client-side navigation to it would only be a 404 inside this router.
+    await expect(page.locator(BACK_LINK)).toHaveAttribute(
+      'href',
+      `${WEBAPP}/admin/${CLASS}/dashboard`
+    );
+  });
+
+  test('so do the builder and the responses view', async ({ page }) => {
+    await loginAs(page, 'owner', `/${CLASS}/forms/${FORM_SLUG}/edit`);
+    await expect(page.locator(BACK_LINK)).toHaveAttribute(
+      'href',
+      `${WEBAPP}/admin/${CLASS}/dashboard`
+    );
+
+    await page.goto(`/${CLASS}/forms/${FORM_SLUG}/responses`);
+    await expect(page.locator(BACK_LINK)).toHaveAttribute(
+      'href',
+      `${WEBAPP}/admin/${CLASS}/dashboard`
+    );
+  });
+});
+
+test.describe('Copy link, from the builder', () => {
+  test('copies the same public URL the list copies', async ({ page }) => {
+    const expected = `${PAGES}/${CLASS}/forms/${FORM_SLUG}`;
+
+    await loginAs(page, 'owner', `/${CLASS}/forms/${FORM_SLUG}/edit`);
+
+    const copy = page.getByRole('button', { name: 'Copy link' });
+    await expect(copy).toBeVisible();
+    await copy.click();
+
+    // The label only flips once `writeText` has resolved, so this is the
+    // confirmation the instructor actually gets, not a proxy for it.
+    await expect(page.getByRole('button', { name: 'Copied' })).toBeVisible();
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(expected);
+  });
+
+  test('and the list copies that same URL', async ({ page }) => {
+    const expected = `${PAGES}/${CLASS}/forms/${FORM_SLUG}`;
+
+    await loginAs(page, 'owner', `/${CLASS}/forms`);
+    await page.getByRole('button', { name: 'Copy link to ZZ E2E Chrome' }).click();
+
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(expected);
+  });
+});

--- a/apps/pages/tests/e2e/forms-site-link.spec.ts
+++ b/apps/pages/tests/e2e/forms-site-link.spec.ts
@@ -25,8 +25,12 @@ import { getPagesBaseURL, getTestClassroomSlug, getTestPrisma } from '../helpers
  * this file at it:
  *
  *   cd apps/pages && npm run pages:build
- *   SITE_BASE_DOMAIN=lvh.me PAGES_URL=http://localhost:7159 PORT=7159 \
- *     NODE_ENV=production node --experimental-strip-types server.ts
+ *   # devport.sh run is not optional: it exports the DATABASE_URL of THIS
+ *   # worktree's database. Without it the server boots against the default
+ *   # `classmoji` one and the fixture below is written to the wrong place.
+ *   ../../scripts/devport.sh run env SITE_BASE_DOMAIN=lvh.me PORT=7159 \
+ *     PAGES_URL=http://localhost:7159 NODE_ENV=production \
+ *     node --experimental-strip-types server.ts
  *   FORMS_SITE_PAGES_URL=http://localhost:7159 \
  *     npx playwright test tests/e2e/forms-site-link.spec.ts
  *

--- a/apps/pages/tests/e2e/forms-site-link.spec.ts
+++ b/apps/pages/tests/e2e/forms-site-link.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+import { getPagesBaseURL, getTestClassroomSlug, getTestPrisma } from '../helpers';
+
+/**
+ * The short form link on a class-site host, over real HTTP.
+ *
+ * The product owner hit this in production: `cs52.classmoji.io/forms/cs52-
+ * waitlist` 404'd while `cs52.classmoji.io/` served fine. The `_site` subtree
+ * declared no `forms` route, so the rewritten path matched nothing. What is
+ * asserted here is the fix: a site host answers those paths with a 302 to the
+ * canonical pages host, carrying the query string — which for `/verify?token=…`
+ * IS the magic link, so dropping it would break every emailed link shared over
+ * a course site.
+ *
+ * ── Why this can skip, and what covers it when it does ─────────────────────
+ * The rewriter is inert unless SITE_BASE_DOMAIN is set, and the ordinary dev
+ * stack deliberately leaves it unset: setting it derives a `.lvh.me` cookie
+ * domain, and a `.lvh.me` cookie is never sent to `localhost`, so every
+ * localhost login in the stack would stop working. Rather than pretend, this
+ * file PROBES the server it is pointed at and skips with a message when sites
+ * are off there.
+ *
+ * To actually run it, start a second pages server with the feature on and point
+ * this file at it:
+ *
+ *   cd apps/pages && npm run pages:build
+ *   SITE_BASE_DOMAIN=lvh.me PAGES_URL=http://localhost:7159 PORT=7159 \
+ *     NODE_ENV=production node --experimental-strip-types server.ts
+ *   FORMS_SITE_PAGES_URL=http://localhost:7159 \
+ *     npx playwright test tests/e2e/forms-site-link.spec.ts
+ *
+ * The bridge's decision — which shapes bridge and which are refused — is a pure
+ * function with its own spec in `tests/unit/forms-site-bridge.spec.ts`, so the
+ * skip costs coverage of the wiring, not of the rule.
+ */
+
+const CLASS = getTestClassroomSlug();
+const BASE = process.env.FORMS_SITE_PAGES_URL || getPagesBaseURL();
+const SITE_BASE_DOMAIN = process.env.SITE_BASE_DOMAIN || 'lvh.me';
+/** A DNS label no instructor would claim, so the fixture cannot collide. */
+const SUBDOMAIN = 'zz-e2e-shortlink';
+const FORM_SLUG = 'zz-e2e-short-link';
+
+const PORT = new URL(BASE).port;
+const siteHost = `${SUBDOMAIN}.${SITE_BASE_DOMAIN}${PORT ? `:${PORT}` : ''}`;
+
+/**
+ * Does the server behind BASE have the class-site rewriter switched on?
+ *
+ * A hostname nobody claims is a plain-text 404 from the middleware when the
+ * feature is live, and falls through to the editor app's HTML when it is inert.
+ * That difference is the whole capability check, and it needs no fixture.
+ */
+async function sitesEnabled(request: APIRequestContext): Promise<boolean> {
+  const response = await request.get(`${BASE}/`, {
+    headers: { host: 'nobody-claims-this.example' },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  return response.status() === 404;
+}
+
+/** The site row this file owns, and whatever it displaced. */
+let restore: (() => Promise<void>) | null = null;
+
+test.beforeAll(async ({ request }) => {
+  if (!(await sitesEnabled(request))) return;
+
+  const prisma = await getTestPrisma();
+  const classroom = await prisma.classroom.findUnique({
+    where: { slug: CLASS },
+    select: { id: true },
+  });
+  if (!classroom) throw new Error(`test classroom ${CLASS} not found`);
+
+  // A classroom holds at most one site (classroom_id is unique), so this may be
+  // displacing a real one on a developer's machine. Remember what was there and
+  // put it back — deleting somebody's claimed subdomain would be a rude test.
+  const existing = await prisma.classroomSite.findUnique({
+    where: { classroom_id: classroom.id },
+  });
+
+  await prisma.classroomSite.upsert({
+    where: { classroom_id: classroom.id },
+    create: { classroom_id: classroom.id, subdomain: SUBDOMAIN, is_enabled: true },
+    update: { subdomain: SUBDOMAIN, is_enabled: true },
+  });
+
+  restore = async () => {
+    if (existing) {
+      await prisma.classroomSite.update({
+        where: { classroom_id: classroom.id },
+        data: { subdomain: existing.subdomain, is_enabled: existing.is_enabled },
+      });
+    } else {
+      await prisma.classroomSite.delete({ where: { classroom_id: classroom.id } });
+    }
+  };
+});
+
+test.afterAll(async () => {
+  if (restore) await restore();
+  restore = null;
+});
+
+test.describe('the short form link on a class-site host', () => {
+  test.beforeEach(async ({ request }) => {
+    test.skip(
+      !(await sitesEnabled(request)),
+      `${BASE} has SITE_BASE_DOMAIN unset — see the header for how to run this`
+    );
+  });
+
+  const bridged = async (request: APIRequestContext, path: string) => {
+    const response = await request.get(`${BASE}${path}`, {
+      headers: { host: siteHost },
+      maxRedirects: 0,
+      failOnStatusCode: false,
+    });
+    expect(response.status(), `${path} should 302`).toBe(302);
+    const location = response.headers()['location'];
+    expect(location, `${path} should carry a Location`).toBeTruthy();
+    return new URL(location);
+  };
+
+  test('a fill link 302s to the canonical host, query intact', async ({ request }) => {
+    const target = await bridged(request, `/forms/${FORM_SLUG}?x=1`);
+
+    expect(target.pathname).toBe(`/${CLASS}/forms/${FORM_SLUG}`);
+    expect(target.search).toBe('?x=1');
+    // The point of the hop: it leaves the tenant hostname behind.
+    expect(target.host).not.toBe(siteHost);
+  });
+
+  test('a magic link keeps its token', async ({ request }) => {
+    // The one query parameter that is not decoration: without it the far side
+    // renders "this link has expired" to someone holding a valid link.
+    const target = await bridged(request, `/forms/${FORM_SLUG}/verify?token=abc123&utm=mail`);
+
+    expect(target.pathname).toBe(`/${CLASS}/forms/${FORM_SLUG}/verify`);
+    expect(target.searchParams.get('token')).toBe('abc123');
+    expect(target.searchParams.get('utm')).toBe('mail');
+  });
+
+  test('the delivery poll is bridged too', async ({ request }) => {
+    const target = await bridged(request, `/forms/${FORM_SLUG}/delivery`);
+    expect(target.pathname).toBe(`/${CLASS}/forms/${FORM_SLUG}/delivery`);
+  });
+
+  test('the admin surfaces are not bridged', async ({ request }) => {
+    // A course site is anonymous and script-less; a staff screen reached from
+    // it could only bounce the visitor to a login on another origin.
+    for (const path of [
+      '/forms',
+      '/forms/new',
+      `/forms/${FORM_SLUG}/edit`,
+      `/forms/${FORM_SLUG}/responses`,
+      `/forms/${FORM_SLUG}/responses/export`,
+    ]) {
+      const response = await request.get(`${BASE}${path}`, {
+        headers: { host: siteHost },
+        maxRedirects: 0,
+        failOnStatusCode: false,
+      });
+      expect(response.status(), `${path} should not bridge`).toBe(404);
+    }
+  });
+
+  test('the internal namespace stays unreachable from the canonical host', async ({ request }) => {
+    // The bridge added a route under `/_site`; the middleware's refusal of that
+    // prefix on the canonical host has to keep covering it.
+    const response = await request.get(`${BASE}/_site/${SUBDOMAIN}/forms/${FORM_SLUG}`, {
+      maxRedirects: 0,
+      failOnStatusCode: false,
+    });
+    expect(response.status()).toBe(404);
+  });
+});

--- a/apps/pages/tests/unit/forms-site-bridge.spec.ts
+++ b/apps/pages/tests/unit/forms-site-bridge.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+
+import { classifyFormsPath, siteFormsBridgePath } from '../../app/utils/formsPaths.ts';
+
+/**
+ * The class-site short-link bridge's decision, as a pure function.
+ *
+ * ── Why this is unit-tested and not only exercised over HTTP ───────────────
+ * The e2e in `forms-site-link.spec.ts` asserts the 302 for real, but it can
+ * only do that against a server with SITE_BASE_DOMAIN configured, which the
+ * ordinary dev stack deliberately is not (a `.lvh.me` cookie domain breaks
+ * localhost logins). So on most runs the HTTP assertions skip and THIS file is
+ * the coverage — which is the same arrangement `site-host.spec.ts` and
+ * `forms-paths.spec.ts` already make for the two other decisions in this
+ * subtree that are pure by design.
+ *
+ * The property that matters most here is the REFUSAL: the function's output
+ * lands in a `Location` header, so anything it does not recognize has to come
+ * back null rather than be forwarded and hoped for.
+ */
+
+test.describe('siteFormsBridgePath — the public fill surfaces', () => {
+  test('a bare form slug bridges', () => {
+    expect(siteFormsBridgePath('cs52-waitlist')).toBe('cs52-waitlist');
+  });
+
+  test('the magic-link review page bridges', () => {
+    expect(siteFormsBridgePath('cs52-waitlist/verify')).toBe('cs52-waitlist/verify');
+  });
+
+  test('the delivery poll bridges', () => {
+    // Classified 'admin' by the auth gate and bridged anyway — see the comment
+    // on BRIDGED_FORM_SUBPATHS. The two sets answer different questions, and
+    // this assertion is what would notice them being collapsed into one.
+    expect(classifyFormsPath('/cs52/forms/w/delivery')).toBe('admin');
+    expect(siteFormsBridgePath('cs52-waitlist/delivery')).toBe('cs52-waitlist/delivery');
+  });
+
+  test('a subpath whose case a mail client touched still resolves', () => {
+    expect(siteFormsBridgePath('cs52-waitlist/VERIFY')).toBe('cs52-waitlist/verify');
+  });
+
+  test('a trailing or doubled slash does not change the answer', () => {
+    expect(siteFormsBridgePath('cs52-waitlist/')).toBe('cs52-waitlist');
+    expect(siteFormsBridgePath('cs52-waitlist//verify')).toBe('cs52-waitlist/verify');
+  });
+});
+
+test.describe('siteFormsBridgePath — everything it refuses', () => {
+  test('the admin list is not bridged', () => {
+    // The empty splat: `{subdomain}.classmoji.io/forms` itself.
+    expect(siteFormsBridgePath('')).toBeNull();
+    expect(siteFormsBridgePath('/')).toBeNull();
+  });
+
+  test('the admin surfaces under a form are not bridged', () => {
+    expect(siteFormsBridgePath('new')).toBeNull();
+    expect(siteFormsBridgePath('cs52-waitlist/edit')).toBeNull();
+    expect(siteFormsBridgePath('cs52-waitlist/responses')).toBeNull();
+    expect(siteFormsBridgePath('cs52-waitlist/responses/export')).toBeNull();
+  });
+
+  test('an unknown subpath is refused rather than forwarded', () => {
+    // Default deny. A route added under the subtree later is not bridged until
+    // somebody lists it, which is the safe end of the ambiguity.
+    expect(siteFormsBridgePath('cs52-waitlist/whatever')).toBeNull();
+  });
+
+  test('a slug that is not a slug is refused', () => {
+    // Everything here would otherwise be spliced into a Location header. The
+    // splat arrives DECODED, so these are the shapes that matter: a smuggled
+    // separator, an absolute URL, a scheme, whitespace, uppercase.
+    for (const rest of [
+      '..',
+      'a/../../etc',
+      'waitlist?x=1',
+      'waitlist#x',
+      'https://evil.example',
+      'evil.example',
+      'wait list',
+      'Waitlist',
+      'wait_list',
+      'wait%2flist',
+      '-leading',
+      'trailing-',
+      // titleToIdentifier collapses hyphen runs, so no real slug looks like this.
+      'double--hyphen',
+    ]) {
+      expect(siteFormsBridgePath(rest), `${rest} must not bridge`).toBeNull();
+    }
+  });
+
+  test('a protocol-relative slug cannot become an off-site redirect', () => {
+    // `//evil.example` as the rest would make the Location protocol-relative if
+    // it were ever concatenated raw. It is two empty segments plus a host, and
+    // the host fails the slug check.
+    expect(siteFormsBridgePath('//evil.example')).toBeNull();
+    expect(siteFormsBridgePath('/\\evil.example')).toBeNull();
+  });
+});

--- a/packages/database/migrations/20260902180000_reserve_forms_page_slug/migration.sql
+++ b/packages/database/migrations/20260902180000_reserve_forms_page_slug/migration.sql
@@ -1,0 +1,89 @@
+-- `forms` joins RESERVED_PAGE_SLUGS: evict the pages already holding it.
+--
+-- Why now: a class site serves the short form link at
+-- `{subdomain}.classmoji.io/forms/{formSlug}`, so `forms` is now a platform-
+-- owned first segment inside a course site the same way `schedule` and `app`
+-- are. Static segments outrank `:pageSlug` in the router, so a page slugged
+-- `forms` is not a security problem — it is simply a page nobody can open, and
+-- the instructor's first hint would be a broken link.
+--
+-- Modelled on 20260821003300_page_slug_backfill_and_unique, which added the
+-- registry's first five entries and says in its own header that a later
+-- addition "needs a new migration modelled on this one". This is that
+-- migration, narrowed to the one thing it has to do: there are no backfills or
+-- duplicates left to repair (the unique index has been enforcing that since
+-- August), so the only case here is an incumbent on a newly reserved slug.
+--
+-- ⚠ The reserved list below is a copy of RESERVED_PAGE_SLUGS in
+-- packages/utils/src/subdomains.ts, which is the single authority (SQL cannot
+-- import it). `subdomains.test.ts` asserts the two agree.
+-- ---------------------------------------------------------------------------
+
+-- The same audit table the August migration wrote to, and for the same reason:
+-- these renames change PUBLIC URLs, and the old value is overwritten in place,
+-- so without a row nothing in the system remembers what a link used to be.
+-- IF NOT EXISTS because that migration created it and nothing has dropped it.
+CREATE TABLE IF NOT EXISTS "_page_slug_repairs" (
+  page_id     TEXT NOT NULL,
+  classroom_id TEXT NOT NULL,
+  old_slug    TEXT,
+  new_slug    TEXT,
+  reason      TEXT NOT NULL,  -- 'backfill' | 'duplicate' | 'reserved'
+  repaired_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+DO $$
+DECLARE
+  -- Mirrors RESERVED_PAGE_SLUGS in packages/utils/src/subdomains.ts, same order.
+  reserved CONSTANT TEXT[] := ARRAY['app', 'classmoji', 'sign-in', 'schedule', 'forms', 'robots.txt'];
+  -- Mirrors PAGE_SLUG_MAX_SUFFIX in packages/services/src/classmoji/page.service.ts.
+  max_suffix CONSTANT INT := 50;
+  loser  RECORD;
+  cands  TEXT[];
+  cand   TEXT;
+  chosen TEXT;
+  n_evicted INT;
+BEGIN
+  SELECT COUNT(*) INTO n_evicted FROM "pages" WHERE "slug" = 'forms';
+  RAISE NOTICE 'reserving page slug "forms": % page(s) to evict', n_evicted;
+
+  -- Every row holding it is evicted, including the oldest: a reserved slug has
+  -- no winner. Ordered so a dry run, staging and production resolve two pages
+  -- in one classroom the same way.
+  FOR loser IN
+    SELECT "id", "classroom_id", "slug" AS old_slug
+    FROM "pages"
+    WHERE "slug" = 'forms'
+    ORDER BY "classroom_id", "created_at", "id"
+  LOOP
+    cands := ARRAY(SELECT loser.old_slug || '-' || n FROM generate_series(2, max_suffix) AS n);
+    chosen := NULL;
+
+    FOREACH cand IN ARRAY cands
+    LOOP
+      CONTINUE WHEN cand = ANY (reserved);
+      -- Reads LIVE state, so an already-present `forms-2` pushes this row onto
+      -- `forms-3` rather than onto a 23505.
+      IF NOT EXISTS (
+        SELECT 1 FROM "pages" other
+        WHERE other."id" <> loser.id
+          AND other."classroom_id" = loser.classroom_id
+          AND other."slug" = cand
+      ) THEN
+        chosen := cand;
+        EXIT;
+      END IF;
+    END LOOP;
+
+    IF chosen IS NULL THEN
+      -- Insurance tail: `id` is a uuid, so this cannot collide. Only reachable
+      -- if one classroom already holds 49 variants of `forms`.
+      chosen := loser.old_slug || '-' || loser.id;
+    END IF;
+
+    INSERT INTO "_page_slug_repairs" (page_id, classroom_id, old_slug, new_slug, reason)
+    VALUES (loser.id, loser.classroom_id, loser.old_slug, chosen, 'reserved');
+
+    UPDATE "pages" SET "slug" = chosen WHERE "id" = loser.id;
+  END LOOP;
+END $$;

--- a/packages/database/migrations/20260902180000_reserve_forms_page_slug/migration.sql
+++ b/packages/database/migrations/20260902180000_reserve_forms_page_slug/migration.sql
@@ -44,16 +44,25 @@ DECLARE
   chosen TEXT;
   n_evicted INT;
 BEGIN
-  SELECT COUNT(*) INTO n_evicted FROM "pages" WHERE "slug" = 'forms';
-  RAISE NOTICE 'reserving page slug "forms": % page(s) to evict', n_evicted;
+  SELECT COUNT(*) INTO n_evicted FROM "pages" WHERE "slug" = ANY (reserved);
+  RAISE NOTICE 'reserving page slug "forms": % page(s) on a reserved slug', n_evicted;
 
-  -- Every row holding it is evicted, including the oldest: a reserved slug has
+  -- Driven off `reserved`, NOT off the literal 'forms', for two reasons. It is
+  -- what makes the array the eviction set rather than decoration — the
+  -- cross-file test in packages/utils asserts exactly that, and a contributor
+  -- copying this file for a seventh reserved slug would otherwise add it to the
+  -- array, watch the test go green, and evict nothing. And it costs nothing:
+  -- the other five were evicted in August and page.service has refused them at
+  -- create ever since, so they match no rows here and a re-apply matches none
+  -- either.
+  --
+  -- Every row holding one is evicted, including the oldest: a reserved slug has
   -- no winner. Ordered so a dry run, staging and production resolve two pages
   -- in one classroom the same way.
   FOR loser IN
     SELECT "id", "classroom_id", "slug" AS old_slug
     FROM "pages"
-    WHERE "slug" = 'forms'
+    WHERE "slug" = ANY (reserved)
     ORDER BY "classroom_id", "created_at", "id"
   LOOP
     cands := ARRAY(SELECT loser.old_slug || '-' || n FROM generate_series(2, max_suffix) AS n);

--- a/packages/utils/src/__tests__/subdomains.test.ts
+++ b/packages/utils/src/__tests__/subdomains.test.ts
@@ -77,19 +77,43 @@ describe('cross-file registry agreement', () => {
   const repoFile = (relative: string) =>
     readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf-8');
 
-  it('RESERVED_PAGE_SLUGS matches the migration that evicted pages holding them', () => {
-    const sql = repoFile(
-      '../../../database/migrations/20260821003300_page_slug_backfill_and_unique/migration.sql'
-    );
+  const reservedArrayIn = (migration: string): Set<string> => {
+    const sql = repoFile(`../../../database/migrations/${migration}/migration.sql`);
     const declaration = sql.match(/reserved CONSTANT TEXT\[\] := ARRAY\[([^\]]+)\]/);
-    if (!declaration) throw new Error('reserved array not found in the migration');
+    if (!declaration) throw new Error(`reserved array not found in ${migration}`);
 
-    const fromSql = declaration[1]
-      .split(',')
-      .map(entry => entry.trim().replace(/^'|'$/g, ''))
-      .filter(Boolean);
+    return new Set(
+      declaration[1]
+        .split(',')
+        .map(entry => entry.trim().replace(/^'|'$/g, ''))
+        .filter(Boolean)
+    );
+  };
 
-    expect(new Set(fromSql)).toEqual(new Set(RESERVED_PAGE_SLUGS));
+  /**
+   * The LATEST eviction migration is the one that has to match exactly: it ran
+   * against every row in the table, so anything reserved but absent from its
+   * array is a slug some page still holds and the router will never reach.
+   * Adding an entry to the registry means adding a migration here too.
+   */
+  it('RESERVED_PAGE_SLUGS matches the migration that evicted pages holding them', () => {
+    expect(reservedArrayIn('20260902180000_reserve_forms_page_slug')).toEqual(
+      new Set(RESERVED_PAGE_SLUGS)
+    );
+  });
+
+  /**
+   * Earlier migrations are HISTORY — they name the registry as it stood when
+   * they ran — so they are only required to be a subset. An entry that vanished
+   * from the registry but still appears in one of them would mean a page was
+   * evicted from a path that is free again, which nothing else would catch.
+   */
+  it('the first eviction migration lists only slugs still reserved today', () => {
+    for (const slug of reservedArrayIn('20260821003300_page_slug_backfill_and_unique')) {
+      expect(RESERVED_PAGE_SLUGS.has(slug), `${slug} was evicted but is no longer reserved`).toBe(
+        true
+      );
+    }
   });
 
   it('SUBDOMAIN_REGEX matches the CHECK constraint that enforces it', () => {

--- a/packages/utils/src/subdomains.ts
+++ b/packages/utils/src/subdomains.ts
@@ -162,10 +162,17 @@ export const RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
  * because the platform answers that path first.
  *
  * Two other places must agree with this set and cannot import it:
- *   - packages/database/migrations/20260821003300_page_slug_backfill_and_unique/migration.sql
- *     re-lists it (SQL has no imports) to evict pages already squatting on one.
+ *   - the migrations that evict pages already squatting on one (SQL has no
+ *     imports, so each re-lists the whole set):
+ *     20260821003300_page_slug_backfill_and_unique added the first five;
+ *     20260902180000_reserve_forms_page_slug added `forms`.
  *   - the site route table, which is what actually claims these paths.
  * page.service's create() DOES import it, so new pages can never land here.
+ *
+ * ADDING AN ENTRY IS TWO CHANGES, not one. Listing a slug here stops new pages
+ * from taking it; it does nothing about the pages already holding it, which
+ * keep a slug the router will never reach. Each addition therefore ships with a
+ * migration that evicts the incumbents, modelled on the August one.
  *
  * `robots.txt` cannot currently be produced by titleToIdentifier (the dot is
  * stripped) and is listed anyway: the registry describes the URL namespace, not
@@ -176,6 +183,8 @@ export const RESERVED_PAGE_SLUGS: ReadonlySet<string> = new Set([
   'classmoji',
   'sign-in',
   'schedule',
+  // The class-site short link to a form: `{subdomain}/forms/{formSlug}`.
+  'forms',
   'robots.txt',
 ]);
 


### PR DESCRIPTION
Three things the product owner hit testing forms in production. One is a real bug; two are gaps.

## 1. The short form link 404'd on a class-site host

`https://cs52.classmoji.io/forms/cs52-waitlist` → 404, while `https://cs52.classmoji.io/` → 200. `server/siteHost.ts` rewrites a class-site request onto `/_site/{subdomain}/…`, and that subtree declared `index`, `sign-in`, `schedule`, `app` and `:pageSlug` — nothing for `forms`. The real forms routes all live under `/:classroomSlug/forms/…` on the canonical pages host, so the rewritten path matched no route at all.

**The design: a 302 bridge**, mirroring `site/app.tsx`, the one-domain bridge already sitting next to it. A site host answers `/forms/{slug}` by redirecting to `${PAGES_URL}/{classroomSlug}/forms/{slug}`, carrying the query string verbatim.

**Why a redirect and not the form.** The `_site` tree is script-less SSR by design — a course site ships no hydration payload and its CSP says so. A form is the opposite: a hydrated React route with client validation, a fetcher and a delivery poll. Serving it on the tenant origin would mean either lifting the site's script rules for every tenant hostname, or maintaining a second non-interactive renderer for the same form. One hop is cheaper than both, and it keeps every submission on **one** origin, which the submission origin check and the magic-link cookie both assume.

**The query string is load-bearing.** `/verify?token=…` *is* the magic link; a bridge that dropped the search would turn every emailed link shared over a course site into an expired-link page. `/delivery` is bridged too, so a fill page that starts on the short link can still poll for a bounce.

**Deliberately not bridged:** the admin list (`/forms`), `/forms/new`, `/…/edit`, `/…/responses` and its export. Those **404** rather than redirecting to the list — a course site host has no session, so a staff screen reached from it could only bounce the visitor to a login on another origin. The shape check refuses by default, so a route invented under the subtree later is not bridged until somebody lists it.

The bridge is a resource route (loader only, no component), like `robots.ts`, and lives outside the site layout so it skips that loader's page-index query on a response nobody renders. It serves exactly as long as the site does: a disabled, archived or unpublished site 404s, because it resolves through the same `resolveSiteContext` every other site loader uses — which also re-reads the tenant from the database, so a re-pointed custom domain can never send a visitor to the previous tenant's form.

**`forms` also joins `RESERVED_PAGE_SLUGS`.** Route ranking already shadows a page slugged `forms`, which is the quiet failure the registry exists to prevent — the instructor's first hint would be a link that goes nowhere. Listing it only stops *new* pages, so it ships with the eviction migration the August one says an addition needs, and the cross-file test now matches the registry against the newest migration (the earlier one is history, checked as a subset).

## 2. A way back to Classmoji from the forms admin

The forms screens are served by the pages app on a different origin from the webapp, so there is no nav shell and every link led further into forms. All three screens now carry a link to the classroom's dashboard. Its target is not a constant: `/admin/:class/**` is owner-only, so a teacher sent there would be turned away from a screen they are entitled to. It resolves through `rolePrefix`, the same function the site's `/app` bridge uses for the same question. Forms admin is OWNER or TEACHER today; the other branches cost nothing and stop being wrong the day that widens.

## 3. Copy link from the builder

The builder is where a form is finished, and the next move after publishing is to send the link to someone — which until now meant navigating back to the list to find the copy button. It shares the list's implementation rather than growing a second one: one hook for the copy-and-flash (the existing inline "copied", not a dialog), one server helper for the URL.

That URL is now the **short** one on a classroom with a course site — the link the bridge above exists to serve. It falls back to the origin that served the request when there is no site, when the site is disabled, when the classroom is still UNPUBLISHED (the site does not serve yet, so the short link would 404), or when `SITE_BASE_DOMAIN` is unset as it is in local dev. That fallback is exactly what the list copied before, so nothing changes for anyone without a site.

## Verification

- `cd apps/pages && npx tsc --noEmit -p tsconfig.json` → **0 errors**. `eslint` on the touched files → 0 errors.
- Full pages e2e via devport → **613 passed, 17 skipped** (the 12 known skips plus 5 from the new site-link spec, which probes the server and skips when `SITE_BASE_DOMAIN` is unset).
- `packages/utils` → 127 passed, including the rewritten cross-file registry test.
- New bridge unit spec → 10 passed. New admin-chrome e2e → 5 passed, including the TEACHER branch of the back link (a hardcoded `/admin` would pass the owner cases).
- Migration applied to the devport database, and its eviction branch exercised in a rolled-back transaction: a page holding `forms` alongside an incumbent `forms-2` was moved to `forms-3`, a stray `schedule` page to `schedule-2`, both logged to `_page_slug_repairs`, and a second apply in the same transaction was a clean no-op.

The bridge was then curled for real, against a local pages server built and started with the feature on (`SITE_BASE_DOMAIN=lvh.me`, `PAGES_URL=http://localhost:7159`, devport `DATABASE_URL`) and a `cs52` site row:

```
$ curl -s -o /dev/null -D - -H 'Host: cs52.lvh.me:7159' \
    'http://localhost:7159/forms/cs52-waitlist?x=1'
HTTP/1.1 302 Found
cache-control: no-store
location: http://localhost:7159/classmoji-dev-winter-2025/forms/cs52-waitlist?x=1
x-robots-tag: noindex

$ curl -s -o /dev/null -D - -H 'Host: cs52.lvh.me:7159' \
    'http://localhost:7159/forms/cs52-waitlist/verify?token=abc123&x=2'
HTTP/1.1 302 Found
location: http://localhost:7159/classmoji-dev-winter-2025/forms/cs52-waitlist/verify?token=abc123&x=2

$ curl -s -o /dev/null -D - -H 'Host: cs52.lvh.me:7159' \
    'http://localhost:7159/forms/cs52-waitlist/delivery'
HTTP/1.1 302 Found
location: http://localhost:7159/classmoji-dev-winter-2025/forms/cs52-waitlist/delivery
```

And the refusals — admin surfaces, an unclaimed subdomain, and the internal namespace on the canonical host:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: cs52.lvh.me:7159' http://localhost:7159/forms
404
$ curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: cs52.lvh.me:7159' http://localhost:7159/forms/cs52-waitlist/edit
404
$ curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: nope.lvh.me:7159' http://localhost:7159/forms/cs52-waitlist
404
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:7159/_site/cs52/forms/cs52-waitlist
404
```

The canonical destination serves: `GET /classmoji-dev-winter-2025/forms/cs52-waitlist?x=1` → 200.

## Review follow-up (`ea640b0a`)

A local review pass found no security issue with the redirect — it tried the encoded separators, the protocol-relative and scheme-prefixed shapes, and the dot segments, and the anchored slug check plus the canonical-Set subpath hold. It did find two claims the code did not quite make:

- `publicFormOrigin` mirrored only half of `getSiteBySubdomain`'s refusal. `is_archived` is a separate boolean from `ClassroomStatus`, and the staff gate does not consider it, so staff of an archived classroom would have copied a short link that 404s. Both conditions now.
- The eviction migration listed the whole registry in `reserved` but evicted on the literal `'forms'`, which made the array decoration — while the cross-file test asserts the array *equals* the registry and reasons from it that every reserved slug has been evicted. It now evicts on `= ANY (reserved)`, as the August migration it is modelled on does. The other five match no rows (evicted then, refused at create ever since).

Both fixed in `ea640b0a`, with the migration re-applied and re-verified. Four low-severity suggestions were noted and deliberately not taken here: the short link does not yet prefer a verified custom domain (`canonicalOriginForSite` already encodes that rule — a good follow-up); `/delivery` is bridged although nothing currently requests it on a site host; `siteOrigin` takes its port from `PAGES_URL`, so on a devport the copied short link would name the default pages port; and the bridge resolves a viewer it does not use, because it shares `resolveSiteContext` with every other site loader.

## Test steps

1. Set `SITE_BASE_DOMAIN` on staging (or run the second server as the spec header describes), give a classroom a site, and open `{subdomain}.{base}/forms/{formSlug}` — it should land on the fill page with any query intact.
2. Open a form's builder as an owner: the header should read "← {Classroom} · Forms", and "Copy link" should copy the site-host URL.
3. Same check on the list and the responses view for the back link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW
