### PR TITLE
ci(content-worker): verifier read the wrong file

### DIFF
--- a/.github/workflows/deploy-cloudflare-staging.yml
+++ b/.github/workflows/deploy-cloudflare-staging.yml
@@ -117,23 +117,10 @@ jobs:
 
           infisical --version
 
-          # Keys only, never values: what this identity can actually see.
-          keys_visible() {
-            infisical export --env=sta --path="$1" --projectId="$INFISICAL_PROJECT_ID" \
-              --format=dotenv --silent 2>/dev/null | cut -d= -f1 | sed 's/^/    /'
-          }
-          if [ ! -s "$RAW_SECRETS" ]; then
-            echo "::warning::Export returned an empty payload. Keys visible to this identity:"
-            echo "  /content-worker:"; keys_visible /content-worker
-            echo "  /:"; keys_visible /
-            echo "  debug log (stderr) for the JSON export:"
-            infisical export --env=sta --path=/content-worker --projectId="$INFISICAL_PROJECT_ID" \
-              --format=json --log-level debug 2>&1 >/dev/null | tail -20 | sed 's/^/    /' || true
-          fi
-
           node --input-type=module -e '
             import { readFileSync, writeFileSync } from "node:fs";
-            const [raw, out] = process.argv.slice(2);
+            // `node -e` puts the first extra argument at argv[1], not argv[2].
+            const [raw, out] = process.argv.slice(1);
             const expected = ["CONTENT_SIGNING_SECRET", "CONTENT_WORKER_SHARED_SECRET"];
 
             const text = readFileSync(raw, "utf8");


### PR DESCRIPTION
## What
With `node -e`, extra arguments start at `process.argv[1]`, so `argv.slice(2)` skipped the export payload and read the empty bulk file, producing `not valid JSON (0 bytes)` for a good export. Fix the index; remove the empty-payload diagnostic added in #284 since the payload was never empty.

CI only.

## Test
Merge → staging Cloudflare workflow → sync step verifies 2 secrets and pushes them; `/healthz` on `content-staging.classmoji.io` reports `configured:true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA