### PR TITLE
fix(content-worker): review follow-ups (404 for dangling, bounded transforms, HEAD, deploy guard)

### DIFF
--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -163,8 +163,83 @@ their minting at the local Worker with `CONTENT_DELIVERY_ORIGIN`; set it to
 `http://localhost:8787` for a local smoke, and remember the port is signed too
 — `:8788` will not verify against a `:8787` signature.
 
+## Operating
+
+### R2 layout, and purging one blob
+
+Keys are content-addressed, so a blob and its variants live together:
+
+```
+blobs/{sha}                 # the original bytes, exactly as GitHub stores them
+blobs/{sha}/w{width}.{fmt}  # a transformed variant: w800.webp, w1600.avif, ...
+trees/{treeSha}.json        # a theme's flattened tree listing
+```
+
+Purging one blob means purging its variants too — they are separate objects and
+nothing cascades:
+
+```sh
+BUCKET=classmoji-content-cache-stg   # -prod in production
+SHA=0123456789abcdef0123456789abcdef01234567
+
+npx wrangler r2 object delete "$BUCKET/blobs/$SHA" --remote
+for W in 800 1600 2560; do
+  for FMT in webp avif; do
+    npx wrangler r2 object delete "$BUCKET/blobs/$SHA/w$W.$FMT" --remote || true
+  done
+done
+```
+
+The delete is safe in the sense that matters: the next request for that sha
+refetches it from GitHub and writes it back. It is *not* scoped to a classroom —
+one object serves every classroom referencing that sha, which is the point of a
+content-addressed key.
+
+### "Reset content cache" busts the edge, not R2
+
+The per-classroom button in the app bumps the classroom's key version, so every
+URL it mints from then on carries a new `v` and a new signature. That retires
+the old URLs at the edge (and in browsers) — it does **not** touch R2. The bytes
+under `blobs/{sha}` stay exactly where they were, which is correct: they are
+addressed by content, so a stale one is a contradiction. Reach for
+`wrangler r2 object delete` only when an object in R2 is genuinely wrong.
+
+### Logs
+
+Workers Logs, in the Cloudflare dashboard: **Workers & Pages → the Worker →
+Logs** (`classmoji-content-staging` or `classmoji-content`), with
+`observability.enabled` set in `wrangler.jsonc` for both. `npx wrangler tail
+--env staging` gives the same stream in a terminal. The lines worth searching:
+
+| Shape | Means |
+| --- | --- |
+| `[content] 403 {reason} classroom=… path=… p=… v=…` | refused: `bad-signature`, `expired`, `malformed`, `unsupported-version`. Never carries `sig` or a query string |
+| `[content] 404 missing classroom=… path=…` | the app minted a `/missing/` URL: a reference that resolves to no blob (deleted, renamed, or a directory). Not an attack — a content bug |
+| `[content] origin blob {sha}: {status}` | GitHub refused the blob; the client got a 502 |
+| `[content] origin error: …` / `[content] unhandled error: …` | 502 / 500 |
+| `[content] image transform failed (w=…, fmt=…)` | Images could not do it; the original was served on `max-age=60` |
+| `[content] skipping transform for {sha}: …ceiling` | source past `MAX_TRANSFORM_SOURCE_BYTES`; the original was streamed instead |
+| `[content] refusing to cache truncated tree {sha}` | the listing was used but not stored |
+| `[content] failed to cache {key}` | the R2 write-back failed; the client was still served |
+
+A burst of `403 bad-signature` on one classroom usually means a stale page in
+someone's browser, not an attacker: signatures expire, and the grace window is
+6h (5m for draft). A burst of `404 missing` means content references drifted
+from the repo — look at the resolver, not the Worker.
+
 ## Deployment
 
 Staging deploys from `.github/workflows/deploy-cloudflare-staging.yml` on pushes
-to `staging`. **Production is defined in `wrangler.jsonc` but has no workflow**:
-deploying `classmoji-content` is a deliberate, manual act.
+to `staging`, as `classmoji-content-staging`.
+
+Production will deploy from a workflow on pushes to `main`, as
+`classmoji-content`. **That workflow is not in the tree yet** — it lands in a
+separate PR; until it does, production is deployed by hand with
+`npx wrangler deploy --env production`.
+
+The top-level config is named `classmoji-content-unconfigured` on purpose. It
+carries no R2 bucket, no Images binding and no vars, and wrangler falls back to
+it whenever no `--env` is given — so a bare `npx wrangler deploy` creates a
+throwaway Worker nothing routes to, instead of replacing production with a
+bindingless build that 503s everything. Every real deploy names its
+environment; `cf:dev` and `cf:types` pass `--env staging` for the same reason.

--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -227,6 +227,12 @@ someone's browser, not an attacker: signatures expire, and the grace window is
 6h (5m for draft). A burst of `404 missing` means content references drifted
 from the repo — look at the resolver, not the Worker.
 
+A `\uFFFD` in a logged path is this Worker defusing the path, not a corrupt
+file: the repo path in a `/missing/` URL arrives from the network, so every
+control character in it is replaced and the whole path is capped at 512
+characters. Otherwise a `%0A` would let an unauthenticated request write its
+own `[content] 403 …` line into the stream you are searching.
+
 ## Deployment
 
 Staging deploys from `.github/workflows/deploy-cloudflare-staging.yml` on pushes

--- a/apps/content/package.json
+++ b/apps/content/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "cf:dev": "wrangler dev --env staging",
-    "cf:types": "wrangler types"
+    "cf:types": "wrangler types --env staging"
   },
   "dependencies": {
     "@classmoji/content-signing": "*"

--- a/apps/content/src/blob.ts
+++ b/apps/content/src/blob.ts
@@ -31,6 +31,17 @@ interface ServeOptions {
   sha: string;
   contentType: string;
   cacheControl: string;
+  /** HEAD: answer from R2 metadata when the object is there, and never buffer. */
+  head?: boolean;
+}
+
+function storedHeaders(object: R2Object, fallbackType: string, cacheControl: string): Headers {
+  const headers = contentHeaders(object.httpMetadata?.contentType ?? fallbackType, cacheControl);
+  headers.set('ETag', object.httpEtag);
+  // R2 knows the length without reading a byte, so there is no reason to make a
+  // client guess at download progress.
+  headers.set('Content-Length', String(object.size));
+  return headers;
 }
 
 function storedResponse(
@@ -38,9 +49,23 @@ function storedResponse(
   fallbackType: string,
   cacheControl: string
 ): Response {
-  const headers = contentHeaders(object.httpMetadata?.contentType ?? fallbackType, cacheControl);
-  headers.set('ETag', object.httpEtag);
-  return new Response(object.body, { headers });
+  return new Response(object.body, { headers: storedHeaders(object, fallbackType, cacheControl) });
+}
+
+/**
+ * A HEAD answered from R2's metadata alone — no bytes read, no origin touched.
+ * Returns null when the object is not there, so the caller can fall through to
+ * the full path (which will warm R2 for the HEAD after this one).
+ */
+async function storedHead(
+  env: Env,
+  key: string,
+  fallbackType: string,
+  cacheControl: string
+): Promise<Response | null> {
+  const object = await env.CACHE.head(key);
+  if (!object) return null;
+  return new Response(null, { headers: storedHeaders(object, fallbackType, cacheControl) });
 }
 
 /** The origin's own `Content-Length`, when it sent a usable one. */
@@ -62,7 +87,8 @@ function streamAndCache(
   key: string,
   body: ReadableStream<Uint8Array>,
   contentType: string,
-  cacheControl: string
+  cacheControl: string,
+  contentLength: number | null
 ): Response {
   const [toClient, toCache] = body.tee();
   ctx.waitUntil(
@@ -70,7 +96,11 @@ function streamAndCache(
       console.warn(`[content] failed to cache ${key}:`, error);
     })
   );
-  return new Response(toClient, { headers: contentHeaders(contentType, cacheControl) });
+  const headers = contentHeaders(contentType, cacheControl);
+  // Only ever forwarded, never computed: working it out would mean buffering
+  // the very stream this path exists to avoid buffering.
+  if (contentLength !== null) headers.set('Content-Length', String(contentLength));
+  return new Response(toClient, { headers });
 }
 
 /** One shape for both ways a source can be too large: declared, and counted. */
@@ -93,6 +123,12 @@ export async function serveBlobBySha(
   options: ServeOptions
 ): Promise<Response> {
   const key = blobKey(options.sha);
+
+  if (options.head) {
+    const head = await storedHead(env, key, options.contentType, options.cacheControl);
+    if (head) return head;
+  }
+
   const hit = await env.CACHE.get(key);
   if (hit) return storedResponse(hit, options.contentType, options.cacheControl);
 
@@ -121,7 +157,15 @@ export async function serveBlobBySha(
     return errorResponse(502, 'origin unavailable');
   }
 
-  return streamAndCache(env, ctx, key, response.body, options.contentType, options.cacheControl);
+  return streamAndCache(
+    env,
+    ctx,
+    key,
+    response.body,
+    options.contentType,
+    options.cacheControl,
+    declaredLength(response.headers)
+  );
 }
 
 /**
@@ -159,7 +203,15 @@ async function loadOriginalBytes(
   const declared = declaredLength(response.headers);
   if (declared !== null && declared > MAX_TRANSFORM_SOURCE_BYTES) {
     warnOversizedSource(options.sha, declared);
-    return streamAndCache(env, ctx, key, response.body, options.contentType, SHORT_CACHE_CONTROL);
+    return streamAndCache(
+      env,
+      ctx,
+      key,
+      response.body,
+      options.contentType,
+      SHORT_CACHE_CONTROL,
+      declared
+    );
   }
 
   const bytes = await readBounded(response.body, MAX_TRANSFORM_SOURCE_BYTES);
@@ -191,6 +243,11 @@ async function serveVariant(
 ): Promise<Response> {
   const format = negotiateFormat(verified.transform?.fmt, request.headers.get('Accept'));
   const key = variantKey(options.sha, width, format);
+
+  if (options.head) {
+    const head = await storedHead(env, key, mediaTypeFor(format), options.cacheControl);
+    if (head) return head;
+  }
 
   const hit = await env.CACHE.get(key);
   if (hit) return storedResponse(hit, mediaTypeFor(format), options.cacheControl);
@@ -234,6 +291,7 @@ export async function serveBlob(
     sha: verified.sha,
     contentType: contentTypeForExtension(verified.ext),
     cacheControl: cacheControlFor(verified.tier, verified.exp, nowSeconds()),
+    head: request.method === 'HEAD',
   };
 
   const width = verified.transform?.w;

--- a/apps/content/src/blob.ts
+++ b/apps/content/src/blob.ts
@@ -10,7 +10,13 @@ import type { Env } from './env.ts';
 import { GitHubOrigin } from './origins/github.ts';
 import { deliveryStrategy, type OriginAdapter } from './origins/types.ts';
 import { withOriginRetry } from './token.ts';
-import { negotiateFormat, mediaTypeFor, transformImage } from './transform.ts';
+import {
+  MAX_TRANSFORM_SOURCE_BYTES,
+  negotiateFormat,
+  mediaTypeFor,
+  readBounded,
+  transformImage,
+} from './transform.ts';
 import { cacheControlFor, nowSeconds, type BlobVerification } from './verify.ts';
 
 /** The success half of the verification union. */
@@ -35,6 +41,45 @@ function storedResponse(
   const headers = contentHeaders(object.httpMetadata?.contentType ?? fallbackType, cacheControl);
   headers.set('ETag', object.httpEtag);
   return new Response(object.body, { headers });
+}
+
+/** The origin's own `Content-Length`, when it sent a usable one. */
+function declaredLength(headers: Headers): number | null {
+  const raw = headers.get('Content-Length');
+  if (raw === null) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+/**
+ * Stream an origin body to the client while a tee'd copy lands in R2. Bytes are
+ * never buffered here — this is the path every untransformed miss takes, and
+ * the one the transform path falls back to when its source is too big to hold.
+ */
+function streamAndCache(
+  env: Env,
+  ctx: ExecutionContext,
+  key: string,
+  body: ReadableStream<Uint8Array>,
+  contentType: string,
+  cacheControl: string
+): Response {
+  const [toClient, toCache] = body.tee();
+  ctx.waitUntil(
+    env.CACHE.put(key, toCache, { httpMetadata: { contentType } }).catch(error => {
+      console.warn(`[content] failed to cache ${key}:`, error);
+    })
+  );
+  return new Response(toClient, { headers: contentHeaders(contentType, cacheControl) });
+}
+
+/** One shape for both ways a source can be too large: declared, and counted. */
+function warnOversizedSource(sha: string, size: number | null): void {
+  const measured = size === null ? 'over the' : `${size} bytes, over the`;
+  console.warn(
+    `[content] skipping transform for ${sha}: source is ${measured} ` +
+      `${MAX_TRANSFORM_SOURCE_BYTES} byte ceiling`
+  );
 }
 
 /**
@@ -76,24 +121,17 @@ export async function serveBlobBySha(
     return errorResponse(502, 'origin unavailable');
   }
 
-  const [toClient, toCache] = response.body.tee();
-  ctx.waitUntil(
-    env.CACHE.put(key, toCache, { httpMetadata: { contentType: options.contentType } }).catch(
-      error => {
-        console.warn(`[content] failed to cache ${key}:`, error);
-      }
-    )
-  );
-
-  return new Response(toClient, {
-    headers: contentHeaders(options.contentType, options.cacheControl),
-  });
+  return streamAndCache(env, ctx, key, response.body, options.contentType, options.cacheControl);
 }
 
 /**
  * Materialize a blob's bytes for the transform path (R2 first, else origin,
- * caching the original on the way through). Returns an error Response when the
- * origin fails, so the caller can pass it straight back.
+ * caching the original on the way through).
+ *
+ * Returns a Response instead of bytes when there are none to hand back: an
+ * origin failure, or a source past `MAX_TRANSFORM_SOURCE_BYTES`, which is
+ * streamed untransformed on the short TTL a failed transform gets. Either way
+ * the caller passes it straight through.
  */
 async function loadOriginalBytes(
   env: Env,
@@ -102,17 +140,37 @@ async function loadOriginalBytes(
 ): Promise<ArrayBuffer | Response> {
   const key = blobKey(options.sha);
   const hit = await env.CACHE.get(key);
-  if (hit) return hit.arrayBuffer();
+  if (hit) {
+    if (hit.size > MAX_TRANSFORM_SOURCE_BYTES) {
+      warnOversizedSource(options.sha, hit.size);
+      return storedResponse(hit, options.contentType, SHORT_CACHE_CONTROL);
+    }
+    return hit.arrayBuffer();
+  }
 
   const response = await withOriginRetry(env, options.classroomId, ref =>
     origin.fetchBlob({ ...ref, sha: options.sha })
   );
-  if (!response.ok) {
+  if (!response.ok || !response.body) {
     console.warn(`[content] origin blob ${options.sha}: ${response.status}`);
     return errorResponse(502, 'origin unavailable');
   }
 
-  const bytes = await response.arrayBuffer();
+  const declared = declaredLength(response.headers);
+  if (declared !== null && declared > MAX_TRANSFORM_SOURCE_BYTES) {
+    warnOversizedSource(options.sha, declared);
+    return streamAndCache(env, ctx, key, response.body, options.contentType, SHORT_CACHE_CONTROL);
+  }
+
+  const bytes = await readBounded(response.body, MAX_TRANSFORM_SOURCE_BYTES);
+  if (bytes === null) {
+    // The origin declared no size, so the ceiling could only be enforced by
+    // counting - and the bytes counted are gone with the cancelled stream. The
+    // untransformed path fetches it again and streams it, caching on the way.
+    warnOversizedSource(options.sha, null);
+    return serveBlobBySha(env, ctx, { ...options, cacheControl: SHORT_CACHE_CONTROL });
+  }
+
   ctx.waitUntil(
     env.CACHE.put(key, bytes, { httpMetadata: { contentType: options.contentType } }).catch(
       error => {

--- a/apps/content/src/blob.ts
+++ b/apps/content/src/blob.ts
@@ -68,12 +68,26 @@ async function storedHead(
   return new Response(null, { headers: storedHeaders(object, fallbackType, cacheControl) });
 }
 
-/** The origin's own `Content-Length`, when it sent a usable one. */
+/**
+ * The origin's own `Content-Length`, when it sent one we can honestly forward.
+ *
+ * A compressed response is the trap. The runtime adds `Accept-Encoding` to
+ * every subrequest and GitHub gzips text, so `Content-Length` describes the
+ * ENCODED body — but reading `response.body` (to tee it, here) hands us the
+ * decoded bytes. Copying the header onto the decoded stream promises a length
+ * we then fail to deliver, and the browser aborts with
+ * ERR_CONTENT_LENGTH_MISMATCH on every cold css, svg or json blob. When the
+ * origin says it encoded the body, we say nothing about its length.
+ *
+ * `Number` is too generous on its own: it reads '0x10' as 16 and ' 12 ' as 12,
+ * so the digits are checked before the conversion.
+ */
 function declaredLength(headers: Headers): number | null {
+  if (headers.has('Content-Encoding')) return null;
   const raw = headers.get('Content-Length');
-  if (raw === null) return null;
+  if (raw === null || !/^\d+$/.test(raw)) return null;
   const value = Number(raw);
-  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  return Number.isSafeInteger(value) ? value : null;
 }
 
 /**
@@ -252,6 +266,14 @@ async function serveVariant(
   const hit = await env.CACHE.get(key);
   if (hit) return storedResponse(hit, mediaTypeFor(format), options.cacheControl);
 
+  // A HEAD on a COLD variant deliberately falls through to the whole transform,
+  // paying an Images call for a reply that carries no bytes. The alternative —
+  // HEAD the original and answer from its headers — would be cheaper and wrong:
+  // it would report the original's content type and length for a URL that asked
+  // for an 800px webp, which is the one thing a HEAD exists to tell you. The
+  // transform is cached on the way past, so the cost is paid once and the GET
+  // behind it is a hit. HEAD on an image variant is rare (monitoring, not
+  // browsers), so this is not a hot path.
   const original = await loadOriginalBytes(env, ctx, options);
   if (original instanceof Response) return original;
 

--- a/apps/content/src/cache.ts
+++ b/apps/content/src/cache.ts
@@ -57,7 +57,10 @@ export function finalizeHeaders(headers: Headers): Headers {
  * its way to R2.
  */
 export function withoutBody(response: Response): Response {
-  void response.body?.cancel();
+  // Swallowed, not ignored: cancelling a tee'd branch whose partner already
+  // errored rejects, and an unhandled rejection here would take down a request
+  // that has otherwise succeeded.
+  response.body?.cancel().catch(() => {});
   return new Response(null, {
     status: response.status,
     statusText: response.statusText,

--- a/apps/content/src/cache.ts
+++ b/apps/content/src/cache.ts
@@ -49,6 +49,22 @@ export function finalizeHeaders(headers: Headers): Headers {
   return headers;
 }
 
+/**
+ * The same response with its body dropped — what a HEAD gets.
+ *
+ * The body is cancelled rather than abandoned: on the origin path it is one
+ * half of a `tee()`, and a branch nobody reads eventually stalls the branch on
+ * its way to R2.
+ */
+export function withoutBody(response: Response): Response {
+  void response.body?.cancel();
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 export function finalize(response: Response): Response {
   const headers = finalizeHeaders(new Headers(response.headers));
   return new Response(response.body, {

--- a/apps/content/src/index.ts
+++ b/apps/content/src/index.ts
@@ -13,7 +13,7 @@
  *   OPTIONS *
  */
 import { serveBlob } from './blob.ts';
-import { errorResponse, jsonResponse, preflightResponse } from './cache.ts';
+import { errorResponse, jsonResponse, preflightResponse, withoutBody } from './cache.ts';
 import { isConfigured, type Env } from './env.ts';
 import { OriginError } from './origins/types.ts';
 import { serveTheme } from './theme.ts';
@@ -40,66 +40,78 @@ function decodeForLog(value: string): string {
   }
 }
 
+/**
+ * The whole request, minus the one guarantee applied to its answer.
+ *
+ * A HEAD is answered from R2 metadata wherever the object is already there
+ * (see `serveBlobBySha`); when it is not, it falls through to the full path so
+ * the cache warms — and `withoutBody` in the caller is what keeps that
+ * fall-through from putting bytes on the wire.
+ */
+async function handle(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  if (request.method === 'OPTIONS') return preflightResponse();
+
+  const url = new URL(request.url);
+
+  if (url.pathname === '/healthz') {
+    return jsonResponse(
+      { ok: true, environment: env.ENVIRONMENT ?? 'unknown', configured: isConfigured(env) },
+      200
+    );
+  }
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return errorResponse(405, 'method not allowed');
+  }
+
+  if (!url.pathname.startsWith('/c/')) return errorResponse(404, 'not found');
+
+  const missing = MISSING_PATH.exec(url.pathname);
+  if (missing) {
+    // The repo path is the app's own reference, not a credential — but the
+    // query string still never reaches a log.
+    console.warn(`[content] 404 missing classroom=${missing[1]} path=${decodeForLog(missing[2])}`);
+    return errorResponse(404, 'missing');
+  }
+
+  const signingSecret = env.CONTENT_SIGNING_SECRET;
+  if (!signingSecret || !env.CONTENT_WORKER_SHARED_SECRET || !env.CONTENT_TOKEN_ENDPOINT) {
+    return errorResponse(503, 'not configured');
+  }
+
+  const verified = await verifyContentUrl(signingSecret, request.url);
+  if (!verified.ok) {
+    // Structural parse only (no crypto) - just to recover the classroom id
+    // for a URL whose signature we don't yet trust. Never log `sig`, the
+    // query string, or the full URL: those can leak a valid credential.
+    const classroomId = parseContentUrl(request.url)?.classroomId ?? 'unknown';
+    const p = url.searchParams.get('p');
+    const v = url.searchParams.get('v');
+    let message = `[content] 403 ${verified.reason} classroom=${classroomId} path=${url.pathname}`;
+    if (p !== null) message += ` p=${p}`;
+    if (v !== null) message += ` v=${v}`;
+    console.warn(message);
+    return errorResponse(403, verified.reason);
+  }
+
+  try {
+    return verified.kind === 'blob'
+      ? await serveBlob(env, ctx, request, verified)
+      : await serveTheme(env, ctx, verified, request.method === 'HEAD');
+  } catch (error) {
+    if (error instanceof OriginError) {
+      console.warn('[content] origin error:', error.message);
+      return errorResponse(502, 'origin unavailable');
+    }
+    console.error('[content] unhandled error:', error);
+    return errorResponse(500, 'internal error');
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    if (request.method === 'OPTIONS') return preflightResponse();
-
-    const url = new URL(request.url);
-
-    if (url.pathname === '/healthz') {
-      return jsonResponse(
-        { ok: true, environment: env.ENVIRONMENT ?? 'unknown', configured: isConfigured(env) },
-        200
-      );
-    }
-
-    if (request.method !== 'GET' && request.method !== 'HEAD') {
-      return errorResponse(405, 'method not allowed');
-    }
-
-    if (!url.pathname.startsWith('/c/')) return errorResponse(404, 'not found');
-
-    const missing = MISSING_PATH.exec(url.pathname);
-    if (missing) {
-      // The repo path is the app's own reference, not a credential — but the
-      // query string still never reaches a log.
-      console.warn(
-        `[content] 404 missing classroom=${missing[1]} path=${decodeForLog(missing[2])}`
-      );
-      return errorResponse(404, 'missing');
-    }
-
-    const signingSecret = env.CONTENT_SIGNING_SECRET;
-    if (!signingSecret || !env.CONTENT_WORKER_SHARED_SECRET || !env.CONTENT_TOKEN_ENDPOINT) {
-      return errorResponse(503, 'not configured');
-    }
-
-    const verified = await verifyContentUrl(signingSecret, request.url);
-    if (!verified.ok) {
-      // Structural parse only (no crypto) - just to recover the classroom id
-      // for a URL whose signature we don't yet trust. Never log `sig`, the
-      // query string, or the full URL: those can leak a valid credential.
-      const classroomId = parseContentUrl(request.url)?.classroomId ?? 'unknown';
-      const p = url.searchParams.get('p');
-      const v = url.searchParams.get('v');
-      let message = `[content] 403 ${verified.reason} classroom=${classroomId} path=${url.pathname}`;
-      if (p !== null) message += ` p=${p}`;
-      if (v !== null) message += ` v=${v}`;
-      console.warn(message);
-      return errorResponse(403, verified.reason);
-    }
-
-    try {
-      return verified.kind === 'blob'
-        ? await serveBlob(env, ctx, request, verified)
-        : await serveTheme(env, ctx, verified);
-    } catch (error) {
-      if (error instanceof OriginError) {
-        console.warn('[content] origin error:', error.message);
-        return errorResponse(502, 'origin unavailable');
-      }
-      console.error('[content] unhandled error:', error);
-      return errorResponse(500, 'internal error');
-    }
+    const response = await handle(request, env, ctx);
+    // One place decides that a HEAD carries no body — every route included.
+    return request.method === 'HEAD' ? withoutBody(response) : response;
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/content/src/index.ts
+++ b/apps/content/src/index.ts
@@ -17,7 +17,7 @@ import { errorResponse, jsonResponse, preflightResponse, withoutBody } from './c
 import { isConfigured, type Env } from './env.ts';
 import { OriginError } from './origins/types.ts';
 import { serveTheme } from './theme.ts';
-import { parseContentUrl, verifyContentUrl } from './verify.ts';
+import { isClassroomId, parseContentUrl, verifyContentUrl } from './verify.ts';
 
 /**
  * `/c/{classroomId}/missing/{encodedRepoPath}` — the deterministic URL the
@@ -27,17 +27,44 @@ import { parseContentUrl, verifyContentUrl } from './verify.ts';
  * renamed is not a tampered URL, and the two must not share a log line. Every
  * OTHER unknown third segment stays a 403 — an unrecognized shape is exactly
  * what tampering looks like.
+ *
+ * The classroom segment is captured loosely and then checked with the signing
+ * package's own `isClassroomId`, so this and the verifier cannot drift apart on
+ * what a classroom id is.
  */
-const MISSING_PATH =
-  /^\/c\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/missing\/(.+)$/;
+const MISSING_PATH = /^\/c\/([^/]+)\/missing\/(.+)$/;
 
-/** Best-effort decode for the log line only; a bad escape logs the raw segment. */
+/** A repo path is the app's own string, but it arrives from the network. */
+const MAX_LOGGED_PATH = 512;
+
+/** C0 controls, DEL, and the C1 block - everything a log line must not contain. */
+function isControl(code: number): boolean {
+  return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+}
+
+/**
+ * Make one untrusted segment safe to put in a log line.
+ *
+ * `url.pathname` keeps its percent-escapes, so decoding is what turns `%0A`
+ * into a real newline — and a newline in `console.warn` is a whole forged
+ * entry. An unauthenticated request could otherwise write a convincing
+ * `[content] 403 bad-signature classroom=…` line into the log an operator is
+ * told to search. Every control character becomes U+FFFD, and the result is
+ * capped so one request cannot flood the stream either.
+ */
 function decodeForLog(value: string): string {
+  let decoded: string;
   try {
-    return decodeURIComponent(value);
+    decoded = decodeURIComponent(value);
   } catch {
-    return value;
+    decoded = value;
   }
+
+  let safe = '';
+  for (const char of decoded.slice(0, MAX_LOGGED_PATH)) {
+    safe += isControl(char.codePointAt(0) ?? 0) ? '\uFFFD' : char;
+  }
+  return safe;
 }
 
 /**
@@ -67,7 +94,7 @@ async function handle(request: Request, env: Env, ctx: ExecutionContext): Promis
   if (!url.pathname.startsWith('/c/')) return errorResponse(404, 'not found');
 
   const missing = MISSING_PATH.exec(url.pathname);
-  if (missing) {
+  if (missing && isClassroomId(missing[1])) {
     // The repo path is the app's own reference, not a credential — but the
     // query string still never reaches a log.
     console.warn(`[content] 404 missing classroom=${missing[1]} path=${decodeForLog(missing[2])}`);

--- a/apps/content/src/index.ts
+++ b/apps/content/src/index.ts
@@ -19,6 +19,27 @@ import { OriginError } from './origins/types.ts';
 import { serveTheme } from './theme.ts';
 import { parseContentUrl, verifyContentUrl } from './verify.ts';
 
+/**
+ * `/c/{classroomId}/missing/{encodedRepoPath}` — the deterministic URL the
+ * app's resolver mints for a reference it cannot resolve (see `missingUrl` in
+ * `contentDelivery.service.ts`). It carries no signature and never will, so it
+ * is routed before verification and answered 404: a file that was deleted or
+ * renamed is not a tampered URL, and the two must not share a log line. Every
+ * OTHER unknown third segment stays a 403 — an unrecognized shape is exactly
+ * what tampering looks like.
+ */
+const MISSING_PATH =
+  /^\/c\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/missing\/(.+)$/;
+
+/** Best-effort decode for the log line only; a bad escape logs the raw segment. */
+function decodeForLog(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     if (request.method === 'OPTIONS') return preflightResponse();
@@ -37,6 +58,16 @@ export default {
     }
 
     if (!url.pathname.startsWith('/c/')) return errorResponse(404, 'not found');
+
+    const missing = MISSING_PATH.exec(url.pathname);
+    if (missing) {
+      // The repo path is the app's own reference, not a credential — but the
+      // query string still never reaches a log.
+      console.warn(
+        `[content] 404 missing classroom=${missing[1]} path=${decodeForLog(missing[2])}`
+      );
+      return errorResponse(404, 'missing');
+    }
 
     const signingSecret = env.CONTENT_SIGNING_SECRET;
     if (!signingSecret || !env.CONTENT_WORKER_SHARED_SECRET || !env.CONTENT_TOKEN_ENDPOINT) {

--- a/apps/content/src/theme.ts
+++ b/apps/content/src/theme.ts
@@ -59,8 +59,11 @@ export function findEntry(entries: TreeEntry[], relPath: string): TreeEntry | un
 export async function serveTheme(
   env: Env,
   ctx: ExecutionContext,
-  verified: VerifiedTheme
+  verified: VerifiedTheme,
+  head = false
 ): Promise<Response> {
+  // The tree is read either way: a theme URL names a path, and only the listing
+  // turns that into the sha a HEAD would look up.
   const entries = await loadTree(env, ctx, verified.classroomId, verified.treeSha);
   const entry = findEntry(entries, verified.relPath);
   if (!entry) return errorResponse(404, 'not found');
@@ -70,5 +73,6 @@ export async function serveTheme(
     sha: entry.sha,
     contentType: contentTypeForPath(verified.relPath),
     cacheControl: cacheControlFor(verified.tier, verified.exp, nowSeconds()),
+    head,
   });
 }

--- a/apps/content/src/transform.ts
+++ b/apps/content/src/transform.ts
@@ -18,6 +18,58 @@ export function negotiateFormat(
   return accept?.includes('image/avif') ? 'avif' : 'webp';
 }
 
+/**
+ * Ceiling on the bytes we are willing to materialize for a transform.
+ *
+ * The transform path is the one place this Worker buffers a whole object, and
+ * it does so inside a shared 128 MB isolate serving every concurrent request on
+ * the colo. GitHub will hand us blobs up to 100 MB, and a handful of those
+ * arriving together is an OOM that takes down unrelated traffic. Past this
+ * ceiling the transform is skipped and the original is streamed instead — a
+ * large image beats a dead isolate.
+ */
+export const MAX_TRANSFORM_SOURCE_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Read a stream into one buffer, refusing to grow past `limit`.
+ *
+ * Returns null — having cancelled the rest of the source — when the stream is
+ * bigger than the ceiling. For a source whose size is unknown up front, this is
+ * the only way to hold the bound: `arrayBuffer()` commits to the whole thing
+ * before it knows how big it is.
+ */
+export async function readBounded(
+  stream: ReadableStream<Uint8Array>,
+  limit: number
+): Promise<ArrayBuffer | null> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > limit) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged.buffer;
+}
+
 export type ConcreteMediaType = 'image/webp' | 'image/avif';
 
 export function mediaTypeFor(format: ConcreteFormat): ConcreteMediaType {

--- a/apps/content/src/transform.ts
+++ b/apps/content/src/transform.ts
@@ -37,13 +37,17 @@ export const MAX_TRANSFORM_SOURCE_BYTES = 20 * 1024 * 1024;
  * bigger than the ceiling. For a source whose size is unknown up front, this is
  * the only way to hold the bound: `arrayBuffer()` commits to the whole thing
  * before it knows how big it is.
+ *
+ * Each chunk is dropped as it is copied into the result. Holding the chunk list
+ * and the merged buffer at once would put peak usage at twice the ceiling,
+ * which is the number that actually has to fit in the isolate.
  */
 export async function readBounded(
   stream: ReadableStream<Uint8Array>,
   limit: number
 ): Promise<ArrayBuffer | null> {
   const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: Array<Uint8Array | undefined> = [];
   let total = 0;
 
   try {
@@ -63,9 +67,12 @@ export async function readBounded(
 
   const merged = new Uint8Array(total);
   let offset = 0;
-  for (const chunk of chunks) {
+  for (let index = 0; index < chunks.length; index += 1) {
+    const chunk = chunks[index];
+    if (!chunk) continue;
     merged.set(chunk, offset);
     offset += chunk.byteLength;
+    chunks[index] = undefined;
   }
   return merged.buffer;
 }

--- a/apps/content/tests/helpers.ts
+++ b/apps/content/tests/helpers.ts
@@ -38,14 +38,40 @@ export interface FakeBucket {
     value: unknown,
     options?: { httpMetadata?: { contentType?: string } }
   ): Promise<unknown>;
-  readonly puts: Array<{ key: string; contentType?: string }>;
+  readonly puts: Array<{ key: string; contentType?: string; bytes: number }>;
   readonly gets: string[];
   readonly heads: string[];
 }
 
+/**
+ * Consume whatever R2 was handed, and say how big it was.
+ *
+ * Real R2 reads the stream it is given; a fake that only records the key would
+ * hide the bug that matters here. The write-back half of a `tee()` is a stream
+ * nobody else reads, so if the delivery half is abandoned rather than
+ * cancelled, this read is where it stalls — and a hung `ctx.settled()` or a
+ * short byte count is the test failing, which is the point.
+ */
+async function drain(value: unknown): Promise<number> {
+  if (value instanceof ReadableStream) {
+    const reader = (value as ReadableStream<Uint8Array>).getReader();
+    let total = 0;
+    for (;;) {
+      const { done, value: chunk } = await reader.read();
+      if (done) break;
+      total += chunk.byteLength;
+    }
+    return total;
+  }
+  if (typeof value === 'string') return new TextEncoder().encode(value).byteLength;
+  if (value instanceof ArrayBuffer) return value.byteLength;
+  if (ArrayBuffer.isView(value)) return value.byteLength;
+  return 0;
+}
+
 export function fakeBucket(initial: Record<string, StoredObject> = {}): FakeBucket {
   const store = new Map(Object.entries(initial));
-  const puts: Array<{ key: string; contentType?: string }> = [];
+  const puts: Array<{ key: string; contentType?: string; bytes: number }> = [];
   const gets: string[] = [];
   const heads: string[] = [];
 
@@ -76,8 +102,9 @@ export function fakeBucket(initial: Record<string, StoredObject> = {}): FakeBuck
       const object = store.get(key);
       return object ? metadata(key, object) : null;
     },
-    async put(key: string, _value: unknown, options?: { httpMetadata?: { contentType?: string } }) {
-      puts.push({ key, contentType: options?.httpMetadata?.contentType });
+    async put(key: string, value: unknown, options?: { httpMetadata?: { contentType?: string } }) {
+      const bytes = await drain(value);
+      puts.push({ key, contentType: options?.httpMetadata?.contentType, bytes });
       store.set(key, { body: 'stored', contentType: options?.httpMetadata?.contentType });
       return {};
     },

--- a/apps/content/tests/helpers.ts
+++ b/apps/content/tests/helpers.ts
@@ -32,6 +32,7 @@ interface StoredObject {
 
 export interface FakeBucket {
   get(key: string): Promise<unknown>;
+  head(key: string): Promise<unknown>;
   put(
     key: string,
     value: unknown,
@@ -39,29 +40,41 @@ export interface FakeBucket {
   ): Promise<unknown>;
   readonly puts: Array<{ key: string; contentType?: string }>;
   readonly gets: string[];
+  readonly heads: string[];
 }
 
 export function fakeBucket(initial: Record<string, StoredObject> = {}): FakeBucket {
   const store = new Map(Object.entries(initial));
   const puts: Array<{ key: string; contentType?: string }> = [];
   const gets: string[] = [];
+  const heads: string[] = [];
+
+  const metadata = (key: string, object: StoredObject) => ({
+    httpMetadata: { contentType: object.contentType },
+    httpEtag: `"${key}"`,
+    size: object.size ?? new TextEncoder().encode(object.body).byteLength,
+  });
 
   return {
     puts,
     gets,
+    heads,
     async get(key: string) {
       gets.push(key);
       const object = store.get(key);
       if (!object) return null;
       return {
+        ...metadata(key, object),
         body: new Response(object.body).body,
-        httpMetadata: { contentType: object.contentType },
-        httpEtag: `"${key}"`,
-        size: object.size ?? new TextEncoder().encode(object.body).byteLength,
         arrayBuffer: async () => new TextEncoder().encode(object.body).buffer,
         json: async () => JSON.parse(object.body),
         text: async () => object.body,
       };
+    },
+    async head(key: string) {
+      heads.push(key);
+      const object = store.get(key);
+      return object ? metadata(key, object) : null;
     },
     async put(key: string, _value: unknown, options?: { httpMetadata?: { contentType?: string } }) {
       puts.push({ key, contentType: options?.httpMetadata?.contentType });

--- a/apps/content/tests/helpers.ts
+++ b/apps/content/tests/helpers.ts
@@ -26,6 +26,8 @@ export const THEME_BLOB_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 interface StoredObject {
   body: string;
   contentType?: string;
+  /** Override the reported size, so a ceiling can be tested without the bytes. */
+  size?: number;
 }
 
 export interface FakeBucket {
@@ -55,6 +57,7 @@ export function fakeBucket(initial: Record<string, StoredObject> = {}): FakeBuck
         body: new Response(object.body).body,
         httpMetadata: { contentType: object.contentType },
         httpEtag: `"${key}"`,
+        size: object.size ?? new TextEncoder().encode(object.body).byteLength,
         arrayBuffer: async () => new TextEncoder().encode(object.body).buffer,
         json: async () => JSON.parse(object.body),
         text: async () => object.body,

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -236,6 +236,125 @@ describe('blob delivery', () => {
     expect(bucket.gets).toEqual([`blobs/${BLOB_SHA}`]);
   });
 
+  it('carries Content-Length on an R2 hit, straight from the stored size', async () => {
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: { body: 'cached-bytes', contentType: 'image/png' },
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.headers.get('Content-Length')).toBe(String('cached-bytes'.length));
+  });
+
+  it("forwards the origin's Content-Length without buffering to find it", async () => {
+    stubUpstreams({
+      blob: () => new Response('origin-bytes', { headers: { 'Content-Length': '12' } }),
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());
+
+    expect(response.headers.get('Content-Length')).toBe('12');
+  });
+
+  it('omits Content-Length when the origin sent none', async () => {
+    stubUpstreams();
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());
+
+    expect(response.headers.get('Content-Length')).toBeNull();
+  });
+
+  it('answers HEAD on a cached blob from R2 metadata - no body, no origin', async () => {
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: { body: 'cached-bytes', contentType: 'image/png' },
+    });
+    const fetchSpy = vi.fn(() => {
+      throw new Error('HEAD must not reach the origin');
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png' });
+
+    const response = await worker.fetch(
+      new Request(url, { method: 'HEAD' }),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+    expect(response.headers.get('Content-Type')).toBe('image/png');
+    expect(response.headers.get('Content-Length')).toBe(String('cached-bytes'.length));
+    expect(response.headers.get('ETag')).toBe(`"blobs/${BLOB_SHA}"`);
+    expect(response.headers.get('Cache-Control')).toMatch(/^public, max-age=\d+, immutable$/);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'none'; sandbox");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Metadata only: the object's bytes were never opened.
+    expect(bucket.heads).toEqual([`blobs/${BLOB_SHA}`]);
+    expect(bucket.gets).toEqual([]);
+  });
+
+  it('answers HEAD on a cached variant from the variant key', async () => {
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}/w800.webp`]: { body: 'webp-bytes', contentType: 'image/webp' },
+    });
+    const url = await signedBlobUrl({
+      sha: BLOB_SHA,
+      ext: 'jpg',
+      transform: { w: 800, fmt: 'webp' },
+    });
+
+    const response = await worker.fetch(
+      new Request(url, { method: 'HEAD' }),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+    expect(response.headers.get('Content-Type')).toBe('image/webp');
+    expect(bucket.heads).toEqual([`blobs/${BLOB_SHA}/w800.webp`]);
+    expect(bucket.gets).toEqual([]);
+  });
+
+  it('falls through to the origin for HEAD on a cold blob, and still sends no body', async () => {
+    // Warming the cache on a HEAD is the point: the GET behind it is a hit.
+    stubUpstreams();
+    const bucket = fakeBucket();
+    const ctx = fakeContext();
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(
+      new Request(url, { method: 'HEAD' }),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+    expect(bucket.heads).toEqual([`blobs/${BLOB_SHA}`]);
+    await ctx.settled();
+    expect(bucket.puts.map(put => put.key)).toEqual([`blobs/${BLOB_SHA}`]);
+  });
+
+  it('sends no body on a HEAD that is refused', async () => {
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}/robots.txt`, { method: 'HEAD' }),
+      fakeEnv(),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe('');
+  });
+
   it('marks draft content no-store, but still writes it to R2', async () => {
     // Deliberate: `no-store` governs the SHARED caches in front of the Worker,
     // which must never hold draft bytes. R2 sits behind the signature gate and

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import worker from '../src/index.ts';
 import { clearOriginCache } from '../src/token.ts';
+import { MAX_TRANSFORM_SOURCE_BYTES } from '../src/transform.ts';
 import { nowSeconds } from '../src/verify.ts';
 import {
   BLOB_SHA,
@@ -352,6 +353,115 @@ describe('blob delivery', () => {
 
     expect(response.status).toBe(200);
     expect(bucket.gets).toEqual([`blobs/${BLOB_SHA}`]);
+  });
+
+  it('skips the transform when R2 already knows the source is too big', async () => {
+    // The transform path is the one place a whole object is buffered, inside a
+    // shared 128 MB isolate. A known-oversize source never enters it.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: {
+        body: 'huge-bytes',
+        contentType: 'image/jpeg',
+        size: MAX_TRANSFORM_SOURCE_BYTES + 1,
+      },
+    });
+    const images = { input: vi.fn() } as unknown as ImagesBinding;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const url = await signedBlobUrl({
+      sha: BLOB_SHA,
+      ext: 'jpg',
+      transform: { w: 800, fmt: 'webp' },
+    });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket, IMAGES: images }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('huge-bytes');
+    expect(response.headers.get('Content-Type')).toBe('image/jpeg');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=60');
+    expect((images as unknown as { input: ReturnType<typeof vi.fn> }).input).not.toHaveBeenCalled();
+    expect(warn.mock.calls[0]?.[0]).toContain(`skipping transform for ${BLOB_SHA}`);
+  });
+
+  it("skips the transform when the origin's Content-Length is over the ceiling", async () => {
+    stubUpstreams({
+      blob: () =>
+        new Response('huge-bytes', {
+          headers: { 'Content-Length': String(MAX_TRANSFORM_SOURCE_BYTES + 1) },
+        }),
+    });
+    const bucket = fakeBucket();
+    const images = { input: vi.fn() } as unknown as ImagesBinding;
+    const ctx = fakeContext();
+    const url = await signedBlobUrl({
+      sha: BLOB_SHA,
+      ext: 'jpg',
+      transform: { w: 800, fmt: 'webp' },
+    });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket, IMAGES: images }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('huge-bytes');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=60');
+    expect((images as unknown as { input: ReturnType<typeof vi.fn> }).input).not.toHaveBeenCalled();
+    // Streamed, not buffered - the original still lands in R2 on the way past.
+    await ctx.settled();
+    expect(bucket.puts.map(put => put.key)).toEqual([`blobs/${BLOB_SHA}`]);
+  });
+
+  it('aborts a transform whose source outgrows the ceiling mid-stream', async () => {
+    // No Content-Length: the only way to hold the bound is to count as we read,
+    // and the counted bytes go with the cancelled stream.
+    let call = 0;
+    stubUpstreams({
+      blob: () => {
+        call += 1;
+        if (call > 1) return new Response('origin-bytes');
+        let sent = 0;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (sent > MAX_TRANSFORM_SOURCE_BYTES) return controller.close();
+              sent += 1024 * 1024;
+              controller.enqueue(new Uint8Array(1024 * 1024));
+            },
+          })
+        );
+      },
+    });
+    const bucket = fakeBucket();
+    const images = { input: vi.fn() } as unknown as ImagesBinding;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ctx = fakeContext();
+    const url = await signedBlobUrl({
+      sha: BLOB_SHA,
+      ext: 'jpg',
+      transform: { w: 800, fmt: 'webp' },
+    });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket, IMAGES: images }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=60');
+    expect(await response.text()).toBe('origin-bytes');
+    expect((images as unknown as { input: ReturnType<typeof vi.fn> }).input).not.toHaveBeenCalled();
+    expect(call).toBe(2);
+    expect(
+      warn.mock.calls.some(([message]) => String(message).includes('skipping transform'))
+    ).toBe(true);
   });
 
   it('serves the original bytes when the Images binding throws', async () => {

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -186,8 +186,42 @@ describe('routing', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     const [message] = warn.mock.calls[0] as [string];
-    expect(message).toBe(`[content] 404 missing classroom=${CLASSROOM} path=${ref}`);
+    expect(message).toContain(`[content] 404 missing classroom=${CLASSROOM}`);
+    expect(message).toContain(`path=${ref}`);
     expect(message).not.toContain('cb=1');
+  });
+
+  it('cannot be made to forge a second log line through the repo path', async () => {
+    // `url.pathname` keeps its escapes, so decoding is what would turn %0A into
+    // a real newline - and a newline in console.warn is a whole fake entry, in
+    // exactly the shape the README tells operators to search for.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const forged = `logo.png\n[content] 403 bad-signature classroom=${CLASSROOM} path=/c/x`;
+    await worker.fetch(
+      new Request(`${ORIGIN}/c/${CLASSROOM}/missing/${encodeURIComponent(forged)}`),
+      fakeEnv(),
+      fakeContext()
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).not.toContain('\n');
+    expect(message).not.toContain('\r');
+    // The text survives, defanged - an operator still sees what was asked for.
+    expect(message).toContain('logo.png');
+    expect(message).toContain('\uFFFD');
+  });
+
+  it('caps the logged repo path so one request cannot flood the stream', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await worker.fetch(
+      new Request(`${ORIGIN}/c/${CLASSROOM}/missing/${'a'.repeat(4000)}`),
+      fakeEnv(),
+      fakeContext()
+    );
+
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message.length).toBeLessThan(700);
   });
 
   it('403s any other unknown segment - only /missing/ is a known unsigned shape', async () => {
@@ -260,6 +294,36 @@ describe('blob delivery', () => {
     const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());
 
     expect(response.headers.get('Content-Length')).toBe('12');
+  });
+
+  it('drops the Content-Length of a compressed origin response', async () => {
+    // The runtime adds Accept-Encoding and GitHub gzips text, so the header
+    // describes the ENCODED body while `tee()` hands us the decoded bytes.
+    // Forwarding it would abort the download with a length mismatch.
+    stubUpstreams({
+      blob: () =>
+        new Response('origin-bytes', {
+          headers: { 'Content-Length': '17', 'Content-Encoding': 'gzip' },
+        }),
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());
+
+    expect(response.headers.get('Content-Length')).toBeNull();
+    expect(await response.text()).toBe('origin-bytes');
+  });
+
+  it('ignores a Content-Length that is not plain digits', async () => {
+    // Number('0x10') is 16, and a hex length forwarded as decimal is a mismatch.
+    stubUpstreams({
+      blob: () => new Response('origin-bytes', { headers: { 'Content-Length': '0x10' } }),
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());
+
+    expect(response.headers.get('Content-Length')).toBeNull();
   });
 
   it('omits Content-Length when the origin sent none', async () => {
@@ -341,7 +405,15 @@ describe('blob delivery', () => {
     expect(await response.text()).toBe('');
     expect(bucket.heads).toEqual([`blobs/${BLOB_SHA}`]);
     await ctx.settled();
-    expect(bucket.puts.map(put => put.key)).toEqual([`blobs/${BLOB_SHA}`]);
+    // The whole object, not a stalled prefix: the delivery half of the tee is
+    // cancelled rather than abandoned, so the write-back half runs to the end.
+    expect(bucket.puts).toEqual([
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'text/css; charset=utf-8',
+        bytes: 'origin-bytes'.length,
+      },
+    ]);
   });
 
   it('sends no body on a HEAD that is refused', async () => {
@@ -375,7 +447,9 @@ describe('blob delivery', () => {
 
     expect(response.headers.get('Cache-Control')).toBe('no-store');
     await ctx.settled();
-    expect(bucket.puts).toEqual([{ key: `blobs/${BLOB_SHA}`, contentType: 'image/png' }]);
+    expect(bucket.puts).toEqual([
+      { key: `blobs/${BLOB_SHA}`, contentType: 'image/png', bytes: 'origin-bytes'.length },
+    ]);
   });
 
   it('pulls a miss from the origin and writes it back to R2', async () => {
@@ -392,7 +466,11 @@ describe('blob delivery', () => {
     expect(await response.text()).toBe('origin-bytes');
     await ctx.settled();
     expect(bucket.puts).toEqual([
-      { key: `blobs/${BLOB_SHA}`, contentType: 'text/css; charset=utf-8' },
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'text/css; charset=utf-8',
+        bytes: 'origin-bytes'.length,
+      },
     ]);
   });
 

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -156,6 +156,58 @@ describe('routing', () => {
     expect(await response.json()).toEqual({ error: 'malformed' });
   });
 
+  it("404s the resolver's dangling-reference URL rather than 403ing it", async () => {
+    // The app mints /c/{classroomId}/missing/{encodedRepoPath} for a reference
+    // it cannot resolve. A deleted file is not a tampered URL.
+    const ref = 'assets/img/logo v2.png';
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}/c/${CLASSROOM}/missing/${encodeURIComponent(ref)}`),
+      fakeEnv(),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'missing' });
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'none'; sandbox");
+  });
+
+  it('logs the classroom and the decoded repo path on a 404 missing - never the query', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ref = 'assets/img/logo.png';
+    await worker.fetch(
+      new Request(`${ORIGIN}/c/${CLASSROOM}/missing/${encodeURIComponent(ref)}?cb=1`),
+      fakeEnv(),
+      fakeContext()
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toBe(`[content] 404 missing classroom=${CLASSROOM} path=${ref}`);
+    expect(message).not.toContain('cb=1');
+  });
+
+  it('403s any other unknown segment - only /missing/ is a known unsigned shape', async () => {
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}/c/${CLASSROOM}/other/x`),
+      fakeEnv(),
+      fakeContext()
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'malformed' });
+  });
+
+  it('403s a /missing/ URL whose classroom is not a uuid', async () => {
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}/c/not-a-uuid/missing/logo.png`),
+      fakeEnv(),
+      fakeContext()
+    );
+    expect(response.status).toBe(403);
+  });
+
   it('403s an expired URL with the reason', async () => {
     const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png', exp: nowSeconds() - 86400 });
     const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());

--- a/apps/content/wrangler.jsonc
+++ b/apps/content/wrangler.jsonc
@@ -1,6 +1,13 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
-  "name": "classmoji-content",
+  // Deliberately NOT the production name, and deliberately bindingless.
+  // wrangler applies the top level when no --env is given, so if this said
+  // "classmoji-content" a bare `npx wrangler deploy` would overwrite the
+  // production script with a build that has no R2 bucket, no Images binding
+  // and no vars — a 503 on content.classmoji.io from a one-word slip. Every
+  // real deploy names its environment (`--env staging` / `--env production`);
+  // a bare one lands here, on a throwaway Worker nothing routes to.
+  "name": "classmoji-content-unconfigured",
   "main": "src/index.ts",
   "compatibility_date": "2026-09-03",
   "workers_dev": false,

--- a/packages/content-signing/src/index.ts
+++ b/packages/content-signing/src/index.ts
@@ -21,6 +21,7 @@ export {
   TRANSFORM_WIDTHS,
   blobCanonicalString,
   hostOf,
+  isClassroomId,
   themeCanonicalString,
 } from './canonical.ts';
 


### PR DESCRIPTION
## What
Post-staging review items for the content Worker, five commits:

1. **Dangling references answer 404.** The resolver's `/c/{classroom}/missing/{path}` form used to 403 as *malformed*, so a deleted file and a tampered URL were indistinguishable in logs. Now `404 {"error":"missing"}`, `no-store`, logged as `[content] 404 missing …` with the path decoded, control characters replaced and length capped (the route needs no signature, so the log line must not be forgeable).
2. **Bounded transform source.** 20 MB ceiling on the bytes a transform will buffer (known size from R2/origin, or counted while streaming with an abort); oversize sources serve the original on the short-TTL fallback.
3. **`Content-Length` and a real `HEAD`.** Length from `object.size` on R2 hits and forwarded from the origin only when the body is identity-encoded (a gzip'd origin declares the compressed length). HEAD answers from `CACHE.head` on warm objects, strips the body on every route, and a HEAD miss still warms R2.
4. **Bare `wrangler deploy` can't hit production.** Top-level config renamed to `classmoji-content-unconfigured`; both envs unchanged. README gains Deployment + Operating sections (R2 key layout and purge, what Reset content cache does and doesn't, Workers Logs line shapes).
5. Review follow-ups: log scrub, compressed-length guard, `isClassroomId` shared with the signing package (now exported), bounded peak memory, drained fake bucket in tests.

## Test
Worker 127 passed (was 109), typecheck 0, lint clean; content-signing 80 / 0. `wrangler deploy --dry-run` verified for staging, production, and bare. After deploy: `curl -sI` a warm blob on `content-staging.classmoji.io` and compare `Content-Length` to the GET body size (the runtime's HEAD behaviour can't be tested from inside the isolate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA