### PR TITLE
fix(content): record uploads in the asset map at upload time

### DIFF
--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -948,6 +948,17 @@ export const action = async ({
         message: `Upload image for slides: ${slide.title}`,
       });
 
+      // Record the row now rather than waiting for the push webhook: a deck
+      // saved right after the upload stores this repo path, and a render that
+      // misses the asset map signs a dangling URL. Never throws.
+      if (slide.classroom_id) {
+        await ClassmojiService.contentAssets.recordContentAsset(slide.classroom_id, {
+          path: result.path,
+          sha: result.sha,
+          size: buffer.length,
+        });
+      }
+
       // Return content proxy URL instead of raw.githubusercontent.com
       // Content proxy handles MIME types correctly and has CDN+API fallback
       return {

--- a/packages/database/migrations/20260904000000_content_assets_synced_at/migration.sql
+++ b/packages/database/migrations/20260904000000_content_assets_synced_at/migration.sql
@@ -1,0 +1,26 @@
+-- When a classroom's asset map was last rebuilt from the content repo's TREE.
+--
+-- The freshness of the map used to be read as MAX(content_assets.synced_at) for
+-- the classroom, and that conflated two different writes. A full sync stamps
+-- every row it wrote and then sweeps everything below the stamp, so its stamp
+-- means "the whole map was rebuilt from the repo". An incremental webhook apply
+-- — and, since uploads record their own row, a single teacher dropping one
+-- image into the editor — also stamps rows `now`, and means nothing of the
+-- kind. Reading the rows therefore let ONE upload make an arbitrarily stale map
+-- look fresh for another 24 hours: on a classroom whose push webhook is not
+-- arriving, pushed files kept rendering as dangling URLs and deleted files were
+-- never swept, for as long as anyone kept uploading.
+--
+-- So the freshness stamp moves off the rows and onto the classroom, where only
+-- a full sync writes it. The 24-hour refresh exists precisely to repair dropped
+-- webhooks, so it has to fire daily no matter how much incremental traffic
+-- there was; one tree read per classroom per day is not a cost worth optimizing
+-- away with a value that cannot distinguish a repair from a single upload.
+--
+-- NULLABLE with no default, and deliberately no backfill: NULL reads as "never
+-- fully synced", which makes every existing classroom sync once on its next
+-- render or nightly pass. That is the correct state to start from — it is also
+-- exactly what these classrooms looked like before any of this existed — and it
+-- is self-healing, where backfilling now() would suppress the first repair on
+-- every classroom in the table.
+ALTER TABLE "classrooms" ADD COLUMN "content_assets_synced_at" TIMESTAMP(3);

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -371,43 +371,50 @@ model GitOrganization {
 }
 
 model Classroom {
-  id                  String          @id @default(uuid())
+  id                       String          @id @default(uuid())
   // GLOBALLY unique. The slug is the sole key in every app URL — /admin/:class,
   // /student/:class, the ICS calendar feed, and the autograde callback — and
   // none of them carry an org segment, so a slug reused across orgs resolves to
   // the wrong classroom. e.g. "cs101-fall-2025".
-  slug                String          @unique
-  git_org_id          String
-  name                String
+  slug                     String          @unique
+  git_org_id               String
+  name                     String
   // Internal identifier only. Historically the content repo name was derived
   // as content-{orgLogin}-{content_namespace}; it no longer names any repo.
-  content_namespace   String
+  content_namespace        String
   // The GitHub repo (in git_organization) holding this classroom's pages &
   // slides content. STORED and fully user-editable — never re-derived. Set at
   // creation for every classroom; defaults to `content-{content_namespace}`.
   // NOT the same as ClassroomSettings.content_repo_name, which is a legacy
   // ORG-level content repo override (`content-{login}`) for a DIFFERENT repo.
-  content_repo        String
+  content_repo             String
   // GitHub Classroom course id, set on import; null for classrooms created
   // directly in Classmoji. Unique because one GitHub Classroom course maps to at
   // most one Classmoji classroom, which makes it the stable idempotency key for
   // re-imports — the slug can be suffixed on collision, so it can't be.
   // (Postgres allows many NULLs under a unique index, which is the semantics we
   // want: existing imported rows stay null and never collide.)
-  github_classroom_id Int?            @unique
-  status              ClassroomStatus @default(ACTIVE)
-  is_archived         Boolean         @default(false)
+  github_classroom_id      Int?            @unique
+  status                   ClassroomStatus @default(ACTIVE)
+  is_archived              Boolean         @default(false)
   // True for the auto-provisioned per-user "Example Course" sandbox used by the
   // in-classroom onboarding tour. Backed by a mock GitOrganization (no live GitHub).
-  is_example          Boolean         @default(false)
+  is_example               Boolean         @default(false)
   // Edge-cache bust for this classroom's content. Every signed content URL
   // carries it, so bumping it changes ALL of them at once and the CDN misses
   // on every asset until it refills. Old URLs STILL VERIFY — this is not a
   // revocation, and nothing already handed out stops working; it only stops
   // being the URL the app links to.
-  content_key_version Int             @default(0)
-  created_at          DateTime        @default(now())
-  updated_at          DateTime        @default(now()) @updatedAt
+  content_key_version      Int             @default(0)
+  // When the asset map was last rebuilt FROM THE REPO'S TREE — a full sync, and
+  // only a full sync. This is what `ensureContentAssets` measures its 24h
+  // refresh against, deliberately NOT the newest `content_assets.synced_at`:
+  // incremental webhook applies and upload-time writes both stamp rows `now`,
+  // so reading the rows would let a single upload make a stale map look fresh
+  // and suppress the daily repair for another day. Null means never synced.
+  content_assets_synced_at DateTime?
+  created_at               DateTime        @default(now())
+  updated_at               DateTime        @default(now()) @updatedAt
 
   git_organization      GitOrganization       @relation(fields: [git_org_id], references: [id], onDelete: Cascade)
   settings              ClassroomSettings?
@@ -1708,9 +1715,9 @@ model FormMagicToken {
   /// because the set belongs to the provider, and an unfamiliar event type
   /// should become a value we ignore rather than a migration that blocks a
   /// webhook.
-  delivery_state  String?
+  delivery_state      String?
   /// The provider's stated reason, for the staff row. Never shown to a filler.
-  delivery_detail String?
+  delivery_detail     String?
 
   response FormResponse @relation(fields: [response_id], references: [id], onDelete: Cascade)
 
@@ -1743,9 +1750,11 @@ model ContentAsset {
   /// rather than freezing a signed URL into the content. Any matching row will
   /// do — content-addressed means every path with this sha is byte-identical.
   @@index([classroom_id, sha])
-  /// Freshness probe: `ensureContentAssets` reads the newest `synced_at` for a
-  /// classroom on the render path. Without this it scans and sorts every row
-  /// the classroom has, on every render.
+  /// The full sync's sweep: after stamping every row it wrote with one
+  /// `synced_at`, it deletes this classroom's rows still below that stamp —
+  /// the paths that have left the repo. Freshness is NOT read from here;
+  /// `Classroom.content_assets_synced_at` holds that, so an incremental or
+  /// upload-time row cannot pass for a completed sync.
   @@index([classroom_id, synced_at])
   @@map("content_assets")
 }

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -46,6 +46,7 @@ vi.mock('../../content/ContentService.ts', () => ({
 const {
   syncContentAssets,
   ensureContentAssets,
+  recordContentAsset,
   lookupContentAsset,
   lookupContentTree,
   lookupContentAssetBySha,
@@ -359,6 +360,84 @@ describe('contentAssets.service', () => {
 
       expect(result?.mode).toBe('full');
       expect(getTree).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('recordContentAsset', () => {
+    it('upserts one blob row with the same shape a sync would write', async () => {
+      // The point of the whole helper: the row exists before any webhook or
+      // 24-hour refresh, so the very next render resolves the path instead of
+      // signing a dangling URL for it.
+      await expect(
+        recordContentAsset('class-1', { path: 'pages/home/assets/x.png', sha: 'sha-x', size: 512 })
+      ).resolves.toBe(true);
+
+      expect(contentAssetUpsert).toHaveBeenCalledTimes(1);
+      const [args] = contentAssetUpsert.mock.calls[0];
+      expect(args.where).toEqual({
+        classroom_id_path: { classroom_id: 'class-1', path: 'pages/home/assets/x.png' },
+      });
+      // An upload writes a file, never a tree.
+      expect(args.create).toMatchObject({
+        classroom_id: 'class-1',
+        path: 'pages/home/assets/x.png',
+        sha: 'sha-x',
+        type: 'blob',
+        size: 512,
+      });
+      expect(args.update).toMatchObject({ sha: 'sha-x', type: 'blob', size: 512 });
+      // Stamped now, so the next full sync's sweep keeps it rather than
+      // deleting a row for a file that is genuinely in the repo.
+      expect(args.create.synced_at).toBeInstanceOf(Date);
+      expect(args.update.synced_at).toEqual(args.create.synced_at);
+    });
+
+    it('defaults a missing size to 0, as the tree entries do', async () => {
+      await recordContentAsset('class-1', { path: 'images/a.png', sha: 'sha-a' });
+
+      expect(contentAssetUpsert.mock.calls[0][0].create.size).toBe(0);
+    });
+
+    it('no-ops for a classroom the delivery layer cannot serve', async () => {
+      // GitLab-backed, the mock org behind an example classroom, or no content
+      // repo. The upload itself still succeeded, so this must not throw.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        git_organization: { ...CLASSROOM.git_organization, provider: 'GITLAB' },
+      });
+
+      await expect(
+        recordContentAsset('class-1', { path: 'images/a.png', sha: 'sha-a' })
+      ).resolves.toBe(false);
+      expect(contentAssetUpsert).not.toHaveBeenCalled();
+    });
+
+    it('no-ops for a classroom with no content repo', async () => {
+      classroomFindUnique.mockResolvedValue({ ...CLASSROOM, content_repo: null });
+
+      await expect(
+        recordContentAsset('class-1', { path: 'images/a.png', sha: 'sha-a' })
+      ).resolves.toBe(false);
+      expect(contentAssetUpsert).not.toHaveBeenCalled();
+    });
+
+    it('resolves false instead of throwing when the write fails', async () => {
+      // It sits on an upload path. A file that reached the repo must never be
+      // reported as a failed upload because a cache row could not be written.
+      contentAssetUpsert.mockImplementation(() => {
+        throw new Error('connection terminated');
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await expect(
+        recordContentAsset('class-1', { path: 'images/a.png', sha: 'sha-a' })
+      ).resolves.toBe(false);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not record images/a.png for class-1'),
+        expect.any(Error)
+      );
+      warn.mockRestore();
     });
   });
 

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -17,11 +17,12 @@ const contentAssetDeleteMany = vi.fn();
 const contentAssetFindFirst = vi.fn();
 const contentAssetFindUnique = vi.fn();
 const classroomFindUnique = vi.fn();
+const classroomUpdate = vi.fn();
 const transaction = vi.fn();
 
 vi.mock('@classmoji/database', () => ({
   default: () => ({
-    classroom: { findUnique: classroomFindUnique },
+    classroom: { findUnique: classroomFindUnique, update: classroomUpdate },
     contentAsset: {
       upsert: contentAssetUpsert,
       deleteMany: contentAssetDeleteMany,
@@ -55,13 +56,22 @@ const {
 const CLASSROOM = {
   id: 'class-1',
   content_repo: 'content-cs101',
+  // Freshness lives HERE, not on the newest row — see ensureContentAssets.
+  content_assets_synced_at: null as Date | null,
   git_organization: { id: 'org-1', provider: 'GITHUB', login: 'dartmouth-cs' },
 };
+
+/** A classroom whose last FULL sync finished `ms` ago. */
+const syncedAgo = (ms: number) => ({
+  ...CLASSROOM,
+  content_assets_synced_at: new Date(Date.now() - ms),
+});
 
 /** The upsert/deleteMany mocks return tagged markers so ops stay identifiable. */
 const setupTransaction = (deletedCount = 0) => {
   contentAssetUpsert.mockImplementation(args => ({ op: 'upsert', args }));
   contentAssetDeleteMany.mockImplementation(args => ({ op: 'deleteMany', args }));
+  classroomUpdate.mockImplementation(args => ({ op: 'classroomUpdate', args }));
   transaction.mockImplementation((ops: { op: string }[]) =>
     Promise.resolve(ops.map(op => (op.op === 'deleteMany' ? { count: deletedCount } : op)))
   );
@@ -136,6 +146,51 @@ describe('contentAssets.service', () => {
       await syncContentAssets('class-1');
 
       expect(contentAssetUpsert.mock.calls[0][0].create.size).toBe(0);
+    });
+
+    it('stamps the classroom with the run, inside the same transaction', async () => {
+      // A run that read the whole tree is the ONLY thing entitled to say the
+      // map matches the repo, and the stamp is what `ensureContentAssets`
+      // measures against. In the transaction so a sync that fails leaves the
+      // classroom looking exactly as unsynced as it is.
+      getTree.mockResolvedValue({
+        sha: 'r',
+        truncated: false,
+        entries: [{ path: 'images/a.png', sha: 'sha-a', type: 'blob', size: 1 }],
+      });
+
+      await syncContentAssets('class-1');
+
+      expect(classroomUpdate).toHaveBeenCalledTimes(1);
+      const [stamp] = classroomUpdate.mock.calls[0];
+      expect(stamp.where).toEqual({ id: 'class-1' });
+      // The run's one stamp — the same instant every row it wrote carries.
+      const rowStamp = contentAssetUpsert.mock.calls[0][0].create.synced_at;
+      expect(stamp.data.content_assets_synced_at).toEqual(rowStamp);
+
+      const ops = transaction.mock.calls[0][0] as { op: string }[];
+      expect(ops).toContainEqual({ op: 'classroomUpdate', args: stamp });
+      // Ahead of the sweep, which the result's delete count is read off the
+      // tail of — see fullSync.
+      expect(ops[0].op).toBe('classroomUpdate');
+      expect(ops.at(-1)?.op).toBe('deleteMany');
+    });
+
+    it('stamps even when the tree came back truncated', async () => {
+      // It read the tree and applied everything that arrived, which is as
+      // current as this classroom can get. Refusing to stamp would put a repo
+      // that is simply too big into a permanent re-sync loop.
+      getTree.mockResolvedValue({
+        sha: 'r',
+        truncated: true,
+        entries: [{ path: 'images/a.png', sha: 'sha-a', type: 'blob', size: 1 }],
+      });
+
+      await syncContentAssets('class-1');
+
+      expect(classroomUpdate).toHaveBeenCalledTimes(1);
+      const ops = transaction.mock.calls[0][0] as { op: string }[];
+      expect(ops[0].op).toBe('classroomUpdate');
     });
   });
 
@@ -271,11 +326,26 @@ describe('contentAssets.service', () => {
 
       expect(result.mode).toBe('full');
     });
+
+    it('does NOT stamp the classroom', async () => {
+      // It applied the paths one push named and knows nothing about the rest of
+      // the repo. Stamping here would let a steady trickle of webhooks suppress
+      // the daily full refresh — which exists to repair the webhooks that never
+      // arrive at all.
+      getMeta.mockResolvedValue({ sha: 'sha-a', size: 10 });
+
+      const result = await syncContentAssets('class-1', {
+        changes: { added: ['images/a.png'], modified: [], removed: [] },
+      });
+
+      expect(result.mode).toBe('incremental');
+      expect(classroomUpdate).not.toHaveBeenCalled();
+    });
   });
 
   describe('ensureContentAssets', () => {
-    it('no-ops when the map is fresher than maxAgeMs', async () => {
-      contentAssetFindFirst.mockResolvedValue({ synced_at: new Date(Date.now() - 1000) });
+    it('no-ops when the last FULL sync is fresher than maxAgeMs', async () => {
+      classroomFindUnique.mockResolvedValue(syncedAgo(1000));
 
       const result = await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
 
@@ -283,13 +353,50 @@ describe('contentAssets.service', () => {
       expect(getTree).not.toHaveBeenCalled();
     });
 
-    it('syncs when the map is stale', async () => {
-      contentAssetFindFirst.mockResolvedValue({ synced_at: new Date(Date.now() - 120_000) });
+    it('syncs when the last full sync is older than maxAgeMs', async () => {
+      classroomFindUnique.mockResolvedValue(syncedAgo(120_000));
       getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
 
       const result = await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
 
       expect(result?.mode).toBe('full');
+    });
+
+    it('still refreshes a stale map that a fresh UPLOAD row just touched', async () => {
+      // THE regression this guards. `recordContentAsset` stamps its row `now`,
+      // so reading freshness off the newest row let one teacher uploading one
+      // image make a week-old map look fresh for another 24 hours — on exactly
+      // the classrooms that need the repair, the ones whose push webhook is not
+      // arriving. Pushed files stay dangling and deleted files never get swept
+      // for as long as anyone keeps uploading.
+      const DAY = 24 * 60 * 60 * 1000;
+      classroomFindUnique.mockResolvedValue(syncedAgo(7 * DAY));
+      getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
+
+      await recordContentAsset('class-1', { path: 'pages/home/assets/x.png', sha: 'sha-x' });
+      expect(contentAssetUpsert).toHaveBeenCalled();
+
+      // What the upload leaves behind: a row stamped NOW on a map whose last
+      // real sync was a week ago. Seeded explicitly, because the old probe read
+      // exactly this and would answer "fresh" — the bug.
+      contentAssetFindFirst.mockResolvedValue({ synced_at: new Date() });
+
+      const result = await ensureContentAssets('class-1', { maxAgeMs: DAY });
+
+      // The classroom stamp is untouched, so the daily repair still fires.
+      expect(getTree).toHaveBeenCalledTimes(1);
+      expect(result?.mode).toBe('full');
+    });
+
+    it('syncs when the classroom has never fully synced', async () => {
+      // Null stamp, whatever the rows say.
+      classroomFindUnique.mockResolvedValue({ ...CLASSROOM, content_assets_synced_at: null });
+      getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
+
+      const result = await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
+
+      expect(result?.mode).toBe('full');
+      expect(getTree).toHaveBeenCalledTimes(1);
     });
 
     it('no-ops instead of throwing for a classroom the delivery layer cannot serve', async () => {
@@ -302,7 +409,6 @@ describe('contentAssets.service', () => {
 
       await expect(ensureContentAssets('class-1', { maxAgeMs: 60_000 })).resolves.toBeNull();
       expect(getTree).not.toHaveBeenCalled();
-      expect(contentAssetFindFirst).not.toHaveBeenCalled();
     });
 
     it('no-ops for a classroom with no content repo', async () => {
@@ -316,7 +422,6 @@ describe('contentAssets.service', () => {
       // The render-path contract. A GitHub 403 rate limit or a 5xx must cost
       // staleness, not a broken page — the previous map is still in the table
       // and still usable.
-      contentAssetFindFirst.mockResolvedValue(null);
       getTree.mockRejectedValue(
         Object.assign(new Error('API rate limit exceeded'), {
           status: 403,
@@ -342,24 +447,11 @@ describe('contentAssets.service', () => {
     });
 
     it('reads the classroom once, not once per guard', async () => {
-      contentAssetFindFirst.mockResolvedValue(null);
       getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
 
       await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
 
       expect(classroomFindUnique).toHaveBeenCalledTimes(1);
-    });
-
-    it('syncs when the classroom has never synced', async () => {
-      // Self-bootstrapping: no backfill job, no migration. The first render of
-      // a classroom that has no map builds one.
-      contentAssetFindFirst.mockResolvedValue(null);
-      getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
-
-      const result = await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
-
-      expect(result?.mode).toBe('full');
-      expect(getTree).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -419,6 +511,14 @@ describe('contentAssets.service', () => {
         recordContentAsset('class-1', { path: 'images/a.png', sha: 'sha-a' })
       ).resolves.toBe(false);
       expect(contentAssetUpsert).not.toHaveBeenCalled();
+    });
+
+    it('does NOT stamp the classroom as fully synced', async () => {
+      // One file is not the repo. This is the whole reason freshness moved off
+      // the rows — see the ensureContentAssets suite.
+      await recordContentAsset('class-1', { path: 'images/a.png', sha: 'sha-a' });
+
+      expect(classroomUpdate).not.toHaveBeenCalled();
     });
 
     it('resolves false instead of throwing when the write fails', async () => {

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -27,6 +27,14 @@ vi.mock('../../content/ContentService.ts', () => ({
   },
 }));
 
+// The asset map row is written at upload time rather than left to the push
+// webhook — see recordContentAsset. Mocked here so this suite keeps pinning the
+// GitHub interactions and nothing reaches Prisma.
+const recordContentAssetMock = vi.fn();
+vi.mock('../contentAssets.service.ts', () => ({
+  recordContentAsset: (...args: unknown[]) => recordContentAssetMock(...args),
+}));
+
 const {
   loadPageContent,
   savePageContent,
@@ -259,6 +267,7 @@ describe('pageContent.uploadPageAsset', () => {
       // A real 40-hex blob sha — the signer refuses anything else.
       sha: 'c'.repeat(40),
     });
+    recordContentAssetMock.mockResolvedValue(true);
     delete process.env.CONTENT_DELIVERY_ORIGIN;
     delete process.env.CONTENT_SIGNING_SECRET;
   });
@@ -306,6 +315,31 @@ describe('pageContent.uploadPageAsset', () => {
       path: 'pages/syllabus/assets/a.png',
       displayUrl: null,
     });
+  });
+
+  it('records the uploaded blob in the asset map before returning', async () => {
+    // THE regression this guards: without the row, the save stores a repo path
+    // the next render cannot resolve, and the viewer gets the resolver's
+    // "dangling" URL until a push webhook or the 24-hour refresh catches up.
+    const classroomPage = {
+      ...page,
+      classroom: { ...page.classroom, id: '3f2504e0-4f89-41d3-9a0c-0305e82c3301' },
+    };
+    const buffer = Buffer.from('image-bytes');
+
+    await uploadPageAsset(classroomPage, buffer, 'a.png');
+
+    expect(recordContentAssetMock).toHaveBeenCalledWith('3f2504e0-4f89-41d3-9a0c-0305e82c3301', {
+      path: 'pages/syllabus/assets/a.png',
+      sha: 'c'.repeat(40),
+      size: buffer.length,
+    });
+  });
+
+  it('skips the map write when there is no classroom id to key it on', async () => {
+    await uploadPageAsset(page, Buffer.from('x'), 'a.png');
+
+    expect(recordContentAssetMock).not.toHaveBeenCalled();
   });
 
   it('falls back the same way when the classroom has no id to sign against', async () => {

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -402,6 +402,52 @@ export async function ensureContentAssets(
 }
 
 /**
+ * Record ONE just-uploaded blob in the map, now, without waiting for a sync.
+ *
+ * The map is otherwise filled by a push webhook or by `ensureContentAssets`'
+ * 24-hour refresh, and both are too late for the file a teacher just dropped
+ * into the editor: the save stores a repo path, the next render looks that path
+ * up, misses, and the resolver emits its "dangling" URL. The upload already
+ * knows everything a row needs — path, blob sha, size — so writing it here
+ * removes the round trip entirely.
+ *
+ * A later full sync overwrites this row with identical values and its sweep
+ * keeps it (the stamp is `now`), so this is only an early write of what the
+ * sync would have written anyway. Type is always `blob`: an upload writes a
+ * file, never a tree.
+ *
+ * NEVER THROWS, for the same reason `ensureContentAssets` does not — it sits on
+ * an upload path, and an upload that reached the repo must not be reported as
+ * failed because a cache row could not be written. Returns whether the row was
+ * written: false covers both "this classroom is not served by the delivery
+ * layer" (GitLab-backed, mock org, no content repo) and "the write failed".
+ */
+export async function recordContentAsset(
+  classroomId: string,
+  entry: { path: string; sha: string; size?: number }
+): Promise<boolean> {
+  try {
+    // Configuration, checked rather than caught — same split as ensureContentAssets.
+    const classroom = await loadClassroomRaw(classroomId);
+    if (!isDeliverable(classroom)) return false;
+
+    await upsertOp(
+      classroomId,
+      { path: entry.path, sha: entry.sha, type: 'blob', size: entry.size },
+      new Date()
+    );
+    return true;
+  } catch (error: unknown) {
+    console.warn(
+      `[contentAssets] Could not record ${entry.path} for ${classroomId}; ` +
+        'the next sync will pick it up:',
+      error
+    );
+    return false;
+  }
+}
+
+/**
  * One path → the git object behind it. Null when the map has never heard of it.
  */
 export async function lookupContentAsset(

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -132,7 +132,7 @@ async function resolveClassroom(classroomId: string): Promise<ResolvedClassroom>
  * already-loaded row rather than its own query, so a caller reads the classroom
  * once and both this and `toResolvedClassroom` work from that one read.
  */
-function isDeliverable(classroom: ClassroomRecord): boolean {
+function isDeliverable(classroom: ClassroomRecord): classroom is NonNullable<ClassroomRecord> {
   return Boolean(
     classroom?.content_repo &&
     classroom.git_organization?.login &&
@@ -205,22 +205,40 @@ function upsertOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
  * does not delete, which can only leave the map too large — a superset, whose
  * worst case is a stale row, rather than a subset, whose worst case is a
  * missing asset on a live page.
+ *
+ * THIS is also the only thing that stamps `Classroom.content_assets_synced_at`,
+ * the value `ensureContentAssets` measures its refresh against. Only a run that
+ * read the repo's whole tree can honestly claim the map matches the repo, so an
+ * incremental apply and an upload-time row must not move it — see
+ * `ensureContentAssets`. The stamp goes INSIDE the transaction, so a sync that
+ * fails leaves the classroom looking exactly as unsynced as it is. A truncated
+ * run still stamps: it read the tree and applied everything that arrived, which
+ * is as current as this classroom can get, and refusing to stamp would put it
+ * into a permanent re-sync loop against a repo that is simply too big.
  */
 async function fullSync(classroom: ResolvedClassroom): Promise<SyncContentAssetsResult> {
   const { entries, truncated } = await readRepoTree(classroom);
   const syncedAt = new Date();
+
+  // FIRST, not last. The sweep's count is read off the tail of the results, so
+  // the stamp goes in front of the upserts rather than after the delete.
+  const stampOp = getPrisma().classroom.update({
+    where: { id: classroom.id },
+    data: { content_assets_synced_at: syncedAt },
+  });
 
   const operations = entries.map(entry => upsertOp(classroom.id, entry, syncedAt));
 
   let deleted = 0;
 
   if (truncated) {
-    await getPrisma().$transaction(operations);
+    await getPrisma().$transaction([stampOp, ...operations]);
   } else {
     // Destructured rather than indexed off the tail: the sweep's count is
     // positionally coupled to it being the LAST operation, and appending
     // another op later would otherwise report a wrong count silently.
     const [...results] = await getPrisma().$transaction([
+      stampOp,
       ...operations,
       getPrisma().contentAsset.deleteMany({
         where: { classroom_id: classroom.id, synced_at: { lt: syncedAt } },
@@ -346,12 +364,16 @@ export async function syncContentAssets(
 /**
  * Make sure the map exists and is not older than `maxAgeMs`, syncing if not.
  *
+ * Age is `Classroom.content_assets_synced_at`, which only a FULL sync writes —
+ * the one thing that can claim the map matches the repo. See the body.
+ *
  * This is what makes the system self-bootstrapping. No classroom needs to be
  * migrated into the delivery layer and no backfill job has to run: the first
- * render of a classroom that has never synced finds no rows, syncs, and
- * proceeds. It is also the backstop for a missed push webhook — a delivery that
- * never arrived costs staleness bounded by `maxAgeMs`, not a permanently wrong
- * map.
+ * render of a classroom that has never fully synced finds a null stamp, syncs,
+ * and proceeds. It is also the backstop for a missed push webhook — a delivery
+ * that never arrived costs staleness bounded by `maxAgeMs`, not a permanently
+ * wrong map — which is why the bound has to hold no matter how much OTHER
+ * write traffic the classroom saw in the meantime.
  *
  * NEVER THROWS — see the body. Returns null whenever no sync happened, whether
  * because the map was fresh, the classroom is not served by this layer, or the
@@ -379,13 +401,18 @@ export async function ensureContentAssets(
     return null;
   }
 
-  const newest = await getPrisma().contentAsset.findFirst({
-    where: { classroom_id: classroomId },
-    orderBy: { synced_at: 'desc' },
-    select: { synced_at: true },
-  });
+  // Read off the CLASSROOM, not off the newest row. The rows cannot answer this
+  // question: an incremental webhook apply stamps the paths one push touched,
+  // and `recordContentAsset` stamps the single file a teacher just uploaded,
+  // both with `now` — so the newest row says "something was written recently",
+  // never "the map matches the repo". Measuring against it let one upload
+  // suppress the daily repair for another 24 hours on exactly the classrooms
+  // that need it most: the ones whose push webhook is not arriving, where
+  // pushed files render as dangling URLs and deleted files are never swept.
+  // Only `fullSync` writes this stamp. Null means never fully synced.
+  const lastFullSync = classroom.content_assets_synced_at;
 
-  if (newest && Date.now() - newest.synced_at.getTime() < maxAgeMs) {
+  if (lastFullSync && Date.now() - lastFullSync.getTime() < maxAgeMs) {
     return null;
   }
 

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { signBlobUrl } from '@classmoji/content-signing';
 import { z } from 'zod';
 import { ContentService } from '../content/ContentService.ts';
+import { recordContentAsset } from './contentAssets.service.ts';
 import {
   dedupeMergedTreeIds,
   indexResolutions,
@@ -266,6 +267,12 @@ export async function savePageContent(
  * than looked up in the asset map, because the push webhook that would put a
  * row there has not fired yet — a map lookup here would reliably miss.
  *
+ * Which is also why the row is written HERE. `displayUrl` only covers the
+ * editor's own preview; the moment the page is saved and re-rendered, the
+ * stored path goes through the map like any other, and a miss there renders as
+ * a dangling URL. The upload already has the path, the sha and the size, so the
+ * row is recorded from them rather than left to a webhook round trip.
+ *
  * @returns `{ url, path, displayUrl }`. `path` is always the repo path.
  *   `displayUrl` is null when the delivery layer is off, and `url` is then the
  *   legacy absolute URL rather than the path.
@@ -286,6 +293,17 @@ export async function uploadPageAsset(
     branch: 'main',
     message: `Upload asset for ${page.title || 'page'}`,
   });
+
+  const classroomId = (page.classroom as { id?: unknown }).id;
+  if (typeof classroomId === 'string') {
+    // Never throws, and its failure is not this caller's problem: the file is
+    // already in the repo, and the next sync writes the same row.
+    await recordContentAsset(classroomId, {
+      path: result.path,
+      sha: result.sha,
+      size: buffer.length,
+    });
+  }
 
   const displayUrl = await signUploadedAsset(page, result.path, result.sha);
 


### PR DESCRIPTION
## What
A freshly uploaded image rendered as the resolver's dangling `/c/{classroom}/missing/…` URL until the push webhook → Trigger sync round-trip completed (and on staging that webhook is lost while hook-station is autostopped). Two commits:

1. **Write-through on upload.** `recordContentAsset(classroomId, { path, sha, size })` upserts the one blob row from the values GitHub just returned, called from `uploadPageAsset` (covers the editor upload API and header/cover uploads) and the slides `upload-image` action. No-op for GitLab / no-content-repo classrooms; never throws on the upload path.
2. **Freshness stamp moves off the rows.** `ensureContentAssets` used `MAX(content_assets.synced_at)` to decide whether to full-sync, so one upload would mark a stale map fresh for 24 h and disable the very backstop this relies on. New nullable `classrooms.content_assets_synced_at`, written only by `fullSync` inside its transaction; `null` → sync. One migration, no backfill (every classroom reconciles once on its next render or nightly pass).

Not covered on purpose: batch import/copy flows (the sync task's job) and shared-theme saves (tree-SHA-addressed; tracked as a follow-up).

## Test
- services: 1401 passed, 13 failed (known GitLabProvider baseline), +11 tests incl. one that fails under the old probe.
- typecheck: services 16 (known GitLabProvider), tasks/pages/database/slides 0, webapp 1 (known `RequireGitProvider`).
- On staging after deploy: reload `cs98-test.staging.classmoji.io`; the `low-poly-texture-16.png` block should render via `content-staging.classmoji.io` with a signed `srcset`; upload a new image in the editor and it renders on the class site without waiting for a webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA