### PR TITLE
feat(slides): make Cloudinary video hosting a Pro feature

### DIFF
--- a/apps/slides/app/components/properties/ElementSelectionContext.tsx
+++ b/apps/slides/app/components/properties/ElementSelectionContext.tsx
@@ -106,6 +106,8 @@ interface ElementSelectionProviderProps {
   onDeleteTheme?: (id: string) => void;
   customThemes?: SlideCustomTheme[];
   sharedThemes?: SlideSharedTheme[];
+  /** Whether the slide's classroom is on the Pro tier (gates Cloudinary video hosting). */
+  isPro?: boolean;
 }
 
 /** Value provided by the ElementSelectionContext */
@@ -131,6 +133,15 @@ export interface ElementSelectionContextValue {
   onDeleteTheme?: (id: string) => void;
   customThemes: SlideCustomTheme[];
   sharedThemes: SlideSharedTheme[];
+  /**
+   * Whether the slide's classroom is on the Pro tier. Read by VideoProperties
+   * to decide whether to offer Cloudinary upload. Presentation only — the
+   * api.video.upload-cloudinary route re-decides on every request.
+   *
+   * Defaults to false, so a provider that forgets to pass it hides the paid
+   * feature rather than offering an upload the server will refuse.
+   */
+  isPro: boolean;
 }
 
 const ElementSelectionContext = createContext<ElementSelectionContextValue | null>(null);
@@ -277,6 +288,7 @@ export function ElementSelectionProvider({
   onDeleteTheme,
   customThemes = [],
   sharedThemes = [],
+  isPro = false,
 }: ElementSelectionProviderProps) {
   const [selectedElement, setSelectedElement] = useState<HTMLElement | null>(null);
   const [elementType, setElementType] = useState<SlideElementType>(null);
@@ -627,6 +639,8 @@ export function ElementSelectionProvider({
     customThemes,
     // Shared themes (folder-based themes from slides.com imports)
     sharedThemes,
+    // Plan tier — gates the Cloudinary upload button in VideoProperties
+    isPro,
   };
 
   return (

--- a/apps/slides/app/components/properties/editors/VideoProperties.tsx
+++ b/apps/slides/app/components/properties/editors/VideoProperties.tsx
@@ -16,7 +16,7 @@ import { useElementSelection } from '../ElementSelectionContext';
  */
 
 export default function VideoProperties({ element }: { element: HTMLVideoElement }) {
-  const { onContentChange, onSaveContent } = useElementSelection();
+  const { onContentChange, onSaveContent, isPro } = useElementSelection();
 
   // State for all properties
   const [url, setUrl] = useState(() => element?.src || '');
@@ -121,6 +121,9 @@ export default function VideoProperties({ element }: { element: HTMLVideoElement
   // Upload to Cloudinary for optimized CDN delivery
   const handleUploadToCloudinary = useCallback(async () => {
     if (!element?.src) return;
+    // The button is hidden for non-Pro classrooms; this only matters if a
+    // stale render slips through. The route refuses it either way.
+    if (!isPro) return;
 
     // Get slide ID from the URL path
     const pathParts = window.location.pathname.split('/');
@@ -173,7 +176,7 @@ export default function VideoProperties({ element }: { element: HTMLVideoElement
     } finally {
       setUploading(false);
     }
-  }, [element, onContentChange]);
+  }, [element, isPro, onContentChange, onSaveContent]);
 
   // Check if video is already on Cloudinary
   const isCloudinaryUrl = url?.includes('cloudinary.com');
@@ -210,7 +213,13 @@ export default function VideoProperties({ element }: { element: HTMLVideoElement
               <span>Hosted on Cloudinary CDN</span>
             </div>
           ) : (
-            url && (
+            // Pro-only: Cloudinary bills per account. A classroom that is not
+            // Pro is not offered the upload at all — the route refuses it too.
+            // The "already hosted" branch above stays visible either way, so a
+            // classroom that has since dropped to free can still see and manage
+            // videos it uploaded while it was Pro.
+            url &&
+            isPro && (
               <Button
                 icon={<CloudUploadOutlined />}
                 onClick={handleUploadToCloudinary}
@@ -223,8 +232,10 @@ export default function VideoProperties({ element }: { element: HTMLVideoElement
             )
           )}
           {!isCloudinaryUrl && url && (
-            <p className="text-xs text-gray-400 mt-1">
-              Optimize for web delivery & format compatibility
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {isPro
+                ? 'Optimize for web delivery & format compatibility'
+                : 'Cloudinary video hosting is a Pro feature.'}
             </p>
           )}
         </div>

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -403,8 +403,18 @@ export const loader = async ({
     }
   }
 
+  // Cloudinary video hosting is Pro-only, and the properties panel offers an
+  // "Upload to Cloudinary" button. Resolved ONLY for editors: viewers never see
+  // that button, and this loader is on the hot path for every student opening
+  // every slide, so a tier query for them would be pure cost. The real gate is
+  // in api.video.upload-cloudinary, which re-decides per request.
+  const isPro = canEdit
+    ? (await ClassmojiService.subscription.getProStateForClassroomId(slide.classroom_id)).isPro
+    : false;
+
   return {
     slide,
+    isPro,
     contentUrl,
     slideContent,
     contentError,
@@ -1594,6 +1604,7 @@ export const action = async ({
 export default function SlideViewer() {
   const {
     slide,
+    isPro,
     contentUrl,
     slideContent,
     contentError,
@@ -2390,6 +2401,7 @@ export default function SlideViewer() {
       onDeleteTheme={handleDeleteTheme}
       customThemes={customThemes}
       sharedThemes={sharedThemes}
+      isPro={isPro}
     >
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
         {/* Navbar - uses grid layout to center toolbar when editing */}

--- a/apps/slides/app/routes/api.slides.import.start/route.ts
+++ b/apps/slides/app/routes/api.slides.import.start/route.ts
@@ -15,8 +15,11 @@
 
 import { randomUUID } from 'crypto';
 import getPrisma from '@classmoji/database';
+import { ClassmojiService } from '@classmoji/services';
 import { requireClassroomStaff } from '@classmoji/auth/server';
+import { cloudinaryVideoSelection } from '@classmoji/utils';
 import { processZipImport } from '~/utils/slidesComImporter.server';
+import { isCloudinaryConfigured } from '~/utils/cloudinaryService.server';
 import { importStreamManager } from '~/utils/importStreamManager';
 
 // Max file size for ZIP uploads (in bytes)
@@ -38,7 +41,10 @@ export const action = async ({ request }: { request: Request }) => {
   try {
     const cloudinaryVideoPathsRaw = formData.get('cloudinaryVideoPaths') as string | null;
     if (cloudinaryVideoPathsRaw) {
-      cloudinaryVideoPaths = JSON.parse(cloudinaryVideoPathsRaw);
+      const parsed = JSON.parse(cloudinaryVideoPathsRaw);
+      // Client-supplied: valid JSON is not necessarily the array everything
+      // downstream assumes.
+      cloudinaryVideoPaths = Array.isArray(parsed) ? parsed.filter(p => typeof p === 'string') : [];
     }
   } catch (e: unknown) {
     console.warn('Failed to parse cloudinaryVideoPaths:', e);
@@ -102,6 +108,34 @@ export const action = async ({ request }: { request: Request }) => {
     return Response.json(
       { error: 'Classroom content namespace not configured' },
       { status: 400 }
+    );
+  }
+
+  // Cloudinary video hosting is a Pro feature — Cloudinary bills per account,
+  // and the form field below is client-supplied, so this is the enforcement
+  // point rather than the import page's UI.
+  //
+  // A non-Pro classroom DEGRADES instead of being refused: an empty selection
+  // is exactly the state `slidesComImporter.server.ts` already handles when
+  // Cloudinary is unconfigured, so every video is committed to the content repo
+  // and the import still succeeds. Refusing here would break imports that
+  // worked yesterday for a reason the uploader cannot fix mid-upload.
+  //
+  // Reads the tier through `subscription.getProStateForClassroomId`, the single
+  // owner of what "Pro" means (it is what `assertProTier` calls too) — a second
+  // copy of the rule here is how a lapsed subscription keeps one surface open
+  // after it has closed in another.
+  const { isPro } = await ClassmojiService.subscription.getProStateForClassroomId(classroom.id);
+  const requestedCloudinaryVideoPaths = cloudinaryVideoPaths;
+  cloudinaryVideoPaths = cloudinaryVideoSelection({
+    isPro,
+    configured: isCloudinaryConfigured(),
+    requested: requestedCloudinaryVideoPaths,
+  });
+
+  if (!isPro && requestedCloudinaryVideoPaths.length > 0) {
+    console.info(
+      `[import.start] Classroom ${classroomSlug} is not Pro — ${requestedCloudinaryVideoPaths.length} video(s) requested for Cloudinary will be stored in the content repo instead`
     );
   }
 

--- a/apps/slides/app/routes/api.video.upload-cloudinary/route.tsx
+++ b/apps/slides/app/routes/api.video.upload-cloudinary/route.tsx
@@ -15,6 +15,7 @@
 
 import { v2 as cloudinary } from 'cloudinary';
 import getPrisma from '@classmoji/database';
+import { ClassmojiService } from '@classmoji/services';
 import { ContentService } from '@classmoji/content';
 import { assertSlideAccess } from '@classmoji/auth/server';
 import { fetchContent, getMimeType } from '~/utils/contentProxy';
@@ -59,6 +60,31 @@ export const action = async ({ request }: { request: Request }) => {
       slide,
       accessType: 'edit',
     });
+
+    // Cloudinary video hosting is a Pro feature — Cloudinary bills per account.
+    //
+    // `assertSlideAccess({ accessType: 'edit' })` above only proves the caller
+    // is staff on THIS slide's classroom; it says nothing about the plan, so
+    // without this every classroom could push video into a paid account.
+    //
+    // Unlike the slides IMPORT path, which silently degrades to the content
+    // repo, this is an explicit "Upload to Cloudinary" click: refuse it and say
+    // why, rather than appearing to succeed while doing something else.
+    //
+    // Placed BEFORE the credential config, the upload, and the GitHub delete
+    // below — the delete is destructive and irreversible, so ordering is the
+    // whole point. Fails closed: if the tier lookup throws, the catch at the
+    // bottom returns 500 and nothing has been uploaded or deleted yet.
+    const { isPro } = await ClassmojiService.subscription.getProStateForClassroomId(
+      slide.classroom_id
+    );
+
+    if (!isPro) {
+      return new Response(JSON.stringify({ error: 'Cloudinary video hosting is a Pro feature' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     // Configure Cloudinary from environment variables
     const cloudName = process.env.CLOUDINARY_CLOUD_NAME;

--- a/apps/slides/app/routes/import/route.tsx
+++ b/apps/slides/app/routes/import/route.tsx
@@ -6,7 +6,7 @@
  * Requires OWNER or TEACHER role.
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useLoaderData, useNavigate } from 'react-router';
 import { useDropzone, type FileRejection } from 'react-dropzone';
 import getPrisma from '@classmoji/database';
@@ -68,7 +68,12 @@ export const loader = async ({ request }: { request: Request }) => {
     : getContentRepoName({ login: gitOrgLogin });
   const savedThemes = await listSavedThemes(gitOrgLogin, repoName);
 
+  // Cloudinary video hosting is Pro-only. This drives the UI ONLY — the real
+  // gate is in api.slides.import.start, which re-decides on every submission.
+  const { isPro } = await ClassmojiService.subscription.getProStateForClassroomId(classroom.id);
+
   return {
+    isPro,
     classroomSlug,
     contentNamespace: classroom.content_namespace,
     gitOrgLogin,
@@ -93,7 +98,7 @@ export const loader = async ({ request }: { request: Request }) => {
 // and stream progress via SSE
 
 export default function ImportPage() {
-  const { classroomSlug, classroom, repositories, savedThemes, webappUrl, slidesListUrl } =
+  const { isPro, classroomSlug, classroom, repositories, savedThemes, webappUrl, slidesListUrl } =
     useLoaderData<typeof loader>();
   const userContext = useUser();
   const user = userContext?.user;
@@ -113,6 +118,15 @@ export default function ImportPage() {
   const [showVideoModal, setShowVideoModal] = useState(false);
   const [cloudinaryVideoPaths, setCloudinaryVideoPaths] = useState<string[]>([]);
   const [analyzingVideos, setAnalyzingVideos] = useState(false);
+
+  // What actually leaves the browser. A non-Pro classroom never offers the
+  // Cloudinary choice, so the state should already be empty; deriving it here
+  // means no future edit can reintroduce a populated field on that path. The
+  // server re-decides regardless — this is presentation, not the gate.
+  const submittedCloudinaryVideoPaths = useMemo(
+    () => (isPro ? cloudinaryVideoPaths : []),
+    [isPro, cloudinaryVideoPaths]
+  );
 
   // Import progress state (SSE-based)
   const [importId, setImportId] = useState<string | null>(null);
@@ -138,36 +152,45 @@ export default function ImportPage() {
   const canImport = membership?.role === 'OWNER' || membership?.role === 'TEACHER';
 
   // File dropzone
-  const onDrop = useCallback(async (acceptedFiles: File[]) => {
-    if (acceptedFiles.length > 0) {
-      const file = acceptedFiles[0];
-      setSelectedFile(file);
-      setDropzoneError(null); // Clear any previous error
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      if (acceptedFiles.length > 0) {
+        const file = acceptedFiles[0];
+        setSelectedFile(file);
+        setDropzoneError(null); // Clear any previous error
 
-      // Analyze ZIP for videos (client-side, reads only metadata)
-      setAnalyzingVideos(true);
-      try {
-        const videos = await analyzeZipForVideos(file);
+        // Analyze ZIP for videos (client-side, reads only metadata)
+        setAnalyzingVideos(true);
+        try {
+          const videos = await analyzeZipForVideos(file);
 
-        if (videos.length > 0) {
-          setDetectedVideos(videos);
-          // Pre-select videos recommended for Cloudinary
-          const suggested = videos.filter(v => v.suggestCloudinary).map(v => v.path);
-          setCloudinaryVideoPaths(suggested);
-          setShowVideoModal(true);
-        } else {
-          // No videos found, clear any previous state
-          setDetectedVideos([]);
-          setCloudinaryVideoPaths([]);
+          if (videos.length > 0) {
+            setDetectedVideos(videos);
+            // Non-Pro classrooms still get the count — it is useful either way —
+            // but never the Cloudinary choice, so no selection and no modal.
+            if (isPro) {
+              // Pre-select videos recommended for Cloudinary
+              const suggested = videos.filter(v => v.suggestCloudinary).map(v => v.path);
+              setCloudinaryVideoPaths(suggested);
+              setShowVideoModal(true);
+            } else {
+              setCloudinaryVideoPaths([]);
+            }
+          } else {
+            // No videos found, clear any previous state
+            setDetectedVideos([]);
+            setCloudinaryVideoPaths([]);
+          }
+        } catch (err: unknown) {
+          console.error('Failed to analyze ZIP for videos:', err);
+          // Don't block import if analysis fails
+        } finally {
+          setAnalyzingVideos(false);
         }
-      } catch (err: unknown) {
-        console.error('Failed to analyze ZIP for videos:', err);
-        // Don't block import if analysis fails
-      } finally {
-        setAnalyzingVideos(false);
       }
-    }
-  }, []);
+    },
+    [isPro]
+  );
 
   const onDropRejected = useCallback((fileRejections: FileRejection[]) => {
     const rejection = fileRejections[0];
@@ -229,7 +252,7 @@ export default function ImportPage() {
         }
 
         // Add cloudinary video paths
-        formData.set('cloudinaryVideoPaths', JSON.stringify(cloudinaryVideoPaths));
+        formData.set('cloudinaryVideoPaths', JSON.stringify(submittedCloudinaryVideoPaths));
 
         // POST to the async start endpoint
         const response = await fetch('/api/slides/import/start', {
@@ -253,7 +276,7 @@ export default function ImportPage() {
         setIsSubmitting(false);
       }
     },
-    [selectedFile, cloudinaryVideoPaths]
+    [selectedFile, submittedCloudinaryVideoPaths]
   );
 
   // Handle import cancellation (close modal and reset state)
@@ -322,7 +345,7 @@ export default function ImportPage() {
             <input
               type="hidden"
               name="cloudinaryVideoPaths"
-              value={JSON.stringify(cloudinaryVideoPaths)}
+              value={JSON.stringify(submittedCloudinaryVideoPaths)}
             />
 
             {/* Error message */}
@@ -403,21 +426,29 @@ export default function ImportPage() {
                         {detectedVideos.length} video{detectedVideos.length !== 1 ? 's' : ''}
                       </span>{' '}
                       detected
-                      {cloudinaryVideoPaths.length > 0 && (
+                      {isPro && cloudinaryVideoPaths.length > 0 && (
                         <span className="ml-1">
                           ({cloudinaryVideoPaths.length} → Cloudinary,{' '}
                           {detectedVideos.length - cloudinaryVideoPaths.length} → GitHub)
                         </span>
                       )}
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => setShowVideoModal(true)}
-                      className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-                    >
-                      Change
-                    </button>
+                    {isPro && (
+                      <button
+                        type="button"
+                        onClick={() => setShowVideoModal(true)}
+                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        Change
+                      </button>
+                    )}
                   </div>
+                  {!isPro && (
+                    <p className="mt-2 text-xs text-blue-700 dark:text-blue-300">
+                      Videos are stored in the content repo — files over 100 MB will fail the
+                      import. Cloudinary video hosting is a Pro feature.
+                    </p>
+                  )}
                 </div>
               )}
 

--- a/packages/utils/src/__tests__/cloudinaryVideos.test.ts
+++ b/packages/utils/src/__tests__/cloudinaryVideos.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { cloudinaryVideoSelection } from '../cloudinaryVideos.ts';
+
+// Cloudinary video hosting is billed per account, so it is Pro-only. These
+// cases pin the gate itself: apps/slides has Playwright only, so without them
+// nothing would notice the import route silently honouring `requested` again.
+describe('cloudinaryVideoSelection', () => {
+  const requested = ['videos/intro.mp4', 'videos/demo.webm'];
+
+  it('passes the requested paths through for a Pro classroom with Cloudinary configured', () => {
+    expect(cloudinaryVideoSelection({ isPro: true, configured: true, requested })).toEqual(
+      requested
+    );
+  });
+
+  it('drops every path for a non-Pro classroom, even when Cloudinary is configured', () => {
+    expect(cloudinaryVideoSelection({ isPro: false, configured: true, requested })).toEqual([]);
+  });
+
+  it('drops every path when Cloudinary is not configured, even for a Pro classroom', () => {
+    expect(cloudinaryVideoSelection({ isPro: true, configured: false, requested })).toEqual([]);
+  });
+
+  it('returns an empty list when nothing was requested', () => {
+    expect(cloudinaryVideoSelection({ isPro: true, configured: true, requested: [] })).toEqual([]);
+  });
+
+  // The route hands the result straight to processZipImport, which builds a Set
+  // from it; returning the caller's own array would let later mutation of one
+  // reach the other.
+  it('returns a copy rather than the caller’s array', () => {
+    const result = cloudinaryVideoSelection({ isPro: true, configured: true, requested });
+    expect(result).not.toBe(requested);
+  });
+});

--- a/packages/utils/src/cloudinaryVideos.ts
+++ b/packages/utils/src/cloudinaryVideos.ts
@@ -1,0 +1,30 @@
+/**
+ * Which videos in a slides import may go to Cloudinary (browser-safe, pure).
+ *
+ * Cloudinary hosting is billed per account, so it is a Pro feature. The
+ * decision is a pure function here — rather than inline in the import route —
+ * so it can be unit tested: `apps/slides` runs Playwright only, and an
+ * entitlement gate that nothing asserts is a gate that quietly stops holding.
+ *
+ * Non-Pro is treated exactly like Cloudinary-not-configured: the caller passes
+ * an empty list, `slidesComImporter.server.ts` finds nothing in its
+ * `cloudinaryVideoSet`, and every video is committed to the content repo
+ * instead. The import DEGRADES rather than failing — a classroom that never had
+ * Cloudinary still gets its slides, with its videos served from GitHub.
+ *
+ * `requested` is attacker-controlled (it arrives as a form field), which is the
+ * whole reason this runs server-side on every import. The UI also hides the
+ * choice for non-Pro classrooms, but that is cosmetic.
+ */
+export function cloudinaryVideoSelection({
+  isPro,
+  configured,
+  requested,
+}: {
+  isPro: boolean;
+  configured: boolean;
+  requested: readonly string[];
+}): string[] {
+  if (!isPro || !configured) return [];
+  return [...requested];
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,6 +21,7 @@ export * from './grades.ts';
 export * from './emojis.ts';
 export * from './quiz.ts';
 export * from './content.ts';
+export * from './cloudinaryVideos.ts';
 export * from './repoNames.ts';
 export * from './subdomains.ts';
 export * from './debounce.ts';


### PR DESCRIPTION
## What

Cloudinary-hosted video for slides is now a Pro-tier feature. Both entry points are gated through the single shared Pro decision (`ClassmojiService.subscription.getProStateForClassroomId`, the same call `assertProTier` makes):

- **Import** (`api.slides.import.start`): a non-Pro classroom's Cloudinary selection is dropped server-side and videos go to the content repo — the same path a deployment without Cloudinary configured already takes. The import page no longer offers the Cloudinary choice for non-Pro classrooms and shows a short note, including that files over 100 MB cannot be stored in the repo.
- **Editor** (`api.video.upload-cloudinary`, the "Upload to Cloudinary" button): refuses with a 403 before any credential config, upload, or GitHub delete. The button is hidden for non-Pro classrooms.

Deletes stay ungated so a classroom that drops to free can still manage legacy videos.

## Why

Cloudinary bills per account and ours is near its ceiling. Hosting is a paid feature and should be scoped to Pro.

## Test

- `packages/utils`: new pure helper `cloudinaryVideoSelection` + vitest (132 passed)
- `npm run typecheck -w @classmoji/slides` clean
- Manual: as staff on a **free** classroom — import a deck with a >5 MB video: no Cloudinary modal, note shown, import succeeds with video in the repo. Open a deck, select a video element: no "Upload to Cloudinary" button. As staff on a **Pro** classroom: both flows unchanged.

## Follow-up (not in this PR)

`api.video.upload-cloudinary` reports an `assertSlideAccess` denial as a 500 (`[object Response]`) because the throw lands in the generic catch — pre-existing; the new 403 is an explicit return and unaffected. It also accepts an arbitrary external `videoUrl` with no size cap (now Pro-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA