### PR TITLE
fix(content-worker): log the reason on signature 403s

### DIFF
--- a/apps/content/src/index.ts
+++ b/apps/content/src/index.ts
@@ -17,7 +17,7 @@ import { errorResponse, jsonResponse, preflightResponse } from './cache.ts';
 import { isConfigured, type Env } from './env.ts';
 import { OriginError } from './origins/types.ts';
 import { serveTheme } from './theme.ts';
-import { verifyContentUrl } from './verify.ts';
+import { parseContentUrl, verifyContentUrl } from './verify.ts';
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -44,7 +44,19 @@ export default {
     }
 
     const verified = await verifyContentUrl(signingSecret, request.url);
-    if (!verified.ok) return errorResponse(403, verified.reason);
+    if (!verified.ok) {
+      // Structural parse only (no crypto) - just to recover the classroom id
+      // for a URL whose signature we don't yet trust. Never log `sig`, the
+      // query string, or the full URL: those can leak a valid credential.
+      const classroomId = parseContentUrl(request.url)?.classroomId ?? 'unknown';
+      const p = url.searchParams.get('p');
+      const v = url.searchParams.get('v');
+      let message = `[content] 403 ${verified.reason} classroom=${classroomId} path=${url.pathname}`;
+      if (p !== null) message += ` p=${p}`;
+      if (v !== null) message += ` v=${v}`;
+      console.warn(message);
+      return errorResponse(403, verified.reason);
+    }
 
     try {
       return verified.kind === 'blob'

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -123,6 +123,25 @@ describe('routing', () => {
     expect(response.headers.get('Cache-Control')).toBe('no-store');
   });
 
+  it('logs the reason, classroom, path, and p/v on a 403 - never the signature', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const path = `/c/${CLASSROOM}/blob/${BLOB_SHA}.png`;
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}${path}?p=public&v=1&exp=${futureExp()}&sig=nope`),
+      fakeEnv(),
+      fakeContext()
+    );
+    expect(response.status).toBe(403);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain('bad-signature');
+    expect(message).toContain(`classroom=${CLASSROOM}`);
+    expect(message).toContain(`path=${path}`);
+    expect(message).toContain('p=public');
+    expect(message).toContain('v=1');
+    expect(message).not.toContain('sig=');
+  });
+
   it('403s a URL minted for a different delivery host', async () => {
     const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png', signedHost: 'evil.example.com' });
     const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());


### PR DESCRIPTION
## What
A signature-verification 403 in the content Worker emitted nothing, so a report of broken images gave a status count and no cause. Now warns once per 403 with the reason (expired / bad signature / wrong host / malformed…), classroom id, request path, and the `p`/`v` query values. Never the signature, query string, or full URL.

## Test
Worker suite 109 passed (+1: a tampered-signature request emits exactly one warn containing the reason and path and not `sig=`); typecheck 0. On staging: request a tampered signed URL → 403, and the line shows up in Workers Logs for `classmoji-content-staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA