### PR TITLE
ci(staging): keep hook-station running so webhooks stop timing out

### DIFF
--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -125,8 +125,12 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy hook-station
         run: |
-          CONFIG=$(scripts/fly-autostop-config.sh apps/hook-station/fly.toml stop)
-          flyctl deploy --config "$CONFIG" --dockerfile apps/hook-station/Dockerfile --remote-only --app classmoji-hook-station-staging
+          # hook-station is the one staging app that must NOT scale to zero: a
+          # cold start takes ~20 s and GitHub gives a webhook delivery 10 s with
+          # no retry, so every push/issue event that arrived while it slept was
+          # lost. Deploy the production config as-is (auto_stop off, one machine
+          # always running; shared-cpu-1x, pennies).
+          flyctl deploy --config apps/hook-station/fly.toml --dockerfile apps/hook-station/Dockerfile --remote-only --app classmoji-hook-station-staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## What
Staging rewrites every Fly config to scale-to-zero at deploy time. hook-station's cold start (~20 s measured) exceeds GitHub's 10 s webhook delivery timeout, and GitHub does not retry, so push events were lost whenever the machine slept. This exempts hook-station on staging: deploy its production config as-is (auto_stop off, one shared-cpu-1x machine always running).

## Test
Next staging deploy of hook-station keeps a machine `started`; a push to a staging content repo reaches hook-station and triggers the sync task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA