### PR TITLE
ci(content-worker): diagnose empty Infisical export (keys only)

### DIFF
--- a/.github/workflows/deploy-cloudflare-staging.yml
+++ b/.github/workflows/deploy-cloudflare-staging.yml
@@ -108,6 +108,22 @@ jobs:
             --projectId="$INFISICAL_PROJECT_ID" \
             --format=json > "$RAW_SECRETS"
 
+          infisical --version
+
+          # Keys only, never values: what this identity can actually see.
+          keys_visible() {
+            infisical export --env=sta --path="$1" --projectId="$INFISICAL_PROJECT_ID" \
+              --format=dotenv --silent 2>/dev/null | cut -d= -f1 | sed 's/^/    /'
+          }
+          if [ ! -s "$RAW_SECRETS" ]; then
+            echo "::warning::Export returned an empty payload. Keys visible to this identity:"
+            echo "  /content-worker:"; keys_visible /content-worker
+            echo "  /:"; keys_visible /
+            echo "  debug log (stderr) for the JSON export:"
+            infisical export --env=sta --path=/content-worker --projectId="$INFISICAL_PROJECT_ID" \
+              --format=json --log-level debug 2>&1 >/dev/null | tail -20 | sed 's/^/    /' || true
+          fi
+
           node --input-type=module -e '
             import { readFileSync, writeFileSync } from "node:fs";
             const [raw, out] = process.argv.slice(2);


### PR DESCRIPTION
## What
The Worker secret sync now fails with a **0-byte** export and nothing on stderr. This adds a diagnostic that runs only when the payload is empty: the CLI version, the key *names* (never values) the identity can see under `/content-worker` and `/`, and the CLI's debug log for the JSON export.

CI only; no app code.

## Test
Merge → staging Cloudflare workflow runs → the sync step either succeeds or prints the diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA