### PR TITLE
fix(slides): deliver deck assets on present, follow and speaker routes

### DIFF
--- a/apps/slides/app/root.tsx
+++ b/apps/slides/app/root.tsx
@@ -66,7 +66,9 @@ const App = () => {
                       document.documentElement.classList.remove('dark');
                     }
                   });
-                } catch (error: unknown) { console.log(error); }
+                  // NOTE: this string is injected verbatim as JavaScript — no
+                  // TypeScript syntax here, or every page logs a SyntaxError.
+                } catch (error) { console.log(error); }
               })();
             `,
           }}

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -34,6 +34,7 @@ import { fetchContent } from '~/utils/contentProxy';
 import { diffDeckSnapshots, extractDeckSnapshot, type DeckSnapshot } from '~/utils/deckOpsDiff';
 import { getThemeUrls } from '~/utils/themeService.server';
 import {
+  deckAccessFor,
   deckDeliveryContext,
   resolveDeckAssets,
   resolveDeliveryThemeUrls,
@@ -172,11 +173,12 @@ export const loader = async ({
   // Per-VIEWER tier: staff and preview readers get short-lived draft URLs, a
   // public deck's anonymous readers get the long public bucket, everyone else
   // the enrolled one. This is the reason a signed URL cannot live in the deck.
-  const deliveryCtx = deckDeliveryContext(slide, gitOrgLogin, repo, {
-    canEdit,
-    preview: previewActive,
-    isPublicSite: slide.is_public,
-  });
+  const deliveryCtx = deckDeliveryContext(
+    slide,
+    gitOrgLogin,
+    repo,
+    deckAccessFor('viewer', { canEdit, previewActive }, slide)
+  );
 
   // GitHub's free diff UI for the pending preview (branch segment URL-encoded —
   // preview branch names contain slashes).
@@ -711,7 +713,12 @@ export const action = async ({
             loaded.deck,
             gitOrgLogin,
             repo,
-            deckDeliveryContext(slide, gitOrgLogin, repo, { canEdit: true })
+            deckDeliveryContext(
+              slide,
+              gitOrgLogin,
+              repo,
+              deckAccessFor('viewer', { canEdit: true }, slide)
+            )
           );
           return {
             intent: 'fetch-latest',

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -18,7 +18,6 @@ import {
   loadDeck,
   parseSlidesFragment,
   previewBranchName,
-  rewriteDeckAssetUrls,
   resolveDeckPreviewConflicts,
   saveDeck,
   saveDeckFromOps,
@@ -34,6 +33,12 @@ import { useUser } from '~/hooks';
 import { fetchContent } from '~/utils/contentProxy';
 import { diffDeckSnapshots, extractDeckSnapshot, type DeckSnapshot } from '~/utils/deckOpsDiff';
 import { getThemeUrls } from '~/utils/themeService.server';
+import {
+  deckDeliveryContext,
+  resolveDeckAssets,
+  resolveDeliveryThemeUrls,
+  resolveReadThemeUrls,
+} from '~/utils/deckDelivery.server';
 import RevealSlides, { type RevealSlidesHandle } from '~/components/RevealSlides';
 import SlideToolbar from '~/components/SlideToolbar';
 import SlideNotesPanel from '~/components/SlideNotesPanel';
@@ -52,133 +57,6 @@ import {
   type ConflictUnit,
   type OrderConflict,
 } from '~/components/preview/PreviewControls';
-
-/**
- * Resolve shared-theme URLs for read-side deck rendering (Phase 4c). Same
- * resolution the save path uses (getThemeUrls with identical args), so the
- * generated document matches the saved index.html artifact byte-for-byte.
- * Unlike the save path (which is about to persist and falls back to theme
- * 'white'), a resolve failure on a READ must not mutate the deck — we just
- * render without theme links (generateDeckHtml warns).
- */
-async function resolveReadThemeUrls(
-  deck: DeckJson,
-  gitOrgLogin: string,
-  repo: string
-): Promise<DeckThemeUrls | undefined> {
-  if (!deck.theme.startsWith('shared:')) return undefined;
-  const sharedThemeName = deck.theme.replace('shared:', '');
-  try {
-    const urls = await getThemeUrls(gitOrgLogin, repo, sharedThemeName);
-    return {
-      libCssUrl: urls.libCssUrl,
-      customThemeUrl: urls.customThemeUrl,
-      bodyClasses: urls.bodyClasses,
-    };
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Could not resolve shared theme URLs for "${sharedThemeName}":`, message);
-    return undefined;
-  }
-}
-
-/**
- * The classroom shape the content resolver needs, or null when this deck's
- * classroom cannot be served by the delivery layer at all.
- */
-function deliveryContext(
-  slide: {
-    classroom?: { id?: string; content_key_version?: number; content_repo?: string } | null;
-  },
-  gitOrgLogin: string | undefined,
-  repo: string | undefined,
-  tier: 'public' | 'enrolled' | 'draft'
-) {
-  const classroom = slide.classroom;
-  if (!classroom?.id || !repo || !gitOrgLogin) return null;
-  return {
-    classroom: {
-      id: classroom.id,
-      content_key_version: classroom.content_key_version ?? 0,
-      content_repo: repo,
-      git_organization: { login: gitOrgLogin },
-    },
-    tier,
-  };
-}
-
-type DeliveryContext = ReturnType<typeof deliveryContext>;
-
-/**
- * Read-side theme URLs, signed when the delivery layer is on.
- *
- * `getThemeUrls` still does the work that needs GitHub — which lib CSS variant
- * exists, whether there is a custom-theme.css, what the manifest's bodyClasses
- * are. This only swaps the BASE those files hang off, from the content proxy to
- * the signed theme folder, keeping the exact filenames it resolved. Deriving
- * the filenames independently would silently downgrade a deck on `offline-v1`
- * to a 404, and would invent a custom-theme.css for themes that have none.
- *
- * A theme is signed as a FOLDER, so the CSS's own relative `url()` references
- * inherit the signature and keep resolving.
- */
-async function resolveDeliveryThemeUrls(
-  deck: DeckJson,
-  gitOrgLogin: string,
-  repo: string,
-  ctx: DeliveryContext
-): Promise<DeckThemeUrls | undefined> {
-  const base = await resolveReadThemeUrls(deck, gitOrgLogin, repo);
-  if (!base || !ctx || !deck.theme.startsWith('shared:')) return base;
-
-  const themeName = deck.theme.replace('shared:', '');
-  const signedBase = await ClassmojiService.contentDelivery.resolveThemeBase(ctx, themeName);
-  if (!signedBase) return base;
-
-  // `/content/{org}/{repo}/.slidesthemes/{theme}/lib/offline-v2.css` → `lib/offline-v2.css`
-  const marker = `/.slidesthemes/${themeName}/`;
-  const rebase = (url: string | null | undefined): string | null | undefined => {
-    if (!url) return url;
-    const at = url.indexOf(marker);
-    return at === -1 ? url : `${signedBase}${url.slice(at + marker.length)}`;
-  };
-
-  return {
-    ...base,
-    libCssUrl: rebase(base.libCssUrl),
-    customThemeUrl: rebase(base.customThemeUrl),
-  };
-}
-
-/**
- * Sign the image references inside already-rendered deck HTML.
- *
- * READ ONLY. The stored document keeps `/content/{org}/{repo}/{path}`, and this
- * is the view of it — which is why it is never applied to content on its way
- * into the editor: the editor posts its document back on save, and a signed URL
- * that made that round trip would be committed into deck.json, freezing one
- * viewer's expiring signature into the deck forever.
- *
- * A failure renders the deck with its stored URLs, which still work through the
- * content proxy. Nothing here is allowed to break a deck read.
- */
-async function resolveDeckAssets(html: string, ctx: DeliveryContext): Promise<string> {
-  if (!ctx || !html) return html;
-
-  try {
-    return await rewriteDeckAssetUrls(html, async refs => {
-      // Theme assets are excluded on purpose: a theme is signed as a folder
-      // (so its relative url() keeps working) and rewriting one of its files
-      // to a standalone blob URL would break precisely that.
-      const wanted = refs.filter(ref => !ref.includes('.slidesthemes/'));
-      return ClassmojiService.contentDelivery.resolveMany(ctx, wanted);
-    });
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn('[slides] Asset resolution failed, serving stored URLs:', message);
-    return html;
-  }
-}
 
 // Loader to fetch slide metadata and content from database/GitHub
 export const loader = async ({
@@ -294,16 +172,11 @@ export const loader = async ({
   // Per-VIEWER tier: staff and preview readers get short-lived draft URLs, a
   // public deck's anonymous readers get the long public bucket, everyone else
   // the enrolled one. This is the reason a signed URL cannot live in the deck.
-  const deliveryCtx = deliveryContext(
-    slide,
-    gitOrgLogin,
-    repo,
-    ClassmojiService.contentDelivery.tierFor({
-      canEdit,
-      preview: previewActive,
-      isPublicSite: slide.is_public,
-    })
-  );
+  const deliveryCtx = deckDeliveryContext(slide, gitOrgLogin, repo, {
+    canEdit,
+    preview: previewActive,
+    isPublicSite: slide.is_public,
+  });
 
   // GitHub's free diff UI for the pending preview (branch segment URL-encoded —
   // preview branch names contain slashes).
@@ -838,12 +711,7 @@ export const action = async ({
             loaded.deck,
             gitOrgLogin,
             repo,
-            deliveryContext(
-              slide,
-              gitOrgLogin,
-              repo,
-              ClassmojiService.contentDelivery.tierFor({ canEdit: true })
-            )
+            deckDeliveryContext(slide, gitOrgLogin, repo, { canEdit: true })
           );
           return {
             intent: 'fetch-latest',

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -5,6 +5,7 @@ import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
 import { fetchContent } from '~/utils/contentProxy';
+import { deckDeliveryContext, resolveDeckDelivery } from '~/utils/deckDelivery.server';
 
 /**
  * Follow route - Audience sync view
@@ -43,7 +44,7 @@ export const loader = async ({
   }
 
   // Authorization: check view access (supports public slides, membership, and shareCode)
-  const { accessGrantedVia, canViewSpeakerNotes } = await assertSlideAccess({
+  const { accessGrantedVia, canEdit, canViewSpeakerNotes } = await assertSlideAccess({
     request,
     slideId,
     slide,
@@ -78,7 +79,17 @@ export const loader = async ({
   });
 
   if (contentResult) {
-    slideContent = contentResult.content as string;
+    // Same read-side delivery pass the deck viewer runs. A follower is usually
+    // a student or a shareCode guest, so the tier lands on `enrolled`/`public`
+    // rather than the staff `draft` bucket — `tierFor` decides, not this route.
+    const { html } = await resolveDeckDelivery(
+      contentResult.content as string,
+      deckDeliveryContext(slide, gitOrgLogin, repo, {
+        canEdit,
+        isPublicSite: slide.is_public,
+      })
+    );
+    slideContent = html;
 
     // Strip speaker notes from content if user doesn't have permission to view them
     // Followers are typically students/public who shouldn't see notes unless show_speaker_notes is enabled

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -5,7 +5,11 @@ import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
 import { fetchContent } from '~/utils/contentProxy';
-import { deckDeliveryContext, resolveDeckDelivery } from '~/utils/deckDelivery.server';
+import {
+  deckAccessFor,
+  deckDeliveryContext,
+  resolveDeckDelivery,
+} from '~/utils/deckDelivery.server';
 
 /**
  * Follow route - Audience sync view
@@ -82,12 +86,11 @@ export const loader = async ({
     // Same read-side delivery pass the deck viewer runs. A follower is usually
     // a student or a shareCode guest, so the tier lands on `enrolled`/`public`
     // rather than the staff `draft` bucket — `tierFor` decides, not this route.
+    // The `preview` local above is this route's THUMBNAIL flag and is
+    // deliberately not part of the access shape; `deckAccessFor` cannot see it.
     const { html } = await resolveDeckDelivery(
       contentResult.content as string,
-      deckDeliveryContext(slide, gitOrgLogin, repo, {
-        canEdit,
-        isPublicSite: slide.is_public,
-      })
+      deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('follow', { canEdit }, slide))
     );
     slideContent = html;
 

--- a/apps/slides/app/routes/$slideId_.present/route.tsx
+++ b/apps/slides/app/routes/$slideId_.present/route.tsx
@@ -5,6 +5,7 @@ import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
 import { fetchContent } from '~/utils/contentProxy';
+import { deckDeliveryContext, resolveDeckDelivery } from '~/utils/deckDelivery.server';
 
 export const loader = async ({
   params,
@@ -32,7 +33,7 @@ export const loader = async ({
   }
 
   // Authorization: require present permission (owner/teacher/assistant)
-  const { canPresent } = await assertSlideAccess({
+  const { canPresent, canEdit } = await assertSlideAccess({
     request,
     slideId,
     slide,
@@ -64,7 +65,17 @@ export const loader = async ({
   });
 
   if (contentResult) {
-    slideContent = contentResult.content as string;
+    // Same read-side delivery pass the deck viewer runs: the stored document
+    // holds `/content/...` refs, and a presenter must see the signed ones or a
+    // private content repo shows them nothing.
+    const { html } = await resolveDeckDelivery(
+      contentResult.content as string,
+      deckDeliveryContext(slide, gitOrgLogin, repo, {
+        canEdit,
+        isPublicSite: slide.is_public,
+      })
+    );
+    slideContent = html;
   } else {
     contentError = 'Failed to load slide content';
   }

--- a/apps/slides/app/routes/$slideId_.present/route.tsx
+++ b/apps/slides/app/routes/$slideId_.present/route.tsx
@@ -5,7 +5,11 @@ import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
 import { fetchContent } from '~/utils/contentProxy';
-import { deckDeliveryContext, resolveDeckDelivery } from '~/utils/deckDelivery.server';
+import {
+  deckAccessFor,
+  deckDeliveryContext,
+  resolveDeckDelivery,
+} from '~/utils/deckDelivery.server';
 
 export const loader = async ({
   params,
@@ -67,13 +71,11 @@ export const loader = async ({
   if (contentResult) {
     // Same read-side delivery pass the deck viewer runs: the stored document
     // holds `/content/...` refs, and a presenter must see the signed ones or a
-    // private content repo shows them nothing.
+    // private content repo shows them nothing. `deckAccessFor` deliberately
+    // does NOT hand this surface the draft tier — see its comment.
     const { html } = await resolveDeckDelivery(
       contentResult.content as string,
-      deckDeliveryContext(slide, gitOrgLogin, repo, {
-        canEdit,
-        isPublicSite: slide.is_public,
-      })
+      deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('present', { canEdit }, slide))
     );
     slideContent = html;
   } else {

--- a/apps/slides/app/routes/$slideId_.speaker/route.tsx
+++ b/apps/slides/app/routes/$slideId_.speaker/route.tsx
@@ -3,6 +3,7 @@ import getPrisma from '@classmoji/database';
 import { assertSlideAccess } from '@classmoji/auth/server';
 import SpeakerView from '~/components/SpeakerView';
 import { fetchContent } from '~/utils/contentProxy';
+import { deckDeliveryContext, resolveDeckDelivery } from '~/utils/deckDelivery.server';
 
 /**
  * Speaker route - Remote speaker notes view
@@ -39,7 +40,7 @@ export const loader = async ({
   }
 
   // Authorization: require speakerNotes access (staff, or viewers when show_speaker_notes=true)
-  await assertSlideAccess({
+  const { canEdit } = await assertSlideAccess({
     request,
     slideId,
     slide,
@@ -67,9 +68,20 @@ export const loader = async ({
   });
 
   if (contentResult) {
+    // Sign the deck's references BEFORE the fragment is cut out: the speaker
+    // view renders these slides too, and a raw `/content/...` ref is dead the
+    // moment the content repo goes private.
+    const { html } = await resolveDeckDelivery(
+      contentResult.content as string,
+      deckDeliveryContext(slide, gitOrgLogin, repo, {
+        canEdit,
+        isPublicSite: slide.is_public,
+      })
+    );
+
     // Parse the HTML to extract just the slides content
     const parser = await import('cheerio');
-    const $ = parser.load(contentResult.content);
+    const $ = parser.load(html ?? '');
     slideContent = $('.slides').html();
   } else {
     contentError = 'Failed to load slide content';

--- a/apps/slides/app/routes/$slideId_.speaker/route.tsx
+++ b/apps/slides/app/routes/$slideId_.speaker/route.tsx
@@ -3,7 +3,7 @@ import getPrisma from '@classmoji/database';
 import { assertSlideAccess } from '@classmoji/auth/server';
 import SpeakerView from '~/components/SpeakerView';
 import { fetchContent } from '~/utils/contentProxy';
-import { deckDeliveryContext, resolveDeckDelivery } from '~/utils/deckDelivery.server';
+import { deckAccessFor, deckDeliveryContext, resolveDeckAssets } from '~/utils/deckDelivery.server';
 
 /**
  * Speaker route - Remote speaker notes view
@@ -70,13 +70,12 @@ export const loader = async ({
   if (contentResult) {
     // Sign the deck's references BEFORE the fragment is cut out: the speaker
     // view renders these slides too, and a raw `/content/...` ref is dead the
-    // moment the content repo goes private.
-    const { html } = await resolveDeckDelivery(
+    // moment the content repo goes private. Assets only — this view keeps the
+    // `.slides` fragment and throws the document's <head> away, so resolving a
+    // theme base here would be a lookup for an answer nobody reads.
+    const html = await resolveDeckAssets(
       contentResult.content as string,
-      deckDeliveryContext(slide, gitOrgLogin, repo, {
-        canEdit,
-        isPublicSite: slide.is_public,
-      })
+      deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('speaker', { canEdit }, slide))
     );
 
     // Parse the HTML to extract just the slides content

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -47,6 +47,50 @@ export interface DeliveryAccess {
   isPublicSite?: boolean;
 }
 
+/** The deck surfaces that resolve content. Each has its own tier posture. */
+export type DeckSurface = 'viewer' | 'present' | 'speaker' | 'follow';
+
+/** The slice of `assertSlideAccess`'s result a tier decision may look at. */
+export interface SlideAccessResultLike {
+  canEdit: boolean;
+  /** The viewer's `previewActive` — a staff read of the preview BRANCH. */
+  previewActive?: boolean;
+}
+
+/**
+ * `assertSlideAccess`'s answer + the deck's flags → the tier inputs, per surface.
+ *
+ * A function rather than four inline object literals because the surfaces do
+ * NOT agree, and the places they disagree are the places this went wrong
+ * before:
+ *
+ *   - `present` and `speaker` pin `canEdit: false` on purpose. Both stay open
+ *     for hours, and `draft` is an exact `now + 4h` with five minutes of grace,
+ *     so an instructor who opens the presenter in the morning and reaches slide
+ *     40 after lunch would get a 403 on a lazily-loaded Reveal background.
+ *     Content is sha-addressed and immutable, so the longer bucket shows the
+ *     same bytes; `draft` exists for the editor's 403-and-revalidate flow, not
+ *     for presenting.
+ *   - only `viewer` honours `previewActive`. `follow` has a `?preview=true`
+ *     query param of its own that means "thumbnail render", and letting that
+ *     reach `tierFor` would mint draft URLs for a hall full of students.
+ */
+export function deckAccessFor(
+  surface: DeckSurface,
+  access: SlideAccessResultLike,
+  slide: { is_public?: boolean | null }
+): DeliveryAccess {
+  const isPublicSite = Boolean(slide.is_public);
+  if (surface === 'present' || surface === 'speaker') {
+    return { canEdit: false, isPublicSite };
+  }
+  return {
+    canEdit: access.canEdit,
+    preview: surface === 'viewer' ? Boolean(access.previewActive) : false,
+    isPublicSite,
+  };
+}
+
 /**
  * The classroom shape the content resolver needs, or null when this deck's
  * classroom cannot be served by the delivery layer at all.
@@ -63,6 +107,12 @@ export function deckDeliveryContext(
   repo: string | undefined,
   access: DeliveryAccess
 ) {
+  // A deployment with no signing secret or no origin can never rewrite
+  // anything, and every pass below would be a cheerio parse and re-serialize
+  // for a byte-identical result. Refusing the context here is what keeps that
+  // off the read path entirely.
+  if (!ClassmojiService.contentDelivery.isContentDeliveryConfigured()) return null;
+
   const classroom = slide.classroom;
   if (!classroom?.id || !repo || !gitOrgLogin) return null;
   return {

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -1,0 +1,267 @@
+/**
+ * deckDelivery.server.ts — the ONE read-side content-delivery pass for decks.
+ *
+ * A deck is stored with plain repo references — `/content/{org}/{repo}/{path}`
+ * for its images, and the same shape for the `<link>`s of a shared theme. The
+ * delivery layer turns those into signed `content-*.classmoji.io` URLs at READ
+ * time, per viewer, and never stores the result (a signature expires, a sha
+ * moves, and the tier is per-viewer — see contentDelivery.service).
+ *
+ * Every surface that renders a stored deck goes through here: the deck viewer
+ * (`$slideId`), the presenter (`$slideId_.present`), the audience follow view
+ * (`$slideId_.follow`) and the remote speaker view (`$slideId_.speaker`). This
+ * module exists because they did NOT: the rewrite lived inside the viewer
+ * route, so the other three served raw `/content/...` URLs and broke the moment
+ * a content repo went private.
+ *
+ * READ ONLY. None of this may reach a document on its way INTO the editor: the
+ * editor posts its document back on save, and a signed URL that made that round
+ * trip would be committed into deck.json, freezing one viewer's expiring
+ * signature into the deck forever.
+ *
+ * Every failure degrades to the stored URLs, which still work through the
+ * content proxy. Nothing here is allowed to break a deck read.
+ */
+
+import { ClassmojiService } from '@classmoji/services';
+import {
+  rewriteDeckAssetUrls,
+  type DeckJson,
+  type DeckThemeUrls,
+} from '@classmoji/services/slides';
+import { getThemeUrls } from '~/utils/themeService.server';
+
+/** Where shared slide themes live in a content repo. Mirrors contentDelivery. */
+const THEMES_FOLDER = '.slidesthemes';
+
+/** The slide fields a delivery context needs. Narrow on purpose. */
+interface DeliverySlide {
+  classroom?: { id?: string; content_key_version?: number; content_repo?: string } | null;
+}
+
+/** What the viewer's tier decision is made of. Passed straight to `tierFor`. */
+export interface DeliveryAccess {
+  canEdit: boolean;
+  /** The staff-only preview BRANCH read — not a thumbnail render. */
+  preview?: boolean;
+  isPublicSite?: boolean;
+}
+
+/**
+ * The classroom shape the content resolver needs, or null when this deck's
+ * classroom cannot be served by the delivery layer at all.
+ *
+ * The tier is decided HERE, by `ClassmojiService.contentDelivery.tierFor`, so
+ * the four deck surfaces cannot drift into four different answers to "which
+ * bucket is this viewer in". Staff and preview readers get short-lived draft
+ * URLs, a public deck's anonymous readers the long public bucket, everyone else
+ * the enrolled one. This is the reason a signed URL cannot live in the deck.
+ */
+export function deckDeliveryContext(
+  slide: DeliverySlide,
+  gitOrgLogin: string | undefined,
+  repo: string | undefined,
+  access: DeliveryAccess
+) {
+  const classroom = slide.classroom;
+  if (!classroom?.id || !repo || !gitOrgLogin) return null;
+  return {
+    classroom: {
+      id: classroom.id,
+      content_key_version: classroom.content_key_version ?? 0,
+      content_repo: repo,
+      git_organization: { login: gitOrgLogin },
+    },
+    tier: ClassmojiService.contentDelivery.tierFor(access),
+  };
+}
+
+export type DeliveryContext = ReturnType<typeof deckDeliveryContext>;
+
+/** The `shared:` theme a rendered deck declares, or null. */
+export function sharedThemeName(html: string | null | undefined): string | null {
+  if (!html) return null;
+  const match = html.match(/data-theme="shared:([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+/** True for a reference that points inside a shared theme folder. */
+export function isThemeRef(ref: string): boolean {
+  return ref.includes(`${THEMES_FOLDER}/`);
+}
+
+/**
+ * `/content/{org}/{repo}/.slidesthemes/{theme}/lib/offline-v2.css` →
+ * `{signedBase}lib/offline-v2.css`, or null when the ref is not in this theme.
+ *
+ * A theme is signed as a FOLDER (so the CSS's own relative `url()` references
+ * inherit the signature), which is why this keeps the filename the resolver
+ * already worked out rather than deriving one.
+ */
+export function rebaseThemeRef(
+  ref: string | null | undefined,
+  themeName: string,
+  signedBase: string
+): string | null {
+  if (!ref) return null;
+  const marker = `/${THEMES_FOLDER}/${themeName}/`;
+  const at = ref.indexOf(marker);
+  if (at === -1) return null;
+  return `${signedBase}${ref.slice(at + marker.length)}`;
+}
+
+/**
+ * The two content-delivery calls this module makes.
+ *
+ * A parameter rather than a hard import so the composition below — which refs
+ * reach the blob resolver, which are rebased onto the theme folder, what
+ * happens to the ones nobody claims — is testable without a database behind
+ * the asset map. Production always uses the default.
+ */
+export interface DeckDeliveryResolvers {
+  resolveMany(ctx: NonNullable<DeliveryContext>, refs: string[]): Promise<Map<string, string>>;
+  resolveThemeBase(ctx: NonNullable<DeliveryContext>, themeName: string): Promise<string | null>;
+}
+
+const defaultResolvers: DeckDeliveryResolvers = {
+  resolveMany: (ctx, refs) => ClassmojiService.contentDelivery.resolveMany(ctx, refs),
+  resolveThemeBase: (ctx, themeName) =>
+    ClassmojiService.contentDelivery.resolveThemeBase(ctx, themeName),
+};
+
+/**
+ * Sign the asset — and optionally the shared-theme — references inside an
+ * already-rendered deck document.
+ *
+ * `themeName` defaults to whatever the document declares; pass `null` to skip
+ * the theme pass entirely (the deck viewer does, because it resolves its theme
+ * links through `resolveDeliveryThemeUrls` on the generated document instead).
+ *
+ * The returned `themeBase` is the signed folder the theme now hangs off, so a
+ * caller that also needs it (a preload hint, a client-side link) does not pay a
+ * second lookup.
+ */
+export async function resolveDeckDelivery(
+  html: string | null,
+  ctx: DeliveryContext,
+  opts: { themeName?: string | null; resolvers?: DeckDeliveryResolvers } = {}
+): Promise<{ html: string | null; themeBase: string | null }> {
+  if (!ctx || !html) return { html, themeBase: null };
+
+  const resolvers = opts.resolvers ?? defaultResolvers;
+
+  const themeName = opts.themeName === undefined ? sharedThemeName(html) : opts.themeName;
+
+  let themeBase: string | null = null;
+  if (themeName) {
+    try {
+      themeBase = await resolvers.resolveThemeBase(ctx, themeName);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[slides] Theme base resolution failed for "${themeName}":`, message);
+    }
+  }
+
+  try {
+    const rewritten = await rewriteDeckAssetUrls(html, async refs => {
+      // Theme assets never go through the blob resolver: a theme is signed as a
+      // folder, and rewriting one of its files to a standalone blob URL would
+      // break precisely the relative `url()` references the folder exists for.
+      const resolved = await resolvers.resolveMany(
+        ctx,
+        refs.filter(ref => !isThemeRef(ref))
+      );
+      if (themeName && themeBase) {
+        for (const ref of refs) {
+          const rebased = rebaseThemeRef(ref, themeName, themeBase);
+          if (rebased) resolved.set(ref, rebased);
+        }
+      }
+      return resolved;
+    });
+    return { html: rewritten, themeBase };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn('[slides] Asset resolution failed, serving stored URLs:', message);
+    return { html, themeBase };
+  }
+}
+
+/**
+ * The image-only pass, for callers whose theme links are resolved elsewhere.
+ *
+ * The deck viewer's edit-mode read is the reason this exists as its own entry
+ * point: it renders the deck through `generateDeckHtml` with theme URLs already
+ * signed by `resolveDeliveryThemeUrls`, and re-deriving them here would be a
+ * second lookup for the same answer.
+ */
+export async function resolveDeckAssets(
+  html: string | null,
+  ctx: DeliveryContext,
+  opts: { resolvers?: DeckDeliveryResolvers } = {}
+): Promise<string | null> {
+  const { html: next } = await resolveDeckDelivery(html, ctx, { ...opts, themeName: null });
+  return next;
+}
+
+/**
+ * Resolve shared-theme URLs for read-side deck rendering (Phase 4c). Same
+ * resolution the save path uses (getThemeUrls with identical args), so the
+ * generated document matches the saved index.html artifact byte-for-byte.
+ * Unlike the save path (which is about to persist and falls back to theme
+ * 'white'), a resolve failure on a READ must not mutate the deck — we just
+ * render without theme links (generateDeckHtml warns).
+ */
+export async function resolveReadThemeUrls(
+  deck: DeckJson,
+  gitOrgLogin: string,
+  repo: string
+): Promise<DeckThemeUrls | undefined> {
+  if (!deck.theme.startsWith('shared:')) return undefined;
+  const themeName = deck.theme.replace('shared:', '');
+  try {
+    const urls = await getThemeUrls(gitOrgLogin, repo, themeName);
+    return {
+      libCssUrl: urls.libCssUrl,
+      customThemeUrl: urls.customThemeUrl,
+      bodyClasses: urls.bodyClasses,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Could not resolve shared theme URLs for "${themeName}":`, message);
+    return undefined;
+  }
+}
+
+/**
+ * Read-side theme URLs, signed when the delivery layer is on.
+ *
+ * `getThemeUrls` still does the work that needs GitHub — which lib CSS variant
+ * exists, whether there is a custom-theme.css, what the manifest's bodyClasses
+ * are. This only swaps the BASE those files hang off, from the content proxy to
+ * the signed theme folder, keeping the exact filenames it resolved. Deriving
+ * the filenames independently would silently downgrade a deck on `offline-v1`
+ * to a 404, and would invent a custom-theme.css for themes that have none.
+ */
+export async function resolveDeliveryThemeUrls(
+  deck: DeckJson,
+  gitOrgLogin: string,
+  repo: string,
+  ctx: DeliveryContext
+): Promise<DeckThemeUrls | undefined> {
+  const base = await resolveReadThemeUrls(deck, gitOrgLogin, repo);
+  if (!base || !ctx || !deck.theme.startsWith('shared:')) return base;
+
+  const themeName = deck.theme.replace('shared:', '');
+  const signedBase = await ClassmojiService.contentDelivery.resolveThemeBase(ctx, themeName);
+  if (!signedBase) return base;
+
+  const rebase = (url: string | null | undefined): string | null | undefined =>
+    rebaseThemeRef(url, themeName, signedBase) ?? url;
+
+  return {
+    ...base,
+    libCssUrl: rebase(base.libCssUrl),
+    customThemeUrl: rebase(base.customThemeUrl),
+  };
+}

--- a/apps/slides/tests/unit/deck-delivery.spec.ts
+++ b/apps/slides/tests/unit/deck-delivery.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for `deckDelivery.server` — the ONE read-side content-delivery
+ * pass every deck surface runs.
+ *
+ * These run in the Playwright runner WITHOUT a browser or the dev stack. The
+ * asset map lives in Postgres, so the two delivery calls are injected
+ * (`opts.resolvers`); what is pinned here is the COMPOSITION the module owns —
+ * which references reach the blob resolver, which are rebased onto the signed
+ * theme folder, and what happens to the ones nobody claims. The resolver's own
+ * "is this URL even ours" rule is pinned separately, in
+ * `packages/services/src/classmoji/__tests__/contentDelivery.resolve.test.ts`.
+ *
+ * The regression that produced this file: the rewrite lived inside the deck
+ * VIEWER route, so `/present`, `/follow` and `/speaker` served raw
+ * `/content/{org}/{repo}/...` URLs — dead the moment a content repo goes
+ * private. The last test in this file guards that wiring at the source level,
+ * because a loader test would need Postgres, GitHub and a session.
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  deckDeliveryContext,
+  isThemeRef,
+  rebaseThemeRef,
+  resolveDeckAssets,
+  resolveDeckDelivery,
+  sharedThemeName,
+  type DeckDeliveryResolvers,
+  type DeliveryContext,
+} from '../../app/utils/deckDelivery.server.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const ORG = 'cs98-org';
+const REPO = 'cs98-content';
+const CLASSROOM = '11111111-2222-3333-4444-555555555555';
+const ORIGIN = 'https://content-staging.classmoji.io';
+
+const SLIDE = {
+  classroom: { id: CLASSROOM, content_key_version: 3, content_repo: REPO },
+};
+
+function ctx(): NonNullable<DeliveryContext> {
+  const built = deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true });
+  if (!built) throw new Error('expected a delivery context');
+  return built;
+}
+
+/**
+ * Stands in for `contentDelivery.resolveMany`: signs whatever lives under this
+ * classroom's own content path and hands everything else straight back, which
+ * is the contract the real resolver keeps.
+ */
+function fakeResolvers(overrides: Partial<DeckDeliveryResolvers> = {}): DeckDeliveryResolvers {
+  return {
+    async resolveMany(_ctx, refs) {
+      const out = new Map<string, string>();
+      const own = `/content/${ORG}/${REPO}/`;
+      for (const ref of refs) {
+        out.set(
+          ref,
+          ref.startsWith(own)
+            ? `${ORIGIN}/c/${CLASSROOM}/blob/sha-${ref.split('/').pop()}?p=draft`
+            : ref
+        );
+      }
+      return out;
+    },
+    async resolveThemeBase() {
+      return null;
+    },
+    ...overrides,
+  };
+}
+
+test.describe('tier selection', () => {
+  test('runs through tierFor rather than a per-route rule', () => {
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true })?.tier).toBe('draft');
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false })?.tier).toBe('enrolled');
+    expect(
+      deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false, isPublicSite: true })?.tier
+    ).toBe('public');
+    // A staff preview outranks a public deck — editing, not browsing.
+    expect(
+      deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false, preview: true, isPublicSite: true })
+        ?.tier
+    ).toBe('draft');
+  });
+
+  test('no context at all when the classroom cannot be served', () => {
+    expect(deckDeliveryContext(SLIDE, undefined, REPO, { canEdit: true })).toBeNull();
+    expect(deckDeliveryContext(SLIDE, ORG, undefined, { canEdit: true })).toBeNull();
+    expect(deckDeliveryContext({ classroom: null }, ORG, REPO, { canEdit: true })).toBeNull();
+  });
+});
+
+test.describe('asset rewriting', () => {
+  test('signs image references into this repo', async () => {
+    const html = `<div class="slides"><section><img src="/content/${ORG}/${REPO}/slides/w1/images/hero.jpeg"></section></div>`;
+    const { html: out } = await resolveDeckDelivery(html, ctx(), {
+      resolvers: fakeResolvers(),
+    });
+    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=draft`);
+    expect(out).not.toContain(`/content/${ORG}/${REPO}/slides`);
+  });
+
+  test('leaves foreign and inline URLs byte-identical', async () => {
+    const html = [
+      '<div class="slides"><section>',
+      '<img src="https://example.com/outside.png">',
+      '<img src="/content/other-org/other-repo/a.png">',
+      '<img src="data:image/gif;base64,R0lGOD">',
+      '</section></div>',
+    ].join('');
+    const { html: out } = await resolveDeckDelivery(html, ctx(), {
+      resolvers: fakeResolvers(),
+    });
+    expect(out).toBe(html);
+  });
+
+  test('is a no-op without a delivery context', async () => {
+    const html = `<img src="/content/${ORG}/${REPO}/a.png">`;
+    const { html: out, themeBase } = await resolveDeckDelivery(html, null);
+    expect(out).toBe(html);
+    expect(themeBase).toBeNull();
+  });
+
+  test('is a no-op when the delivery layer is unconfigured', async () => {
+    // The REAL resolvers, with CONTENT_SIGNING_SECRET / CONTENT_DELIVERY_ORIGIN
+    // unset: resolveMany hands every ref back unchanged before it ever reaches
+    // the asset map, and resolveThemeBase returns null.
+    delete process.env.CONTENT_SIGNING_SECRET;
+    delete process.env.CONTENT_DELIVERY_ORIGIN;
+    const html = [
+      `<link rel="stylesheet" href="/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css">`,
+      `<div class="reveal" data-theme="shared:cs98"><div class="slides">`,
+      `<section><img src="/content/${ORG}/${REPO}/slides/w1/images/hero.jpeg"></section>`,
+      `</div></div>`,
+    ].join('');
+    const { html: out, themeBase } = await resolveDeckDelivery(html, ctx());
+    expect(out).toBe(html);
+    expect(themeBase).toBeNull();
+  });
+
+  test('a resolver blow-up serves the stored URLs instead of failing the read', async () => {
+    const html = `<img src="/content/${ORG}/${REPO}/a.png">`;
+    const { html: out } = await resolveDeckDelivery(html, ctx(), {
+      resolvers: fakeResolvers({
+        async resolveMany() {
+          throw new Error('asset map is down');
+        },
+      }),
+    });
+    expect(out).toBe(html);
+  });
+});
+
+test.describe('shared theme links', () => {
+  const BASE = `${ORIGIN}/c/${CLASSROOM}/theme/cs98/${'a'.repeat(40)}/draft.3.999.sig/`;
+
+  test('reads the declared theme off the document', () => {
+    expect(sharedThemeName('<div class="reveal" data-theme="shared:cs98-dark">')).toBe('cs98-dark');
+    expect(sharedThemeName('<div class="reveal" data-theme="black">')).toBeNull();
+    expect(sharedThemeName(null)).toBeNull();
+  });
+
+  test('rebases a theme file onto the signed folder, keeping the filename', () => {
+    expect(
+      rebaseThemeRef(`/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css`, 'cs98', BASE)
+    ).toBe(`${BASE}lib/offline-v2.css`);
+    expect(
+      rebaseThemeRef(`/content/${ORG}/${REPO}/.slidesthemes/cs98/custom-theme.css`, 'cs98', BASE)
+    ).toBe(`${BASE}custom-theme.css`);
+    // Another theme's file is not this theme's problem.
+    expect(
+      rebaseThemeRef(`/content/${ORG}/${REPO}/.slidesthemes/other/lib/a.css`, 'cs98', BASE)
+    ).toBeNull();
+    expect(rebaseThemeRef('/content/o/r/slides/w1/images/hero.jpeg', 'cs98', BASE)).toBeNull();
+    expect(isThemeRef(`/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/a.css`)).toBe(true);
+    expect(isThemeRef(`/content/${ORG}/${REPO}/slides/w1/images/hero.jpeg`)).toBe(false);
+  });
+
+  test('signs the head links and keeps them out of the blob resolver', async () => {
+    const seen: string[] = [];
+    const html = [
+      `<html><head>`,
+      `<link rel="stylesheet" href="/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css">`,
+      `<link rel="stylesheet" href="/content/${ORG}/${REPO}/.slidesthemes/cs98/custom-theme.css">`,
+      `</head><body><div class="reveal" data-theme="shared:cs98"><div class="slides">`,
+      `<section><img src="/content/${ORG}/${REPO}/slides/w1/images/hero.jpeg"></section>`,
+      `</div></div></body></html>`,
+    ].join('');
+
+    const { html: out, themeBase } = await resolveDeckDelivery(html, ctx(), {
+      resolvers: fakeResolvers({
+        async resolveMany(_ctx, refs) {
+          seen.push(...refs);
+          return fakeResolvers().resolveMany(_ctx, refs);
+        },
+        async resolveThemeBase() {
+          return BASE;
+        },
+      }),
+    });
+
+    expect(themeBase).toBe(BASE);
+    expect(out).toContain(`${BASE}lib/offline-v2.css`);
+    expect(out).toContain(`${BASE}custom-theme.css`);
+    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=draft`);
+    // A theme file signed as a standalone blob would break the relative
+    // `url()` references the folder signature exists for.
+    expect(seen.some(ref => ref.includes('.slidesthemes/'))).toBe(false);
+  });
+
+  test('resolveDeckAssets skips the theme pass entirely', async () => {
+    let themeCalls = 0;
+    const html = [
+      `<link rel="stylesheet" href="/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css">`,
+      `<div class="reveal" data-theme="shared:cs98"><div class="slides">`,
+      `<section><img src="/content/${ORG}/${REPO}/slides/w1/images/hero.jpeg"></section>`,
+      `</div></div>`,
+    ].join('');
+
+    const out = await resolveDeckAssets(html, ctx(), {
+      resolvers: fakeResolvers({
+        async resolveThemeBase() {
+          themeCalls += 1;
+          return BASE;
+        },
+      }),
+    });
+
+    expect(themeCalls).toBe(0);
+    expect(out).toContain(`/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css`);
+    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=draft`);
+  });
+});
+
+test.describe('every deck surface runs the pass', () => {
+  // A loader test would need Postgres, GitHub and a session; this is the
+  // cheapest honest guard that the three presentation routes did not quietly
+  // stop resolving. Precedent: tests/unit/session-cookie.spec.ts.
+  const ROUTES = ['$slideId_.present', '$slideId_.follow', '$slideId_.speaker'];
+
+  for (const route of ROUTES) {
+    test(`${route} resolves deck assets in its loader`, () => {
+      const file = path.join(__dirname, '../../app/routes', route, 'route.tsx');
+      const source = fs.readFileSync(file, 'utf-8');
+      expect(source).toContain("from '~/utils/deckDelivery.server'");
+      expect(source).toContain('resolveDeckDelivery(');
+      expect(source).toContain('deckDeliveryContext(');
+      // The tier comes from the access result, never from a literal.
+      expect(source).toMatch(/canEdit[,\s]/);
+    });
+  }
+
+  test('$slideId keeps resolving through the shared module', () => {
+    const file = path.join(__dirname, '../../app/routes/$slideId/route.tsx');
+    const source = fs.readFileSync(file, 'utf-8');
+    expect(source).toContain("from '~/utils/deckDelivery.server'");
+    expect(source).toContain('resolveDeckAssets(slideContent, deliveryCtx)');
+  });
+});

--- a/apps/slides/tests/unit/deck-delivery.spec.ts
+++ b/apps/slides/tests/unit/deck-delivery.spec.ts
@@ -13,15 +13,13 @@
  * The regression that produced this file: the rewrite lived inside the deck
  * VIEWER route, so `/present`, `/follow` and `/speaker` served raw
  * `/content/{org}/{repo}/...` URLs — dead the moment a content repo goes
- * private. The last test in this file guards that wiring at the source level,
- * because a loader test would need Postgres, GitHub and a session.
+ * private. `deckAccessFor` is the per-surface half of the fix, and the last
+ * block here pins it against the shapes `assertSlideAccess` actually returns.
  */
 
 import { test, expect } from '@playwright/test';
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
 import {
+  deckAccessFor,
   deckDeliveryContext,
   isThemeRef,
   rebaseThemeRef,
@@ -32,8 +30,6 @@ import {
   type DeliveryContext,
 } from '../../app/utils/deckDelivery.server.ts';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 const ORG = 'cs98-org';
 const REPO = 'cs98-content';
 const CLASSROOM = '11111111-2222-3333-4444-555555555555';
@@ -41,13 +37,44 @@ const ORIGIN = 'https://content-staging.classmoji.io';
 
 const SLIDE = {
   classroom: { id: CLASSROOM, content_key_version: 3, content_repo: REPO },
+  is_public: false,
 };
+
+/**
+ * `deckDeliveryContext` refuses to exist when the delivery layer is off, so
+ * every test that wants a context has to switch it on — and put the process
+ * back exactly as it found it. The runner is `workers: 1`, so a leaked delete
+ * here would silently disable the layer for every later spec in the file.
+ */
+const ENV_KEYS = ['CONTENT_SIGNING_SECRET', 'CONTENT_DELIVERY_ORIGIN'] as const;
+let savedEnv: Record<string, string | undefined> = {};
+
+test.beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]));
+  process.env.CONTENT_SIGNING_SECRET = 'test-master-secret';
+  process.env.CONTENT_DELIVERY_ORIGIN = ORIGIN;
+});
+
+test.afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
 
 function ctx(): NonNullable<DeliveryContext> {
   const built = deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true });
   if (!built) throw new Error('expected a delivery context');
   return built;
 }
+
+/** Owner / teacher: edits anything. */
+const OWNER = { canEdit: true };
+/** Assistant on a colleague's deck without `allow_team_edit`: staff, no edit. */
+const ASSISTANT_NO_EDIT = { canEdit: false };
+/** Student, and a shareCode guest — same shape from the tier's point of view. */
+const STUDENT = { canEdit: false };
+const PUBLIC_SLIDE = { ...SLIDE, is_public: true };
 
 /**
  * Stands in for `contentDelivery.resolveMany`: signs whatever lives under this
@@ -95,6 +122,15 @@ test.describe('tier selection', () => {
     expect(deckDeliveryContext(SLIDE, ORG, undefined, { canEdit: true })).toBeNull();
     expect(deckDeliveryContext({ classroom: null }, ORG, REPO, { canEdit: true })).toBeNull();
   });
+
+  test('no context at all when the delivery layer is switched off', () => {
+    delete process.env.CONTENT_SIGNING_SECRET;
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true })).toBeNull();
+
+    process.env.CONTENT_SIGNING_SECRET = 'test-master-secret';
+    delete process.env.CONTENT_DELIVERY_ORIGIN;
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true })).toBeNull();
+  });
 });
 
 test.describe('asset rewriting', () => {
@@ -128,21 +164,41 @@ test.describe('asset rewriting', () => {
     expect(themeBase).toBeNull();
   });
 
-  test('is a no-op when the delivery layer is unconfigured', async () => {
-    // The REAL resolvers, with CONTENT_SIGNING_SECRET / CONTENT_DELIVERY_ORIGIN
-    // unset: resolveMany hands every ref back unchanged before it ever reaches
-    // the asset map, and resolveThemeBase returns null.
-    delete process.env.CONTENT_SIGNING_SECRET;
-    delete process.env.CONTENT_DELIVERY_ORIGIN;
+  test('is a no-op when the delivery layer is unconfigured — and does no work', async () => {
     const html = [
       `<link rel="stylesheet" href="/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css">`,
       `<div class="reveal" data-theme="shared:cs98"><div class="slides">`,
       `<section><img src="/content/${ORG}/${REPO}/slides/w1/images/hero.jpeg"></section>`,
       `</div></div>`,
     ].join('');
-    const { html: out, themeBase } = await resolveDeckDelivery(html, ctx());
+
+    delete process.env.CONTENT_SIGNING_SECRET;
+    delete process.env.CONTENT_DELIVERY_ORIGIN;
+
+    // The route builds its context exactly like this, and gets nothing — which
+    // is what keeps the cheerio parse and both delivery calls off the read
+    // path of a deployment that could not have rewritten anything anyway.
+    const offCtx = deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true });
+    expect(offCtx).toBeNull();
+
+    let calls = 0;
+    const counting: DeckDeliveryResolvers = {
+      async resolveMany(_ctx, refs) {
+        calls += 1;
+        return fakeResolvers().resolveMany(_ctx, refs);
+      },
+      async resolveThemeBase() {
+        calls += 1;
+        return null;
+      },
+    };
+
+    const { html: out, themeBase } = await resolveDeckDelivery(html, offCtx, {
+      resolvers: counting,
+    });
     expect(out).toBe(html);
     expect(themeBase).toBeNull();
+    expect(calls).toBe(0);
   });
 
   test('a resolver blow-up serves the stored URLs instead of failing the read', async () => {
@@ -239,28 +295,76 @@ test.describe('shared theme links', () => {
   });
 });
 
-test.describe('every deck surface runs the pass', () => {
-  // A loader test would need Postgres, GitHub and a session; this is the
-  // cheapest honest guard that the three presentation routes did not quietly
-  // stop resolving. Precedent: tests/unit/session-cookie.spec.ts.
-  const ROUTES = ['$slideId_.present', '$slideId_.follow', '$slideId_.speaker'];
-
-  for (const route of ROUTES) {
-    test(`${route} resolves deck assets in its loader`, () => {
-      const file = path.join(__dirname, '../../app/routes', route, 'route.tsx');
-      const source = fs.readFileSync(file, 'utf-8');
-      expect(source).toContain("from '~/utils/deckDelivery.server'");
-      expect(source).toContain('resolveDeckDelivery(');
-      expect(source).toContain('deckDeliveryContext(');
-      // The tier comes from the access result, never from a literal.
-      expect(source).toMatch(/canEdit[,\s]/);
+test.describe('deckAccessFor — the tier inputs, per surface', () => {
+  test('the viewer follows the access result exactly', () => {
+    expect(deckAccessFor('viewer', OWNER, SLIDE)).toEqual({
+      canEdit: true,
+      preview: false,
+      isPublicSite: false,
     });
-  }
+    expect(deckAccessFor('viewer', ASSISTANT_NO_EDIT, SLIDE)).toEqual({
+      canEdit: false,
+      preview: false,
+      isPublicSite: false,
+    });
+    expect(deckAccessFor('viewer', STUDENT, PUBLIC_SLIDE)).toEqual({
+      canEdit: false,
+      preview: false,
+      isPublicSite: true,
+    });
+  });
 
-  test('$slideId keeps resolving through the shared module', () => {
-    const file = path.join(__dirname, '../../app/routes/$slideId/route.tsx');
-    const source = fs.readFileSync(file, 'utf-8');
-    expect(source).toContain("from '~/utils/deckDelivery.server'");
-    expect(source).toContain('resolveDeckAssets(slideContent, deliveryCtx)');
+  test('only the viewer honours a preview-BRANCH read', () => {
+    const staffPreview = { canEdit: true, previewActive: true };
+    expect(deckAccessFor('viewer', staffPreview, SLIDE).preview).toBe(true);
+    // /follow has a `?preview=true` of its own that means "thumbnail". Even
+    // handed the viewer's flag, this surface must never mint draft URLs — a
+    // lecture hall of students would be signing into the 4h bucket.
+    expect(deckAccessFor('follow', staffPreview, SLIDE).preview).toBe(false);
+    expect(deckAccessFor('present', staffPreview, SLIDE).preview).toBeUndefined();
+    expect(deckAccessFor('speaker', staffPreview, SLIDE).preview).toBeUndefined();
+  });
+
+  test('present and speaker never claim edit access, whoever is looking', () => {
+    // Both surfaces stay open for hours; draft is an exact now+4h with five
+    // minutes of grace, so a lazily-loaded background on slide 40 would 403
+    // after lunch. Content is sha-addressed, so the longer bucket is the same
+    // bytes.
+    for (const surface of ['present', 'speaker'] as const) {
+      for (const access of [OWNER, ASSISTANT_NO_EDIT, STUDENT]) {
+        expect(deckAccessFor(surface, access, SLIDE)).toEqual({
+          canEdit: false,
+          isPublicSite: false,
+        });
+      }
+      expect(deckAccessFor(surface, OWNER, PUBLIC_SLIDE).isPublicSite).toBe(true);
+    }
+  });
+
+  test('follow passes a follower through untouched', () => {
+    // A shareCode guest and an enrolled student are the same shape here.
+    expect(deckAccessFor('follow', STUDENT, SLIDE)).toEqual({
+      canEdit: false,
+      preview: false,
+      isPublicSite: false,
+    });
+    // Staff following along still edit, so they still get the draft bucket.
+    expect(deckAccessFor('follow', OWNER, SLIDE).canEdit).toBe(true);
+  });
+
+  test('the tiers those shapes actually produce', () => {
+    const tierOf = (
+      surface: Parameters<typeof deckAccessFor>[0],
+      access: typeof OWNER,
+      slide = SLIDE
+    ) => deckDeliveryContext(slide, ORG, REPO, deckAccessFor(surface, access, slide))?.tier;
+
+    expect(tierOf('viewer', OWNER)).toBe('draft');
+    expect(tierOf('present', OWNER)).toBe('enrolled');
+    expect(tierOf('speaker', OWNER)).toBe('enrolled');
+    expect(tierOf('present', OWNER, PUBLIC_SLIDE)).toBe('public');
+    expect(tierOf('follow', STUDENT)).toBe('enrolled');
+    expect(tierOf('follow', STUDENT, PUBLIC_SLIDE)).toBe('public');
+    expect(tierOf('follow', OWNER)).toBe('draft');
   });
 });

--- a/packages/services/src/classmoji/__tests__/contentDelivery.resolve.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.resolve.test.ts
@@ -22,6 +22,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const ensureContentAssets = vi.fn();
 const lookupContentAsset = vi.fn();
 const lookupContentAssetBySha = vi.fn();
+const lookupContentAssets = vi.fn();
 const lookupContentTree = vi.fn();
 
 vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
@@ -29,6 +30,7 @@ vi.mock('../contentAssets.service.ts', () => ({
   ensureContentAssets: (...args: unknown[]) => ensureContentAssets(...args),
   lookupContentAsset: (...args: unknown[]) => lookupContentAsset(...args),
   lookupContentAssetBySha: (...args: unknown[]) => lookupContentAssetBySha(...args),
+  lookupContentAssets: (...args: unknown[]) => lookupContentAssets(...args),
   lookupContentTree: (...args: unknown[]) => lookupContentTree(...args),
 }));
 
@@ -82,6 +84,12 @@ beforeEach(() => {
   vi.spyOn(console, 'warn').mockImplementation(() => {});
   ensureContentAssets.mockResolvedValue(null);
   lookupContentAsset.mockResolvedValue({ sha: BLOB_SHA, type: 'blob', size: 1234 });
+  // The batch form answers for whatever paths it is handed, so a test only has
+  // to override it when it wants a path to be MISSING from the map.
+  lookupContentAssets.mockImplementation(
+    async (_classroomId: string, paths: string[]) =>
+      new Map(paths.map(path => [path, { sha: BLOB_SHA, type: 'blob', size: 1234 }]))
+  );
   lookupContentTree.mockResolvedValue({ sha: TREE_SHA, type: 'tree', size: 0 });
   configure();
 });
@@ -247,11 +255,12 @@ describe('with the delivery layer switched off', () => {
 
     expect(ensureContentAssets).not.toHaveBeenCalled();
     expect(lookupContentAsset).not.toHaveBeenCalled();
+    expect(lookupContentAssets).not.toHaveBeenCalled();
   });
 });
 
 describe('resolveMany', () => {
-  it('refreshes the map ONCE for the batch, then looks each ref up', async () => {
+  it('refreshes the map ONCE for the batch, and reads it in ONE query', async () => {
     const map = await resolveMany(ctx, [REPO_PATH, RAW_URL, 'https://example.com/x.png']);
 
     expect(ensureContentAssets).toHaveBeenCalledTimes(1);
@@ -259,15 +268,55 @@ describe('resolveMany', () => {
       maxAgeMs: 24 * 60 * 60 * 1000,
     });
 
-    // Both stored shapes name the same file, so both look up the same path.
-    expect(lookupContentAsset).toHaveBeenCalledTimes(2);
+    // One lookup for the whole document, never one per reference.
+    expect(lookupContentAssets).toHaveBeenCalledTimes(1);
+    expect(lookupContentAsset).not.toHaveBeenCalled();
+    // Both stored shapes name the same file, so the batch asks for it once —
+    // and the foreign URL never reaches the map at all.
+    expect(lookupContentAssets).toHaveBeenCalledWith(CLASSROOM_ID, [REPO_PATH]);
+
     expect(map.get('https://example.com/x.png')).toBe('https://example.com/x.png');
     expect(parseContentUrl(map.get(REPO_PATH)!)).toMatchObject({ sha: BLOB_SHA });
   });
 
+  it('maps every ref back to its own URL from the one batched read', async () => {
+    const OTHER = 'pages/lab-2/assets/diagram.png';
+    const OTHER_SHA = 'c'.repeat(40);
+    lookupContentAssets.mockResolvedValue(
+      new Map([
+        [REPO_PATH, { sha: BLOB_SHA, type: 'blob', size: 1 }],
+        [OTHER, { sha: OTHER_SHA, type: 'blob', size: 2 }],
+      ])
+    );
+
+    const map = await resolveMany(ctx, [REPO_PATH, RAW_URL, PAGES_URL, OTHER, 'x.png']);
+
+    expect(lookupContentAssets).toHaveBeenCalledTimes(1);
+    // All three shapes of the same file get that file's sha...
+    for (const ref of [REPO_PATH, RAW_URL, PAGES_URL]) {
+      expect(parseContentUrl(map.get(ref)!)).toMatchObject({ sha: BLOB_SHA });
+    }
+    // ...and a different file gets its own, from the same single read.
+    expect(parseContentUrl(map.get(OTHER)!)).toMatchObject({ sha: OTHER_SHA });
+    // A path the batch did not return is the dangling /missing/ URL, exactly
+    // as the single-ref resolver reports it.
+    expect(map.get('x.png')).toBe(`${ORIGIN}/c/${CLASSROOM_ID}/missing/x.png`);
+  });
+
+  it('never blob-signs a tree row', async () => {
+    lookupContentAssets.mockResolvedValue(
+      new Map([[REPO_PATH, { sha: TREE_SHA, type: 'tree', size: 0 }]])
+    );
+    const map = await resolveMany(ctx, [REPO_PATH]);
+    expect(map.get(REPO_PATH)).toBe(
+      `${ORIGIN}/c/${CLASSROOM_ID}/missing/${encodeURIComponent(REPO_PATH)}`
+    );
+  });
+
   it('de-duplicates repeated references', async () => {
     await resolveMany(ctx, [REPO_PATH, REPO_PATH, REPO_PATH]);
-    expect(lookupContentAsset).toHaveBeenCalledTimes(1);
+    expect(lookupContentAssets).toHaveBeenCalledTimes(1);
+    expect(lookupContentAssets).toHaveBeenCalledWith(CLASSROOM_ID, [REPO_PATH]);
   });
 
   it('keys the result by the ORIGINAL reference, so a caller can look up blind', async () => {

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -488,6 +488,36 @@ export async function lookupContentAsset(
 }
 
 /**
+ * Many paths → the git objects behind them, in ONE query.
+ *
+ * The batch form exists because a render resolves a whole document at once: a
+ * forty-image deck opened by a lecture hall of students was forty `findUnique`
+ * round trips per view through `lookupContentAsset`. Paths the map has never
+ * heard of are simply absent from the returned map, which is the same "null"
+ * the single-path lookup reports, and lets the caller keep its per-ref
+ * branching unchanged.
+ */
+export async function lookupContentAssets(
+  classroomId: string,
+  paths: string[]
+): Promise<Map<string, ContentAssetRecord>> {
+  const wanted = [...new Set(paths)];
+  if (wanted.length === 0) return new Map();
+
+  const rows = await getPrisma().contentAsset.findMany({
+    where: { classroom_id: classroomId, path: { in: wanted } },
+    select: { path: true, sha: true, type: true, size: true },
+  });
+
+  return new Map(
+    rows.map((row: { path: string } & ContentAssetRecord) => [
+      row.path,
+      { sha: row.sha, type: row.type, size: row.size },
+    ])
+  );
+}
+
+/**
  * A directory's tree object, for the folders that are served whole — themes.
  *
  * Explicitly filtered to `type: 'tree'` rather than just looked up by path: a

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -13,6 +13,7 @@ import {
   ensureContentAssets,
   lookupContentAsset,
   lookupContentAssetBySha,
+  lookupContentAssets,
   lookupContentTree,
 } from './contentAssets.service.ts';
 import { extractOwnRepoPath } from './contentRefs.ts';
@@ -407,10 +408,10 @@ export async function resolveThemeBase(
 /**
  * Resolve a whole page's references in one pass.
  *
- * This is the entry point a render should use. The map freshness check happens
- * ONCE for the batch (it is a DB read, and possibly a GitHub tree call) rather
- * than once per image, which is the difference between a page with twenty
- * images costing one ensure and costing twenty.
+ * This is the entry point a render should use. Both the map freshness check
+ * (a DB read, and possibly a GitHub tree call) and the map lookup itself
+ * happen ONCE for the batch rather than once per image — a page with twenty
+ * images costs one ensure and one query, not twenty of each.
  *
  * Every input ref appears in the returned map, including the ones that resolve
  * to themselves, so a caller can look up unconditionally.
@@ -430,9 +431,35 @@ export async function resolveMany(
 
   await ensureMap(ctx.classroom.id);
 
+  // Reduce first, look up once. A reference that is not ours resolves to
+  // itself without ever reaching the map, and the ones that remain share a
+  // single `findMany` — the difference between a forty-image deck costing one
+  // query per view and costing forty.
+  const wanted = new Map<string, string>();
+  for (const ref of unique) {
+    const path = toRepoPath(ctx, ref);
+    if (path) wanted.set(ref, path);
+    else resolved.set(ref, ref);
+  }
+
+  if (wanted.size === 0) return resolved;
+
+  const assets = await lookupContentAssets(ctx.classroom.id, [...new Set(wanted.values())]);
+
   await Promise.all(
-    unique.map(async ref => {
-      resolved.set(ref, await resolveOne(ctx, env, ref));
+    [...wanted].map(async ([ref, path]) => {
+      const asset = assets.get(path);
+      // Identical branching to `resolveOne`: a path the map has never heard of
+      // and a TREE row both mean "there is no blob here", and both get the
+      // deterministic /missing/ URL rather than a confidently-wrong signature.
+      if (!asset || asset.type !== 'blob') {
+        console.warn(
+          `[contentDelivery] No blob row for "${ref}" (path ${path}) in classroom ${ctx.classroom.id}`
+        );
+        resolved.set(ref, missingUrl(env.origin, ctx.classroom.id, ref));
+        return;
+      }
+      resolved.set(ref, await signAsset(ctx, env, ref, path, asset.sha));
     })
   );
 

--- a/packages/services/src/slides/__tests__/deckAssets.test.ts
+++ b/packages/services/src/slides/__tests__/deckAssets.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import * as cheerio from 'cheerio';
 import { rewriteDeckAssetUrls } from '../deckAssets.ts';
 
 const SIGNED = 'https://cdn.test/c/3f2504e0-4f89-41d3-9a0c-0305e82c3301/blob/abc.png?sig=x';
@@ -102,6 +103,26 @@ describe('rewriteDeckAssetUrls', () => {
       '<section data-background-video="https://example.com/a.mp4, https://example.com/b.webm"></section>';
 
     await expect(rewriteDeckAssetUrls(html, resolver({ [REF]: SIGNED }))).resolves.toBe(html);
+  });
+
+  it("escapes a signed URL's query string so it survives serialization", async () => {
+    // Every real signed URL carries a multi-parameter policy. Serialized into
+    // an attribute the `&` must become `&amp;`, and must decode back to the
+    // exact URL the resolver minted — an over- or under-escaped one is a
+    // broken signature, not a cosmetic difference.
+    const MULTI = `https://cdn.test/c/3f2504e0-4f89-41d3-9a0c-0305e82c3301/blob/abc.png?p=enrolled&v=0&exp=1&sig=abc`;
+    const html = `<section data-background-image="${REF}"><img src="${REF}"></section>`;
+
+    const out = await rewriteDeckAssetUrls(html, resolver({ [REF]: MULTI }));
+
+    expect(out).toContain('?p=enrolled&amp;v=0&amp;exp=1&amp;sig=abc');
+    expect(out).not.toContain('?p=enrolled&v=0');
+
+    // Re-parsing is what the browser and the deck parser both do; the URL that
+    // comes back out must be the one that went in.
+    const $ = cheerio.load(out);
+    expect($('img').attr('src')).toBe(MULTI);
+    expect($('section').attr('data-background-image')).toBe(MULTI);
   });
 
   it('keeps a full document a full document', async () => {

--- a/packages/services/src/slides/__tests__/deckAssets.test.ts
+++ b/packages/services/src/slides/__tests__/deckAssets.test.ts
@@ -2,10 +2,12 @@
  * The read-time asset rewrite for deck HTML.
  *
  * What this guards is that the pass is a DOM pass and behaves like one: it
- * changes the four attributes that actually carry a URL, leaves everything the
- * resolver declines byte-identical, and — the reason it is not a regex — does
- * not touch URL-shaped text that merely lives inside an author's `data-*`
- * attribute or code sample.
+ * changes the attributes that actually carry a URL — including Reveal's
+ * slide-background pair, which is a repo asset addressed from `data-*` rather
+ * than from an `<img>` — leaves everything the resolver declines
+ * byte-identical, and — the reason it is not a regex — does not touch
+ * URL-shaped text that merely lives inside an author's `data-*` attribute or
+ * code sample.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -59,6 +61,46 @@ describe('rewriteDeckAssetUrls', () => {
 
   it('returns the input untouched when nothing resolves — no re-serialization', async () => {
     const html = '<section><p>no assets here</p></section>';
+    await expect(rewriteDeckAssetUrls(html, resolver({ [REF]: SIGNED }))).resolves.toBe(html);
+  });
+
+  it("signs Reveal's slide background image", async () => {
+    const html = `<section ${'data-background-image'}="${REF}" data-background-size="cover"><h2>t</h2></section>`;
+
+    const out = await rewriteDeckAssetUrls(html, resolver({ [REF]: SIGNED }));
+
+    expect(out).toContain(`data-background-image="${SIGNED}"`);
+    // Sibling background settings are not URLs and are left alone.
+    expect(out).toContain('data-background-size="cover"');
+    expect(out).not.toContain(REF);
+  });
+
+  it('leaves a foreign or inline slide background exactly as it found it', async () => {
+    const html =
+      '<section data-background-image="https://example.com/hero.png"></section>' +
+      '<section data-background-image="data:image/gif;base64,R0lGOD"></section>' +
+      // A page to embed, not an asset: never signed, whatever the resolver says.
+      `<section data-background-iframe="${REF}"></section>`;
+
+    await expect(rewriteDeckAssetUrls(html, resolver({ [REF]: SIGNED }))).resolves.toBe(html);
+  });
+
+  it('signs each source of a background video list and keeps the order', async () => {
+    const FOREIGN = 'https://example.com/promo.webm';
+    const MP4 = '/content/org/repo/slides/deck/video/clip.mp4';
+    const MP4_SIGNED = 'https://cdn.test/c/3f2504e0-4f89-41d3-9a0c-0305e82c3301/blob/def.mp4?sig=y';
+    const html = `<section data-background-video="${MP4}, ${FOREIGN}" data-background-video-loop></section>`;
+
+    const out = await rewriteDeckAssetUrls(html, resolver({ [MP4]: MP4_SIGNED }));
+
+    expect(out).toContain(`data-background-video="${MP4_SIGNED},${FOREIGN}"`);
+    expect(out).not.toContain(MP4);
+  });
+
+  it('leaves a background video list alone when no source resolves', async () => {
+    const html =
+      '<section data-background-video="https://example.com/a.mp4, https://example.com/b.webm"></section>';
+
     await expect(rewriteDeckAssetUrls(html, resolver({ [REF]: SIGNED }))).resolves.toBe(html);
   });
 

--- a/packages/services/src/slides/deckAssets.ts
+++ b/packages/services/src/slides/deckAssets.ts
@@ -53,9 +53,13 @@ function splitSrcSet(value: string): { url: string; descriptor: string }[] {
 /**
  * Split a `data-background-video` source list.
  *
- * Reveal accepts a comma-separated list of sources and trims each one itself,
- * so the trimmed form is what goes back; order is preserved, and a list whose
- * items all decline is never written back at all (the `changed` flag below).
+ * Reveal splits this on commas but does NOT trim the pieces (unlike
+ * `data-background-image`, which it does trim), so a list written as
+ * `a.mp4, b.webm` already depends on the browser tolerating the leading space.
+ * We trim deliberately and write the trimmed form back — it is what Reveal
+ * would need anyway — and preserve order. A list whose sources all decline is
+ * never written back at all (the `changed` flag below), so an untouched deck
+ * keeps its original spacing byte for byte.
  */
 function splitVideoSources(value: string): string[] {
   return value
@@ -179,7 +183,10 @@ export async function rewriteDeckAssetUrls(
 
   if (!changed) return html;
 
-  // A full document keeps its doctype/head; a fragment round-trips as a
-  // fragment. cheerio's `html()` on the root does the right thing for both.
+  // A full document keeps its doctype/head. A FRAGMENT does not survive as a
+  // fragment — cheerio promotes one to a full `<html><head><body>` document on
+  // parse, and serializing the root gives that back. What keeps a fragment
+  // caller safe is the `changed` short-circuit above: a document with nothing
+  // to rewrite is returned as the caller's own string, never re-serialized.
   return $.root().html() ?? html;
 }

--- a/packages/services/src/slides/deckAssets.ts
+++ b/packages/services/src/slides/deckAssets.ts
@@ -11,18 +11,30 @@ import * as cheerio from 'cheerio';
  * samples, and inside anything else an instructor pasted. Parsing and
  * re-serializing cannot have that class of bug.
  *
- * Four places hold a URL worth rewriting:
+ * Six places hold a URL worth rewriting:
  *   - `src`     — images, videos, iframes;
  *   - `href`    — downloadable attachments (and stylesheet links, which the
  *                 caller is expected to exclude — see below);
  *   - `srcset`  — a comma-separated candidate list, each with its own URL;
- *   - `style`   — inline `background-image: url(...)` and friends.
+ *   - `style`   — inline `background-image: url(...)` and friends;
+ *   - `data-background-image` — Reveal's slide background, which is a real
+ *                 repo asset that happens to be addressed from a `data-*`
+ *                 attribute rather than an `<img>`;
+ *   - `data-background-video` — same, as a comma-separated source list.
+ *
+ * `data-background-iframe` is deliberately NOT in that list: it names a PAGE
+ * to embed, not an asset in the content repo, and signing it as a blob would
+ * point the iframe at a file the Worker serves with the wrong content type.
  *
  * Everything the resolver does not map is left byte-identical. That includes
  * theme stylesheets: a theme is signed as a FOLDER so its relative `url()`
  * references keep working, and rewriting its `<link href>` to a blob URL would
  * break exactly that. The caller's resolver is what declines those.
  */
+
+/** Reveal's slide-background attributes that name a repo asset. */
+const BG_IMAGE = 'data-background-image';
+const BG_VIDEO = 'data-background-video';
 
 /** Split a `srcset` into its candidates without losing the descriptors. */
 function splitSrcSet(value: string): { url: string; descriptor: string }[] {
@@ -36,6 +48,20 @@ function splitSrcSet(value: string): { url: string; descriptor: string }[] {
         ? { url: part, descriptor: '' }
         : { url: part.slice(0, space), descriptor: part.slice(space) };
     });
+}
+
+/**
+ * Split a `data-background-video` source list.
+ *
+ * Reveal accepts a comma-separated list of sources and trims each one itself,
+ * so the trimmed form is what goes back; order is preserved, and a list whose
+ * items all decline is never written back at all (the `changed` flag below).
+ */
+function splitVideoSources(value: string): string[] {
+  return value
+    .split(',')
+    .map(part => part.trim())
+    .filter(part => part.length > 0);
 }
 
 /** Every `url(...)` in a CSS declaration list, with its quoting preserved. */
@@ -73,14 +99,20 @@ export async function rewriteDeckAssetUrls(
   const $ = cheerio.load(html);
   const candidates = new Set<string>();
 
-  const elements = $('[src], [srcset], [href], [style]').toArray();
+  const elements = $(
+    '[src], [srcset], [href], [style], [data-background-image], [data-background-video]'
+  ).toArray();
 
   for (const el of elements) {
     const { src, srcset, href, style } = el.attribs;
+    const bgImage = el.attribs[BG_IMAGE];
+    const bgVideo = el.attribs[BG_VIDEO];
     if (src) candidates.add(src);
     if (href) candidates.add(href);
     if (srcset) for (const part of splitSrcSet(srcset)) candidates.add(part.url);
     if (style) for (const url of cssUrls(style)) candidates.add(url);
+    if (bgImage) candidates.add(bgImage);
+    if (bgVideo) for (const source of splitVideoSources(bgVideo)) candidates.add(source);
   }
 
   if (candidates.size === 0) return html;
@@ -97,6 +129,8 @@ export async function rewriteDeckAssetUrls(
 
   for (const el of elements) {
     const { src, srcset, href, style } = el.attribs;
+    const bgImage = el.attribs[BG_IMAGE];
+    const bgVideo = el.attribs[BG_VIDEO];
 
     const nextSrc = src ? map(src) : undefined;
     if (nextSrc !== undefined) {
@@ -124,6 +158,20 @@ export async function rewriteDeckAssetUrls(
       const nextStyle = rewriteCssUrls(style, map);
       if (nextStyle !== style) {
         el.attribs['style'] = nextStyle;
+        changed = true;
+      }
+    }
+
+    const nextBgImage = bgImage ? map(bgImage) : undefined;
+    if (nextBgImage !== undefined) {
+      el.attribs[BG_IMAGE] = nextBgImage;
+      changed = true;
+    }
+
+    if (bgVideo) {
+      const sources = splitVideoSources(bgVideo);
+      if (sources.some(source => map(source) !== undefined)) {
+        el.attribs[BG_VIDEO] = sources.map(source => map(source) ?? source).join(',');
         changed = true;
       }
     }


### PR DESCRIPTION
## What
Browser testing on staging showed the deck **viewer** serving images through the signed content layer while **/present** served the stored legacy `/content/{org}/{repo}/…` refs: the present, follow and speaker loaders loaded `index.html` themselves and never ran the rewrite. Three commits:

1. **One shared module** (`apps/slides/app/utils/deckDelivery.server.ts`) owns context building, `tierFor`, the asset pass and the shared-theme rebase; the viewer route now imports it and the three read routes run it. `deckAccessFor(surface, access, slide)` maps route access to tier inputs in one tested place. Also fixes a `catch (error: unknown)` inside the inline dark-mode script in `root.tsx` (a parse error on every slides page).
2. **Reveal backgrounds**: `data-background-image` and `data-background-video` (comma list) are now signed like `src`; `data-background-iframe` deliberately not.
3. **Review follow-ups**: unconfigured deployments skip the parse entirely; `resolveMany` does ONE `findMany` for all paths instead of one query per ref (matters on `/follow` with a lecture hall); `/present` and `/speaker` sign at the `enrolled`/`public` tier so a deck left open for hours doesn't 403 lazily-loaded backgrounds after the 4 h draft window; speaker view no longer computes a theme base it discards; test hygiene.

Unset delivery env → byte-identical HTML on every route, no DB or GitHub calls.

## Test
- slides unit specs 89 passed; slides typecheck 0.
- services 1408 passed, 13 failed (known GitLabProvider baseline); typecheck 16 known GitLabProvider errors only.
- On staging (`cs98-test`): open a deck's `/present` and `/speaker`; images and backgrounds load from `content-staging.classmoji.io/c/…/blob/…?p=enrolled…` with no legacy `/content/…` requests; the per-page console `SyntaxError` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA