### PR TITLE
fix(pages): render a not-found for unmatched class-site URLs

### DIFF
--- a/apps/pages/app/root.tsx
+++ b/apps/pages/app/root.tsx
@@ -6,6 +6,7 @@ import {
   ScrollRestoration,
   redirect,
   useLocation,
+  isRouteErrorResponse,
   useRouteError,
   useLoaderData,
   useRouteLoaderData,
@@ -393,9 +394,22 @@ const Root = () => {
 
 // Error boundary
 export function ErrorBoundary() {
-  const error = useRouteError() as { message?: string; stack?: string } | undefined;
+  const routeError = useRouteError();
+  const error = routeError as { message?: string; stack?: string } | undefined;
   const location = useLocation();
   const isDevelopment = import.meta.env.MODE === 'development';
+
+  /**
+   * A 404 is a bad address, not a broken server, and telling someone to "try
+   * again in a moment" is advice that can never work — it reads as an outage we
+   * are about to fix.
+   *
+   * Every site route now throws its own 404 into the class-site layout's
+   * boundary (see `site/not-found.tsx`), so this is the BACKSTOP for whatever
+   * still reaches the root: a 404 thrown above the layout, or one on the editor
+   * app's own tree.
+   */
+  const isNotFound = isRouteErrorResponse(routeError) && routeError.status === 404;
 
   // The loader may be what threw, so the site flag is derived from the URL
   // rather than loader data.
@@ -412,10 +426,14 @@ export function ErrorBoundary() {
         <body className="bg-gray-50 dark:bg-[#191919]">
           <div className="min-h-screen flex flex-col items-center justify-center px-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-              This page is unavailable
+              {isNotFound ? 'Not found' : 'This page is unavailable'}
             </h1>
             <p className="text-gray-600 dark:text-gray-400">
-              {isDevelopment ? error?.message : 'Try again in a moment.'}
+              {isNotFound
+                ? 'That address does not match anything on this site.'
+                : isDevelopment
+                  ? error?.message
+                  : 'Try again in a moment.'}
             </p>
             {isDevelopment && error?.stack && (
               <pre className="mt-4 p-4 bg-gray-100 rounded-md text-xs overflow-auto max-w-2xl">
@@ -440,18 +458,26 @@ export function ErrorBoundary() {
         <div className="min-h-screen flex flex-col items-center justify-center px-4">
           <div className="text-6xl mb-4 text-center">📄</div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-            Something went wrong
+            {isNotFound ? 'Not found' : 'Something went wrong'}
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            {isDevelopment ? error?.message : 'Please try refreshing the page.'}
+            {isNotFound
+              ? 'That address does not match anything here.'
+              : isDevelopment
+                ? error?.message
+                : 'Please try refreshing the page.'}
           </p>
           <div className="flex gap-4">
-            <button
-              onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800"
-            >
-              Refresh
-            </button>
+            {/* Reloading a 404 reproduces the 404. Only the way back out is
+                worth offering. */}
+            {isNotFound ? null : (
+              <button
+                onClick={() => window.location.reload()}
+                className="px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800"
+              >
+                Refresh
+              </button>
+            )}
             <button
               onClick={() => window.history.back()}
               className="px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50"

--- a/apps/pages/app/routes.ts
+++ b/apps/pages/app/routes.ts
@@ -80,6 +80,16 @@ export default [
       route('schedule', 'site/schedule.tsx'),
       route('app', 'site/app.tsx'),
       route(':pageSlug', 'site/page.tsx'),
+
+      // Everything else on a course site. Inside the layout ON PURPOSE: the
+      // shell's ErrorBoundary is the only thing that renders a branded 404, and
+      // without this route a two-segment address matched nothing and fell all
+      // the way to the ROOT boundary's generic "try again in a moment".
+      //
+      // A splat carries `splatPenalty` and therefore always ranks LAST, so it
+      // cannot shadow a sibling: `forms/*`, `:pageSlug`, the static segments and
+      // the index all outrank it. Asserted in `tests/unit/site-routes.spec.ts`.
+      route('*', 'site/not-found.tsx'),
     ]),
   ]),
 ] satisfies RouteConfig;

--- a/apps/pages/app/site/layout.tsx
+++ b/apps/pages/app/site/layout.tsx
@@ -105,13 +105,37 @@ const SiteLayout = () => {
  *
  * A missing subdomain and a switched-off site render the same 404 shape on
  * purpose: telling a stranger "this subdomain exists but is disabled" is an
- * enumeration oracle over every course we host.
+ * enumeration oracle over every course we host. That merge is between those
+ * TWO, and only those two.
+ *
+ * A bad path on a site that resolved is the third case, and it is safe to name:
+ * this boundary only renders it after the layout's own loader has already
+ * resolved the tenant, so the site is known to exist and to be switched on
+ * before the sentence is written. Saying "there's no page at this address"
+ * there discloses nothing a visitor could not learn by loading the home page,
+ * and telling them "there's no site here" while they are looking at the site's
+ * own chrome is simply wrong. `no-page` is thrown by page.tsx, schedule.tsx and
+ * not-found.tsx; `missing` stays reserved for the hostname that resolves to
+ * nothing.
  */
 export function ErrorBoundary() {
   const error = useRouteError();
 
   if (isRouteErrorResponse(error)) {
     if (error.status === 404) {
+      if (error.data === 'no-page') {
+        return (
+          <SiteNotice
+            title="There's no page at this address"
+            message="Nothing on this course site lives at that address. Check the link, or start from the site's home page."
+            // Relative on purpose: the same markup is served from the
+            // subdomain and from a verified custom domain, and an absolute
+            // origin would send half the visitors to the other hostname.
+            action={{ href: '/', label: 'Go to the site home' }}
+          />
+        );
+      }
+
       const unavailable = error.data === 'unavailable';
       return (
         <SiteNotice

--- a/apps/pages/app/site/not-found.tsx
+++ b/apps/pages/app/site/not-found.tsx
@@ -1,0 +1,56 @@
+import type { HeadersFunction, LoaderFunctionArgs } from 'react-router';
+
+import { routeSiteHeaders, siteHeaders } from './headers.server.ts';
+
+/**
+ * The catch-all inside the class-site shell: any URL on a course site that
+ * matches no other route.
+ *
+ * ── What this fixes ────────────────────────────────────────────────────────
+ * `/{pageSlug}` already 404s properly for a slug nobody authored — page.tsx
+ * throws a 404 Response and the layout's ErrorBoundary renders the branded
+ * notice. But anything with a SECOND segment
+ * (`cs52.classmoji.io/dartmouth-cs52-26f/forms/cs52-waitlist`, a real link
+ * somebody shared) matched nothing at all, so React Router's built-in 404
+ * bubbled past the layout to the ROOT boundary — which rendered "This page is
+ * unavailable / Try again in a moment." A mistyped link read as an outage, and
+ * "try again" is advice that can never work.
+ *
+ * Throwing the same 404 as page.tsx puts every unmatched address through the
+ * one boundary that already knows how to say "there's nothing here", with the
+ * site's CSP and `no-store`/`noindex` headers attached.
+ *
+ * ── Ranking ────────────────────────────────────────────────────────────────
+ * A splat scores LOWEST in React Router's ranking (`splatPenalty`), so it can
+ * never shadow its siblings: on `/_site/:subdomain/…`, `forms/*` scores 27 and
+ * `:pageSlug` 21 against this route's 16, and the index route outranks it on
+ * the bare site root. `tests/unit/site-routes.spec.ts` asserts that against the
+ * real route config rather than trusting the arithmetic.
+ */
+export const loader = ({ request }: LoaderFunctionArgs) => {
+  // Byte-identical to page.tsx's "no such page" refusal: same status, same
+  // `error.data`, so the layout's ErrorBoundary renders ONE not-found for both
+  // and there is no second copy to keep in sync.
+  throw new Response('missing', {
+    status: 404,
+    headers: siteHeaders({ request, cacheable: false, noindex: true }),
+  });
+};
+
+export const headers: HeadersFunction = args => routeSiteHeaders(args);
+
+/**
+ * Never rendered — the loader always throws — but it must EXIST.
+ *
+ * React Router's server treats a leaf match whose module exports neither
+ * `default` nor `ErrorBoundary` as a resource request: the loader's thrown
+ * Response is sent back verbatim, which here would be a bare `text/plain`
+ * `missing` body instead of the site's branded 404 document. So this is not a
+ * stray export to tidy away into a resource route like `robots.ts`; it is what
+ * routes the throw through the layout's boundary.
+ *
+ * Returning null keeps the page script-less, exactly like the rest of the tree.
+ */
+const SiteNotFound = () => null;
+
+export default SiteNotFound;

--- a/apps/pages/app/site/not-found.tsx
+++ b/apps/pages/app/site/not-found.tsx
@@ -31,7 +31,12 @@ export const loader = ({ request }: LoaderFunctionArgs) => {
   // Byte-identical to page.tsx's "no such page" refusal: same status, same
   // `error.data`, so the layout's ErrorBoundary renders ONE not-found for both
   // and there is no second copy to keep in sync.
-  throw new Response('missing', {
+  //
+  // `no-page` rather than `missing`: the layout resolved this site before this
+  // loader ran, so the visitor is looking at a course website that exists — the
+  // address is what is wrong. `missing` stays reserved for a hostname that
+  // points at no site at all.
+  throw new Response('no-page', {
     status: 404,
     headers: siteHeaders({ request, cacheable: false, noindex: true }),
   });

--- a/apps/pages/app/site/page.tsx
+++ b/apps/pages/app/site/page.tsx
@@ -45,7 +45,12 @@ export const loader = async (args: LoaderFunctionArgs) => {
   )) as SitePageRow | null;
 
   if (!page || page.is_draft) {
-    throw new Response('missing', {
+    // `no-page`, not `missing`: the layout resolved this site before this
+    // loader ran, so the visitor is on a course website that exists and is
+    // switched on — they just followed a link to nothing. `missing` is reserved
+    // for a hostname that resolves to no site at all, which is a different
+    // sentence to read (see the layout's ErrorBoundary).
+    throw new Response('no-page', {
       status: 404,
       headers: siteHeaders({ request, cacheable: false, noindex: true }),
     });

--- a/apps/pages/app/site/schedule.tsx
+++ b/apps/pages/app/site/schedule.tsx
@@ -28,7 +28,10 @@ export const loader = async (args: LoaderFunctionArgs) => {
   const { site, viewer, seoOrigin } = await resolveSiteContext(args);
 
   if (!site.show_schedule) {
-    throw new Response('missing', {
+    // A course that does not publish a schedule has no page at this address —
+    // the same refusal a missing page slug gets, and deliberately NOT the
+    // `missing` a hostname pointing at no site at all gets.
+    throw new Response('no-page', {
       status: 404,
       headers: siteHeaders({ request, cacheable: false, noindex: true }),
     });

--- a/apps/pages/tests/e2e/forms-site-link.spec.ts
+++ b/apps/pages/tests/e2e/forms-site-link.spec.ts
@@ -171,6 +171,36 @@ test.describe('the short form link on a class-site host', () => {
     }
   });
 
+  test('an address that matches no route is a branded not-found, not an outage', async ({
+    request,
+  }) => {
+    // Lives in this file to reuse its site fixture (the `beforeAll` above is
+    // the only place a class site is claimed for a test host), and because it
+    // is the same class of bug: a link somebody shared, on a course host, that
+    // the `_site` tree had no route for. The forms bridge got a route; two
+    // segments past the host still fell through to React Router's built-in 404
+    // and the ROOT error boundary's "This page is unavailable / Try again in a
+    // moment." — a bad link reading as a broken server.
+    //
+    // The route-ranking half of the fix is covered without a server in
+    // `tests/unit/site-routes.spec.ts`; this is the rendered proof.
+    const response = await request.get(`${BASE}/dartmouth-cs52-26f/forms/cs52-waitlist`, {
+      headers: { host: siteHost },
+      maxRedirects: 0,
+      failOnStatusCode: false,
+    });
+
+    expect(response.status()).toBe(404);
+    const body = await response.text();
+    // The apostrophe in "There's no site here" is HTML-escaped by the SSR pass,
+    // so match the halves that survive verbatim.
+    expect(body).toContain('no site here');
+    expect(body).toContain('Classmoji course website');
+    expect(body).not.toContain('Try again in a moment.');
+    // The site tree is script-less; an error document is no exception.
+    expect(body).not.toContain('window.__reactRouterContext');
+  });
+
   test('the internal namespace stays unreachable from the canonical host', async ({ request }) => {
     // The bridge added a route under `/_site`; the middleware's refusal of that
     // prefix on the canonical host has to keep covering it.

--- a/apps/pages/tests/e2e/forms-site-link.spec.ts
+++ b/apps/pages/tests/e2e/forms-site-link.spec.ts
@@ -184,21 +184,29 @@ test.describe('the short form link on a class-site host', () => {
     //
     // The route-ranking half of the fix is covered without a server in
     // `tests/unit/site-routes.spec.ts`; this is the rendered proof.
-    const response = await request.get(`${BASE}/dartmouth-cs52-26f/forms/cs52-waitlist`, {
-      headers: { host: siteHost },
-      maxRedirects: 0,
-      failOnStatusCode: false,
-    });
+    // Both shapes of "nothing here" on a site that DOES exist: an address the
+    // route tree has no route for, and a page slug nobody authored. They are
+    // one sentence for the reader and must stay one sentence in the markup.
+    for (const path of ['/dartmouth-cs52-26f/forms/cs52-waitlist', '/no-such-page']) {
+      const response = await request.get(`${BASE}${path}`, {
+        headers: { host: siteHost },
+        maxRedirects: 0,
+        failOnStatusCode: false,
+      });
 
-    expect(response.status()).toBe(404);
-    const body = await response.text();
-    // The apostrophe in "There's no site here" is HTML-escaped by the SSR pass,
-    // so match the halves that survive verbatim.
-    expect(body).toContain('no site here');
-    expect(body).toContain('Classmoji course website');
-    expect(body).not.toContain('Try again in a moment.');
-    // The site tree is script-less; an error document is no exception.
-    expect(body).not.toContain('window.__reactRouterContext');
+      expect(response.status(), path).toBe(404);
+      const body = await response.text();
+      // The apostrophe in "There's no page at this address" is HTML-escaped by
+      // the SSR pass, so match the halves that survive verbatim.
+      expect(body, path).toContain('no page at this address');
+      expect(body, path).toContain('Check the link');
+      // The root boundary's outage copy, and the missing-SITE copy: this site
+      // resolved, so neither sentence is true here.
+      expect(body, path).not.toContain('Try again in a moment.');
+      expect(body, path).not.toContain('no site here');
+      // The site tree is script-less; an error document is no exception.
+      expect(body, path).not.toContain('window.__reactRouterContext');
+    }
   });
 
   test('the internal namespace stays unreachable from the canonical host', async ({ request }) => {

--- a/apps/pages/tests/unit/site-routes.spec.ts
+++ b/apps/pages/tests/unit/site-routes.spec.ts
@@ -139,8 +139,10 @@ test.describe('the not-found route module', () => {
     const response = thrown as Response;
     expect(response.status).toBe(404);
     // Same `error.data` page.tsx throws, so the layout's boundary renders ONE
-    // not-found for both a missing page and an unmatched address.
-    expect(await response.text()).toBe('missing');
+    // not-found for both a missing page and an unmatched address — and NOT the
+    // `missing` reserved for a hostname that resolves to no site, whose copy
+    // ("there's no site here") would be a lie on a site that just rendered.
+    expect(await response.text()).toBe('no-page');
     expect(response.headers.get('Cache-Control')).toBe('no-store');
     expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
     expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'none'");

--- a/apps/pages/tests/unit/site-routes.spec.ts
+++ b/apps/pages/tests/unit/site-routes.spec.ts
@@ -1,0 +1,158 @@
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+import { test, expect } from '@playwright/test';
+import { matchRoutes, type RouteObject } from 'react-router';
+
+/**
+ * The class-site route tree's SHAPE, asserted against the real `app/routes.ts`.
+ *
+ * ── What this is protecting ────────────────────────────────────────────────
+ * A URL on a course site with two or more segments — the real one that started
+ * this, `cs52.classmoji.io/dartmouth-cs52-26f/forms/cs52-waitlist` — matched no
+ * route at all. React Router's built-in 404 then bubbled past the site layout
+ * to the ROOT error boundary, which renders "This page is unavailable / Try
+ * again in a moment.": a mistyped link dressed up as an outage.
+ *
+ * The fix is a splat inside the layout (`site/not-found.tsx`) that throws the
+ * same 404 a missing page slug throws, so the layout's boundary — the one that
+ * already knows how to say "there's nothing here" — handles both.
+ *
+ * A splat that ranks even one point too high would silently eat `:pageSlug` or
+ * the `forms/*` bridge, and nothing else in the suite would notice: the site
+ * would just start 404ing pages that exist. So this file matches REAL paths
+ * against the REAL config rather than re-deriving React Router's scoring.
+ *
+ * ── Why the private global ─────────────────────────────────────────────────
+ * `app/routes.ts` calls `flatRoutes()`, which reads the app directory from
+ * `globalThis.__reactRouterAppDirectory` — a variable the dev server sets and
+ * nothing else does. Setting it here is what makes the route config importable
+ * outside a build. It is React Router internals; if this import ever starts
+ * failing, that is the thing to look at first.
+ */
+
+const APP_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../app');
+(globalThis as unknown as { __reactRouterAppDirectory?: string }).__reactRouterAppDirectory =
+  APP_DIR;
+
+const routeConfig = (await import('../../app/routes.ts')).default;
+
+type ConfigEntry = {
+  path?: string;
+  index?: boolean;
+  file: string;
+  children?: ConfigEntry[];
+};
+
+/** The route config, in the shape `matchRoutes` reads. `file` rides along as the id. */
+const toRouteObjects = (entries: ConfigEntry[]): RouteObject[] =>
+  entries.map(entry => ({
+    path: entry.path,
+    index: entry.index,
+    id: entry.file,
+    children: entry.children ? toRouteObjects(entry.children) : undefined,
+  })) as RouteObject[];
+
+const routes = toRouteObjects(routeConfig as unknown as ConfigEntry[]);
+
+/** Every route module in the match, outermost first. */
+const chainFor = (pathname: string): string[] => {
+  const matches = matchRoutes(routes, pathname);
+  expect(matches, `${pathname} should match something`).toBeTruthy();
+  return matches!.map(m => m.route.id!);
+};
+
+/** The module that actually answers a request. */
+const leafFor = (pathname: string): string => {
+  const chain = chainFor(pathname);
+  return chain[chain.length - 1];
+};
+
+const SITE = '/_site/cs52';
+
+test.describe('the class-site route tree', () => {
+  test('a multi-segment address lands on the not-found route, inside the layout', () => {
+    // The exact production URL from the bug report.
+    const chain = chainFor(`${SITE}/dartmouth-cs52-26f/forms/cs52-waitlist`);
+
+    expect(chain[chain.length - 1]).toBe('site/not-found.tsx');
+    // Inside the layout is the whole point: the layout's ErrorBoundary is what
+    // renders the branded 404. A splat declared as a sibling of the layout
+    // would still return 404 — with the root boundary's outage copy.
+    expect(chain).toContain('site/layout.tsx');
+  });
+
+  test('deeper and stranger addresses land there too', () => {
+    for (const pathname of [
+      `${SITE}/a/b`,
+      `${SITE}/a/b/c/d`,
+      `${SITE}/schedule/nope`,
+      `${SITE}/robots.txt/nope`,
+    ]) {
+      expect(leafFor(pathname), pathname).toBe('site/not-found.tsx');
+    }
+  });
+
+  test('the splat never shadows a real page slug', () => {
+    // Single-segment slugs — the ones an instructor authors — must keep
+    // reaching page.tsx, which does the real lookup and 404s on its own terms.
+    // React Router's `splatPenalty` is what guarantees this regardless of
+    // declaration order; assert it rather than trust it.
+    expect(leafFor(`${SITE}/no-such-page`)).toBe('site/page.tsx');
+    expect(leafFor(`${SITE}/syllabus`)).toBe('site/page.tsx');
+  });
+
+  test('the splat never shadows the static siblings', () => {
+    expect(leafFor(`${SITE}`)).toBe('site/home.tsx');
+    expect(leafFor(`${SITE}/`)).toBe('site/home.tsx');
+    expect(leafFor(`${SITE}/sign-in`)).toBe('site/sign-in.tsx');
+    expect(leafFor(`${SITE}/schedule`)).toBe('site/schedule.tsx');
+    expect(leafFor(`${SITE}/app`)).toBe('site/app.tsx');
+    expect(leafFor(`${SITE}/robots.txt`)).toBe('site/robots.ts');
+  });
+
+  test('the forms short-link bridge still outranks the splat', () => {
+    // Both are splats; `forms/*` carries one more static segment and so scores
+    // higher. If this ever flipped, every short link shared on a course site
+    // would 404 instead of bridging.
+    expect(leafFor(`${SITE}/forms/cs52-waitlist`)).toBe('site/forms.ts');
+    expect(leafFor(`${SITE}/forms/cs52-waitlist/verify`)).toBe('site/forms.ts');
+    expect(leafFor(`${SITE}/forms`)).toBe('site/forms.ts');
+  });
+});
+
+test.describe('the not-found route module', () => {
+  test('its loader throws a 404 carrying the site headers', async () => {
+    const { loader } = await import('../../app/site/not-found.tsx');
+
+    const request = new Request('https://cs52.classmoji.io/_site/cs52/a/b');
+    let thrown: unknown;
+    try {
+      // The loader reads nothing but `request`, so the rest of the route args
+      // would be dead weight here.
+      await (loader as unknown as (args: { request: Request }) => unknown)({ request });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown, 'the loader must throw, never return').toBeInstanceOf(Response);
+    const response = thrown as Response;
+    expect(response.status).toBe(404);
+    // Same `error.data` page.tsx throws, so the layout's boundary renders ONE
+    // not-found for both a missing page and an unmatched address.
+    expect(await response.text()).toBe('missing');
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('X-Robots-Tag')).toBe('noindex');
+    expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'none'");
+  });
+
+  test('it exports a component, which is what routes the throw to the boundary', async () => {
+    // Not decoration. React Router's server treats a leaf whose module exports
+    // neither `default` nor `ErrorBoundary` as a RESOURCE request and returns
+    // the thrown Response verbatim — a bare `text/plain` "missing" instead of
+    // the branded 404 document. Deleting the component to "make it a resource
+    // route like robots.ts" would silently undo the fix; this is the tripwire.
+    const mod = await import('../../app/site/not-found.tsx');
+    expect(typeof mod.default).toBe('function');
+  });
+});


### PR DESCRIPTION
## What was wrong

On a class site, a URL with two or more segments matched **no route at all** — for example `https://cs52.classmoji.io/dartmouth-cs52-26f/forms/cs52-waitlist`, a link that was actually shared and that prod still 404s. React Router's built-in 404 bubbled past the site layout to the **root** error boundary, which renders:

> **This page is unavailable** — Try again in a moment.

So a bad link looked like an outage, and the one thing it told the reader to do could never work.

A *one*-segment miss (`/no-such-page`) reached the right boundary — but the sentence there was wrong too:

> **There's no site here** — That address does not point at a Classmoji course website.

That is the missing-*subdomain* copy, and it is false on a site the visitor is looking at: the site's own chrome is on screen while it denies existing.

## What changed

**1. Every unmatched address now reaches the site's own boundary.**

- **`app/site/not-found.tsx`** (new): a splat route *inside* the site layout whose loader throws the same 404 `page.tsx` throws (`no-store`, `noindex`, site CSP), so unmatched addresses and missing pages produce one identical not-found instead of two copies to keep in sync.
  - It exports a component that renders `null`. Not decoration: React Router's server treats a leaf whose module exports neither `default` nor `ErrorBoundary` as a **resource request** and returns the thrown Response verbatim — a bare `text/plain` body instead of the branded document. A unit assertion guards that so nobody "tidies" it into a resource route like `robots.ts`.
  - Still script-less: no component that hydrates, no `<Scripts/>`.
- **`app/routes.ts`**: `route('*', 'site/not-found.tsx')` as the last child of the site layout. A splat carries React Router's `splatPenalty` and always ranks last, so it cannot shadow `forms/*`, `:pageSlug`, the static segments or the index.

**2. The copy now says what is actually true.**

- `page.tsx` (missing/draft page), `schedule.tsx` (a course that publishes no schedule) and `not-found.tsx` throw `error.data === 'no-page'` instead of `'missing'`.
- The layout's `ErrorBoundary` answers `no-page` with **"There's no page at this address"** and a **relative** link home (`/`) — relative because the same markup is served from the subdomain and from a verified custom domain.
- The security merge the old comment guards is between *missing subdomain* and *switched-off site* ("this subdomain exists but is disabled" enumerates every course we host). A bad path is not part of that: this boundary only renders it **after** the layout's loader resolved the tenant, so the site is already known to exist and be enabled, and naming it discloses nothing the home page would not. `missing` now means exactly one thing — a hostname that resolves to no site. `unavailable` and the non-404 branches are untouched.

**3. `app/root.tsx`**: the root boundary is status-aware on **both** branches, as a backstop for anything that still reaches it — `isRouteErrorResponse(error) && status === 404` gets a "Not found" heading and one plain sentence; every other status and thrown error keeps today's copy. The app branch also drops its "Refresh" button on a 404, since reloading a 404 reproduces the 404. Both branches stay dark-mode safe, and the site branch stays script-less.

## Route ranking evidence

React Router scores each path (`computeScore` in `react-router/lib/router/utils.ts`): static `10`, dynamic `3`, splat penalty `-2`, plus segment count.

| path | score |
| --- | --- |
| `/_site/:subdomain/forms/*` | 27 |
| `/_site/:subdomain/:pageSlug` | 21 |
| `/_site/:subdomain` (index) | 19 |
| `/_site/:subdomain/*` | **16** |

Not trusted as arithmetic: `tests/unit/site-routes.spec.ts` sets React Router's private `__reactRouterAppDirectory` global, imports the **real** `app/routes.ts`, and runs `matchRoutes` over it — asserting the prod URL above lands on `site/not-found.tsx` *with `site/layout.tsx` in its parent chain*, while `/no-such-page` still lands on `site/page.tsx`, `/forms/<slug>` on `site/forms.ts`, and `/`, `/sign-in`, `/schedule`, `/app`, `/robots.txt` on their own modules. Removing the new route makes that spec fail (verified).

## Test steps

1. `https://<site>/anything/else` → **"There's no page at this address"**, with a "Go to the site home" link. Not "Try again in a moment", not "There's no site here".
2. `https://<site>/no-such-page` → the same page.
3. `https://<site>/schedule` on a course with the schedule switched off → the same page.
4. A hostname nobody claims, and a disabled site → **unchanged**: "There's no site here" / "This site is unavailable".
5. `https://<site>/forms/<slug>` → still 302s to the canonical pages host, query string intact.
6. `https://<site>/`, `/robots.txt` → unchanged.

## Tests run

- `tests/unit/site-routes.spec.ts` — 7 new, all pass; fails as expected with the route removed.
- Loadable unit suite: **436 pass, 0 failures**.
- Three specs (`forms-answer-columns`, `forms-classroom-identity`, `forms-field-type-coverage`) can't load in a worktree at all — `node_modules/@classmoji/services` symlinks to the main checkout, which lacks the `./form-contract` export. Same reason `react-router build` fails here, identically on a clean `origin/staging` (verified by stashing).
- `tsc --noEmit`: **128 errors before and after** — byte-identical set, all from that same symlink, none in any file this PR touches. `eslint` and `prettier --check` clean on every changed file.
- The e2e in `forms-site-link.spec.ts` asserts the rendered 404 body for both an unmatched address and a missing page slug. It self-skips unless pointed at a server with `SITE_BASE_DOMAIN` set, exactly like the rest of that file (see its header for how to run it) — so the rendered HTML has not been observed locally; worth eyeballing on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW
