### PR TITLE
fix(content): asset map and sync correctness from the post-staging review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -242,9 +242,11 @@ CONTENT_WORKER_SHARED_SECRET=""
 #   staging     https://content-staging.classmoji.io
 #   local       http://localhost:8787   (wrangler dev)
 #
-# UNSET: defaults to https://content.classmoji.io — which is correct in
-# production and WRONG everywhere else, so a staging or local deployment that
-# signs URLs must set it or those URLs will address production's Worker.
+# UNSET: there is no default. The delivery layer switches OFF entirely — it
+# needs this and CONTENT_SIGNING_SECRET, and either alone is useless — and every
+# surface renders through the legacy raw/Pages/proxy URLs exactly as it did
+# before any of this existed. That is the safe state, not a broken one, which is
+# why nothing here guesses production's origin on your behalf.
 CONTENT_DELIVERY_ORIGIN="http://localhost:8787"
 
 # =============================================================================

--- a/apps/hook-station/src/routes/github.ts
+++ b/apps/hook-station/src/routes/github.ts
@@ -76,6 +76,10 @@ interface PushCommit {
 interface PushEventPayload {
   ref?: string;
   forced?: boolean;
+  /** The commit the branch pointed at BEFORE this push. */
+  before?: string;
+  /** The commit it points at now. */
+  after?: string;
   commits?: PushCommit[];
   repository?: {
     name?: string;
@@ -155,6 +159,13 @@ async function handlePush(data: PushEventPayload): Promise<void> {
     // against what we last synced and cannot be applied incrementally.
     forced: Boolean(data.forced),
     complete: commits.length < GITHUB_COMMIT_CAP,
+    // The commits this push spans. `before` is the only way the sync can tell
+    // that an EARLIER delivery went missing: a push whose parent is not the
+    // commit the map is level with proves the repo moved unseen, and that run
+    // has to re-read the whole tree rather than apply a diff against a state
+    // nobody holds. `after` is what the map records once it has.
+    before: data.before,
+    after: data.after,
   });
 }
 

--- a/apps/hook-station/src/routes/github.ts
+++ b/apps/hook-station/src/routes/github.ts
@@ -151,22 +151,30 @@ async function handlePush(data: PushEventPayload): Promise<void> {
 
   const commits = data.commits ?? [];
 
-  await Tasks.contentAssetsSyncTask.trigger({
-    classroomId: classroom.id,
-    reason: 'push' as const,
-    changes: aggregateChanges(commits),
-    // A force-push rewrites history, so the commits listed are not a diff
-    // against what we last synced and cannot be applied incrementally.
-    forced: Boolean(data.forced),
-    complete: commits.length < GITHUB_COMMIT_CAP,
-    // The commits this push spans. `before` is the only way the sync can tell
-    // that an EARLIER delivery went missing: a push whose parent is not the
-    // commit the map is level with proves the repo moved unseen, and that run
-    // has to re-read the whole tree rather than apply a diff against a state
-    // nobody holds. `after` is what the map records once it has.
-    before: data.before,
-    after: data.after,
-  });
+  await Tasks.contentAssetsSyncTask.trigger(
+    {
+      classroomId: classroom.id,
+      reason: 'push' as const,
+      changes: aggregateChanges(commits),
+      // A force-push rewrites history, so the commits listed are not a diff
+      // against what we last synced and cannot be applied incrementally.
+      forced: Boolean(data.forced),
+      complete: commits.length < GITHUB_COMMIT_CAP,
+      // The commits this push spans. `before` is the only way the sync can tell
+      // that an EARLIER delivery went missing: a push whose parent is not the
+      // commit the map is level with proves the repo moved unseen, and that run
+      // has to re-read the whole tree rather than apply a diff against a state
+      // nobody holds. `after` is what the map records once it has.
+      before: data.before,
+      after: data.after,
+    },
+    {
+      // One sync per classroom at a time. Two deliveries for one repo applied
+      // concurrently can record their commits in either order, moving the map's
+      // recorded commit backwards and hiding the gap `before` exists to expose.
+      concurrencyKey: classroom.id,
+    }
+  );
 }
 
 export default async function githubRoutes(fastify: FastifyInstance): Promise<void> {

--- a/apps/hook-station/tests/github-push.test.ts
+++ b/apps/hook-station/tests/github-push.test.ts
@@ -58,6 +58,8 @@ const buildApp = async (): Promise<FastifyInstance> => {
 interface PushOverrides {
   ref?: string;
   forced?: boolean;
+  before?: string;
+  after?: string;
   repo?: string;
   owner?: string;
   defaultBranch?: string;
@@ -70,12 +72,14 @@ const pushBody = ({
   repo = 'content-cs101',
   owner = 'acme',
   defaultBranch = 'main',
+  before = 'a'.repeat(40),
+  after = 'b'.repeat(40),
   commits = [{ added: ['images/one.png'], modified: [], removed: [] }],
 }: PushOverrides = {}): string =>
   JSON.stringify({
     ref,
-    before: 'a'.repeat(40),
-    after: 'b'.repeat(40),
+    before,
+    after,
     forced,
     commits,
     repository: {
@@ -134,7 +138,24 @@ describe('which pushes are ours', () => {
       },
       forced: false,
       complete: true,
+      before: 'a'.repeat(40),
+      after: 'b'.repeat(40),
     });
+  });
+
+  /**
+   * `before` is the only way the sync can tell an EARLIER delivery went
+   * missing: a push whose parent is not the commit the map is level with proves
+   * the repo moved unseen, and that run has to re-read the whole tree instead of
+   * applying a diff against a state nobody holds. `after` is the commit the map
+   * records once it has applied this one.
+   */
+  it('reports the commits the push spans, so a dropped delivery is detectable', async () => {
+    await post(app, pushBody({ before: 'c'.repeat(40), after: 'd'.repeat(40) }));
+
+    const payload = contentAssetsSync.mock.calls[0][0];
+    expect(payload.before).toBe('c'.repeat(40));
+    expect(payload.after).toBe('d'.repeat(40));
   });
 
   /**

--- a/apps/hook-station/tests/github-push.test.ts
+++ b/apps/hook-station/tests/github-push.test.ts
@@ -60,6 +60,8 @@ interface PushOverrides {
   forced?: boolean;
   before?: string;
   after?: string;
+  created?: boolean;
+  deleted?: boolean;
   repo?: string;
   owner?: string;
   defaultBranch?: string;
@@ -74,12 +76,16 @@ const pushBody = ({
   defaultBranch = 'main',
   before = 'a'.repeat(40),
   after = 'b'.repeat(40),
+  created = false,
+  deleted = false,
   commits = [{ added: ['images/one.png'], modified: [], removed: [] }],
 }: PushOverrides = {}): string =>
   JSON.stringify({
     ref,
     before,
     after,
+    created,
+    deleted,
     forced,
     commits,
     repository: {
@@ -128,19 +134,25 @@ describe('which pushes are ours', () => {
       select: { id: true },
     });
     expect(contentAssetsSync).toHaveBeenCalledTimes(1);
-    expect(contentAssetsSync).toHaveBeenCalledWith({
-      classroomId: 'classroom-1',
-      reason: 'push',
-      changes: {
-        added: ['images/one.png'],
-        modified: ['pages/intro.md'],
-        removed: ['images/old.png'],
+    expect(contentAssetsSync).toHaveBeenCalledWith(
+      {
+        classroomId: 'classroom-1',
+        reason: 'push',
+        changes: {
+          added: ['images/one.png'],
+          modified: ['pages/intro.md'],
+          removed: ['images/old.png'],
+        },
+        forced: false,
+        complete: true,
+        before: 'a'.repeat(40),
+        after: 'b'.repeat(40),
       },
-      forced: false,
-      complete: true,
-      before: 'a'.repeat(40),
-      after: 'b'.repeat(40),
-    });
+      // One sync per classroom at a time: two deliveries for one repo applied
+      // concurrently can record their commits in either order, moving the map's
+      // recorded commit backwards and hiding the gap `before` exists to expose.
+      { concurrencyKey: 'classroom-1' }
+    );
   });
 
   /**
@@ -156,6 +168,39 @@ describe('which pushes are ours', () => {
     const payload = contentAssetsSync.mock.calls[0][0];
     expect(payload.before).toBe('c'.repeat(40));
     expect(payload.after).toBe('d'.repeat(40));
+  });
+
+  /**
+   * GitHub sends 40 zeros as `before` when a ref is CREATED. Forwarded as-is:
+   * it is not the commit any map is level with, so the sync treats it as the
+   * gap it is and re-reads the whole tree rather than applying a diff against
+   * a state nobody holds.
+   */
+  it('forwards the all-zero before of a branch-creation push', async () => {
+    await post(app, pushBody({ before: '0'.repeat(40), created: true }));
+
+    expect(contentAssetsSync).toHaveBeenCalledTimes(1);
+    expect(contentAssetsSync.mock.calls[0][0].before).toBe('0'.repeat(40));
+  });
+
+  /**
+   * `created` and `deleted` are fields the handler has no opinion about. It
+   * must not choke on them — a push it fails to answer is a delivery GitHub
+   * records as failed and a map that silently stops converging.
+   */
+  it('handles created/deleted push flags without breaking', async () => {
+    const created = await post(app, pushBody({ created: true, before: '0'.repeat(40) }));
+    expect(created.statusCode).toBe(200);
+
+    contentAssetsSync.mockClear();
+
+    const deleted = await post(
+      app,
+      pushBody({ deleted: true, after: '0'.repeat(40), commits: [] })
+    );
+    expect(deleted.statusCode).toBe(200);
+    expect(contentAssetsSync).toHaveBeenCalledTimes(1);
+    expect(contentAssetsSync.mock.calls[0][0].after).toBe('0'.repeat(40));
   });
 
   /**

--- a/apps/slides/app/utils/themeService.server.ts
+++ b/apps/slides/app/utils/themeService.server.ts
@@ -169,10 +169,16 @@ export async function saveTheme({
 
   // A theme is delivered by the SHA of its TREE, so a save that does not
   // refresh the asset map leaves every deck in the classroom signing the
-  // PREVIOUS tree — the author reloads and the edge hands back the old CSS,
-  // until a push webhook or the nightly sweep catches up. Full mode, because no
-  // per-file update can produce a tree SHA. Never throws: the commit already
-  // reached GitHub and the save has succeeded whatever the cache does.
+  // PREVIOUS tree — the edge keeps handing back the old CSS until a push
+  // webhook or the nightly sweep catches up. Full mode, because no per-file
+  // update can produce a tree SHA.
+  //
+  // AWAITED, and the ordering is the point. The only caller is the slides.com
+  // zip importer, which runs fire-and-forget behind an SSE progress stream and
+  // writes its deck rows immediately after this returns — so nothing is
+  // blocking on a user's request here, and the map has to be level with the new
+  // theme BEFORE the decks that reference it exist. Never throws: the commit
+  // already reached GitHub and the save has succeeded whatever the cache does.
   await ClassmojiService.contentAssets.syncContentAssetsForRepo(org, repoName, 'theme-save');
 
   return {

--- a/apps/slides/app/utils/themeService.server.ts
+++ b/apps/slides/app/utils/themeService.server.ts
@@ -6,7 +6,7 @@
  */
 
 import { ContentService } from '@classmoji/content';
-import { GitHubProvider } from '@classmoji/services';
+import { ClassmojiService, GitHubProvider } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
 
 const THEMES_FOLDER = '.slidesthemes';
@@ -166,6 +166,14 @@ export async function saveTheme({
     message: `Save shared theme: ${themeName}`,
     onProgress,
   });
+
+  // A theme is delivered by the SHA of its TREE, so a save that does not
+  // refresh the asset map leaves every deck in the classroom signing the
+  // PREVIOUS tree — the author reloads and the edge hands back the old CSS,
+  // until a push webhook or the nightly sweep catches up. Full mode, because no
+  // per-file update can produce a tree SHA. Never throws: the commit already
+  // reached GitHub and the save has succeeded whatever the cache does.
+  await ClassmojiService.contentAssets.syncContentAssetsForRepo(org, repoName, 'theme-save');
 
   return {
     themePath,

--- a/packages/database/migrations/20260905000000_content_assets_synced_commit/migration.sql
+++ b/packages/database/migrations/20260905000000_content_assets_synced_commit/migration.sql
@@ -1,0 +1,23 @@
+-- The content-repo commit a classroom's asset map was last brought level with.
+--
+-- The map is kept current by push webhooks, and webhook delivery is not
+-- guaranteed: hook-station can be down, GitHub can drop a delivery, a repo can
+-- be pushed to before its App install finishes. A dropped delivery used to be
+-- INVISIBLE. The next push applied cleanly — its own added/modified/removed
+-- lists are internally consistent — so the map silently kept rows for paths the
+-- missing push deleted and missed the ones it added, and stayed wrong until the
+-- nightly full sweep happened to run.
+--
+-- A push webhook names the commit it built on (`before`) as well as the one it
+-- landed (`after`), which makes the gap detectable for the cost of one column:
+-- record the commit each sync brought the map level with, and compare the next
+-- push's `before` against it. A mismatch means the repo moved without the map
+-- seeing it, and that run escalates to a full tree read instead of applying a
+-- diff against a state we never had.
+--
+-- NULLABLE with no default and no backfill. NULL means "never synced", and it
+-- escalates nothing: there is no chain yet for a push to have a gap in, and
+-- inventing one would make every classroom's first webhook a full sync for no
+-- reason. Every existing classroom starts here and picks the chain up on its
+-- next sync.
+ALTER TABLE "classrooms" ADD COLUMN "content_assets_synced_commit" TEXT;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -371,50 +371,58 @@ model GitOrganization {
 }
 
 model Classroom {
-  id                       String          @id @default(uuid())
+  id                           String          @id @default(uuid())
   // GLOBALLY unique. The slug is the sole key in every app URL — /admin/:class,
   // /student/:class, the ICS calendar feed, and the autograde callback — and
   // none of them carry an org segment, so a slug reused across orgs resolves to
   // the wrong classroom. e.g. "cs101-fall-2025".
-  slug                     String          @unique
-  git_org_id               String
-  name                     String
+  slug                         String          @unique
+  git_org_id                   String
+  name                         String
   // Internal identifier only. Historically the content repo name was derived
   // as content-{orgLogin}-{content_namespace}; it no longer names any repo.
-  content_namespace        String
+  content_namespace            String
   // The GitHub repo (in git_organization) holding this classroom's pages &
   // slides content. STORED and fully user-editable — never re-derived. Set at
   // creation for every classroom; defaults to `content-{content_namespace}`.
   // NOT the same as ClassroomSettings.content_repo_name, which is a legacy
   // ORG-level content repo override (`content-{login}`) for a DIFFERENT repo.
-  content_repo             String
+  content_repo                 String
   // GitHub Classroom course id, set on import; null for classrooms created
   // directly in Classmoji. Unique because one GitHub Classroom course maps to at
   // most one Classmoji classroom, which makes it the stable idempotency key for
   // re-imports — the slug can be suffixed on collision, so it can't be.
   // (Postgres allows many NULLs under a unique index, which is the semantics we
   // want: existing imported rows stay null and never collide.)
-  github_classroom_id      Int?            @unique
-  status                   ClassroomStatus @default(ACTIVE)
-  is_archived              Boolean         @default(false)
+  github_classroom_id          Int?            @unique
+  status                       ClassroomStatus @default(ACTIVE)
+  is_archived                  Boolean         @default(false)
   // True for the auto-provisioned per-user "Example Course" sandbox used by the
   // in-classroom onboarding tour. Backed by a mock GitOrganization (no live GitHub).
-  is_example               Boolean         @default(false)
+  is_example                   Boolean         @default(false)
   // Edge-cache bust for this classroom's content. Every signed content URL
   // carries it, so bumping it changes ALL of them at once and the CDN misses
   // on every asset until it refills. Old URLs STILL VERIFY — this is not a
   // revocation, and nothing already handed out stops working; it only stops
   // being the URL the app links to.
-  content_key_version      Int             @default(0)
+  content_key_version          Int             @default(0)
   // When the asset map was last rebuilt FROM THE REPO'S TREE — a full sync, and
   // only a full sync. This is what `ensureContentAssets` measures its 24h
   // refresh against, deliberately NOT the newest `content_assets.synced_at`:
   // incremental webhook applies and upload-time writes both stamp rows `now`,
   // so reading the rows would let a single upload make a stale map look fresh
   // and suppress the daily repair for another day. Null means never synced.
-  content_assets_synced_at DateTime?
-  created_at               DateTime        @default(now())
-  updated_at               DateTime        @default(now()) @updatedAt
+  content_assets_synced_at     DateTime?
+  // The content-repo commit the map was last brought level with: the head commit
+  // a full sync read the tree at, or the `after` sha an incremental apply
+  // landed. This is how a DROPPED push webhook becomes visible — the next push
+  // names the commit it built on, and if that is not this value then something
+  // changed the repo the map never saw, so the run escalates to a full tree read
+  // rather than applying a diff against a state we do not have. Null means never
+  // synced: no chain yet, so nothing to have a gap in.
+  content_assets_synced_commit String?
+  created_at                   DateTime        @default(now())
+  updated_at                   DateTime        @default(now()) @updatedAt
 
   git_organization      GitOrganization       @relation(fields: [git_org_id], references: [id], onDelete: Cascade)
   settings              ClassroomSettings?

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -40,7 +40,8 @@ vi.mock('@classmoji/database', () => ({
 
 const getTree = vi.fn();
 const getDefaultBranch = vi.fn();
-const getGitProvider = vi.fn(() => ({ getTree, getDefaultBranch }));
+const getLatestCommitSHA = vi.fn();
+const getGitProvider = vi.fn(() => ({ getTree, getDefaultBranch, getLatestCommitSHA }));
 vi.mock('../../git/index.ts', () => ({
   getGitProvider: (...a: unknown[]) => getGitProvider(...(a as [])),
 }));
@@ -60,11 +61,16 @@ const {
   lookupContentAssetBySha,
 } = await import('../contentAssets.service.ts');
 
+/** The default branch head every full sync in this file reads the tree at. */
+const HEAD_COMMIT = 'f'.repeat(40);
+
 const CLASSROOM = {
   id: 'class-1',
   content_repo: 'content-cs101',
   // Freshness lives HERE, not on the newest row — see ensureContentAssets.
   content_assets_synced_at: null as Date | null,
+  // The commit the map is level with; null = never synced, no chain to gap.
+  content_assets_synced_commit: null as string | null,
   git_organization: { id: 'org-1', provider: 'GITHUB', login: 'dartmouth-cs' },
 };
 
@@ -90,6 +96,7 @@ describe('contentAssets.service', () => {
     classroomFindUnique.mockResolvedValue(CLASSROOM);
     classroomFindFirst.mockResolvedValue({ id: 'class-1' });
     getDefaultBranch.mockResolvedValue('main');
+    getLatestCommitSHA.mockResolvedValue(HEAD_COMMIT);
     setupTransaction();
   });
 
@@ -109,8 +116,11 @@ describe('contentAssets.service', () => {
       const result = await syncContentAssets('class-1');
 
       expect(result).toEqual({ mode: 'full', upserted: 3, deleted: 4, truncated: false });
-      expect(getTree).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'main', true);
+      // Read AT the head commit, not at the moving branch — so the commit the
+      // run records describes exactly the entries it stored.
       expect(getDefaultBranch).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101');
+      expect(getLatestCommitSHA).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'main');
+      expect(getTree).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', HEAD_COMMIT, true);
       expect(contentAssetUpsert).toHaveBeenCalledTimes(3);
 
       // Directories are rows too — theme folders are addressed by tree SHA, so
@@ -188,7 +198,7 @@ describe('contentAssets.service', () => {
 
       await syncContentAssets('class-1');
 
-      expect(getTree).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'master', true);
+      expect(getLatestCommitSHA).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'master');
     });
 
     it('defaults a missing size to 0 rather than writing undefined', async () => {
@@ -219,6 +229,10 @@ describe('contentAssets.service', () => {
       expect(classroomUpdate).toHaveBeenCalledTimes(1);
       const [stamp] = classroomUpdate.mock.calls[0];
       expect(stamp.where).toEqual({ id: 'class-1' });
+      // The commit the tree was read at rides along with the timestamp: it is
+      // the state the map is now level with, and the next push's `before` is
+      // measured against it.
+      expect(stamp.data.content_assets_synced_commit).toBe(HEAD_COMMIT);
       // The run's one stamp — the same instant every row it wrote carries.
       const rowStamp = contentAssetUpsert.mock.calls[0][0].create.synced_at;
       expect(stamp.data.content_assets_synced_at).toEqual(rowStamp);
@@ -382,11 +396,11 @@ describe('contentAssets.service', () => {
       expect(result.mode).toBe('full');
     });
 
-    it('does NOT stamp the classroom', async () => {
+    it('does NOT stamp the classroom as fully synced', async () => {
       // It applied the paths one push named and knows nothing about the rest of
-      // the repo. Stamping here would let a steady trickle of webhooks suppress
-      // the daily full refresh — which exists to repair the webhooks that never
-      // arrive at all.
+      // the repo. Stamping the TIMESTAMP here would let a steady trickle of
+      // webhooks suppress the daily full refresh — which exists to repair the
+      // webhooks that never arrive at all.
       getMeta.mockResolvedValue({ sha: 'sha-a', size: 10 });
 
       const result = await syncContentAssets('class-1', {
@@ -395,6 +409,108 @@ describe('contentAssets.service', () => {
 
       expect(result.mode).toBe('incremental');
       expect(classroomUpdate).not.toHaveBeenCalled();
+    });
+
+    it('records the push it landed as the commit the map is level with', async () => {
+      // The other half of dropped-delivery detection: without this, every push
+      // would look like a gap against a commit only full syncs ever move.
+      // Commit only — the freshness timestamp stays untouched, so the daily
+      // full refresh still fires.
+      getMeta.mockResolvedValue({ sha: 'sha-a', size: 10 });
+
+      await syncContentAssets('class-1', {
+        changes: { added: ['images/a.png'], modified: [], removed: [] },
+        before: null,
+        after: 'b'.repeat(40),
+      });
+
+      expect(classroomUpdate).toHaveBeenCalledTimes(1);
+      const [update] = classroomUpdate.mock.calls[0];
+      expect(update).toEqual({
+        where: { id: 'class-1' },
+        data: { content_assets_synced_commit: 'b'.repeat(40) },
+      });
+      // In the transaction, so a failed apply cannot claim a commit it never
+      // applied — and ahead of the sweep, whose count is read off the tail.
+      const ops = transaction.mock.calls[0][0] as { op: string }[];
+      expect(ops[0].op).toBe('classroomUpdate');
+      expect(ops.at(-1)?.op).toBe('deleteMany');
+    });
+  });
+
+  describe('dropped-delivery detection', () => {
+    const LEVEL = 'a'.repeat(40);
+    const changes = { added: ['images/a.png'], modified: [], removed: [] };
+
+    beforeEach(() => {
+      getMeta.mockResolvedValue({ sha: 'sha-a', size: 10 });
+      getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
+    });
+
+    it('escalates to a full sync when the push does not build on the stored commit', async () => {
+      // THE regression this guards. A dropped delivery used to be invisible:
+      // the next push applies cleanly — its own lists are internally consistent
+      // — so the map silently keeps rows for paths the missing push deleted and
+      // never learns about the ones it added, and it all looks healthy until
+      // the nightly sweep happens to run.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await syncContentAssets('class-1', {
+        changes,
+        before: 'c'.repeat(40),
+        after: 'd'.repeat(40),
+      });
+
+      expect(result.mode).toBe('full');
+      expect(getMeta).not.toHaveBeenCalled();
+      // Silently escalating would hide a webhook that is permanently failing.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('a delivery was missed'));
+      warn.mockRestore();
+    });
+
+    it('stays incremental when the push builds on exactly the stored commit', async () => {
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+
+      const result = await syncContentAssets('class-1', {
+        changes,
+        before: LEVEL,
+        after: 'd'.repeat(40),
+      });
+
+      expect(result.mode).toBe('incremental');
+      expect(getTree).not.toHaveBeenCalled();
+    });
+
+    it('does not treat a first sync as a missed delivery', async () => {
+      // Null stored commit means there is no chain yet, not a gap in one. Every
+      // classroom in the table starts here, so counting it would make the first
+      // push after this shipped a full sync for all of them at once.
+      const result = await syncContentAssets('class-1', {
+        changes,
+        before: 'c'.repeat(40),
+        after: 'd'.repeat(40),
+      });
+
+      expect(result.mode).toBe('incremental');
+    });
+
+    it('does not escalate a caller that cannot answer the question', async () => {
+      // A manual or TTL run carries no `before`. Silence is not evidence.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+
+      const result = await syncContentAssets('class-1', { changes });
+
+      expect(result.mode).toBe('incremental');
     });
   });
 

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -113,7 +113,9 @@ describe('contentAssets.service', () => {
 
       // The sweep is what deletes paths removed from the repo. Every row
       // written this run carries the same stamp, so `lt` matches only rows an
-      // earlier run wrote and this one did not refresh.
+      // earlier run wrote and this one did not refresh — and the stamp is taken
+      // BEFORE the tree read, so a row written while it was in flight is above
+      // it rather than below. See the ordering test below.
       const [sweep] = contentAssetDeleteMany.mock.calls[0];
       expect(sweep.where.classroom_id).toBe('class-1');
       expect(sweep.where.synced_at.lt).toBeInstanceOf(Date);
@@ -137,6 +139,33 @@ describe('contentAssets.service', () => {
 
       expect(result).toEqual({ mode: 'full', upserted: 1, deleted: 0, truncated: true });
       expect(contentAssetDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('takes its stamp BEFORE the tree read, so a row written during it survives', async () => {
+      // THE race this guards. Reading a repo's tree is a network round trip,
+      // and `recordContentAsset` writes a row for a just-uploaded file stamped
+      // `now`. Stamping AFTER the read puts the run's stamp ahead of that row,
+      // and the sweep's `synced_at < stamp` deletes it — a file that IS in the
+      // repo, simply newer than the snapshot this run read, and the teacher who
+      // just uploaded it watches it render as a dangling URL.
+      vi.useFakeTimers();
+      try {
+        let midRead = 0;
+        getTree.mockImplementation(async () => {
+          // The read takes time; a concurrent upload's row stamps in here.
+          vi.advanceTimersByTime(5_000);
+          midRead = Date.now();
+          return { sha: 'r', truncated: false, entries: [] };
+        });
+
+        await syncContentAssets('class-1');
+
+        const [sweep] = contentAssetDeleteMany.mock.calls[0];
+        expect(sweep.where.synced_at.lt.getTime()).toBeLessThan(midRead);
+      } finally {
+        getTree.mockReset();
+        vi.useRealTimers();
+      }
     });
 
     it('reads the tree at the repo default branch, not a hardcoded main', async () => {

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -19,6 +19,8 @@ const contentAssetFindUnique = vi.fn();
 const classroomFindUnique = vi.fn();
 const classroomFindFirst = vi.fn();
 const classroomUpdate = vi.fn();
+const classroomUpdateMany = vi.fn();
+const contentAssetFindMany = vi.fn();
 const transaction = vi.fn();
 
 vi.mock('@classmoji/database', () => ({
@@ -27,11 +29,13 @@ vi.mock('@classmoji/database', () => ({
       findUnique: classroomFindUnique,
       findFirst: classroomFindFirst,
       update: classroomUpdate,
+      updateMany: classroomUpdateMany,
     },
     contentAsset: {
       upsert: contentAssetUpsert,
       deleteMany: contentAssetDeleteMany,
       findFirst: contentAssetFindFirst,
+      findMany: contentAssetFindMany,
       findUnique: contentAssetFindUnique,
     },
     $transaction: transaction,
@@ -54,6 +58,7 @@ vi.mock('../../content/ContentService.ts', () => ({
 const {
   syncContentAssets,
   syncContentAssetsForRepo,
+  lookupContentAssetsBySha,
   ensureContentAssets,
   recordContentAsset,
   lookupContentAsset,
@@ -80,13 +85,24 @@ const syncedAgo = (ms: number) => ({
   content_assets_synced_at: new Date(Date.now() - ms),
 });
 
-/** The upsert/deleteMany mocks return tagged markers so ops stay identifiable. */
-const setupTransaction = (deletedCount = 0) => {
+/**
+ * The upsert/deleteMany mocks return tagged markers so ops stay identifiable.
+ * `casCount` models the compare-and-swap: 1 when it lands, 0 when another run
+ * moved the classroom's commit first.
+ */
+const setupTransaction = (deletedCount = 0, casCount = 1) => {
   contentAssetUpsert.mockImplementation(args => ({ op: 'upsert', args }));
   contentAssetDeleteMany.mockImplementation(args => ({ op: 'deleteMany', args }));
   classroomUpdate.mockImplementation(args => ({ op: 'classroomUpdate', args }));
+  classroomUpdateMany.mockImplementation(args => ({ op: 'classroomUpdateMany', args }));
   transaction.mockImplementation((ops: { op: string }[]) =>
-    Promise.resolve(ops.map(op => (op.op === 'deleteMany' ? { count: deletedCount } : op)))
+    Promise.resolve(
+      ops.map(op => {
+        if (op.op === 'deleteMany') return { count: deletedCount };
+        if (op.op === 'classroomUpdateMany') return { count: casCount };
+        return op;
+      })
+    )
   );
 };
 
@@ -264,6 +280,19 @@ describe('contentAssets.service', () => {
   });
 
   describe('incremental sync', () => {
+    /** The commit the map is level with. */
+    const LEVEL = 'a'.repeat(40);
+
+    beforeEach(() => {
+      // An incremental sync only ever happens for a classroom whose tree has
+      // already been read once — a null commit escalates to full, deliberately,
+      // because a diff cannot build a map out of nothing.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+    });
+
     it('re-reads changed paths uncached, upserts them, and deletes removed ones', async () => {
       getMeta.mockImplementation(({ path }: { path: string }) =>
         Promise.resolve({ sha: `sha-${path}`, size: 10 })
@@ -424,17 +453,72 @@ describe('contentAssets.service', () => {
         after: 'b'.repeat(40),
       });
 
-      expect(classroomUpdate).toHaveBeenCalledTimes(1);
-      const [update] = classroomUpdate.mock.calls[0];
+      // A COMPARE-AND-SWAP: matched on the commit this run read, so a slower
+      // concurrent run cannot move the map's commit backwards.
+      expect(classroomUpdateMany).toHaveBeenCalledTimes(1);
+      const [update] = classroomUpdateMany.mock.calls[0];
       expect(update).toEqual({
-        where: { id: 'class-1' },
+        where: { id: 'class-1', content_assets_synced_commit: LEVEL },
         data: { content_assets_synced_commit: 'b'.repeat(40) },
       });
+      // The freshness timestamp is untouched, so the daily full refresh fires.
+      expect(classroomUpdate).not.toHaveBeenCalled();
       // In the transaction, so a failed apply cannot claim a commit it never
       // applied — and ahead of the sweep, whose count is read off the tail.
       const ops = transaction.mock.calls[0][0] as { op: string }[];
-      expect(ops[0].op).toBe('classroomUpdate');
+      expect(ops[0].op).toBe('classroomUpdateMany');
       expect(ops.at(-1)?.op).toBe('deleteMany');
+    });
+
+    it('drops the commit claim when a concurrent run got there first', async () => {
+      // The CAS matched nothing: something moved the classroom past the commit
+      // this run read. The ROWS it wrote stay — they are content-addressed and
+      // idempotent — but it must not claim a level it cannot vouch for. The
+      // winner's commit will not match the next push's `before`, which
+      // escalates, and that is the repair.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+      setupTransaction(0, /* casCount */ 0);
+      getMeta.mockResolvedValue({ sha: 'sha-a', size: 10 });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await syncContentAssets('class-1', {
+        changes: { added: ['images/a.png'], modified: [], removed: [] },
+        before: LEVEL,
+        after: 'b'.repeat(40),
+      });
+
+      expect(result.mode).toBe('incremental');
+      expect(result.upserted).toBe(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Concurrent sync for class-1'));
+      warn.mockRestore();
+    });
+
+    it('does NOT record a commit when the listing came back truncated', async () => {
+      // It could not apply the deletions it inferred, so the map is not level
+      // with `after` and must not say it is. Recording would make the next
+      // push look clean against a map that is missing rows.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+      const many = Array.from({ length: 31 }, (_unused, i) => `images/f${i}.png`);
+      getTree.mockResolvedValue({
+        sha: 'r',
+        truncated: true,
+        entries: [{ path: many[0], sha: 'sha-0', type: 'blob', size: 1 }],
+      });
+
+      const result = await syncContentAssets('class-1', {
+        changes: { added: many, modified: [], removed: [] },
+        before: LEVEL,
+        after: 'b'.repeat(40),
+      });
+
+      expect(result.truncated).toBe(true);
+      expect(classroomUpdateMany).not.toHaveBeenCalled();
     });
   });
 
@@ -488,17 +572,51 @@ describe('contentAssets.service', () => {
       expect(getTree).not.toHaveBeenCalled();
     });
 
-    it('does not treat a first sync as a missed delivery', async () => {
-      // Null stored commit means there is no chain yet, not a gap in one. Every
-      // classroom in the table starts here, so counting it would make the first
-      // push after this shipped a full sync for all of them at once.
+    it('escalates a FIRST sync because there is no map, not because of a gap', async () => {
+      // Null stored commit is not a gap in the chain — there is no chain — so
+      // this is not reported as a missed delivery. It still goes full, and for
+      // a different reason: a diff cannot build a map out of nothing. Applying
+      // one push's paths would leave every untouched file missing and then
+      // record that half-map as level with `after`, starting the chain from a
+      // state that was never true.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
       const result = await syncContentAssets('class-1', {
         changes,
         before: 'c'.repeat(40),
         after: 'd'.repeat(40),
       });
 
-      expect(result.mode).toBe('incremental');
+      expect(result.mode).toBe('full');
+      expect(getMeta).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('a delivery was missed'));
+      warn.mockRestore();
+    });
+
+    it('escalates a first sync even when the push carries no before at all', async () => {
+      const result = await syncContentAssets('class-1', { changes, after: 'd'.repeat(40) });
+
+      expect(result.mode).toBe('full');
+    });
+
+    it('escalates a branch-creation push, whose before is all zeros', async () => {
+      // GitHub sends 40 zeros as `before` when a ref is created. It is not the
+      // commit the map is level with, so it is a gap like any other.
+      classroomFindUnique.mockResolvedValue({
+        ...CLASSROOM,
+        content_assets_synced_commit: LEVEL,
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await syncContentAssets('class-1', {
+        changes,
+        before: '0'.repeat(40),
+        after: 'd'.repeat(40),
+      });
+
+      expect(result.mode).toBe('full');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('a delivery was missed'));
+      warn.mockRestore();
     });
 
     it('does not escalate a caller that cannot answer the question', async () => {
@@ -784,6 +902,36 @@ describe('contentAssets.service', () => {
         where: { classroom_id: 'class-1', path: '.slidesthemes/midnight', type: 'tree' },
         select: { sha: true, type: true, size: true },
       });
+    });
+
+    it('resolves many shas in ONE query, lowest path winning a tie', async () => {
+      // An import rewrites a course's worth of content at once; per-sha lookups
+      // were a round trip per image per page.
+      contentAssetFindMany.mockResolvedValue([
+        { path: 'pages/lab-1/a.png', sha: 'sha-a' },
+        { path: 'pages/lab-9/copy-of-a.png', sha: 'sha-a' },
+        { path: 'pages/lab-2/b.png', sha: 'sha-b' },
+      ]);
+
+      const found = await lookupContentAssetsBySha('class-1', ['sha-a', 'sha-b', 'sha-a']);
+
+      expect(contentAssetFindMany).toHaveBeenCalledTimes(1);
+      expect(contentAssetFindMany).toHaveBeenCalledWith({
+        where: { classroom_id: 'class-1', sha: { in: ['sha-a', 'sha-b'] } },
+        select: { path: true, sha: true },
+        orderBy: { path: 'asc' },
+      });
+      // Two paths at one sha are byte-identical, so either is correct — the
+      // order is pinned so repeated imports produce the same output.
+      expect(found.get('sha-a')).toBe('pages/lab-1/a.png');
+      expect(found.get('sha-b')).toBe('pages/lab-2/b.png');
+      // A sha the map has never heard of is simply absent.
+      expect(found.has('sha-z')).toBe(false);
+    });
+
+    it('does not query at all for an empty sha list', async () => {
+      await expect(lookupContentAssetsBySha('class-1', [])).resolves.toEqual(new Map());
+      expect(contentAssetFindMany).not.toHaveBeenCalled();
     });
 
     it('resolves a sha back to a path, deterministically', async () => {

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -34,7 +34,8 @@ vi.mock('@classmoji/database', () => ({
 }));
 
 const getTree = vi.fn();
-const getGitProvider = vi.fn(() => ({ getTree }));
+const getDefaultBranch = vi.fn();
+const getGitProvider = vi.fn(() => ({ getTree, getDefaultBranch }));
 vi.mock('../../git/index.ts', () => ({
   getGitProvider: (...a: unknown[]) => getGitProvider(...(a as [])),
 }));
@@ -81,6 +82,7 @@ describe('contentAssets.service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     classroomFindUnique.mockResolvedValue(CLASSROOM);
+    getDefaultBranch.mockResolvedValue('main');
     setupTransaction();
   });
 
@@ -101,6 +103,7 @@ describe('contentAssets.service', () => {
 
       expect(result).toEqual({ mode: 'full', upserted: 3, deleted: 4, truncated: false });
       expect(getTree).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'main', true);
+      expect(getDefaultBranch).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101');
       expect(contentAssetUpsert).toHaveBeenCalledTimes(3);
 
       // Directories are rows too — theme folders are addressed by tree SHA, so
@@ -134,6 +137,22 @@ describe('contentAssets.service', () => {
 
       expect(result).toEqual({ mode: 'full', upserted: 1, deleted: 0, truncated: true });
       expect(contentAssetDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('reads the tree at the repo default branch, not a hardcoded main', async () => {
+      // A course imported from an older org is on `master`. Against `main` the
+      // tree call 404s, the sync throws, and the classroom keeps an EMPTY map —
+      // every asset falls back to the legacy path forever.
+      getDefaultBranch.mockResolvedValue('master');
+      getTree.mockResolvedValue({
+        sha: 'r',
+        truncated: false,
+        entries: [{ path: 'images/a.png', sha: 'sha-a', type: 'blob', size: 1 }],
+      });
+
+      await syncContentAssets('class-1');
+
+      expect(getTree).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'master', true);
     });
 
     it('defaults a missing size to 0 rather than writing undefined', async () => {

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -17,12 +17,17 @@ const contentAssetDeleteMany = vi.fn();
 const contentAssetFindFirst = vi.fn();
 const contentAssetFindUnique = vi.fn();
 const classroomFindUnique = vi.fn();
+const classroomFindFirst = vi.fn();
 const classroomUpdate = vi.fn();
 const transaction = vi.fn();
 
 vi.mock('@classmoji/database', () => ({
   default: () => ({
-    classroom: { findUnique: classroomFindUnique, update: classroomUpdate },
+    classroom: {
+      findUnique: classroomFindUnique,
+      findFirst: classroomFindFirst,
+      update: classroomUpdate,
+    },
     contentAsset: {
       upsert: contentAssetUpsert,
       deleteMany: contentAssetDeleteMany,
@@ -47,6 +52,7 @@ vi.mock('../../content/ContentService.ts', () => ({
 
 const {
   syncContentAssets,
+  syncContentAssetsForRepo,
   ensureContentAssets,
   recordContentAsset,
   lookupContentAsset,
@@ -82,6 +88,7 @@ describe('contentAssets.service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     classroomFindUnique.mockResolvedValue(CLASSROOM);
+    classroomFindFirst.mockResolvedValue({ id: 'class-1' });
     getDefaultBranch.mockResolvedValue('main');
     setupTransaction();
   });
@@ -388,6 +395,52 @@ describe('contentAssets.service', () => {
 
       expect(result.mode).toBe('incremental');
       expect(classroomUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('syncContentAssetsForRepo', () => {
+    it('full-syncs the classroom that owns the repo', async () => {
+      // What a theme save needs. A theme is delivered by the SHA of its TREE,
+      // so until the map is rebuilt every deck keeps signing the PREVIOUS tree
+      // and the edge keeps serving the previous CSS — the author reloads and
+      // their change has not taken. Full mode, because no per-file update can
+      // produce a tree SHA.
+      getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
+
+      const result = await syncContentAssetsForRepo('dartmouth-cs', 'content-cs101', 'theme-save');
+
+      expect(classroomFindFirst).toHaveBeenCalledWith({
+        where: { content_repo: 'content-cs101', git_organization: { login: 'dartmouth-cs' } },
+        select: { id: true },
+      });
+      expect(result?.mode).toBe('full');
+    });
+
+    it('no-ops for a repo no classroom claims as its content repo', async () => {
+      classroomFindFirst.mockResolvedValue(null);
+
+      await expect(
+        syncContentAssetsForRepo('someone-else', 'other-repo', 'theme-save')
+      ).resolves.toBeNull();
+      expect(getTree).not.toHaveBeenCalled();
+    });
+
+    it('resolves null instead of throwing when the sync fails', async () => {
+      // It runs AFTER a commit that already reached GitHub. A save that
+      // succeeded must never be reported as failed because a cache could not
+      // be refreshed.
+      getTree.mockRejectedValue(new Error('API rate limit exceeded'));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await expect(
+        syncContentAssetsForRepo('dartmouth-cs', 'content-cs101', 'theme-save')
+      ).resolves.toBeNull();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('theme-save sync failed for dartmouth-cs/content-cs101'),
+        expect.any(Error)
+      );
+      warn.mockRestore();
     });
   });
 

--- a/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
@@ -9,7 +9,7 @@
  * 404s the moment the source classroom is deleted with GitHub cleanup.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
 vi.mock('../../content/ContentService.ts', () => ({ ContentService: {} }));
@@ -17,8 +17,19 @@ vi.mock('../../git/index.ts', () => ({ getGitProvider: vi.fn() }));
 vi.mock('../page.service.ts', () => ({ ensureContentRepo: vi.fn() }));
 vi.mock('../contentManifest.service.ts', () => ({ saveManifest: vi.fn() }));
 
-const { isTextContentPath, rewriteContentUrls, rewriteStagedFiles, collectSignedBlobShas } =
-  await import('../contentImport.service.ts');
+/** The one asset-map query the sha sweep makes; asserted on below. */
+const lookupContentAssetsBySha = vi.fn();
+vi.mock('../contentAssets.service.ts', () => ({
+  lookupContentAssetsBySha: (...a: unknown[]) => lookupContentAssetsBySha(...a),
+}));
+
+const {
+  isTextContentPath,
+  rewriteContentUrls,
+  rewriteStagedFiles,
+  collectSignedBlobShas,
+  resolveShaPaths,
+} = await import('../contentImport.service.ts');
 
 /** Source and target deliberately live in DIFFERENT orgs — the org segment of
  *  every URL must be swapped too, not just the repo name. */
@@ -114,6 +125,40 @@ describe('rewriteContentUrls', () => {
     );
   });
 
+  it('rewrites a fully-qualified refs/heads raw URL, folder remap and all', () => {
+    // THE shape GitHub's own "Raw" button emits. Taking one segment as the
+    // branch reads `refs` as the branch and `heads/main/pages/lab-1/…` as the
+    // path, so the item folder is never recognized — the copy lands on a path
+    // no repo has, and every image 404s in the target.
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text =
+      'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/refs/heads/main/pages/lab-1/a.png';
+    expect(rewriteContentUrls(text, suffixed)).toBe(
+      'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/refs/heads/main/pages/lab-1-2/a.png'
+    );
+  });
+
+  it('rewrites a refs/tags raw URL the same way', () => {
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text =
+      'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/refs/tags/v1/pages/lab-1/a.png';
+    expect(rewriteContentUrls(text, suffixed)).toBe(
+      'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/refs/tags/v1/pages/lab-1-2/a.png'
+    );
+  });
+
+  it('leaves a COMMIT-pinned raw URL completely alone, repo swap included', () => {
+    // It asks for one exact historical revision, and that commit exists only in
+    // the SOURCE repo — a fresh import's target has none of its history.
+    // Repointing it guarantees a 404; leaving it resolves for as long as the
+    // source repo is around.
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text = `https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/${'a'.repeat(
+      40
+    )}/pages/lab-1/a.png`;
+    expect(rewriteContentUrls(text, suffixed)).toBe(text);
+  });
+
   it('rewrites the /content/{org}/{repo} proxy shape, item-specific and general', () => {
     const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
     const own = '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/pages/lab-1/a.svg';
@@ -140,6 +185,14 @@ describe('rewriteContentUrls', () => {
     // path belongs to a repo this import has nothing to do with.
     const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
     const text = 'https://raw.githubusercontent.com/someone-else/other-repo/main/pages/lab-1/x.png';
+    expect(rewriteContentUrls(text, suffixed)).toBe(text);
+  });
+
+  it('does not rewrite a bare path sitting in a foreign URL’s query string', () => {
+    // `=` is not a value boundary: `?src=pages/lab-1/a.png` on somebody else's
+    // host is their query string, not our repo path.
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text = 'https://images.example.com/resize?src=pages/lab-1/a.png&w=800';
     expect(rewriteContentUrls(text, suffixed)).toBe(text);
   });
 
@@ -322,5 +375,68 @@ describe('rewriteStagedFiles', () => {
     );
     expect(out[1]!.content).toBe(binary);
     expect(out).toHaveLength(2);
+  });
+});
+
+/**
+ * The sha sweep: every signed blob an import references, resolved against the
+ * SOURCE classroom's asset map in one query for the whole run.
+ */
+describe('resolveShaPaths', () => {
+  const CLASS_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+  const SHA = 'c'.repeat(40);
+  const OTHER = 'd'.repeat(40);
+
+  beforeEach(() => {
+    lookupContentAssetsBySha.mockReset();
+  });
+
+  it('makes ONE query for every sha across every text it is given', async () => {
+    // THE regression this guards: resolving per sha, inside the staging loop,
+    // was a round trip per image per page — on the one code path whose entire
+    // job is copying a course's worth of images.
+    lookupContentAssetsBySha.mockResolvedValue(new Map([[SHA, 'pages/lab-1/a.png']]));
+
+    const found = await resolveShaPaths(CLASS_ID, [
+      `<img src="/c/${CLASS_ID}/blob/${SHA}.png?p=draft">`,
+      `<img src="/c/${CLASS_ID}/blob/${OTHER}.svg?p=live">`,
+      // The same sha again, and a shape that carries none.
+      `<img src="/c/${CLASS_ID}/blob/${SHA}.png?p=live">`,
+      'pages/lab-1/plain.png',
+    ]);
+
+    expect(lookupContentAssetsBySha).toHaveBeenCalledTimes(1);
+    const [classroomId, shas] = lookupContentAssetsBySha.mock.calls[0];
+    expect(classroomId).toBe(CLASS_ID);
+    expect([...(shas as string[])].sort()).toEqual([SHA, OTHER].sort());
+    expect(found.get(SHA)).toBe('pages/lab-1/a.png');
+  });
+
+  it('does not query when the content references no signed blobs', async () => {
+    await expect(resolveShaPaths(CLASS_ID, ['{"src":"pages/lab-1/a.png"}'])).resolves.toEqual(
+      new Map()
+    );
+    expect(lookupContentAssetsBySha).not.toHaveBeenCalled();
+  });
+
+  it('degrades to an empty map when the lookup fails', async () => {
+    // Best effort: the rewriter then leaves those URLs alone and warns. An
+    // import must not fail over a reference it could not tidy up.
+    lookupContentAssetsBySha.mockRejectedValue(new Error('connection terminated'));
+
+    await expect(
+      resolveShaPaths(CLASS_ID, [`<img src="/c/${CLASS_ID}/blob/${SHA}.png">`])
+    ).resolves.toEqual(new Map());
+  });
+
+  it('feeds the rewriter, which leaves an unresolved sha verbatim and warns', async () => {
+    lookupContentAssetsBySha.mockResolvedValue(new Map());
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft`;
+    const onWarn = vi.fn();
+
+    const shaPaths = await resolveShaPaths(CLASS_ID, [url]);
+
+    expect(rewriteContentUrls(url, { ...ctx, shaPaths, onWarn })).toBe(url);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining(SHA));
   });
 });

--- a/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../git/index.ts', () => ({ getGitProvider: vi.fn() }));
 vi.mock('../page.service.ts', () => ({ ensureContentRepo: vi.fn() }));
 vi.mock('../contentManifest.service.ts', () => ({ saveManifest: vi.fn() }));
 
-const { isTextContentPath, rewriteContentUrls, rewriteStagedFiles } =
+const { isTextContentPath, rewriteContentUrls, rewriteStagedFiles, collectSignedBlobShas } =
   await import('../contentImport.service.ts');
 
 /** Source and target deliberately live in DIFFERENT orgs — the org segment of
@@ -100,6 +100,173 @@ describe('rewriteContentUrls', () => {
   it('leaves an unrelated org’s GitHub URLs alone', () => {
     const text = 'https://raw.githubusercontent.com/someone-else/other-repo/main/pages/lab-1/x.png';
     expect(rewriteContentUrls(text, ctx)).toBe(text);
+  });
+
+  it('rewrites raw URLs on a branch other than main', () => {
+    // A repo whose default is `master`, or content hand-authored against a
+    // working branch. Pinning the shape to `main` left these pointing at the
+    // SOURCE repo, which 404s the moment it is deleted with GitHub cleanup.
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text =
+      'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/master/pages/lab-1/a.png';
+    expect(rewriteContentUrls(text, suffixed)).toBe(
+      'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/master/pages/lab-1-2/a.png'
+    );
+  });
+
+  it('rewrites the /content/{org}/{repo} proxy shape, item-specific and general', () => {
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const own = '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/pages/lab-1/a.svg';
+    const other = '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/pages/lab-9/b.svg';
+    expect(rewriteContentUrls(own, suffixed)).toBe(
+      '/content/brown-cs32/content-brown-cs32-cs32-26f/pages/lab-1-2/a.svg'
+    );
+    expect(rewriteContentUrls(other, suffixed)).toBe(
+      '/content/brown-cs32/content-brown-cs32-cs32-26f/pages/lab-9/b.svg'
+    );
+  });
+
+  it('rewrites a BARE repo path, which is what pages store now', () => {
+    // The delivery layer signs at render time, so a saved block holds the repo
+    // path itself. Left alone, the imported copy points at a folder that only
+    // exists under the source item's (un-suffixed) name.
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text = '{"src":"pages/lab-1/assets/d.png"}';
+    expect(rewriteContentUrls(text, suffixed)).toBe('{"src":"pages/lab-1-2/assets/d.png"}');
+  });
+
+  it('anchors the bare-path rewrite so it cannot reach inside another org’s URL', () => {
+    // A blanket replace would corrupt this: the folder name matches, but the
+    // path belongs to a repo this import has nothing to do with.
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const text = 'https://raw.githubusercontent.com/someone-else/other-repo/main/pages/lab-1/x.png';
+    expect(rewriteContentUrls(text, suffixed)).toBe(text);
+  });
+
+  it('leaves bare paths alone for a whole-repo clone, which moves nothing', () => {
+    // cloneContentRepo copies every path unchanged and passes an empty
+    // sourcePath; a prefix rewrite there is meaningless.
+    const clone = { ...ctx, sourcePath: '', targetPath: '' };
+    const text = '{"src":"pages/lab-1/assets/d.png"}';
+    expect(rewriteContentUrls(text, clone)).toBe(text);
+  });
+});
+
+/**
+ * A signed URL is bound to the SOURCE classroom's id and key version, and the
+ * imported copy renders under a different classroom. Copying one verbatim does
+ * not produce a stale link — it produces a permanently unauthorized one, and
+ * the image is gone the moment anyone opens the page.
+ */
+describe('rewriteContentUrls: our own signed URLs', () => {
+  const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+  const CLASS_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+  const SHA = 'c'.repeat(40);
+
+  it('turns a signed blob URL back into a repo path via the source map', () => {
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft&v=0&exp=1&sig=x`;
+    const shaPaths = new Map([[SHA, 'pages/lab-1/assets/d.png']]);
+
+    // Resolved to the SOURCE path, then carried onto the target's folder by
+    // the ordinary bare-path rewrite — dedupe suffix and all.
+    expect(rewriteContentUrls(url, { ...suffixed, shaPaths })).toBe('pages/lab-1-2/assets/d.png');
+  });
+
+  it('leaves a blob URL alone and warns when the map has no path for its sha', () => {
+    // A blob URL names CONTENT, not location. Inventing a path would put a
+    // confidently wrong reference into content nobody will think to check;
+    // leaving it keeps the breakage where it already was, and visible.
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft&v=0`;
+    const onWarn = vi.fn();
+
+    expect(rewriteContentUrls(url, { ...suffixed, onWarn })).toBe(url);
+    expect(onWarn).toHaveBeenCalledWith(expect.stringContaining(SHA));
+  });
+
+  it('recovers the reference a /missing/ URL is carrying, no lookup needed', () => {
+    // `/missing/` IS the resolver saying it could not find something — the ref
+    // it could not find is right there in the path.
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/missing/${encodeURIComponent(
+      'pages/lab-1/assets/d.png'
+    )}`;
+
+    expect(rewriteContentUrls(url, suffixed)).toBe('pages/lab-1-2/assets/d.png');
+  });
+
+  it('derives a theme URL’s folder without any lookup', () => {
+    // A theme always lives at `.slidesthemes/{name}`; the tree sha and policy
+    // segments are addressing and authorization, not location.
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/theme/midnight/${'a'.repeat(
+      40
+    )}/draft.0.99.sig/custom-theme.css`;
+
+    expect(rewriteContentUrls(url, suffixed)).toBe('.slidesthemes/midnight/custom-theme.css');
+  });
+
+  it('collects the blob shas a document references, for the map lookup', () => {
+    const other = 'd'.repeat(40);
+    const text = [
+      `/c/${CLASS_ID}/blob/${SHA}.png?p=draft`,
+      `/c/${CLASS_ID}/blob/${other}.svg?p=live`,
+      `/c/${CLASS_ID}/blob/${SHA}.png?p=live`,
+      `/c/${CLASS_ID}/theme/midnight/${'a'.repeat(40)}/draft.0.1.s/`,
+    ].join(' ');
+
+    expect(collectSignedBlobShas(text).sort()).toEqual([SHA, other].sort());
+  });
+});
+
+/**
+ * One document holding every shape at once — which is what real content looks
+ * like, authored across years and surfaces. The clone/import tests elsewhere
+ * mock this function as identity; this is the one place the real thing runs
+ * over the full mix.
+ */
+describe('rewriteContentUrls: a fixture carrying every shape', () => {
+  it('repoints all of them onto the target repo in one pass', () => {
+    const suffixed = { ...ctx, targetPath: 'pages/lab-1-2' };
+    const CLASS_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+    const SHA = 'c'.repeat(40);
+    const shaPaths = new Map([[SHA, 'pages/lab-1/assets/signed.png']]);
+
+    const fixture = JSON.stringify({
+      raw: 'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/main/pages/lab-1/assets/raw.png',
+      rawOtherBranch:
+        'https://raw.githubusercontent.com/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/master/pages/lab-1/assets/old.png',
+      pagesCdn:
+        'https://dartmouth-cs52.github.io/content-dartmouth-cs52-cs52-25s/pages/lab-1/assets/cdn.svg',
+      proxy: '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/pages/lab-1/assets/proxy.svg',
+      bare: 'pages/lab-1/assets/bare.png',
+      crossItem: 'pages/lab-9/assets/other.png',
+      signed: `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft&v=0&exp=1&sig=z`,
+      missing: `https://cdn.classmoji.test/c/${CLASS_ID}/missing/${encodeURIComponent(
+        'pages/lab-1/assets/gone.png'
+      )}`,
+      theme: `https://cdn.classmoji.test/c/${CLASS_ID}/theme/midnight/${'a'.repeat(
+        40
+      )}/draft.0.99.sig/custom-theme.css`,
+      foreign: 'https://raw.githubusercontent.com/someone-else/other-repo/main/pages/lab-1/x.png',
+      external: 'https://example.com/logo.png',
+    });
+
+    expect(JSON.parse(rewriteContentUrls(fixture, { ...suffixed, shaPaths }))).toEqual({
+      raw: 'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/main/pages/lab-1-2/assets/raw.png',
+      rawOtherBranch:
+        'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/master/pages/lab-1-2/assets/old.png',
+      pagesCdn:
+        'https://brown-cs32.github.io/content-brown-cs32-cs32-26f/pages/lab-1-2/assets/cdn.svg',
+      proxy: '/content/brown-cs32/content-brown-cs32-cs32-26f/pages/lab-1-2/assets/proxy.svg',
+      bare: 'pages/lab-1-2/assets/bare.png',
+      // A different item: it keeps its own folder, which is correct whenever
+      // that item was imported un-renamed.
+      crossItem: 'pages/lab-9/assets/other.png',
+      signed: 'pages/lab-1-2/assets/signed.png',
+      missing: 'pages/lab-1-2/assets/gone.png',
+      theme: '.slidesthemes/midnight/custom-theme.css',
+      // Neither of these is ours to touch.
+      foreign: 'https://raw.githubusercontent.com/someone-else/other-repo/main/pages/lab-1/x.png',
+      external: 'https://example.com/logo.png',
+    });
   });
 });
 

--- a/packages/services/src/classmoji/__tests__/contentRefs.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentRefs.test.ts
@@ -1,0 +1,156 @@
+/**
+ * contentRefs.ts — the URL shapes that address a file in a classroom's OWN
+ * content repo, and the ref-splitting both callers share.
+ *
+ * These are the single point of agreement between the delivery resolver (which
+ * strips a prefix off to recover a repo path) and the import rewriter (which
+ * swaps one repo's prefix for another's). A hole here shows up twice: as an
+ * asset that will not resolve, and as an imported page pointing somewhere that
+ * does not exist.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractOwnRepoPath, isCommitRef, splitRawRef } from '../contentRefs.ts';
+
+const LOGIN = 'dartmouth-cs52';
+const REPO = 'content-dartmouth-cs52-cs52-25s';
+const COMMIT = 'a'.repeat(40);
+
+describe('splitRawRef', () => {
+  it('takes one segment as the ref in the short form', () => {
+    expect(splitRawRef('main/pages/lab-1/a.png')).toEqual({
+      ref: 'main',
+      path: 'pages/lab-1/a.png',
+    });
+  });
+
+  it('keeps refs/heads/{branch} together, which is what the Raw button emits', () => {
+    // Splitting on the first slash here yields ref `refs` and path
+    // `heads/main/pages/…` — a path no repo has.
+    expect(splitRawRef('refs/heads/main/pages/lab-1/a.png')).toEqual({
+      ref: 'refs/heads/main',
+      path: 'pages/lab-1/a.png',
+    });
+  });
+
+  it('keeps refs/tags/{tag} together too', () => {
+    expect(splitRawRef('refs/tags/v1.2/pages/lab-1/a.png')).toEqual({
+      ref: 'refs/tags/v1.2',
+      path: 'pages/lab-1/a.png',
+    });
+  });
+
+  it('handles a branch name with slashes in the short form, as one ref cannot', () => {
+    // Positional and unavoidable: `feat/x` is indistinguishable from a ref
+    // `feat` and a path starting `x/`. The qualified form above is the fix a
+    // caller has when it matters.
+    expect(splitRawRef('feat/x/pages/a.png')).toEqual({ ref: 'feat', path: 'x/pages/a.png' });
+  });
+
+  it('returns null when there is no path after the ref', () => {
+    expect(splitRawRef('main')).toBeNull();
+    expect(splitRawRef('/leading')).toBeNull();
+  });
+});
+
+describe('isCommitRef', () => {
+  it('recognizes a 40-hex commit sha, in either case', () => {
+    expect(isCommitRef(COMMIT)).toBe(true);
+    expect(isCommitRef(COMMIT.toUpperCase())).toBe(true);
+  });
+
+  it('rejects branch names, including hex-looking short ones', () => {
+    expect(isCommitRef('main')).toBe(false);
+    expect(isCommitRef('master')).toBe(false);
+    expect(isCommitRef('abc123')).toBe(false);
+    expect(isCommitRef(`${COMMIT}0`)).toBe(false);
+  });
+});
+
+describe('extractOwnRepoPath', () => {
+  it('recovers the path from the raw shape on any branch', () => {
+    expect(
+      extractOwnRepoPath(
+        `https://raw.githubusercontent.com/${LOGIN}/${REPO}/main/pages/lab-1/a.png`,
+        LOGIN,
+        REPO
+      )
+    ).toBe('pages/lab-1/a.png');
+    expect(
+      extractOwnRepoPath(
+        `https://raw.githubusercontent.com/${LOGIN}/${REPO}/master/pages/lab-1/a.png`,
+        LOGIN,
+        REPO
+      )
+    ).toBe('pages/lab-1/a.png');
+  });
+
+  it('recovers the path from a fully-qualified refs/heads raw URL', () => {
+    // THE regression this guards: the one-segment split returned
+    // `heads/main/pages/lab-1/a.png`, which misses the asset map on every
+    // lookup, so the asset silently fell back to the legacy path.
+    expect(
+      extractOwnRepoPath(
+        `https://raw.githubusercontent.com/${LOGIN}/${REPO}/refs/heads/main/pages/lab-1/a.png`,
+        LOGIN,
+        REPO
+      )
+    ).toBe('pages/lab-1/a.png');
+  });
+
+  it('recovers the path from a refs/tags raw URL', () => {
+    expect(
+      extractOwnRepoPath(
+        `https://raw.githubusercontent.com/${LOGIN}/${REPO}/refs/tags/v1/pages/lab-1/a.png`,
+        LOGIN,
+        REPO
+      )
+    ).toBe('pages/lab-1/a.png');
+  });
+
+  it('refuses a COMMIT-pinned raw URL', () => {
+    // It names one exact historical revision. The map holds the DEFAULT
+    // BRANCH's content, so resolving this would quietly serve today's bytes for
+    // a URL that asked for an old one. Null leaves the original URL in place,
+    // which still resolves against GitHub.
+    expect(
+      extractOwnRepoPath(
+        `https://raw.githubusercontent.com/${LOGIN}/${REPO}/${COMMIT}/pages/lab-1/a.png`,
+        LOGIN,
+        REPO
+      )
+    ).toBeNull();
+  });
+
+  it('recovers the path from the Pages CDN and the content proxy', () => {
+    expect(
+      extractOwnRepoPath(`https://${LOGIN}.github.io/${REPO}/pages/lab-1/a.png`, LOGIN, REPO)
+    ).toBe('pages/lab-1/a.png');
+    expect(extractOwnRepoPath(`/content/${LOGIN}/${REPO}/pages/lab-1/a.png`, LOGIN, REPO)).toBe(
+      'pages/lab-1/a.png'
+    );
+  });
+
+  it('drops a query string and percent-decodes once', () => {
+    expect(
+      extractOwnRepoPath(
+        `https://raw.githubusercontent.com/${LOGIN}/${REPO}/main/pages/lab%201/a.png?raw=1`,
+        LOGIN,
+        REPO
+      )
+    ).toBe('pages/lab 1/a.png');
+  });
+
+  it('returns null for anything that is not this repo', () => {
+    expect(extractOwnRepoPath('https://example.com/logo.png', LOGIN, REPO)).toBeNull();
+    expect(
+      extractOwnRepoPath(
+        'https://raw.githubusercontent.com/someone-else/other/main/a.png',
+        LOGIN,
+        REPO
+      )
+    ).toBeNull();
+    expect(extractOwnRepoPath('data:image/png;base64,AAAA', LOGIN, REPO)).toBeNull();
+    expect(extractOwnRepoPath('', LOGIN, REPO)).toBeNull();
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -31,8 +31,10 @@ vi.mock('../../content/ContentService.ts', () => ({
 // webhook — see recordContentAsset. Mocked here so this suite keeps pinning the
 // GitHub interactions and nothing reaches Prisma.
 const recordContentAssetMock = vi.fn();
+const resolveContentBranchMock = vi.fn();
 vi.mock('../contentAssets.service.ts', () => ({
   recordContentAsset: (...args: unknown[]) => recordContentAssetMock(...args),
+  resolveContentBranch: (...args: unknown[]) => resolveContentBranchMock(...args),
 }));
 
 const {
@@ -268,6 +270,7 @@ describe('pageContent.uploadPageAsset', () => {
       sha: 'c'.repeat(40),
     });
     recordContentAssetMock.mockResolvedValue(true);
+    resolveContentBranchMock.mockResolvedValue('main');
     delete process.env.CONTENT_DELIVERY_ORIGIN;
     delete process.env.CONTENT_SIGNING_SECRET;
   });
@@ -283,6 +286,22 @@ describe('pageContent.uploadPageAsset', () => {
     expect(arg.file).toBe(buffer);
     expect(arg.filename).toBe('a.png');
     expect(arg.branch).toBe('main');
+  });
+
+  it('commits to the repo default branch rather than a hardcoded main', async () => {
+    // A course imported from an older org is on `master`. Committing to `main`
+    // there either creates a branch nobody renders from or is refused outright,
+    // and the asset map would then hold a blob the served branch never had.
+    resolveContentBranchMock.mockResolvedValue('master');
+
+    await uploadPageAsset(page, Buffer.from('x'), 'a.png');
+
+    expect(resolveContentBranchMock).toHaveBeenCalledWith(
+      gitOrganization,
+      'test-org',
+      'content-test-org-cs101'
+    );
+    expect(callArg(uploadMock).branch).toBe('master');
   });
 
   it('stores the REPO PATH once the delivery layer can sign it', async () => {

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -394,6 +394,50 @@ export async function syncContentAssets(
 }
 
 /**
+ * Full-sync whatever classroom owns this content repo, addressed by org + repo.
+ *
+ * For writers that commit to a content repo DIRECTLY and need the map to
+ * reflect it before the next render — a shared theme save is the case that
+ * forced this. A theme is served by the SHA of its TREE, so until the map is
+ * rebuilt every deck in the classroom keeps signing the previous tree and the
+ * edge keeps serving the previous CSS. The push webhook would eventually fix
+ * it, but "eventually" is after the author has already reloaded and seen their
+ * change not take.
+ *
+ * Full mode always, for the same reason: no per-file update can produce a tree
+ * SHA, so an incremental apply cannot see a theme edit at all.
+ *
+ * NEVER THROWS. It sits after a write that already succeeded, and a commit that
+ * reached GitHub must not be reported as a failed save because a cache could
+ * not be refreshed. Returns null when nothing was synced — no classroom claims
+ * this repo, or the refresh itself failed and the next sync will repair it.
+ */
+export async function syncContentAssetsForRepo(
+  org: string,
+  repo: string,
+  reason: string
+): Promise<SyncContentAssetsResult | null> {
+  try {
+    const classroom = await getPrisma().classroom.findFirst({
+      where: { content_repo: repo, git_organization: { login: org } },
+      select: { id: true },
+    });
+    // Not ours to care about — the same ordinary, non-error case the push
+    // webhook's classroom lookup treats as "not a content repo".
+    if (!classroom) return null;
+
+    return await syncContentAssets(classroom.id, { full: true });
+  } catch (error: unknown) {
+    console.warn(
+      `[contentAssets] ${reason} sync failed for ${org}/${repo}; ` +
+        'the next webhook or daily sweep will repair it:',
+      error
+    );
+    return null;
+  }
+}
+
+/**
  * Make sure the map exists and is not older than `maxAgeMs`, syncing if not.
  *
  * Age is `Classroom.content_assets_synced_at`, which only a FULL sync writes —

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -60,6 +60,14 @@ export interface ContentAssetChanges {
 export interface SyncContentAssetsOptions {
   full?: boolean;
   changes?: ContentAssetChanges;
+  /**
+   * The commit the push built ON — `before` from the webhook. Compared against
+   * the commit the map was last brought level with; a mismatch means a delivery
+   * went missing and this run escalates to a full tree read.
+   */
+  before?: string | null;
+  /** The commit the push LANDED — `after`. Recorded once the diff is applied. */
+  after?: string | null;
 }
 
 export interface SyncContentAssetsResult {
@@ -79,6 +87,8 @@ interface ResolvedClassroom {
   id: string;
   content_repo: string;
   org: string;
+  /** The commit the map was last brought level with; null = never synced. */
+  syncedCommit: string | null;
   gitOrganization: NonNullable<Awaited<ReturnType<typeof loadClassroomRaw>>>['git_organization'];
 }
 
@@ -92,7 +102,8 @@ async function loadClassroomRaw(classroomId: string) {
 type ClassroomRecord = Awaited<ReturnType<typeof loadClassroomRaw>>;
 
 /**
- * The classroom plus the two things a sync needs from it: which org, which repo.
+ * The classroom plus what a sync needs from it: which org, which repo, and the
+ * commit the map was last brought level with.
  *
  * Throws rather than returning null. Every caller here is already committed to
  * syncing, so "this classroom has no git organization" is a programming or
@@ -114,6 +125,7 @@ function toResolvedClassroom(classroom: ClassroomRecord, classroomId: string): R
     id: classroom.id,
     content_repo: classroom.content_repo,
     org: classroom.git_organization.login,
+    syncedCommit: classroom.content_assets_synced_commit ?? null,
     gitOrganization: classroom.git_organization,
   };
 }
@@ -166,15 +178,27 @@ export async function resolveContentBranch(
   return getGitProvider(gitOrganization).getDefaultBranch(org, repo);
 }
 
+/**
+ * The default branch's tree, plus the commit it was read AT.
+ *
+ * The branch head is resolved first and the tree is then read at that commit
+ * rather than at the branch name, so the commit this returns describes exactly
+ * the entries it returns. That matters because the commit is recorded as the
+ * state the map is level with: reading the tree at a moving branch and asking
+ * for its head separately could record a commit whose tree was never read, and
+ * a later push building on that commit would then find the chain intact and
+ * skip the escalation that should have repaired it.
+ */
 async function readRepoTree(
   classroom: ResolvedClassroom
-): Promise<{ entries: TreeEntry[]; truncated: boolean }> {
+): Promise<{ entries: TreeEntry[]; truncated: boolean; commit: string }> {
   const provider = getGitProvider(classroom.gitOrganization);
   const branch = await provider.getDefaultBranch(classroom.org, classroom.content_repo);
+  const commit = await provider.getLatestCommitSHA(classroom.org, classroom.content_repo, branch);
   const tree = await provider.getTree(
     classroom.org,
     classroom.content_repo,
-    branch,
+    commit,
     /* recursive */ true
   );
 
@@ -188,7 +212,7 @@ async function readRepoTree(
     );
   }
 
-  return { entries: tree.entries, truncated: tree.truncated };
+  return { entries: tree.entries, truncated: tree.truncated, commit };
 }
 
 function upsertOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
@@ -250,13 +274,19 @@ async function fullSync(classroom: ResolvedClassroom): Promise<SyncContentAssets
   // Before the read, not after — see the header. A row written while the tree
   // is in flight must stamp ABOVE this run, or the sweep deletes it.
   const syncedAt = new Date();
-  const { entries, truncated } = await readRepoTree(classroom);
+  const { entries, truncated, commit } = await readRepoTree(classroom);
 
   // FIRST, not last. The sweep's count is read off the tail of the results, so
   // the stamp goes in front of the upserts rather than after the delete.
+  //
+  // The commit rides along with the timestamp: this run read the repo at it, so
+  // it is the state the map is now level with, and the next push's `before` is
+  // measured against it. A truncated run records it too — it did read the tree
+  // at that commit, and refusing to record would leave a repo that is simply
+  // too big permanently claiming a missed delivery on every push.
   const stampOp = getPrisma().classroom.update({
     where: { id: classroom.id },
-    data: { content_assets_synced_at: syncedAt },
+    data: { content_assets_synced_at: syncedAt, content_assets_synced_commit: commit },
   });
 
   const operations = entries.map(entry => upsertOp(classroom.id, entry, syncedAt));
@@ -298,7 +328,8 @@ async function fullSync(classroom: ResolvedClassroom): Promise<SyncContentAssets
  */
 async function incrementalSync(
   classroom: ResolvedClassroom,
-  changes: ContentAssetChanges
+  changes: ContentAssetChanges,
+  after: string | null
 ): Promise<SyncContentAssetsResult> {
   const removed = unique(changes.removed ?? []);
   const touched = unique([...(changes.added ?? []), ...(changes.modified ?? [])]);
@@ -351,7 +382,24 @@ async function incrementalSync(
   const syncedAt = new Date();
   const operations = entries.map(entry => upsertOp(classroom.id, entry, syncedAt));
 
+  // The commit this diff lands the map on — and ONLY the commit. The freshness
+  // timestamp deliberately stays untouched (see `ensureContentAssets`): this run
+  // applied the paths one push named and knows nothing about the rest of the
+  // repo, so it may not suppress the daily full refresh. It may, however, say
+  // which commit the map is now level with, which is what lets the NEXT push
+  // notice a delivery that went missing. Inside the transaction, so a failed
+  // apply does not claim a commit it never applied.
+  const commitOps = after
+    ? [
+        getPrisma().classroom.update({
+          where: { id: classroom.id },
+          data: { content_assets_synced_commit: after },
+        }),
+      ]
+    : [];
+
   const results = await getPrisma().$transaction([
+    ...commitOps,
     ...operations,
     getPrisma().contentAsset.deleteMany({
       where: { classroom_id: classroom.id, path: { in: toDelete } },
@@ -381,6 +429,9 @@ function touchesThemes(changes: ContentAssetChanges): boolean {
  * change under `.slidesthemes/` escalates back to full regardless, because a
  * theme is addressed by its tree SHA and no per-file update can produce one.
  * Pass `full: true` to force the full path even when `changes` is present.
+ *
+ * A push that does not build on the commit the map is level with escalates too
+ * — see `missedDelivery`.
  */
 export async function syncContentAssets(
   classroomId: string,
@@ -388,9 +439,45 @@ export async function syncContentAssets(
 ): Promise<SyncContentAssetsResult> {
   const classroom = await resolveClassroom(classroomId);
 
-  const goFull = opts.full === true || !opts.changes || touchesThemes(opts.changes);
+  const missed = missedDelivery(classroom, opts.before);
+  if (missed) {
+    // Loud, because it is the only evidence that deliveries are being lost. One
+    // line is a hiccup; the same classroom every day is a webhook that needs
+    // looking at, and a map that has been running on the nightly sweep.
+    console.warn(
+      `[contentAssets] Push for ${classroomId} builds on ${opts.before}, but the map is level ` +
+        `with ${classroom.syncedCommit} — a delivery was missed. Escalating to a full sync.`
+    );
+  }
 
-  return goFull ? fullSync(classroom) : incrementalSync(classroom, opts.changes!);
+  const goFull = opts.full === true || !opts.changes || touchesThemes(opts.changes) || missed;
+
+  return goFull
+    ? fullSync(classroom)
+    : incrementalSync(classroom, opts.changes!, opts.after ?? null);
+}
+
+/**
+ * Did the repo move without the map seeing it?
+ *
+ * A push webhook names the commit it built ON as well as the one it landed. If
+ * that parent is not the commit the map was last brought level with, some push
+ * in between never reached us — a dropped delivery, hook-station down, an App
+ * install that finished after the first push — and the diff in hand is a diff
+ * against a state the map does not hold. Applying it converges on nothing: the
+ * paths the missing push added stay absent, the ones it deleted stay behind as
+ * rows the renderer will happily sign 404s for, and the whole thing looks
+ * perfectly healthy until the nightly sweep happens to run.
+ *
+ * BOTH sides have to be present. A null stored commit is a classroom that has
+ * never synced, which is not a gap — there is no chain yet — and every classroom
+ * in the table starts there, so counting it would make the first push after this
+ * shipped a full sync for all of them at once. A push with no `before` is a
+ * caller that cannot answer the question (a manual or TTL run), and silence is
+ * not evidence.
+ */
+function missedDelivery(classroom: ResolvedClassroom, before: string | null | undefined): boolean {
+  return Boolean(before && classroom.syncedCommit && before !== classroom.syncedCommit);
 }
 
 /**

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -389,11 +389,25 @@ async function incrementalSync(
   // which commit the map is now level with, which is what lets the NEXT push
   // notice a delivery that went missing. Inside the transaction, so a failed
   // apply does not claim a commit it never applied.
-  const commitOps = after
+  //
+  // A COMPARE-AND-SWAP, not a write: `updateMany` matched on the commit this
+  // run read, so it lands only if nothing moved the classroom in between.
+  // Deliveries for one classroom are meant to run one at a time (the sync task
+  // carries a per-classroom concurrency key), but a Trigger retry, a manual
+  // sync, or a render-path `ensureContentAssets` can still overlap — and a
+  // blind write from the slower of two runs would move the map's commit
+  // BACKWARDS, which reads as a missed delivery on the next push at best and
+  // hides a real one at worst.
+  //
+  // Suppressed entirely when the listing was truncated: the run could not apply
+  // the deletions it inferred, so the map is not level with `after` and must not
+  // say it is.
+  const casCommit = after && !truncated ? after : null;
+  const commitOps = casCommit
     ? [
-        getPrisma().classroom.update({
-          where: { id: classroom.id },
-          data: { content_assets_synced_commit: after },
+        getPrisma().classroom.updateMany({
+          where: { id: classroom.id, content_assets_synced_commit: classroom.syncedCommit },
+          data: { content_assets_synced_commit: casCommit },
         }),
       ]
     : [];
@@ -405,6 +419,18 @@ async function incrementalSync(
       where: { classroom_id: classroom.id, path: { in: toDelete } },
     }),
   ]);
+
+  if (casCommit && (results[0] as { count: number }).count === 0) {
+    // Lost the race. The ROWS this run wrote are still correct — they are
+    // content-addressed and idempotent — so only the commit claim is dropped.
+    // Whoever won recorded a commit this run cannot vouch for, and the next
+    // push's `before` will not match it, which escalates to a full tree read.
+    // That is the repair, and it is the one the mismatch path already runs.
+    console.warn(
+      `[contentAssets] Concurrent sync for ${classroom.id} moved the map past ` +
+        `${classroom.syncedCommit}; not recording ${casCommit}. The next push escalates.`
+    );
+  }
 
   // Same positional coupling as fullSync: the delete is appended last.
   const deleted = (results.at(-1) as { count: number }).count;
@@ -431,7 +457,8 @@ function touchesThemes(changes: ContentAssetChanges): boolean {
  * Pass `full: true` to force the full path even when `changes` is present.
  *
  * A push that does not build on the commit the map is level with escalates too
- * — see `missedDelivery`.
+ * — see `missedDelivery` — as does the FIRST push for a classroom whose tree
+ * has never been read.
  */
 export async function syncContentAssets(
   classroomId: string,
@@ -450,7 +477,15 @@ export async function syncContentAssets(
     );
   }
 
-  const goFull = opts.full === true || !opts.changes || touchesThemes(opts.changes) || missed;
+  // A classroom with no recorded commit has never had its whole tree read, and
+  // a diff cannot build a map out of nothing: applying one push's paths would
+  // leave every file the push did not touch missing, and then RECORD that
+  // half-map as level with `after` — so the chain starts from a state that was
+  // never true and the gap never shows up again. The first sync reads the tree.
+  const firstSync = Boolean(opts.changes) && !classroom.syncedCommit;
+
+  const goFull =
+    opts.full === true || !opts.changes || touchesThemes(opts.changes) || missed || firstSync;
 
   return goFull
     ? fullSync(classroom)
@@ -700,6 +735,40 @@ export async function lookupContentTree(
     where: { classroom_id: classroomId, path: normalized, type: 'tree' },
     select: { sha: true, type: true, size: true },
   });
+}
+
+/**
+ * Many SHAs → a path holding each, in ONE query.
+ *
+ * The batch form of `lookupContentAssetBySha`, and it exists for the same
+ * reason `lookupContentAssets` does: an import rewrites a whole classroom's
+ * worth of content at once, and resolving each signed URL on its own was a
+ * round trip per image per page. SHAs the map has never heard of are simply
+ * absent from the returned map.
+ *
+ * Where two paths share a SHA the winner is the lowest path, matching the
+ * single-SHA lookup's `orderBy` — content-addressed means they are
+ * byte-identical, so the choice cannot be wrong, only arbitrary, and pinning it
+ * keeps repeated imports of the same content producing the same output.
+ */
+export async function lookupContentAssetsBySha(
+  classroomId: string,
+  shas: string[]
+): Promise<Map<string, string>> {
+  const wanted = [...new Set(shas)];
+  if (wanted.length === 0) return new Map();
+
+  const rows = await getPrisma().contentAsset.findMany({
+    where: { classroom_id: classroomId, sha: { in: wanted } },
+    select: { path: true, sha: true },
+    orderBy: { path: 'asc' },
+  });
+
+  const bySha = new Map<string, string>();
+  for (const row of rows as { path: string; sha: string }[]) {
+    if (!bySha.has(row.sha)) bySha.set(row.sha, row.path);
+  }
+  return bySha;
 }
 
 /**

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -214,6 +214,16 @@ function upsertOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
  * deleted. Doing it this way rather than diffing means the sweep is correct
  * even when the previous state was partial, wrong, or absent.
  *
+ * The stamp is taken BEFORE the tree is read, and that ordering is the whole
+ * safety of the sweep. Reading a repo's tree is a network round trip — often
+ * hundreds of milliseconds, sometimes seconds — and `recordContentAsset` writes
+ * a row for a just-uploaded file stamped `now`. Stamping AFTER the read puts
+ * this run's stamp ahead of that row, and `synced_at < syncedAt` then deletes
+ * it: the file is genuinely in the repo, it is simply newer than the snapshot
+ * this run read, and the teacher who just uploaded it watches it render as a
+ * dangling URL. Stamping first can only ever leave a row the sweep keeps, which
+ * is the same too-large-map trade the truncated case takes below.
+ *
  * The whole thing is ONE transaction: a half-applied sync would leave the map
  * claiming paths at SHAs that never coexisted, and a reader cannot tell that
  * from a good map. All-or-nothing means a failure leaves the previous map
@@ -237,8 +247,10 @@ function upsertOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
  * into a permanent re-sync loop against a repo that is simply too big.
  */
 async function fullSync(classroom: ResolvedClassroom): Promise<SyncContentAssetsResult> {
-  const { entries, truncated } = await readRepoTree(classroom);
+  // Before the read, not after — see the header. A row written while the tree
+  // is in flight must stamp ABOVE this run, or the sweep deletes it.
   const syncedAt = new Date();
+  const { entries, truncated } = await readRepoTree(classroom);
 
   // FIRST, not last. The sweep's count is read off the tail of the results, so
   // the stamp goes in front of the upserts rather than after the delete.

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -27,8 +27,6 @@ import { getGitProvider } from '../git/index.ts';
  *     for vanished paths go away.
  */
 
-const DEFAULT_BRANCH = 'main';
-
 /**
  * Above this many changed paths, one tree call beats N per-path reads.
  *
@@ -147,14 +145,36 @@ interface TreeEntry {
   size?: number;
 }
 
+/**
+ * The branch a classroom's content repo actually serves.
+ *
+ * Asked, never assumed. A course imported from an older org is on `master`, and
+ * against such a repo a hardcoded `main` does not read stale content — the tree
+ * call 404s, the sync throws, and the classroom keeps an empty map while every
+ * asset falls back to the legacy path. One `GET /repos` per sync buys the
+ * difference.
+ *
+ * Deliberately NOT memoised. A default branch can be renamed, the value is only
+ * ever read on the far side of a network call that dwarfs it, and a cache here
+ * would need invalidating from a place that has no idea this module exists.
+ */
+export async function resolveContentBranch(
+  gitOrganization: Parameters<typeof getGitProvider>[0],
+  org: string,
+  repo: string
+): Promise<string> {
+  return getGitProvider(gitOrganization).getDefaultBranch(org, repo);
+}
+
 async function readRepoTree(
   classroom: ResolvedClassroom
 ): Promise<{ entries: TreeEntry[]; truncated: boolean }> {
   const provider = getGitProvider(classroom.gitOrganization);
+  const branch = await provider.getDefaultBranch(classroom.org, classroom.content_repo);
   const tree = await provider.getTree(
     classroom.org,
     classroom.content_repo,
-    DEFAULT_BRANCH,
+    branch,
     /* recursive */ true
   );
 

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -21,7 +21,8 @@
 
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
-import { pagesContentBase, rawContentBase } from './contentRefs.ts';
+import { contentProxyBase, pagesContentBase } from './contentRefs.ts';
+import { lookupContentAssetBySha } from './contentAssets.service.ts';
 import { getGitProvider } from '../git/index.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import { createWithUniquePageSlug, ensureContentRepo, isPageSlugConflict } from './page.service.ts';
@@ -146,31 +147,221 @@ export interface UrlRewriteContext {
   targetRepo: string;
   /** This item's folder in the target repo (may carry a dedupe suffix). */
   targetPath: string;
+  /**
+   * Signed-blob sha → the SOURCE repo path holding it, from the source
+   * classroom's asset map. The only way back from `/c/{id}/blob/{sha}.{ext}`,
+   * which names content and not location. Absent shas are left verbatim and
+   * warned about — see `rewriteSignedUrls`.
+   */
+  shaPaths?: ReadonlyMap<string, string>;
+  /** Where an unresolvable signed URL is reported. Defaults to console.warn. */
+  onWarn?: (detail: string) => void;
+}
+
+const RAW_HOST = 'https://raw.githubusercontent.com';
+
+/** `.slidesthemes/{theme}` — where a signed theme URL's bytes actually live. */
+const THEMES_FOLDER = '.slidesthemes';
+
+/**
+ * Every reference shape the app has ever stored, and what a copy must do to it.
+ *
+ * Content is authored across years and surfaces, so one page's `content.json`
+ * can hold all of these at once:
+ *
+ *   1. `raw.githubusercontent.com/{login}/{repo}/{branch}/{path}` — on ANY
+ *      branch, not just `main`; a repo whose default is `master`, or content
+ *      hand-authored against a working branch, writes something else.
+ *   2. `{login}.github.io/{repo}/{path}` — the Pages CDN.
+ *   3. `/content/{login}/{repo}/{path}` — the slides app's same-origin proxy.
+ *   4. A BARE repo path (`pages/lab-1/assets/d.png`) — what pages store now
+ *      that the delivery layer signs at render time, so it is the shape most
+ *      new content is in.
+ *   5. One of OUR signed URLs — `/c/{classroomId}/blob/…`, `/theme/…`,
+ *      `/missing/…`.
+ *
+ * The first four are the same thing with different prefixes: swap the source
+ * repo's prefix for the target's. The fifth cannot be copied at all. A signed
+ * URL is bound to the SOURCE classroom's id and key version, and the imported
+ * copy renders under a different classroom — so copying one verbatim produces a
+ * link that is not stale, it is permanently unauthorized, and the image is gone
+ * the moment anyone loads the page. They are turned back into repo paths
+ * instead, and the target classroom signs them itself on its next render.
+ *
+ * Order matters. Signed URLs resolve to bare SOURCE paths first, so the
+ * item-specific folder rewrite below then carries them onto the target's
+ * (possibly dedupe-suffixed) folder like any other bare path. Within each
+ * shape the item-specific rewrite runs before the repo-general one, which
+ * catches cross-item references — those keep their original folder, correct
+ * whenever that item was imported un-renamed; a renamed cross-referenced item
+ * is a documented residual.
+ */
+export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string {
+  const rawSourcePrefix = `${RAW_HOST}/${ctx.sourceLogin}/${ctx.sourceRepo}/`;
+  const rawTargetPrefix = `${RAW_HOST}/${ctx.targetLogin}/${ctx.targetRepo}/`;
+
+  const withPaths = rewriteSignedUrls(text, ctx);
+
+  // Branch-agnostic: the branch segment is consumed positionally and carried
+  // across unchanged. Normalizing it would mean guessing the TARGET repo's
+  // default branch, which nothing here knows, and `main` is exactly the guess
+  // that broke this in the first place.
+  const prefixed = rewriteRawUrls(withPaths, rawSourcePrefix, rawTargetPrefix, ctx);
+
+  const bases: [string, string][] = [
+    [
+      pagesContentBase(ctx.sourceLogin, ctx.sourceRepo),
+      pagesContentBase(ctx.targetLogin, ctx.targetRepo),
+    ],
+    [
+      contentProxyBase(ctx.sourceLogin, ctx.sourceRepo),
+      contentProxyBase(ctx.targetLogin, ctx.targetRepo),
+    ],
+  ];
+
+  const rewritten = bases.reduce(
+    (acc, [sourceBase, targetBase]) =>
+      acc
+        .replaceAll(`${sourceBase}/${ctx.sourcePath}/`, `${targetBase}/${ctx.targetPath}/`)
+        .replaceAll(`${sourceBase}/`, `${targetBase}/`),
+    prefixed
+  );
+
+  return rewriteBarePaths(rewritten, ctx);
+}
+
+/** The raw shape, on whatever branch the reference happens to name. */
+function rewriteRawUrls(
+  text: string,
+  sourcePrefix: string,
+  targetPrefix: string,
+  ctx: UrlRewriteContext
+): string {
+  // `[^/\s"'()<>]+` is the branch segment — one path segment, whatever it is
+  // called — and the rest is the repo path, matched non-greedily up to the
+  // first delimiter so surrounding markup or JSON is never swallowed.
+  const pattern = new RegExp(`${escapeRegExp(sourcePrefix)}([^/\\s"'()<>]+)/([^\\s"'()<>]*)`, 'g');
+  const itemPrefix = ctx.sourcePath ? `${ctx.sourcePath}/` : '';
+
+  return text.replace(pattern, (_match, branch: string, repoPath: string) => {
+    const mapped =
+      itemPrefix && repoPath.startsWith(itemPrefix)
+        ? `${ctx.targetPath}/${repoPath.slice(itemPrefix.length)}`
+        : repoPath;
+    return `${targetPrefix}${branch}/${mapped}`;
+  });
 }
 
 /**
- * Rewrite absolute source-repo URLs inside copied text content so imported
- * pages/decks reference THEIR OWN copied assets instead of the source repo —
- * without this, deleting the source classroom (with GitHub cleanup) 404s every
- * image in the imported content. Handles both URL shapes the app emits:
- * raw.githubusercontent.com and the {login}.github.io Pages CDN.
+ * A bare repo path under THIS item's folder → the same path under the target's.
  *
- * Order matters: the item-specific folder rewrite runs first (it may carry a
- * dedupe suffix), then the repo-general rewrite catches cross-item references
- * (which keep their original folder path — correct whenever that item was
- * imported un-renamed; a renamed cross-referenced item is a documented
- * residual).
+ * Anchored on a value boundary — a quote, a bracket, whitespace, start of text
+ * — and never mid-string. A blanket replace would reach inside an unrelated
+ * org's absolute URL that happens to contain the same folder name and corrupt
+ * it, and the absolute shapes above have already handled every occurrence that
+ * legitimately belongs to this repo.
+ *
+ * Skipped when the item's folder does not move: a whole-repo clone copies every
+ * path unchanged and passes an empty `sourcePath`, where a prefix rewrite is
+ * meaningless.
  */
-export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string {
-  const rawSource = rawContentBase(ctx.sourceLogin, ctx.sourceRepo);
-  const rawTarget = rawContentBase(ctx.targetLogin, ctx.targetRepo);
-  const pagesSource = pagesContentBase(ctx.sourceLogin, ctx.sourceRepo);
-  const pagesTarget = pagesContentBase(ctx.targetLogin, ctx.targetRepo);
-  return text
-    .replaceAll(`${rawSource}/${ctx.sourcePath}/`, `${rawTarget}/${ctx.targetPath}/`)
-    .replaceAll(`${rawSource}/`, `${rawTarget}/`)
-    .replaceAll(`${pagesSource}/${ctx.sourcePath}/`, `${pagesTarget}/${ctx.targetPath}/`)
-    .replaceAll(`${pagesSource}/`, `${pagesTarget}/`);
+function rewriteBarePaths(text: string, ctx: UrlRewriteContext): string {
+  if (!ctx.sourcePath || ctx.sourcePath === ctx.targetPath) return text;
+
+  const pattern = new RegExp(`(^|["'(\\s=,>])${escapeRegExp(ctx.sourcePath)}/`, 'g');
+  return text.replace(pattern, (_match, lead: string) => `${lead}${ctx.targetPath}/`);
+}
+
+/**
+ * `/c/{classroomId}/{blob|theme|missing}/…` — the shapes OUR delivery layer
+ * emits, matched by path rather than by host because the origin is deployment
+ * configuration and staging, production and local all differ.
+ */
+const SIGNED_URL_PATTERN =
+  /(?:https?:\/\/[^\s"'()<>]+)?\/c\/[0-9a-fA-F-]{8,36}\/(blob|theme|missing)\/([^\s"'()<>]*)/g;
+
+/** The signed-blob shas a piece of text references, for a map lookup. */
+export function collectSignedBlobShas(text: string): string[] {
+  const shas = new Set<string>();
+  for (const [, kind, tail] of text.matchAll(SIGNED_URL_PATTERN)) {
+    if (kind !== 'blob') continue;
+    const sha = blobShaOf(tail);
+    if (sha) shas.add(sha);
+  }
+  return [...shas];
+}
+
+/**
+ * Turn our own signed URLs back into bare SOURCE repo paths.
+ *
+ * Each kind knows a different amount about where its bytes live:
+ *
+ *   `missing` carries the original reference verbatim in its path — it is the
+ *   resolver saying "I could not find this", so the ref it could not find is
+ *   right there and needs only decoding.
+ *
+ *   `theme` names the theme, and a theme always lives at `.slidesthemes/{name}`
+ *   — derivable with no lookup at all.
+ *
+ *   `blob` names CONTENT, not location: a sha and an extension, deliberately,
+ *   because that is what lets the edge cache it forever. Only the source
+ *   classroom's asset map can say which path held it, so an unresolvable sha is
+ *   left exactly as it was and warned about. Leaving it is the lesser harm:
+ *   the URL is already broken in the copy, and inventing a path would put a
+ *   confidently wrong reference into content nobody will think to check.
+ */
+function rewriteSignedUrls(text: string, ctx: UrlRewriteContext): string {
+  const warn = ctx.onWarn ?? ((detail: string) => console.warn(`[contentImport] ${detail}`));
+
+  return text.replace(SIGNED_URL_PATTERN, (match, kind: string, tail: string) => {
+    if (kind === 'missing') {
+      return decodePathOnce(stripQuery(tail)) || match;
+    }
+
+    if (kind === 'theme') {
+      // `{theme}/{treeSha}/{policy}/{rest}` — the first segment is the theme,
+      // the next two are addressing and authorization, and anything after them
+      // is the path inside the folder.
+      const [theme, , , ...rest] = stripQuery(tail).split('/');
+      if (!theme) return match;
+      const inside = rest.filter(Boolean).join('/');
+      return inside ? `${THEMES_FOLDER}/${theme}/${inside}` : `${THEMES_FOLDER}/${theme}`;
+    }
+
+    const sha = blobShaOf(tail);
+    const path = sha ? ctx.shaPaths?.get(sha) : undefined;
+    if (path) return path;
+
+    warn(
+      `left a signed URL unrewritten — the source classroom's asset map has no path for ` +
+        `${sha ?? 'an unreadable sha'}; the imported copy will not load it`
+    );
+    return match;
+  });
+}
+
+/** `{sha}.{ext}` (plus any query) → the sha, or null if it is not one. */
+function blobShaOf(tail: string): string | null {
+  const name = stripQuery(tail).split('/')[0] ?? '';
+  const sha = name.slice(0, name.indexOf('.') === -1 ? name.length : name.indexOf('.'));
+  return /^[0-9a-f]{40}$/i.test(sha) ? sha.toLowerCase() : null;
+}
+
+function stripQuery(value: string): string {
+  const cut = value.search(/[?#]/);
+  return cut === -1 ? value : value.slice(0, cut);
+}
+
+function decodePathOnce(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -331,6 +522,48 @@ interface StagedItem<Source> {
   targetTitle: string;
   targetSlug: string;
   targetContentPath: string;
+  /** Source-map paths for the signed blobs this item references — see below. */
+  shaPaths: ReadonlyMap<string, string>;
+}
+
+/**
+ * Resolve the signed-blob shas in some text back to SOURCE repo paths.
+ *
+ * A signed URL names content (a sha), not location, so the only way to recover
+ * a path is the source classroom's own asset map. Resolved here, in the import,
+ * because the rewriter itself is pure — it is called from a Trigger task and
+ * from a local clone helper, neither of which should acquire a database.
+ *
+ * Best effort throughout: a sha the map has never heard of simply stays out of
+ * the map, and the rewriter leaves that URL alone and warns. An import must not
+ * fail over a reference it could not tidy up.
+ */
+async function resolveShaPaths(
+  classroomId: string,
+  texts: string[]
+): Promise<ReadonlyMap<string, string>> {
+  const shas = new Set(texts.flatMap(text => collectSignedBlobShas(text)));
+  if (shas.size === 0) return new Map();
+
+  const found = await Promise.all(
+    [...shas].map(async sha => {
+      try {
+        const row = await lookupContentAssetBySha(classroomId, sha);
+        return row ? ([sha, row.path] as [string, string]) : null;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return new Map(found.filter((pair): pair is [string, string] => pair !== null));
+}
+
+/** The decoded text of every rewritable file in a staged batch. */
+function stagedTexts(files: BatchFile[]): string[] {
+  return files
+    .filter(file => isTextContentPath(file.path))
+    .map(file => Buffer.from(file.content, 'base64').toString('utf8'));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -540,8 +773,14 @@ async function importPages({
         warn('pages', `skipped "${page.title}" — no files at ${page.content_path}`);
         continue;
       }
-      // Repoint absolute source-repo asset URLs at the copied files — otherwise
+      // Repoint source-repo asset references at the copied files — otherwise
       // deleting the source classroom (with GitHub cleanup) 404s every image.
+      // The header image goes into the same lookup: it is stored on the row
+      // rather than in the files, but it is the same repo and the same shapes.
+      const shaPaths = await resolveShaPaths(source.classroomId, [
+        ...stagedTexts(files),
+        page.header_image_url ?? '',
+      ]);
       files = rewriteStagedFiles(files, {
         sourceLogin: source.login,
         sourceRepo: source.repo,
@@ -549,8 +788,9 @@ async function importPages({
         targetLogin: target.login,
         targetRepo: target.repo,
         targetPath: targetContentPath,
+        shaPaths,
       });
-      staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath });
+      staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath, shaPaths });
     } finally {
       consumed++;
       emitProgress(onProgress, { kind: 'pages', done: consumed, total });
@@ -606,6 +846,7 @@ async function importPages({
                   targetLogin: target.login,
                   targetRepo: target.repo,
                   targetPath: item.targetContentPath,
+                  shaPaths: item.shaPaths,
                 })
               : item.source.header_image_url,
             header_image_position: item.source.header_image_position,
@@ -703,8 +944,9 @@ async function importSlides({
         warn('slides', `skipped "${slide.title}" — no files at ${slide.content_path}`);
         continue;
       }
-      // Repoint absolute source-repo asset URLs at the copied files (deck.json +
+      // Repoint source-repo asset references at the copied files (deck.json +
       // index.html are rewritten in lockstep, keeping the pair consistent).
+      const shaPaths = await resolveShaPaths(source.classroomId, stagedTexts(files));
       files = rewriteStagedFiles(files, {
         sourceLogin: source.login,
         sourceRepo: source.repo,
@@ -712,6 +954,7 @@ async function importSlides({
         targetLogin: target.login,
         targetRepo: target.repo,
         targetPath: targetContentPath,
+        shaPaths,
       });
       staged.push({
         source: slide,
@@ -719,6 +962,7 @@ async function importSlides({
         targetTitle: slide.title,
         targetSlug,
         targetContentPath,
+        shaPaths,
       });
     } finally {
       consumed++;

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -21,8 +21,8 @@
 
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
-import { contentProxyBase, pagesContentBase } from './contentRefs.ts';
-import { lookupContentAssetBySha } from './contentAssets.service.ts';
+import { contentProxyBase, isCommitRef, pagesContentBase, splitRawRef } from './contentRefs.ts';
+import { lookupContentAssetsBySha } from './contentAssets.service.ts';
 import { getGitProvider } from '../git/index.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import { createWithUniquePageSlug, ensureContentRepo, isPageSlugConflict } from './page.service.ts';
@@ -195,6 +195,18 @@ const THEMES_FOLDER = '.slidesthemes';
  * catches cross-item references — those keep their original folder, correct
  * whenever that item was imported un-renamed; a renamed cross-referenced item
  * is a documented residual.
+ *
+ * RESIDUALS this does not fix, and cannot from here:
+ *
+ *   - A recovered `/theme/` reference becomes `.slidesthemes/{name}`, which is
+ *     outside any item's `sourcePath` and so is carried across unchanged. It
+ *     resolves only if the TARGET repo already has a theme by that name —
+ *     shared themes are per-repo and an import copies pages and decks, not the
+ *     `.slidesthemes/` folder. A deck importing onto a repo without that theme
+ *     falls back to its own CSS, which is visible and fixable; inventing a
+ *     theme copy here would not be.
+ *   - A cross-item bare path (`pages/lab-9/…`) keeps its folder, for the same
+ *     reason and with the same caveat as the URL shapes above.
  */
 export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string {
   const rawSourcePrefix = `${RAW_HOST}/${ctx.sourceLogin}/${ctx.sourceRepo}/`;
@@ -230,25 +242,42 @@ export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string
   return rewriteBarePaths(rewritten, ctx);
 }
 
-/** The raw shape, on whatever branch the reference happens to name. */
+/**
+ * The raw shape, on whatever ref the reference happens to name.
+ *
+ * The ref is whatever `splitRawRef` says it is — including the fully-qualified
+ * `refs/heads/main` that GitHub's own Raw button emits, which is why this does
+ * not just take the first segment. Getting that wrong is not cosmetic: `refs`
+ * would be read as the branch, the item folder would never be recognized, and
+ * the copied page would point at `…/{target}/heads/main/pages/lab-1/…` — a path
+ * that exists in no repo at all.
+ *
+ * A COMMIT-pinned URL is left entirely alone, repo swap included. It asks for
+ * one exact historical revision, and that commit exists only in the SOURCE
+ * repo — a fresh import's target has none of its history. Pointing it at the
+ * target guarantees a 404, where leaving it at least resolves for as long as
+ * the source repo is around.
+ */
 function rewriteRawUrls(
   text: string,
   sourcePrefix: string,
   targetPrefix: string,
   ctx: UrlRewriteContext
 ): string {
-  // `[^/\s"'()<>]+` is the branch segment — one path segment, whatever it is
-  // called — and the rest is the repo path, matched non-greedily up to the
-  // first delimiter so surrounding markup or JSON is never swallowed.
-  const pattern = new RegExp(`${escapeRegExp(sourcePrefix)}([^/\\s"'()<>]+)/([^\\s"'()<>]*)`, 'g');
+  // Everything after the repo, up to the first delimiter, so surrounding markup
+  // or JSON is never swallowed; `splitRawRef` then separates ref from path.
+  const pattern = new RegExp(`${escapeRegExp(sourcePrefix)}([^\\s"'()<>]*)`, 'g');
   const itemPrefix = ctx.sourcePath ? `${ctx.sourcePath}/` : '';
 
-  return text.replace(pattern, (_match, branch: string, repoPath: string) => {
+  return text.replace(pattern, (match, rest: string) => {
+    const split = splitRawRef(rest);
+    if (!split || isCommitRef(split.ref)) return match;
+
     const mapped =
-      itemPrefix && repoPath.startsWith(itemPrefix)
-        ? `${ctx.targetPath}/${repoPath.slice(itemPrefix.length)}`
-        : repoPath;
-    return `${targetPrefix}${branch}/${mapped}`;
+      itemPrefix && split.path.startsWith(itemPrefix)
+        ? `${ctx.targetPath}/${split.path.slice(itemPrefix.length)}`
+        : split.path;
+    return `${targetPrefix}${split.ref}/${mapped}`;
   });
 }
 
@@ -268,7 +297,10 @@ function rewriteRawUrls(
 function rewriteBarePaths(text: string, ctx: UrlRewriteContext): string {
   if (!ctx.sourcePath || ctx.sourcePath === ctx.targetPath) return text;
 
-  const pattern = new RegExp(`(^|["'(\\s=,>])${escapeRegExp(ctx.sourcePath)}/`, 'g');
+  // `=` and `,` are deliberately NOT boundaries: a foreign URL's query string
+  // (`?src=pages/lab-1/a.png`) would otherwise be rewritten inside a link this
+  // import has no business touching.
+  const pattern = new RegExp(`(^|["'(\\s>])${escapeRegExp(ctx.sourcePath)}/`, 'g');
   return text.replace(pattern, (_match, lead: string) => `${lead}${ctx.targetPath}/`);
 }
 
@@ -276,6 +308,12 @@ function rewriteBarePaths(text: string, ctx: UrlRewriteContext): string {
  * `/c/{classroomId}/{blob|theme|missing}/…` — the shapes OUR delivery layer
  * emits, matched by path rather than by host because the origin is deployment
  * configuration and staging, production and local all differ.
+ *
+ * The classroom-id class assumes a UUID (hex and dashes). `Classroom.id` is
+ * `@default(uuid())` and has been since the model existed; if that ever changes
+ * to a slug or a cuid, this stops matching and signed URLs start being copied
+ * verbatim again — silently, since a non-match is indistinguishable from
+ * ordinary text.
  */
 const SIGNED_URL_PATTERN =
   /(?:https?:\/\/[^\s"'()<>]+)?\/c\/[0-9a-fA-F-]{8,36}\/(blob|theme|missing)\/([^\s"'()<>]*)/g;
@@ -365,17 +403,46 @@ function escapeRegExp(value: string): string {
 }
 
 /**
+ * A staged write alongside its decoded text, so the utf8 round trip happens
+ * once.
+ *
+ * The import needs to READ every text file before it rewrites any of them — the
+ * signed-blob shas across the whole batch are resolved in a single query — and
+ * decoding in both passes meant base64-decoding a course's entire content
+ * twice. `text` is null for binaries, which are never decoded at all: their
+ * bytes are not valid utf8 and a round trip would replace them with U+FFFD.
+ */
+export interface DecodedFile {
+  file: BatchFile;
+  text: string | null;
+}
+
+/** Decode the text files of a staged batch; binaries carry a null text. */
+export function decodeStagedFiles(files: BatchFile[]): DecodedFile[] {
+  return files.map(file => ({
+    file,
+    text: isTextContentPath(file.path)
+      ? Buffer.from(file.content, 'base64').toString('utf8')
+      : null,
+  }));
+}
+
+/** Rewrite already-decoded staged files; binaries pass through untouched. */
+export function rewriteDecodedFiles(decoded: DecodedFile[], ctx: UrlRewriteContext): BatchFile[] {
+  return decoded.map(({ file, text }) => {
+    if (text === null) return file;
+    const rewritten = rewriteContentUrls(text, ctx);
+    if (rewritten === text) return file;
+    return { ...file, content: Buffer.from(rewritten, 'utf8').toString('base64') };
+  });
+}
+
+/**
  * Apply `rewriteContentUrls` to the text files in a staged item's writes
  * (base64-decoded, rewritten, re-encoded); binaries pass through untouched.
  */
 export function rewriteStagedFiles(files: BatchFile[], ctx: UrlRewriteContext): BatchFile[] {
-  return files.map(file => {
-    if (!isTextContentPath(file.path)) return file;
-    const decoded = Buffer.from(file.content, 'base64').toString('utf8');
-    const rewritten = rewriteContentUrls(decoded, ctx);
-    if (rewritten === decoded) return file;
-    return { ...file, content: Buffer.from(rewritten, 'utf8').toString('base64') };
-  });
+  return rewriteDecodedFiles(decodeStagedFiles(files), ctx);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -518,52 +585,48 @@ async function collectFolderFiles({
 /** A source content row staged for import after its files were read. */
 interface StagedItem<Source> {
   source: Source;
-  files: BatchFile[];
+  files: DecodedFile[];
   targetTitle: string;
   targetSlug: string;
   targetContentPath: string;
-  /** Source-map paths for the signed blobs this item references — see below. */
-  shaPaths: ReadonlyMap<string, string>;
 }
 
 /**
- * Resolve the signed-blob shas in some text back to SOURCE repo paths.
+ * Resolve every signed-blob sha an import references back to SOURCE repo paths,
+ * in one query for the whole run.
  *
  * A signed URL names content (a sha), not location, so the only way to recover
  * a path is the source classroom's own asset map. Resolved here, in the import,
  * because the rewriter itself is pure — it is called from a Trigger task and
  * from a local clone helper, neither of which should acquire a database.
  *
+ * ONE query, for the whole batch, once. Per-sha lookups inside the staging loop
+ * made this a round trip per image per page, on the code path whose entire job
+ * is copying a course's worth of images.
+ *
  * Best effort throughout: a sha the map has never heard of simply stays out of
  * the map, and the rewriter leaves that URL alone and warns. An import must not
  * fail over a reference it could not tidy up.
  */
-async function resolveShaPaths(
+export async function resolveShaPaths(
   classroomId: string,
   texts: string[]
 ): Promise<ReadonlyMap<string, string>> {
-  const shas = new Set(texts.flatMap(text => collectSignedBlobShas(text)));
-  if (shas.size === 0) return new Map();
+  const shas = [...new Set(texts.flatMap(text => collectSignedBlobShas(text)))];
+  if (shas.length === 0) return new Map();
 
-  const found = await Promise.all(
-    [...shas].map(async sha => {
-      try {
-        const row = await lookupContentAssetBySha(classroomId, sha);
-        return row ? ([sha, row.path] as [string, string]) : null;
-      } catch {
-        return null;
-      }
-    })
-  );
-
-  return new Map(found.filter((pair): pair is [string, string] => pair !== null));
+  try {
+    return await lookupContentAssetsBySha(classroomId, shas);
+  } catch {
+    return new Map();
+  }
 }
 
-/** The decoded text of every rewritable file in a staged batch. */
-function stagedTexts(files: BatchFile[]): string[] {
-  return files
-    .filter(file => isTextContentPath(file.path))
-    .map(file => Buffer.from(file.content, 'base64').toString('utf8'));
+/** Every decoded text a staged item carries, for the sha sweep. */
+function stagedTexts<Source>(items: StagedItem<Source>[]): string[] {
+  return items.flatMap(item =>
+    item.files.map(file => file.text).filter((text): text is string => text !== null)
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -773,24 +836,16 @@ async function importPages({
         warn('pages', `skipped "${page.title}" — no files at ${page.content_path}`);
         continue;
       }
-      // Repoint source-repo asset references at the copied files — otherwise
-      // deleting the source classroom (with GitHub cleanup) 404s every image.
-      // The header image goes into the same lookup: it is stored on the row
-      // rather than in the files, but it is the same repo and the same shapes.
-      const shaPaths = await resolveShaPaths(source.classroomId, [
-        ...stagedTexts(files),
-        page.header_image_url ?? '',
-      ]);
-      files = rewriteStagedFiles(files, {
-        sourceLogin: source.login,
-        sourceRepo: source.repo,
-        sourcePath: page.content_path,
-        targetLogin: target.login,
-        targetRepo: target.repo,
-        targetPath: targetContentPath,
-        shaPaths,
+      // Staged DECODED and un-rewritten. The rewrite needs the signed-blob
+      // shas of the whole batch resolved first, and that is one query for the
+      // run rather than one per page — see resolveShaPaths.
+      staged.push({
+        source: page,
+        files: decodeStagedFiles(files),
+        targetTitle,
+        targetSlug,
+        targetContentPath,
       });
-      staged.push({ source: page, files, targetTitle, targetSlug, targetContentPath, shaPaths });
     } finally {
       consumed++;
       emitProgress(onProgress, { kind: 'pages', done: consumed, total });
@@ -799,12 +854,34 @@ async function importPages({
 
   if (staged.length === 0) return 0;
 
+  // Repoint source-repo asset references at the copied files — otherwise
+  // deleting the source classroom (with GitHub cleanup) 404s every image. The
+  // header images go into the same sweep: they are stored on the row rather
+  // than in the files, but they are the same repo and the same shapes.
+  const shaPaths = await resolveShaPaths(source.classroomId, [
+    ...stagedTexts(staged),
+    ...staged.map(item => item.source.header_image_url ?? ''),
+  ]);
+
+  const written = staged.map(item => ({
+    item,
+    files: rewriteDecodedFiles(item.files, {
+      sourceLogin: source.login,
+      sourceRepo: source.repo,
+      sourcePath: item.source.content_path,
+      targetLogin: target.login,
+      targetRepo: target.repo,
+      targetPath: item.targetContentPath,
+      shaPaths,
+    }),
+  }));
+
   // ONE commit for all page files.
   try {
     await ContentService.uploadBatch({
       gitOrganization: target.gitOrganization,
       repo: target.repo,
-      files: staged.flatMap(s => s.files),
+      files: written.flatMap(w => w.files),
       branch: 'main',
       message: commitMessage,
     });
@@ -846,7 +923,7 @@ async function importPages({
                   targetLogin: target.login,
                   targetRepo: target.repo,
                   targetPath: item.targetContentPath,
-                  shaPaths: item.shaPaths,
+                  shaPaths,
                 })
               : item.source.header_image_url,
             header_image_position: item.source.header_image_position,
@@ -944,25 +1021,14 @@ async function importSlides({
         warn('slides', `skipped "${slide.title}" — no files at ${slide.content_path}`);
         continue;
       }
-      // Repoint source-repo asset references at the copied files (deck.json +
-      // index.html are rewritten in lockstep, keeping the pair consistent).
-      const shaPaths = await resolveShaPaths(source.classroomId, stagedTexts(files));
-      files = rewriteStagedFiles(files, {
-        sourceLogin: source.login,
-        sourceRepo: source.repo,
-        sourcePath: slide.content_path,
-        targetLogin: target.login,
-        targetRepo: target.repo,
-        targetPath: targetContentPath,
-        shaPaths,
-      });
+      // Staged DECODED and un-rewritten — the whole batch's signed-blob shas
+      // resolve in one query below, not one per deck.
       staged.push({
         source: slide,
-        files,
+        files: decodeStagedFiles(files),
         targetTitle: slide.title,
         targetSlug,
         targetContentPath,
-        shaPaths,
       });
     } finally {
       consumed++;
@@ -972,13 +1038,29 @@ async function importSlides({
 
   if (staged.length === 0) return 0;
 
+  // Repoint source-repo asset references at the copied files (deck.json +
+  // index.html are rewritten in lockstep, keeping the pair consistent).
+  const shaPaths = await resolveShaPaths(source.classroomId, stagedTexts(staged));
+
+  const files = staged.flatMap(item =>
+    rewriteDecodedFiles(item.files, {
+      sourceLogin: source.login,
+      sourceRepo: source.repo,
+      sourcePath: item.source.content_path,
+      targetLogin: target.login,
+      targetRepo: target.repo,
+      targetPath: item.targetContentPath,
+      shaPaths,
+    })
+  );
+
   // ONE commit for all slide files (deck.json + generated index.html copied
   // verbatim — never regenerated).
   try {
     await ContentService.uploadBatch({
       gitOrganization: target.gitOrganization,
       repo: target.repo,
-      files: staged.flatMap(s => s.files),
+      files,
       branch: 'main',
       message: commitMessage,
     });

--- a/packages/services/src/classmoji/contentRefs.ts
+++ b/packages/services/src/classmoji/contentRefs.ts
@@ -29,6 +29,45 @@ export function contentProxyBase(login: string, repo: string): string {
   return `/content/${login}/${repo}`;
 }
 
+/**
+ * A commit-pinned ref: 40 hex characters where a branch name would be.
+ *
+ * These are not references to "the current file", they are references to one
+ * exact historical version, and every caller here has to leave them alone for
+ * its own reason. The delivery resolver must not turn one into a repo path,
+ * because the map holds the DEFAULT BRANCH's content and serving that would
+ * quietly hand back today's bytes for a URL that asked for a specific old
+ * revision. The import rewriter must not repoint one at the target repo,
+ * because that commit does not exist there and never will.
+ */
+export function isCommitRef(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+/**
+ * Split `{ref}/{path}` off the tail of a raw URL, where the ref may be
+ * fully qualified.
+ *
+ * GitHub's own "Raw" button emits `refs/heads/main/...`, not `main/...`, and
+ * the two are the same URL. Consuming ONE segment as the ref against the
+ * qualified form leaves `ref: 'refs'` and a path of `heads/main/pages/…` — a
+ * path no repo has, so the resolver misses it and the rewriter carries the
+ * item folder across unremapped. Tags (`refs/tags/v1`) arrive the same way.
+ *
+ * Returns null when there is no path after the ref, which is not a file
+ * reference at all.
+ */
+export function splitRawRef(rest: string): { ref: string; path: string } | null {
+  const qualified = /^(refs\/(?:heads|tags)\/[^/]+)\/(.+)$/.exec(rest);
+  if (qualified) {
+    return { ref: qualified[1], path: qualified[2] };
+  }
+
+  const slash = rest.indexOf('/');
+  if (slash <= 0) return null;
+  return { ref: rest.slice(0, slash), path: rest.slice(slash + 1) };
+}
+
 /** Everything after the first `?` or `#` — never part of a repo path. */
 function stripUrlTail(value: string): string {
   const cut = value.search(/[?#]/);
@@ -49,10 +88,10 @@ function decodePathOnce(path: string): string {
  *
  * Null is the answer for every external URL, every other classroom's repo, and
  * every `data:` — the caller leaves those exactly as it found them. The raw
- * shape is matched branch-agnostically (the rewriter only ever writes `main`,
- * but content imported or hand-authored elsewhere may name another branch),
- * which is why the branch segment is consumed positionally rather than by
- * comparing against a fixed prefix.
+ * shape is matched branch-agnostically (content imported or hand-authored
+ * elsewhere may name any branch), which is why the ref is consumed positionally
+ * rather than by comparing against a fixed prefix. A COMMIT-pinned raw URL is
+ * deliberately not a match: see `isCommitRef`.
  */
 export function extractOwnRepoPath(urlOrRef: string, login: string, repo: string): string | null {
   if (typeof urlOrRef !== 'string' || urlOrRef.length === 0) return null;
@@ -71,11 +110,11 @@ export function extractOwnRepoPath(urlOrRef: string, login: string, repo: string
 
   const rawPrefix = `${RAW_HOST}/${login}/${repo}/`;
   if (bare.startsWith(rawPrefix)) {
-    // The next segment is the branch/ref, whatever it is called.
-    const rest = bare.slice(rawPrefix.length);
-    const slash = rest.indexOf('/');
-    if (slash <= 0) return null;
-    return normalizeExtracted(rest.slice(slash + 1));
+    // The leading segment(s) are the ref, whatever it is called and however it
+    // is qualified.
+    const split = splitRawRef(bare.slice(rawPrefix.length));
+    if (!split || isCommitRef(split.ref)) return null;
+    return normalizeExtracted(split.path);
   }
 
   return null;

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { signBlobUrl } from '@classmoji/content-signing';
 import { z } from 'zod';
 import { ContentService } from '../content/ContentService.ts';
-import { recordContentAsset } from './contentAssets.service.ts';
+import { recordContentAsset, resolveContentBranch } from './contentAssets.service.ts';
 import {
   dedupeMergedTreeIds,
   indexResolutions,
@@ -284,13 +284,19 @@ export async function uploadPageAsset(
 ): Promise<{ url: string; path: string; displayUrl: string | null }> {
   const { gitOrganization, repo } = contentRepoFor(page);
 
+  // Asked, not assumed — the same reason the asset sync asks. A content repo on
+  // `master` would otherwise take every upload onto a branch nobody renders
+  // from, and the map would then sign URLs for a blob the default branch has
+  // never held.
+  const branch = await resolveContentBranch(gitOrganization, gitOrganization.login, repo);
+
   const result = await ContentService.upload({
     gitOrganization,
     repo,
     folder: `${page.content_path}/assets`,
     file: buffer,
     filename,
-    branch: 'main',
+    branch,
     message: `Upload asset for ${page.title || 'page'}`,
   });
 

--- a/packages/services/src/git/GitHubProvider.ts
+++ b/packages/services/src/git/GitHubProvider.ts
@@ -410,6 +410,26 @@ export class GitHubProvider extends GitProvider {
   // ─── Branches & PRs ────────────────────────────────────────────────────────
 
   /**
+   * The repository's default branch.
+   *
+   * `main` for most classrooms and `master` for anything imported from an older
+   * course, so a caller that needs the branch content is actually served from
+   * has to ask. One `GET /repos` — the same request `getRepository` makes.
+   *
+   * @param {string} org - Organization login
+   * @param {string} repo - Repository name
+   * @returns {Promise<string>} Default branch name
+   */
+  async getDefaultBranch(org: string, repo: string): Promise<string> {
+    const octokit = await this.#getOctokit();
+    const { data } = await octokit.request('GET /repos/{owner}/{repo}', {
+      owner: org,
+      repo,
+    });
+    return data.default_branch;
+  }
+
+  /**
    * Get the latest commit SHA for a branch
    * @param {string} org - Organization login
    * @param {string} repo - Repository name

--- a/packages/services/src/git/GitProvider.ts
+++ b/packages/services/src/git/GitProvider.ts
@@ -89,6 +89,20 @@ export class GitProvider {
   }
 
   // ─── Branches & PRs ────────────────────────────────────────────────────────
+  /**
+   * The branch a repository serves as its head — `main` for most, `master` for
+   * anything created before GitHub changed the default, and whatever the owner
+   * renamed it to otherwise.
+   *
+   * Anything that reads a repo's CURRENT content has to ask rather than assume.
+   * A hardcoded `main` against a `master` repo does not read stale content, it
+   * reads nothing at all: the tree call 404s and the classroom ends up with no
+   * asset map, which is exactly the failure the map exists to prevent.
+   */
+  async getDefaultBranch(org: string, repo: string): Promise<string> {
+    throw new Error('getDefaultBranch() must be implemented by subclass');
+  }
+
   async getLatestCommitSHA(org: string, repo: string, branch?: string): Promise<string> {
     throw new Error('getLatestCommitSHA() must be implemented by subclass');
   }

--- a/packages/tasks/src/scripts/bootstrapContentAssets.ts
+++ b/packages/tasks/src/scripts/bootstrapContentAssets.ts
@@ -62,10 +62,15 @@ async function bootstrapContentAssets({ dryRun }: { dryRun: boolean }): Promise<
     // No `changes`, so the task takes the full path: read the whole tree and
     // stamp-and-sweep. That is the only correct mode for a classroom whose map
     // may be absent, partial, or arbitrarily out of date.
-    await Tasks.contentAssetsSyncTask.trigger({
-      classroomId: classroom.id,
-      reason: 'bootstrap' as const,
-    });
+    await Tasks.contentAssetsSyncTask.trigger(
+      {
+        classroomId: classroom.id,
+        reason: 'bootstrap' as const,
+      },
+      // Same per-classroom fence the webhook uses: a bootstrap run must queue
+      // behind a live delivery for that classroom rather than race it.
+      { concurrencyKey: classroom.id }
+    );
     triggered += 1;
     console.log(`   ✅ queued ${label}`);
   }

--- a/packages/tasks/src/workflows/contentAssets.ts
+++ b/packages/tasks/src/workflows/contentAssets.ts
@@ -36,12 +36,20 @@ interface ContentAssetsSyncPayload {
   forced?: boolean;
   /** False when the push payload's `commits[]` was capped (GitHub sends at most 20). */
   complete?: boolean;
+  /**
+   * The commit the push built on. A push whose parent is not the commit the map
+   * is level with means an earlier delivery was lost, and the sync escalates to
+   * a full tree read rather than applying a diff against a state it never had.
+   */
+  before?: string;
+  /** The commit the push landed — recorded as the map's new level. */
+  after?: string;
 }
 
 export const contentAssetsSyncTask = task({
   id: 'content-assets-sync',
   run: async (payload: ContentAssetsSyncPayload) => {
-    const { classroomId, reason, changes, forced, complete } = payload;
+    const { classroomId, reason, changes, forced, complete, before, after } = payload;
 
     // Three separate reasons the incremental path can't be used, all meaning
     // the same thing: we do not have a trustworthy list of what changed.
@@ -50,6 +58,8 @@ export const contentAssetsSyncTask = task({
     const result = await ClassmojiService.contentAssets.syncContentAssets(classroomId, {
       full,
       changes,
+      before,
+      after,
     });
 
     logger.info('Synced content assets', {

--- a/packages/tasks/src/workflows/contentAssets.ts
+++ b/packages/tasks/src/workflows/contentAssets.ts
@@ -48,6 +48,23 @@ interface ContentAssetsSyncPayload {
 
 export const contentAssetsSyncTask = task({
   id: 'content-assets-sync',
+  /**
+   * ONE sync per classroom at a time.
+   *
+   * The map is only self-correcting if the runs that build it are ordered.
+   * Two deliveries for one repo arriving together can apply their diffs in
+   * either order and record either `after` as "the commit the map is level
+   * with" — so the map's commit can move BACKWARDS, which hides the very gap
+   * `before` exists to expose. `concurrencyKey` (passed at trigger time, per
+   * classroom) gives each classroom its own copy of this queue, and the limit
+   * of 1 on that copy is what serializes them. Classrooms still run in
+   * parallel with each other.
+   *
+   * The queue is the fence, not the whole guarantee: a retry or a render-path
+   * `ensureContentAssets` still runs outside it, which is why the incremental
+   * commit write is also a compare-and-swap.
+   */
+  queue: { concurrencyLimit: 1 },
   run: async (payload: ContentAssetsSyncPayload) => {
     const { classroomId, reason, changes, forced, complete, before, after } = payload;
 


### PR DESCRIPTION
## What
Seven commits from today's plan-vs-code review of the content delivery layer's asset map:

- **Default branch, not `main`.** Full sync and page uploads read the repo's default branch; the tree is read at that branch's head commit so the recorded commit and the tree can't drift. GitLab paths fail closed as before.
- **Sync stamp before the tree read**, so a row written by an upload during a full sync is never swept.
- **Theme saves refresh the map** (full sync via `syncContentAssetsForRepo`, never throws; its only caller is the background slides.com importer).
- **Dropped-webhook detection.** New `classrooms.content_assets_synced_commit`; hook-station sends `before`/`after`; an incremental whose `before` isn't the stored commit, a first-ever sync, a branch-creation push, or a truncated tree escalates to a full read. Per-classroom serialization via a Trigger `concurrencyKey` (queue limit 1) plus a compare-and-swap on the commit write.
- **Import URL rewriter** handles every reference shape now in use: raw URLs on any branch incl. `refs/heads/…` (commit-pinned refs left alone), the `/content/{org}/{repo}` proxy shape, bare repo paths, and our signed URLs (`/missing/` and `/theme/` from the path; `/blob/{sha}` via one batched map lookup per import run; unknown SHAs left verbatim and warned). `extractOwnRepoPath` shares the ref parsing.
- `.env.example`: there is no `CONTENT_DELIVERY_ORIGIN` default.

Migration: `20260905000000_content_assets_synced_commit` (nullable, no backfill).

## Test
services 1458 passed / 13 known failures (12 GitLabProvider + 1 pre-existing classroomMembership), typecheck 16 known; hook-station 69; tasks 97; slides typecheck 0. On staging: push a commit to a content repo → sync task runs once per classroom; a second push whose `before` doesn't chain triggers a full read (visible in the task log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA