### PR TITLE
test: end-to-end pack for the content delivery pipeline

### DIFF
--- a/.github/workflows/e2e-content.yml
+++ b/.github/workflows/e2e-content.yml
@@ -1,0 +1,108 @@
+name: Content Delivery E2E
+
+# The content-delivery pack (apps/pages + apps/slides, `content-pipeline.spec.ts`)
+# run against DEPLOYED staging. Modelled on e2e.yml, with one deliberate
+# difference: e2e.yml builds and starts the whole stack on the runner, while
+# this suite has no stack of its own at all — it points a browser and an HTTP
+# client at staging.classmoji.io and content-staging.classmoji.io.
+#
+# Manual-only, and that is a safety property, not a cost saving. The pack writes
+# when it can: an upload lands a real file in a real GitHub content repo, and
+# the gate/cache-reset scenarios write to a database. On a deployed target those
+# are all skipped (see below), but a scheduled or push trigger would be one
+# environment variable away from turning a green pipeline into a writer against
+# a shared environment.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or ref to run the specs from'
+        required: false
+        default: staging
+
+# WHAT ACTUALLY RUNS AGAINST STAGING
+#
+# Roughly a third of the pack. The rest skips with a named reason, and those
+# reasons are real gaps rather than laziness:
+#
+#   - Anything signed-in skips. `/test-login` 404s outside development and
+#     staging has no seeded password, so there is no way to become an owner or
+#     a student. Supplying E2E_SESSION_COOKIE (a `classmoji.session_token` for a
+#     member of cs98-test) is what would unlock the editor and enrolled-tier
+#     scenarios; the pack reads it and skips clearly when it is absent.
+#   - Anything that toggles `content_delivery_enabled` or bumps
+#     `content_key_version` skips unconditionally. Those are database writes,
+#     the pack refuses to open a Prisma client while E2E_TARGET=staging, and
+#     that refusal is deliberate — a cache reset against a shared environment
+#     changes every URL every real viewer holds.
+#   - Uploads skip unless E2E_CD_CONTENT_REPO=1 says the target classroom's repo
+#     is genuinely writable. It is not set here on purpose: nothing scheduled
+#     should be committing fixture PNGs to a course repository.
+#
+# What is left is the part that needs no credentials and writes nothing: the
+# public class-site render at the `public` tier, and the Worker's own contract —
+# 200/HEAD parity, the four 403 refusals, the /missing/ 404, and /healthz.
+env:
+  E2E_TARGET: staging
+  E2E_PAGES_URL: https://pages.staging.classmoji.io
+  E2E_SLIDES_URL: https://slides.staging.classmoji.io
+  E2E_WEBAPP_URL: https://staging.classmoji.io
+  E2E_CLASS_SITE_URL: https://cs98-test.staging.classmoji.io
+  CONTENT_DELIVERY_ORIGIN: https://content-staging.classmoji.io
+  E2E_CLASSROOM_SLUG: cs98-test
+
+jobs:
+  content-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || 'staging' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The specs import @classmoji/services for the resolver assertions, and
+      # that package re-exports @classmoji/database, which builds its client at
+      # module scope. Without a generated client the import throws before a
+      # single skip can be printed.
+      - name: Generate Prisma client
+        run: npm run db:generate
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # OPTIONAL SECRET, and the only one this workflow has any use for.
+      #
+      # `E2E_STAGING_SESSION_COOKIE` is a `classmoji.session_token` value for a
+      # member of cs98-test on staging. With it, the signed-in scenarios (the
+      # editor's draft tier, a member's enrolled tier) run; without it they skip
+      # with that exact instruction. It is NOT created here and no value is
+      # invented: a maintainer mints a session and stores it, or leaves it unset
+      # and accepts the smaller suite.
+      #
+      # It is a live credential with an eight-hour life, so it will go stale;
+      # the skip that follows is correct behaviour, not a broken pipeline.
+      - name: Run the content-delivery pack against staging
+        env:
+          E2E_SESSION_COOKIE: ${{ secrets.E2E_STAGING_SESSION_COOKIE }}
+        run: |
+          npx playwright test --config apps/pages/playwright.config.ts content-pipeline
+          npx playwright test --config apps/slides/playwright.config.ts content-pipeline
+
+      - name: Upload Playwright reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: content-e2e-report
+          path: |
+            apps/pages/playwright-report
+            apps/slides/playwright-report
+          retention-days: 7

--- a/.github/workflows/e2e-content.yml
+++ b/.github/workflows/e2e-content.yml
@@ -22,19 +22,24 @@ on:
 
 # WHAT ACTUALLY RUNS AGAINST STAGING
 #
-# Roughly a third of the pack. The rest skips with a named reason, and those
-# reasons are real gaps rather than laziness:
+# Eight of the nineteen scenarios, verified green against cs98-test on
+# 2026-09-04: the public-tier class-site render with its ladder, /healthz, the
+# 200 + HEAD parity, the four refusals (tampered sig, appended width, extended
+# expiry, foreign classroom) and the /missing/ 404. Every one is a read.
 #
+# The other eleven skip with a named reason, and those reasons are real gaps
+# rather than laziness:
+#
+#   - The pack opens no database against a deployed target — `prisma()` throws
+#     while E2E_TARGET=staging, on purpose. So every scenario that needs a
+#     classroom row skips, and so does every scenario that would WRITE one: a
+#     cache reset against a shared environment changes every URL every real
+#     viewer is holding.
 #   - Anything signed-in skips. `/test-login` 404s outside development and
-#     staging has no seeded password, so there is no way to become an owner or
-#     a student. Supplying E2E_SESSION_COOKIE (a `classmoji.session_token` for a
-#     member of cs98-test) is what would unlock the editor and enrolled-tier
-#     scenarios; the pack reads it and skips clearly when it is absent.
-#   - Anything that toggles `content_delivery_enabled` or bumps
-#     `content_key_version` skips unconditionally. Those are database writes,
-#     the pack refuses to open a Prisma client while E2E_TARGET=staging, and
-#     that refusal is deliberate — a cache reset against a shared environment
-#     changes every URL every real viewer holds.
+#     staging has no seeded credentials, so there is no way to become an owner
+#     or a student. E2E_SESSION_COOKIE (a `classmoji.session_token` for a member
+#     of cs98-test) is the missing piece; the pack reads it and says so when it
+#     is absent.
 #   - Uploads skip unless E2E_CD_CONTENT_REPO=1 says the target classroom's repo
 #     is genuinely writable. It is not set here on purpose: nothing scheduled
 #     should be committing fixture PNGs to a course repository.

--- a/.github/workflows/e2e-content.yml
+++ b/.github/workflows/e2e-content.yml
@@ -35,11 +35,14 @@ on:
 #     classroom row skips, and so does every scenario that would WRITE one: a
 #     cache reset against a shared environment changes every URL every real
 #     viewer is holding.
-#   - Anything signed-in skips. `/test-login` 404s outside development and
-#     staging has no seeded credentials, so there is no way to become an owner
-#     or a student. E2E_SESSION_COOKIE (a `classmoji.session_token` for a member
-#     of cs98-test) is the missing piece; the pack reads it and says so when it
-#     is absent.
+#   - Anything signed-in skips WITHOUT E2E_SESSION_COOKIE. `/test-login` 404s
+#     outside development and staging has no seeded credentials. With the secret
+#     set, the pack attaches that `classmoji.session_token` to the browser
+#     context — scoped to the three staging origins by URL, never by domain, so
+#     it cannot follow a redirect to production — and one more scenario runs:
+#     a member-facing page must not be served at the `public` tier. It cannot
+#     assert `enrolled` exactly, because a staff token would correctly produce
+#     `draft`; the local pack pins the exact values.
 #   - Uploads skip unless E2E_CD_CONTENT_REPO=1 says the target classroom's repo
 #     is genuinely writable. It is not set here on purpose: nothing scheduled
 #     should be committing fixture PNGs to a course repository.
@@ -55,6 +58,12 @@ env:
   E2E_CLASS_SITE_URL: https://cs98-test.staging.classmoji.io
   CONTENT_DELIVERY_ORIGIN: https://content-staging.classmoji.io
   E2E_CLASSROOM_SLUG: cs98-test
+
+# Read-only. This job checks out code and talks to staging over HTTP; it has no
+# reason to write to the repository, and the default token grant is wider than
+# that.
+permissions:
+  contents: read
 
 jobs:
   content-e2e:
@@ -95,12 +104,20 @@ jobs:
       #
       # It is a live credential with an eight-hour life, so it will go stale;
       # the skip that follows is correct behaviour, not a broken pipeline.
-      - name: Run the content-delivery pack against staging
+      # Two steps, not one `&&` chain: the pages pack is where nearly all the
+      # staging coverage lives, and a chained slides failure would have hidden
+      # whether pages had passed. `if: always()` on the second means one report
+      # never suppresses the other.
+      - name: Run the pages content-delivery pack against staging
         env:
           E2E_SESSION_COOKIE: ${{ secrets.E2E_STAGING_SESSION_COOKIE }}
-        run: |
-          npx playwright test --config apps/pages/playwright.config.ts content-pipeline
-          npx playwright test --config apps/slides/playwright.config.ts content-pipeline
+        run: npx playwright test --config apps/pages/playwright.config.ts content-pipeline
+
+      - name: Run the slides content-delivery pack against staging
+        if: always()
+        env:
+          E2E_SESSION_COOKIE: ${{ secrets.E2E_STAGING_SESSION_COOKIE }}
+        run: npx playwright test --config apps/slides/playwright.config.ts content-pipeline
 
       - name: Upload Playwright reports
         if: always()

--- a/apps/content/.gitignore
+++ b/apps/content/.gitignore
@@ -1,3 +1,9 @@
 .wrangler/
 dist/
 worker-configuration.d.ts
+
+# Local secrets for `wrangler dev`. README.md has called this file git-ignored
+# since it was written, and it was not — the signing secret and the token
+# endpoint's bearer were one `git add apps/content` away from the history.
+.dev.vars
+.dev.vars.*

--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -149,8 +149,11 @@ npx wrangler deploy --env staging --dry-run --outdir /tmp/content-dryrun
 #      CONTENT_SIGNING_SECRET="..."
 #      CONTENT_WORKER_SHARED_SECRET="..."
 #      CONTENT_SIGNING_SECRET_PREVIOUS="..."   # optional, only to rehearse a rotation
-# 3. Run it (local R2 + local Images emulation):
-npm run cf:dev -w apps/content
+# 3. Run it (local R2 + local Images emulation), on the local `dev` env:
+npm run cf:dev:local -w apps/content
+#    `cf:dev` runs `--env staging`, whose CONTENT_TOKEN_ENDPOINT is
+#    staging.classmoji.io — fine for a bindings-only smoke, wrong the moment
+#    you want the Worker to fetch a blob. Use `cf:dev:local` for that.
 
 # 4. Health:
 curl -s localhost:8787/healthz
@@ -167,6 +170,86 @@ staging will always 403 here, and that is correct, not a bug. The apps point
 their minting at the local Worker with `CONTENT_DELIVERY_ORIGIN`; set it to
 `http://localhost:8787` for a local smoke, and remember the port is signed too
 — `:8788` will not verify against a `:8787` signature.
+
+### Local end-to-end
+
+Running the whole pipeline — editor upload, signed render, Worker fetch — on
+one machine. This is what `npm run e2e:content` drives; the Playwright pack is
+in `apps/pages/tests/content-pipeline.spec.ts` and
+`apps/slides/tests/content-pipeline.spec.ts`.
+
+Three things have to agree, and all three are easy to get subtly wrong:
+
+1. **The same signing secret in both places.** The apps sign; the Worker
+   verifies. A mismatch is indistinguishable from tampering — every image 403s
+   with `bad-signature` and nothing says why.
+2. **The origin the apps sign for is the origin the Worker answers on**, host
+   *and* port, because the host is inside the canonical string.
+3. **The Worker's token endpoint points at the LOCAL webapp**, not staging.
+
+#### 1. Generate a throwaway pair
+
+Never reuse the staging or production secret locally; a local signature must
+not verify anywhere real.
+
+```sh
+openssl rand -base64 32   # -> CONTENT_SIGNING_SECRET
+openssl rand -base64 32   # -> CONTENT_WORKER_SHARED_SECRET
+```
+
+#### 2. Repo root `.env` (git-ignored) — what the apps sign with
+
+```sh
+CONTENT_SIGNING_SECRET="<the first value>"
+CONTENT_WORKER_SHARED_SECRET="<the second value>"
+CONTENT_DELIVERY_ORIGIN="http://localhost:8787"
+```
+
+`CONTENT_DELIVERY_ORIGIN` has no trailing slash and names the port. Both of
+the first two must be set or `isContentDeliveryConfigured()` is false and every
+app renders legacy refs — the same outcome as the feature being off, which is
+why a "nothing is signed" local run is nearly always a missing env var rather
+than a bug.
+
+#### 3. `apps/content/.dev.vars` (git-ignored) — what the Worker verifies with
+
+```sh
+CONTENT_SIGNING_SECRET="<the SAME first value>"
+CONTENT_WORKER_SHARED_SECRET="<the SAME second value>"
+# Only if the webapp is on a devport rather than 3000:
+# CONTENT_TOKEN_ENDPOINT="http://localhost:3050/api/content/token"
+```
+
+Leave `CONTENT_SIGNING_SECRET_PREVIOUS` out unless you are rehearsing a
+rotation. Then:
+
+```sh
+npm run cf:dev:local -w apps/content
+curl -s localhost:8787/healthz    # {"ok":true,"environment":"development","configured":true}
+```
+
+`configured: false` there means the Worker never read `.dev.vars` — check you
+put it in `apps/content/`, not the repo root.
+
+#### 4. Turn the flag on for one classroom
+
+`content_delivery_enabled` defaults to false, per classroom, and the env check
+above is separate from it. Both have to be true. Locally, flip it directly:
+
+```sh
+# .dev-context has the database this checkout is actually using.
+psql "$DATABASE_URL" -c \
+  "update classrooms set content_delivery_enabled = true where slug = 'cs98-test';"
+```
+
+In the UI it lives at **Settings → Content** for the classroom
+(`/admin/:class/settings/content`), alongside **Reset content cache** — the
+button that increments `content_key_version` and so changes every signed URL
+the classroom hands out.
+
+To watch the gate work, set it back to `false` and reload: every `<img>` goes
+back to a legacy `raw.githubusercontent.com` / `/content/{org}/{repo}/…` ref
+and nothing is requested from `localhost:8787` at all.
 
 ## Operating
 

--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -236,11 +236,23 @@ put it in `apps/content/`, not the repo root.
 `content_delivery_enabled` defaults to false, per classroom, and the env check
 above is separate from it. Both have to be true. Locally, flip it directly:
 
+The pack's default local classroom is `classmoji-dev-winter-2025` — the one
+`npm run db:seed` creates — so that is the slug to flip unless you set
+`E2E_CLASSROOM_SLUG` to something else:
+
 ```sh
 # .dev-context has the database this checkout is actually using.
 psql "$DATABASE_URL" -c \
-  "update classrooms set content_delivery_enabled = true where slug = 'cs98-test';"
+  "update classrooms set content_delivery_enabled = true where slug = 'classmoji-dev-winter-2025';"
 ```
+
+(`cs98-test` is the STAGING classroom; flipping that name locally updates zero
+rows and looks exactly like the feature not working.)
+
+Every write in the pack — the flag, the cache bump, the uploads and the repo
+deletes — is refused unless `DATABASE_URL` resolves to a host on localhost.
+`E2E_ALLOW_REMOTE_DB_I_KNOW_WHAT_I_AM_DOING=1` lifts that for a non-local host,
+and does not lift it for anything that looks managed or production.
 
 In the UI it lives at **Settings → Content** for the classroom
 (`/admin/:class/settings/content`), alongside **Reset content cache** — the

--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -251,6 +251,39 @@ To watch the gate work, set it back to `false` and reload: every `<img>` goes
 back to a legacy `raw.githubusercontent.com` / `/content/{org}/{repo}/…` ref
 and nothing is requested from `localhost:8787` at all.
 
+#### 5. What the classroom actually has to be
+
+Three things beyond the flag, each of which fails in its own confusing way:
+
+- **A content repo that exists on GitHub, in an org with the App installed.**
+  `npm run db:seed` gives the dev classroom the synthetic org `dev-org` and the
+  repo `content-classmoji-dev-winter-2025`, and neither exists. An upload then
+  fails at the GitHub API and tells you nothing about delivery. Point the
+  classroom at a real one (`git_org_id` + `content_repo`, with the org's
+  `github_installation_id` set) before expecting an upload to work.
+- **Pages or decks with real `content_path`s.** The delivery layer resolves
+  references; a classroom with no content has nothing to resolve, and every
+  assertion about it is vacuously true.
+- **`SITE_BASE_DOMAIN`, if you want the `public` tier.** The class-site host
+  rewriter is a no-op without it, and `public` is only ever minted for the
+  class-site surface — so with it unset there is no way to see that tier at all.
+  Start the pages app with e.g. `SITE_BASE_DOMAIN=classmoji.io` and address the
+  site with a `Host:` header; there is no local DNS for it. The site also has to
+  be *enabled* and have a home page — a claimed-but-disabled site 404s.
+
+Then:
+
+```sh
+E2E_CD_CONTENT_REPO=1 npm run e2e:content
+```
+
+`E2E_CD_CONTENT_REPO=1` is your assertion that the classroom's repo is real and
+writable; without it the upload scenarios skip rather than fail. Two caches sit
+between a write and what you see, and the pack waits both out rather than
+sleeping: GitHub's contents API is eventually consistent after a write, and the
+page loader passes `skipCache: canEdit`, so staff read fresh while a student or
+an anonymous site visitor gets a 60-second cache.
+
 ## Operating
 
 ### R2 layout, and purging one blob

--- a/apps/content/package.json
+++ b/apps/content/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "cf:dev": "wrangler dev --env staging",
+    "cf:dev:local": "wrangler dev --env dev",
     "cf:types": "wrangler types --env staging"
   },
   "dependencies": {

--- a/apps/content/wrangler.jsonc
+++ b/apps/content/wrangler.jsonc
@@ -34,6 +34,56 @@
   //     `npx wrangler secret delete CONTENT_SIGNING_SECRET_PREVIOUS --env <env>`.
   //     See "Rotating the signing secret" in README.md.
   "env": {
+    // LOCAL ONLY. Never deployed — `workers_dev` is false and there are no
+    // routes, so a `wrangler deploy --env dev` would publish a script nothing
+    // can reach. It exists so `wrangler dev` stops borrowing `staging`, whose
+    // CONTENT_TOKEN_ENDPOINT points at staging.classmoji.io: a local Worker
+    // asking STAGING to mint a GitHub token is both wrong and a needless reach
+    // into a deployed environment.
+    //
+    // The host is part of every signature, so this env only ever verifies URLs
+    // minted for the exact origin `wrangler dev` listens on — set the apps'
+    // CONTENT_DELIVERY_ORIGIN to `http://localhost:8787`, port included.
+    // See "Local end-to-end" in README.md.
+    //
+    // CONTENT_TOKEN_ENDPOINT defaults to the webapp port `.dev-context` reports
+    // for a plain `npm run dev` (3000). A devport shifts it (3050, 3100, …), so
+    // override rather than editing this file:
+    //
+    //   npm run cf:dev:local -w apps/content -- \
+    //     --var CONTENT_TOKEN_ENDPOINT:http://localhost:3050/api/content/token
+    //
+    // A CONTENT_TOKEN_ENDPOINT line in apps/content/.dev.vars also wins over
+    // the value here.
+    "dev": {
+      "name": "classmoji-content-dev",
+      "workers_dev": false,
+      "vars": {
+        "CONTENT_TOKEN_ENDPOINT": "http://localhost:3000/api/content/token",
+        "ENVIRONMENT": "development"
+      },
+      "r2_buckets": [
+        {
+          // `wrangler dev` keeps this bucket in its on-disk simulator under
+          // .wrangler/state and never touches Cloudflare. The name is still
+          // deliberately neither deployed bucket, so that a `--remote` run
+          // cannot land in the staging or production cache.
+          "binding": "CACHE",
+          "bucket_name": "classmoji-content-cache-dev"
+        }
+      ],
+      "images": {
+        "binding": "IMAGES"
+      },
+      "observability": {
+        "enabled": true
+      },
+      // A local run should always serve what the code in front of you does.
+      "cache": {
+        "enabled": false
+      }
+    },
+
     "staging": {
       "name": "classmoji-content-staging",
       "routes": [

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -28,6 +28,7 @@ import {
   FOREIGN_CLASSROOM_ID,
   type E2EClassroom,
   type RenderedImage,
+  applyStagingSession,
   appendWidth,
   assetRow,
   authSkipReason,
@@ -38,6 +39,8 @@ import {
   deleteRepoFile,
   deliverySkipReason,
   describeSignedUrl,
+  describeUrls,
+  discoverMemberContentUrl,
   e2eTarget,
   harvestSignedFromHtml,
   FIXTURE_PREVIEW_WIDTH,
@@ -51,6 +54,7 @@ import {
   imagesFromHtml,
   keyVersion,
   loadPageBlocks,
+  markScenarioRan,
   loginAs,
   localOnlySkipReason,
   parseMissingUrl,
@@ -60,6 +64,7 @@ import {
   readStoredContent,
   reloadUntilImages,
   savePageBlocks,
+  scenariosThatRan,
   services,
   setDeliveryEnabled,
   storedContentLeaks,
@@ -74,6 +79,18 @@ import {
 const env = targets();
 
 /**
+ * No trace, no video, for this pack specifically.
+ *
+ * Both capture full request URLs, and every URL here is a signed credential
+ * good for up to a month on the public tier. `retries: 0` happens to mean the
+ * config's `on-first-retry` never fires today, but that is a coincidence of a
+ * setting in another file — one `--retries=1` on a command line and the pack
+ * starts writing signatures into an artifact CI uploads. Turned off here so it
+ * cannot.
+ */
+test.use({ trace: 'off', video: 'off' });
+
+/**
  * Resolved once, in `beforeAll`, and consulted by every gate.
  *
  * `test.skip()` inside a test body is what produces a readable reason in the
@@ -86,6 +103,16 @@ let classroomError: string | null = null;
 
 /** Repo paths this run wrote; removed in `afterAll` whatever happened. */
 const uploadedPaths: string[] = [];
+
+/**
+ * The classroom's `content_key_version` before the bump scenario moved it.
+ *
+ * The bump is a relative increment with no product-level undo — correct for a
+ * cache bust, awkward for a test that runs on every commit: the dev classroom's
+ * version climbed by one per run, and the number in a developer's database
+ * became a count of how often the suite had run.
+ */
+let keyVersionBeforeBump: number | null = null;
 
 /**
  * A page's blocks as they were BEFORE this run touched them.
@@ -111,6 +138,21 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await clearMintedSessions();
+
+  // Put the cache-bust version back. Local only, and only if this run moved it.
+  if (keyVersionBeforeBump !== null && localOnlySkipReason() === null) {
+    try {
+      const { getTestPrisma } = await import('./helpers');
+      const prisma = await getTestPrisma();
+      await prisma.classroom.update({
+        where: { id: target!.id },
+        data: { content_key_version: keyVersionBeforeBump },
+      });
+    } catch {
+      // Harmless if it fails: a higher version invalidates caches, it does not
+      // break anything.
+    }
+  }
 
   if (!target || uploadSkipReason() !== null) return;
 
@@ -221,21 +263,52 @@ interface TestPage {
   classroomId: string;
 }
 
-/** A staff-editable page in the target classroom, from the seeded content. */
-async function anyEditablePage(classroomId: string): Promise<TestPage | null> {
-  const service = await services();
-  const pages = await service.page.findByClassroomId(classroomId).catch(() => null);
-  const row = pages?.find(
-    (page: { content_path?: string | null }) => typeof page.content_path === 'string'
+/**
+ * The shape this pack needs from a page row, once it is known to be usable.
+ *
+ * `content_path` is typed nullable on the service's return even though the
+ * column is not, and `is_draft` defaults to TRUE — so "the first page in the
+ * classroom" is quite likely to be an unpublished one with nothing behind it.
+ * Both are filtered here, once, rather than at four call sites that each got it
+ * slightly differently.
+ */
+interface PageRow {
+  id: string;
+  slug: string | null;
+  content_path: string | null;
+  is_public: boolean;
+  is_draft: boolean;
+}
+
+function usablePages(rows: PageRow[]): (PageRow & { content_path: string })[] {
+  return rows.filter(
+    (row): row is PageRow & { content_path: string } =>
+      typeof row.content_path === 'string' && row.content_path.length > 0 && !row.is_draft
   );
-  if (!row) return null;
+}
+
+async function classroomPages(
+  classroomId: string
+): Promise<(PageRow & { content_path: string })[]> {
+  const service = await services();
+  const rows = (await service.page.findByClassroomId(classroomId).catch(() => [])) as PageRow[];
+  return usablePages(rows);
+}
+
+function toTestPage(row: PageRow & { content_path: string }, classroomId: string): TestPage {
   return {
     id: row.id,
-    slug: row.slug,
+    slug: row.slug ?? row.id,
     contentPath: row.content_path,
     classroomSlug: env.classroomSlug,
     classroomId,
   };
+}
+
+/** A staff-editable, published page in the target classroom. */
+async function anyEditablePage(classroomId: string): Promise<TestPage | null> {
+  const row = (await classroomPages(classroomId))[0];
+  return row ? toTestPage(row, classroomId) : null;
 }
 
 /**
@@ -319,6 +392,9 @@ test.describe('E2E CD — pages, the editor', () => {
     page,
   }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
     test.skip(
@@ -332,6 +408,7 @@ test.describe('E2E CD — pages, the editor', () => {
 
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
 
+    markScenarioRan();
     const uploaded = await uploadAsset(
       page,
       target.id,
@@ -400,7 +477,10 @@ test.describe('E2E CD — pages, the editor', () => {
       sizes: expectedSizesFor(FIXTURE_PREVIEW_WIDTH),
     });
 
-    // Exactly one network request for this image. The browser picks ONE
+    // Exactly one network request for this image. This is a safe count only
+    // because the draft tier is served `no-store` — on a cacheable tier a
+    // second navigation legitimately produces zero requests, and asserting
+    // "exactly one" there would be asserting that the cache had missed.
     // candidate out of the set; a page that fetched two is a page that painted
     // a `src` and then swapped in a `srcset` after layout, which is precisely
     // the double-download the block's synchronous attribute wiring prevents.
@@ -413,6 +493,9 @@ test.describe('E2E CD — pages, the editor', () => {
     page,
   }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
 
@@ -420,6 +503,7 @@ test.describe('E2E CD — pages, the editor', () => {
     test.skip(target === null, 'no page with a content_path in the test classroom');
     if (!target) return;
 
+    markScenarioRan();
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
     const uploaded = await uploadAsset(
       page,
@@ -462,6 +546,9 @@ test.describe('E2E CD — pages, the editor', () => {
 
   test('removing the block removes the reference from stored content', async ({ page }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
 
@@ -469,6 +556,7 @@ test.describe('E2E CD — pages, the editor', () => {
     test.skip(target === null, 'no page with a content_path in the test classroom');
     if (!target) return;
 
+    markScenarioRan();
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
     const uploaded = await uploadAsset(
       page,
@@ -498,6 +586,9 @@ test.describe('E2E CD — pages, the editor', () => {
 
   test('a GIF gets a plain signed URL and no responsive ladder', async ({ page }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
     test.skip(
@@ -509,6 +600,7 @@ test.describe('E2E CD — pages, the editor', () => {
     test.skip(target === null, 'no page with a content_path in the test classroom');
     if (!target) return;
 
+    markScenarioRan();
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
     const uploaded = await uploadAsset(
       page,
@@ -558,11 +650,7 @@ test.describe('E2E CD — pages, what each audience sees', () => {
 
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
 
-    const service = await services();
-    const pages = await service.page.findByClassroomId(room.id);
-    const privatePage = pages.find(
-      (row: { is_public?: boolean; is_draft?: boolean }) => row.is_public === false && !row.is_draft
-    );
+    const privatePage = (await classroomPages(room.id)).find(row => row.is_public === false);
     test.skip(privatePage === undefined, 'no published non-public page in this classroom');
     if (!privatePage) return;
 
@@ -578,17 +666,8 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     // test because the tier is a property of the VIEWER, and the only way to
     // observe `enrolled` is to be someone who cannot edit.
     await loginAs(page, 'owner', `/${env.classroomSlug}`);
-    const fixture = await withFixtureImage(
-      page,
-      {
-        id: privatePage.id,
-        slug: privatePage.slug,
-        contentPath: privatePage.content_path,
-        classroomSlug: env.classroomSlug,
-        classroomId: room.id,
-      },
-      'enrolled'
-    );
+    markScenarioRan();
+    const fixture = await withFixtureImage(page, toTestPage(privatePage, room.id), 'enrolled');
 
     await loginAs(page, 'student', `/${env.classroomSlug}/${privatePage.id}`);
 
@@ -616,7 +695,9 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('enrolled');
     }
     expect(log.missing()).toEqual([]);
-    expect(log.legacy(), 'a delivered page must not also fetch legacy refs').toEqual([]);
+    expect(describeUrls(log.legacy()), 'a delivered page must not also fetch legacy refs').toEqual(
+      []
+    );
     log.stop();
   });
 
@@ -629,14 +710,68 @@ test.describe('E2E CD — pages, what each audience sees', () => {
    * the scenario reads what is there; locally it has to make one first,
    * because a freshly seeded classroom has no public site and no pictures.
    */
+  /**
+   * The signed-in half of the staging story, and the only thing
+   * `E2E_SESSION_COOKIE` is for.
+   *
+   * With a member's token the pack can open a page the public site never shows
+   * and check the one property that distinguishes a member render from an
+   * anonymous one: the tier is NOT `public`. It cannot be more specific than
+   * that without knowing the token's role — a student's render is `enrolled`,
+   * a staff member's is `draft`, and both are correct — so the assertion is the
+   * boundary rather than the exact value. The exact values are pinned by the
+   * local scenarios, which know who they signed in as.
+   */
+  test('a signed-in member on staging gets a non-public tier', async ({ page, context }) => {
+    requireDelivery();
+    test.skip(e2eTarget() !== 'staging', 'this is the staging form of the enrolled-tier check');
+    test.skip(authSkipReason() !== null, authSkipReason() ?? '');
+
+    const applied = await applyStagingSession(context);
+    expect(applied, 'a staging session cookie should have been attached').toBe(true);
+
+    const contentUrl = await discoverMemberContentUrl(page, env.classroomSlug);
+    test.skip(
+      contentUrl === null,
+      `no content linked from /${env.classroomSlug} — either the cookie is not valid for this ` +
+        'classroom, or the classroom has no pages'
+    );
+    if (!contentUrl) return;
+
+    const images = await reloadUntilImages(page, contentUrl, seen =>
+      seen.some(image => image.signed !== null)
+    );
+    const signedImages = images.filter(image => image.signed !== null);
+    test.skip(signedImages.length === 0, `no delivered images on ${contentUrl}`);
+
+    markScenarioRan();
+    for (const image of signedImages) {
+      expect(image.signed?.origin).toBe(env.deliveryOrigin);
+      expect(
+        image.signed?.tier,
+        `a member-facing render must not use the public tier: ${describeSignedUrl(image.src)}`
+      ).not.toBe('public');
+    }
+  });
+
   test('a public class site serves the public tier, with its ladder', async ({ request }) => {
     requireDelivery();
     test.skip(e2eTarget() !== 'staging', 'the local form of this scenario is the next test');
 
-    const response = await request.get(env.classSite);
-    expect(response.status(), `${env.classSite} should serve a class site`).toBe(200);
+    markScenarioRan();
+    // Same cold-start allowance as the harvest above.
+    const response = await fetchUntilHtml(
+      async url => {
+        const result = await request.get(url, { timeout: 30_000 });
+        return { status: result.status(), body: await result.text() };
+      },
+      env.classSite,
+      html => imagesFromHtml(html).some(image => image.signed !== null),
+      { attempts: 5, delayMs: 4_000 }
+    );
+    expect(response.status, `${env.classSite} should serve a class site`).toBe(200);
 
-    const html = await response.text();
+    const html = response.body;
     const images = imagesFromHtml(html).filter(image => image.signed !== null);
     expect(images.length, 'the staging class site should carry delivered images').toBeGreaterThan(
       0
@@ -682,44 +817,48 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     );
 
     const service = await services();
-    const pages = await service.page.findByClassroomId(room.id);
-    const publicPage = pages.find((row: { is_public?: boolean }) => row.is_public === true);
-    test.skip(publicPage === undefined, 'no public page in this classroom');
+    // Published AND public: a draft page is invisible on a class site, so
+    // choosing one made the site render a 404 that looked like a delivery bug.
+    const publicPage = (await classroomPages(room.id)).find(row => row.is_public === true);
+    test.skip(publicPage === undefined, 'no published public page in this classroom');
     if (!publicPage || !baseDomain) return;
 
     await loginAs(page, 'owner', `/${env.classroomSlug}/${publicPage.id}`);
-    const fixture = await withFixtureImage(
-      page,
-      {
-        id: publicPage.id,
-        slug: publicPage.slug,
-        contentPath: publicPage.content_path,
-        classroomSlug: env.classroomSlug,
-        classroomId: room.id,
-      },
-      'public'
-    );
+    markScenarioRan();
+    const fixture = await withFixtureImage(page, toTestPage(publicPage, room.id), 'public');
 
     // A classroom holds at most one site, so this may displace an existing row.
     // Whatever was there is put back in the `finally`.
     const existing = await service.site.getSiteForClassroom(room.id).catch(() => null);
     const subdomain = existing?.subdomain ?? `${E2E_SLUG_PREFIX}-${Date.now().toString(36)}`;
-    if (!existing) await service.site.validateAndClaimSubdomain(room.id, subdomain);
-
-    // Both settings applied unconditionally, INCLUDING on a row this run did
-    // not create. Claiming a subdomain only reserves the name: a site that is
-    // claimed but not enabled 404s, which is the least obvious way for this
-    // scenario to fail — and it is exactly what a previous interrupted run
-    // leaves behind. Enabling one without a home page is refused outright.
     const restoreSite = existing
       ? { is_enabled: existing.is_enabled, home_page_id: existing.home_page_id }
       : null;
-    await service.site.upsertSiteSettings(room.id, {
-      is_enabled: true,
-      home_page_id: existing?.home_page_id ?? publicPage.id,
-    });
 
+    // EVERYTHING that mutates the site is inside the try, including the claim.
+    // It was outside, and `upsertSiteSettings` throws HOME_PAGE_REQUIRED when
+    // the home page it is handed is a draft — so the claim succeeded, the
+    // enable threw, the `finally` never ran, and the run left a permanently
+    // claimed `e2e-cd-*` subdomain behind. Setup that can fail belongs under
+    // the same guard as the assertions.
+    let claimed = false;
     try {
+      if (!existing) {
+        await service.site.validateAndClaimSubdomain(room.id, subdomain);
+        claimed = true;
+      }
+
+      // Applied unconditionally, INCLUDING to a row this run did not create.
+      // Claiming a subdomain only reserves the name: a site that is claimed but
+      // not enabled 404s, which is the least obvious way for this scenario to
+      // fail, and is exactly what an interrupted run leaves behind. Enabling one
+      // without a home page is refused outright — hence the published-page
+      // filter above.
+      await service.site.upsertSiteSettings(room.id, {
+        is_enabled: true,
+        home_page_id: existing?.home_page_id ?? publicPage.id,
+      });
+
       // Reached by Host header, not by hostname: there is no DNS for
       // `{subdomain}.{base}` locally. The site tree is script-less by design,
       // so the server's own markup is the whole story — which is precisely why
@@ -756,9 +895,26 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       expect(html).not.toContain('raw.githubusercontent.com');
       expect(html).not.toMatch(/\/c\/[0-9a-f-]{36}\/missing\//i);
     } finally {
+      // Restore in ONE call, with the exact prior pair. Splitting it invites
+      // HOME_PAGE_REQUIRED on the way back (a site cannot be enabled without a
+      // home page, and cannot keep a home page it is not allowed to hold), and
+      // a swallowed failure there leaves someone else's site switched on.
       if (restoreSite) {
-        await service.site.upsertSiteSettings(room.id, restoreSite).catch(() => undefined);
-      } else {
+        try {
+          await service.site.upsertSiteSettings(room.id, restoreSite);
+        } catch (error) {
+          // Deliberately loud. This is a pre-existing site belonging to the
+          // classroom, and leaving it in the state THIS test wanted is a real
+          // change to someone's course that nobody asked for.
+          console.warn(
+            `[e2e] COULD NOT RESTORE the class site for ${room.slug} to ` +
+              `${JSON.stringify(restoreSite)} — it is currently enabled with home page ` +
+              `${publicPage.id}. Fix it by hand. Cause: ${
+                error instanceof Error ? error.message : String(error)
+              }`
+          );
+        }
+      } else if (claimed) {
         await service.site.deleteSiteForClassroom(room.id).catch(() => undefined);
       }
     }
@@ -771,6 +927,9 @@ test.describe('E2E CD — pages, when a file goes away', () => {
     request,
   }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
     test.skip(
@@ -787,6 +946,7 @@ test.describe('E2E CD — pages, when a file goes away', () => {
     // what breaks, the file underneath it is, and the resolver has to turn a
     // reference it can no longer satisfy into something deterministic rather
     // than into a confidently wrong signature.
+    markScenarioRan();
     const uploaded = await withFixtureImage(page, target, 'doomed');
 
     // Remove the file behind the app's back, then run the SAME sync the push
@@ -844,6 +1004,9 @@ test.describe('E2E CD — pages, the gate', () => {
     page,
   }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
 
@@ -857,6 +1020,7 @@ test.describe('E2E CD — pages, the gate', () => {
     // signed" is a real observation rather than the vacuous truth a page with
     // no images would give either way.
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    markScenarioRan();
     const fixture = await withFixtureImage(page, target, 'gate');
     // Wait for the write to be visible BEFORE flipping the gate, so "no signed
     // images" cannot be the consistency window wearing the gate's clothes.
@@ -878,7 +1042,26 @@ test.describe('E2E CD — pages, the gate', () => {
           `still signed with the gate off: ${describeSignedUrl(image.src)}`
         ).toBeNull();
       }
-      expect(log.delivery(), 'the gate is off; the delivery origin must be untouched').toEqual([]);
+      expect(
+        describeUrls(log.delivery()),
+        'the gate is off; the delivery origin must be untouched'
+      ).toEqual([]);
+
+      // The positive half. "Nothing is signed" is also true of a page that
+      // rendered no image at all, or one whose src is an empty string — so the
+      // fixture reference has to come back in a shape the legacy path can
+      // actually serve: the bare repo path, or the `/content/{org}/{repo}/…`
+      // proxy the app emitted before delivery existed.
+      const legacyShapes = images.filter(
+        image =>
+          /\/content\/[^/]+\/[^/]+\//.test(image.src) ||
+          image.src.includes(fixture.path) ||
+          /raw\.githubusercontent\.com/.test(image.src)
+      );
+      expect(
+        legacyShapes.length,
+        `no image fell back to a legacy reference; saw ${images.map(i => i.src.slice(0, 80)).join(', ')}`
+      ).toBeGreaterThan(0);
       log.stop();
 
       // Flip it back and the same page signs again — the point of the gate is
@@ -905,6 +1088,9 @@ test.describe('E2E CD — pages, the gate', () => {
     request,
   }) => {
     requireDelivery();
+    // Uploads, commits and deletes against a real GitHub repo, plus the waits
+    // that outlast a 60s content cache. The default 60s budget is not enough.
+    test.setTimeout(180_000);
     const room = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
@@ -918,6 +1104,7 @@ test.describe('E2E CD — pages, the gate', () => {
     if (!target) return;
 
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    markScenarioRan();
     const fixture = await withFixtureImage(page, target, 'version');
     const settled = await reloadUntilImages(page, `/${target.classroomSlug}/${target.id}`, seen =>
       seen.some(image => image.signed?.sha === fixture.sha)
@@ -931,8 +1118,17 @@ test.describe('E2E CD — pages, the gate', () => {
 
     // Through the same service the settings action calls, so the assertion is
     // about the product's own increment rather than a hand-written update.
+    keyVersionBeforeBump = versionBefore;
     const versionAfter = await bumpKeyVersion(room.id);
     expect(versionAfter).toBe(versionBefore + 1);
+
+    // Re-read rather than trusting the `beforeAll` snapshot: `room` was loaded
+    // once at file scope, so its `content_key_version` is now stale by exactly
+    // the thing this scenario just changed. Anything downstream that signed
+    // from the snapshot would be signing with the old version and asserting
+    // against the new one.
+    const roomAfter = await loadClassroom(room.slug);
+    expect(roomAfter.content_key_version).toBe(versionAfter);
 
     await page.reload();
     await page.waitForLoadState('networkidle');
@@ -983,11 +1179,26 @@ test.describe('E2E CD — the Worker, directly', () => {
     // the Worker's contract is checkable against staging at all.
     if (e2eTarget() === 'staging') {
       try {
-        const response = await request.get(env.classSite);
-        const image = await harvestSignedFromHtml(await response.text());
+        // Staging Fly apps scale to zero, so the first request after a quiet
+        // period can 502 or time out while a machine boots. Retrying on the
+        // CONTENT we need — a signed image in the markup — covers the cold
+        // start without a sleep, and fails honestly if the site is genuinely
+        // serving nothing.
+        const response = await fetchUntilHtml(
+          async url => {
+            const result = await request.get(url, { timeout: 30_000 });
+            return { status: result.status(), body: await result.text() };
+          },
+          env.classSite,
+          html => imagesFromHtml(html).some(image => image.signed !== null),
+          { attempts: 5, delayMs: 4_000 }
+        );
+        const image = await harvestSignedFromHtml(response.body);
         signedUrl = image?.src ?? null;
         if (!signedUrl) {
-          harvestError = `no signed image on ${env.classSite} — is content delivery on for that classroom?`;
+          harvestError =
+            `no signed image on ${env.classSite} (HTTP ${response.status}) — ` +
+            'is content delivery on for that classroom?';
         }
       } catch (error) {
         harvestError = error instanceof Error ? error.message : String(error);
@@ -1031,10 +1242,15 @@ test.describe('E2E CD — the Worker, directly', () => {
   function requireSignedUrl(): string {
     requireDelivery();
     test.skip(signedUrl === null, `no signed URL to work from: ${harvestError}`);
+    markScenarioRan();
     return signedUrl as string;
   }
 
   test('/healthz reports a configured Worker', async ({ request }) => {
+    // Deliberately does NOT count toward `scenariosThatRan`. It is a
+    // connectivity check that passes whenever a Worker is up, including in
+    // exactly the situation the counter exists to catch — every real scenario
+    // skipping. A detector that its own trivial case satisfies detects nothing.
     const response = await request.get(`${env.deliveryOrigin}/healthz`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as { ok: boolean; configured: boolean };
@@ -1065,7 +1281,12 @@ test.describe('E2E CD — the Worker, directly', () => {
     // The interesting forgery: `w=` is a real, valid parameter — it is just not
     // one THIS signature covers. Transforms are inside the canonical string
     // precisely so a client cannot widen an image it was handed.
-    const response = await request.get(appendWidth(requireSignedUrl(), 800));
+    const url = requireSignedUrl();
+    // The forgery only means anything if the URL did not already carry a
+    // width: appending `w=800` to a URL signed WITH `w=800` changes nothing,
+    // and the 403 would then be proving that a valid URL is valid.
+    expect(parseSignedUrl(url)?.w, 'the harvested src should be the untransformed one').toBeNull();
+    const response = await request.get(appendWidth(url, 800));
     expect(response.status()).toBe(403);
   });
 
@@ -1095,4 +1316,33 @@ test.describe('E2E CD — the Worker, directly', () => {
     // re-adds the file, and a cached 404 would outlive the fix.
     expect(response.headers()['cache-control']).toContain('no-store');
   });
+});
+
+/**
+ * The check that the suite did anything at all.
+ *
+ * Every skip in this file is individually defensible, and a run in which ALL of
+ * them fire still reports two green tasks — which is exactly what happened when
+ * turbo silently dropped `E2E_CD_CONTENT_REPO` from the environment. Green
+ * because nothing ran is the one failure mode a test suite cannot report about
+ * itself, so it is asserted here explicitly.
+ *
+ * Ordered last by being declared last: Playwright runs a file's tests in
+ * declaration order with `fullyParallel: false`, so by the time this executes
+ * every scenario above has had its turn.
+ *
+ * Staging is exempt on purpose — there, most scenarios SHOULD skip, and the
+ * ones that run are counted by their own assertions.
+ */
+test('E2E CD — at least one scenario actually ran', async () => {
+  test.skip(
+    e2eTarget() === 'staging',
+    'staging legitimately skips most of the pack; the local run is the one that must not be empty'
+  );
+  expect(
+    scenariosThatRan(),
+    'every scenario in this pack skipped. The run is green and proved nothing — check the skip ' +
+      'reasons above (a missing Worker, E2E_CD_CONTENT_REPO not reaching Playwright, or a ' +
+      'classroom whose content_delivery_enabled is false).'
+  ).toBeGreaterThan(0);
 });

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -22,6 +22,7 @@
  */
 import { expect, test } from './fixtures/test.fixture';
 import {
+  E2E_SLUG_PREFIX,
   EXPECTED_SIZES,
   EXPECTED_WIDTHS,
   FOREIGN_CLASSROOM_ID,
@@ -30,18 +31,24 @@ import {
   appendWidth,
   assetRow,
   authSkipReason,
+  blocksReference,
   bumpKeyVersion,
   classroom as loadClassroom,
   clearMintedSessions,
   deleteRepoFile,
   deliverySkipReason,
   describeSignedUrl,
+  FIXTURE_PREVIEW_WIDTH,
+  expectedSizesFor,
   extendExpiry,
+  fetchUntilHtml,
   fixtureName,
   gifBytes,
+  imageBlock,
   imageForSha,
   imagesFromHtml,
   keyVersion,
+  loadPageBlocks,
   loginAs,
   localOnlySkipReason,
   parseMissingUrl,
@@ -49,6 +56,8 @@ import {
   pngBytes,
   readImages,
   readStoredContent,
+  reloadUntilImages,
+  savePageBlocks,
   services,
   setDeliveryEnabled,
   storedContentLeaks,
@@ -76,6 +85,16 @@ let classroomError: string | null = null;
 /** Repo paths this run wrote; removed in `afterAll` whatever happened. */
 const uploadedPaths: string[] = [];
 
+/**
+ * A page's blocks as they were BEFORE this run touched them.
+ *
+ * The pack edits real pages in a real content repo, so "self-cleaning" has to
+ * mean restoring the document, not merely deleting the file it pointed at — a
+ * page left holding a reference to a file that no longer exists would render a
+ * broken image for a human tomorrow.
+ */
+const restoreBlocks: { pageId: string; blocks: unknown[] }[] = [];
+
 test.beforeAll(async () => {
   deliveryDown = await deliverySkipReason();
 
@@ -92,6 +111,17 @@ test.afterAll(async () => {
   await clearMintedSessions();
 
   if (!target || uploadSkipReason() !== null) return;
+
+  // Documents first, files second. Restoring in the other order would leave a
+  // window where a page in a real repo references a file that is already gone.
+  for (const entry of restoreBlocks.splice(0).reverse()) {
+    try {
+      await savePageBlocks(entry.pageId, entry.blocks);
+    } catch {
+      // Same reasoning as below: a failed cleanup must not turn the suite red.
+    }
+  }
+
   for (const repoPath of uploadedPaths.splice(0)) {
     try {
       await deleteRepoFile(target, repoPath);
@@ -131,7 +161,7 @@ function requireDelivery(): void {
  */
 function expectResponsive(
   image: RenderedImage,
-  expected: { classroomId: string; tier: string; keyVersion?: number }
+  expected: { classroomId: string; tier: string; keyVersion?: number; sizes?: string }
 ): void {
   const signed = image.signed;
   expect(signed, `src is not a signed delivery URL: ${describeSignedUrl(image.src)}`).not.toBeNull();
@@ -148,7 +178,12 @@ function expectResponsive(
   // ignores srcset, and the string a caller pairs its candidate list with.
   expect(signed.w, 'the fallback src must carry no width').toBeNull();
 
-  expect(image.sizes).toBe(EXPECTED_SIZES);
+  // `sizes` is NOT one constant everywhere, and assuming it was is a mistake
+  // worth naming. The viewer, the class site and the deck share `IMAGE_SIZES`,
+  // because none of them knows how wide the image will be laid out. The EDITOR
+  // does — the block carries `previewWidth` — so it emits `min(100vw, Npx)`
+  // instead, which is a better hint, not a drift. Callers say which they expect.
+  expect(image.sizes).toBe(expected.sizes ?? EXPECTED_SIZES);
 
   const widths = image.candidates.map(candidate => candidate.width);
   expect(widths).toEqual([...EXPECTED_WIDTHS]);
@@ -178,6 +213,7 @@ interface TestPage {
   slug: string;
   contentPath: string;
   classroomSlug: string;
+  classroomId: string;
 }
 
 /** A staff-editable page in the target classroom, from the seeded content. */
@@ -193,6 +229,7 @@ async function anyEditablePage(classroomId: string): Promise<TestPage | null> {
     slug: row.slug,
     contentPath: row.content_path,
     classroomSlug: env.classroomSlug,
+    classroomId,
   };
 }
 
@@ -237,6 +274,35 @@ async function uploadAsset(
   expect(body.error, `upload rejected: ${body.error}`).toBeUndefined();
   uploadedPaths.push(body.path);
   return body;
+}
+
+/**
+ * Give a page one image of our own, and register the undo.
+ *
+ * Every scenario that needs a delivered image makes its own rather than hunting
+ * for one in the seeded content. Hunting produces the worst kind of green: a
+ * classroom whose pages happen to carry no images turns every assertion into a
+ * vacuous truth, and the suite reports success for a pipeline it never touched.
+ */
+async function withFixtureImage(
+  page: import('@playwright/test').Page,
+  target: TestPage,
+  label: string
+): Promise<{ path: string; sha: string }> {
+  const uploaded = await uploadAsset(
+    page,
+    target.id,
+    fixtureName('png', label),
+    pngBytes(1500, 60),
+    'image/png'
+  );
+  const before = await loadPageBlocks(target.id);
+  restoreBlocks.push({ pageId: target.id, blocks: before });
+  await savePageBlocks(target.id, [...before, imageBlock(uploaded.path, `E2E CD ${label}`)]);
+
+  const row = await assetRow(target.classroomId, uploaded.path);
+  expect(row?.type, 'the upload should have recorded a blob row').toBe('blob');
+  return { path: uploaded.path, sha: row!.sha };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -288,13 +354,29 @@ test.describe('E2E CD — pages, the editor', () => {
     expect(row?.type).toBe('blob');
     expect(row?.sha).toBe(displaySigned?.sha);
 
+    // Put the uploaded file into the document, through the product's own save
+    // path. `/api/upload` deliberately does NOT place a block — the editor does
+    // that with the value it was handed — so a test that only uploaded would be
+    // rendering a page with nothing on it. Going through `savePageContent` also
+    // runs `canonicalizeAssetRef`, which is exactly the pass the storage
+    // assertion below depends on.
+    const before = await loadPageBlocks(target.id);
+    await savePageBlocks(target.id, [...before, imageBlock(uploaded.path, 'E2E CD fixture')]);
+    restoreBlocks.push({ pageId: target.id, blocks: before });
+
     // Now the render. Watching the network from BEFORE the navigation is the
     // only way to count: a listener attached afterwards has already missed the
     // image requests.
+    // Settle first, then count. Attaching the listener across the retry loop
+    // would count one request per attempt and turn "exactly one fetch" into a
+    // measurement of GitHub's consistency window.
+    await reloadUntilImages(page, `/${target.classroomSlug}/${target.id}`, seen =>
+      seen.some(image => image.signed?.sha === row!.sha)
+    );
+
     const log = trackRequests(page);
     await page.goto(`/${target.classroomSlug}/${target.id}`);
     await page.waitForLoadState('networkidle');
-
     const images = await readImages(page);
     const rendered = imageForSha(images, row!.sha);
     expect(
@@ -303,7 +385,13 @@ test.describe('E2E CD — pages, the editor', () => {
     ).toBeDefined();
     if (!rendered) return;
 
-    expectResponsive(rendered, { classroomId: room.id, tier: 'draft' });
+    // The editor knows its own layout width, so it hints with the block's
+    // `previewWidth` rather than the generic viewer constant.
+    expectResponsive(rendered, {
+      classroomId: room.id,
+      tier: 'draft',
+      sizes: expectedSizesFor(FIXTURE_PREVIEW_WIDTH),
+    });
 
     // Exactly one network request for this image. The browser picks ONE
     // candidate out of the set; a page that fetched two is a page that painted
@@ -334,6 +422,22 @@ test.describe('E2E CD — pages, the editor', () => {
       'image/png'
     );
 
+    // Render the page once with the block in it, so a signature genuinely
+    // exists in a browser and could have been handed back on save. Asserting
+    // the invariant without that step would be asserting about a document no
+    // signature ever reached.
+    const before = await loadPageBlocks(target.id);
+    await savePageBlocks(target.id, [...before, imageBlock(uploaded.path, 'E2E CD stored')]);
+    restoreBlocks.push({ pageId: target.id, blocks: before });
+
+    const shown = await reloadUntilImages(page, `/${target.classroomSlug}/${target.id}`, seen =>
+      seen.some(image => image.signed !== null)
+    );
+    expect(
+      shown.some(image => image.signed !== null),
+      'the render should have produced at least one signature to leak'
+    ).toBe(true);
+
     const stored = await readStoredContent(room, target.contentPath);
 
     // The invariant is about the RAW text, not a walked object: a signature
@@ -344,8 +448,45 @@ test.describe('E2E CD — pages, the editor', () => {
       'derived values leaked into stored content'
     ).toEqual([]);
 
-    // And the path we uploaded is storable as-is: relative, no scheme.
+    // And positively: the bare path IS what got written down.
     expect(uploaded.path.startsWith('http')).toBe(false);
+    expect(stored.raw).toContain(uploaded.path);
+  });
+
+  test('removing the block removes the reference from stored content', async ({ page }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    const uploaded = await uploadAsset(
+      page,
+      target.id,
+      fixtureName('png', 'removed'),
+      pngBytes(700, 40),
+      'image/png'
+    );
+
+    const before = await loadPageBlocks(target.id);
+    restoreBlocks.push({ pageId: target.id, blocks: before });
+    await savePageBlocks(target.id, [...before, imageBlock(uploaded.path, 'E2E CD removable')]);
+    expect(blocksReference(await loadPageBlocks(target.id), uploaded.path)).toBe(true);
+
+    // Take it back out, the way the editor would.
+    await savePageBlocks(target.id, before);
+
+    const after = await loadPageBlocks(target.id);
+    expect(
+      blocksReference(after, uploaded.path),
+      'the removed image is still referenced in stored content'
+    ).toBe(false);
+    // The FILE is untouched by removing a block — the asset stays in the repo
+    // until someone deletes it, which is the next scenario's subject.
+    expect(await assetRow(room.id, uploaded.path)).not.toBeNull();
   });
 
   test('a GIF gets a plain signed URL and no responsive ladder', async ({ page }) => {
@@ -402,6 +543,8 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     test.skip(authSkipReason() !== null, authSkipReason() ?? '');
     test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
 
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+
     const service = await services();
     const pages = await service.page.findByClassroomId(room.id);
     const privatePage = pages.find(
@@ -410,16 +553,51 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     test.skip(privatePage === undefined, 'no published non-public page in this classroom');
     if (!privatePage) return;
 
-    // A STUDENT, deliberately. Staff would be `draft` — the tier is about what
-    // the viewer may see, and only a non-editing member exercises `enrolled`.
+    // A viewer's read of page content is cached for 60 seconds — the loader
+    // passes `skipCache: canEdit`, so staff always read fresh and a student
+    // does not. Two consequences the rest of this test is shaped by: never warm
+    // that cache by visiting the page as staff first (hence the upload happens
+    // from the classroom index, not from the page), and allow more than a
+    // minute for the case where something warmed it anyway.
+    test.setTimeout(180_000);
+
+    // Staff puts the image there; a student looks at it. Two sessions in one
+    // test because the tier is a property of the VIEWER, and the only way to
+    // observe `enrolled` is to be someone who cannot edit.
+    await loginAs(page, 'owner', `/${env.classroomSlug}`);
+    const fixture = await withFixtureImage(
+      page,
+      {
+        id: privatePage.id,
+        slug: privatePage.slug,
+        contentPath: privatePage.content_path,
+        classroomSlug: env.classroomSlug,
+        classroomId: room.id,
+      },
+      'enrolled'
+    );
+
     await loginAs(page, 'student', `/${env.classroomSlug}/${privatePage.id}`);
 
     const log = trackRequests(page);
     await page.goto(`/${env.classroomSlug}/${privatePage.id}`);
     await page.waitForLoadState('networkidle');
 
-    const signedImages = (await readImages(page)).filter(image => image.signed !== null);
-    test.skip(signedImages.length === 0, 'this page carries no delivered images');
+    const rendered = await reloadUntilImages(
+      page,
+      `/${env.classroomSlug}/${privatePage.id}`,
+      images => images.some(image => image.signed?.sha === fixture.sha),
+      // Long enough to outlast the viewer content cache if it was warm.
+      { attempts: 8, delayMs: 10_000 }
+    );
+    const signedImages = rendered.filter(image => image.signed !== null);
+    const ours = signedImages.find(image => image.signed?.sha === fixture.sha);
+    expect(
+      ours,
+      `the student should see the fixture image (sha ${fixture.sha}); saw ${
+        rendered.map(image => describeSignedUrl(image.src)).join(', ') || '<no images>'
+      }`
+    ).toBeDefined();
 
     for (const image of signedImages) {
       expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('enrolled');
@@ -430,42 +608,104 @@ test.describe('E2E CD — pages, what each audience sees', () => {
   });
 
   test('a public class-site page is served at the public tier, with its ladder', async ({
+    page,
     request,
   }) => {
     requireDelivery();
     const room = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+    test.setTimeout(180_000);
+
+    // A site host is only rewritten when the server was started with
+    // SITE_BASE_DOMAIN set; without it the middleware is a deliberate no-op and
+    // there is no public surface to look at.
+    const baseDomain = process.env.SITE_BASE_DOMAIN;
+    test.skip(
+      !baseDomain,
+      'SITE_BASE_DOMAIN is unset, so the class-site rewriter is a no-op — restart the pages app with it set (e.g. SITE_BASE_DOMAIN=classmoji.io)'
+    );
 
     const service = await services();
-    const sites = await service.site.getSiteForClassroom(room.id).catch(() => null);
-    test.skip(
-      !sites?.subdomain,
-      'no class site claimed for this classroom — a public-tier render is only observable on a site host'
-    );
     const pages = await service.page.findByClassroomId(room.id);
     const publicPage = pages.find((row: { is_public?: boolean }) => row.is_public === true);
     test.skip(publicPage === undefined, 'no public page in this classroom');
-    if (!publicPage || !sites?.subdomain) return;
+    if (!publicPage || !baseDomain) return;
 
-    // The site is reached by Host header, not by hostname: locally there is no
-    // DNS for `{subdomain}.classmoji.io`, and the site tree is script-less, so
-    // the server's own markup is the whole story.
-    const response = await request.get(`${env.pages}/${publicPage.slug}`, {
-      headers: { host: `${sites.subdomain}.classmoji.io` },
+    await loginAs(page, 'owner', `/${env.classroomSlug}/${publicPage.id}`);
+    const fixture = await withFixtureImage(
+      page,
+      {
+        id: publicPage.id,
+        slug: publicPage.slug,
+        contentPath: publicPage.content_path,
+        classroomSlug: env.classroomSlug,
+        classroomId: room.id,
+      },
+      'public'
+    );
+
+    // A classroom holds at most one site, so this may displace an existing row.
+    // Whatever was there is put back in the `finally`.
+    const existing = await service.site.getSiteForClassroom(room.id).catch(() => null);
+    const subdomain = existing?.subdomain ?? `${E2E_SLUG_PREFIX}-${Date.now().toString(36)}`;
+    if (!existing) await service.site.validateAndClaimSubdomain(room.id, subdomain);
+
+    // Both settings applied unconditionally, INCLUDING on a row this run did
+    // not create. Claiming a subdomain only reserves the name: a site that is
+    // claimed but not enabled 404s, which is the least obvious way for this
+    // scenario to fail — and it is exactly what a previous interrupted run
+    // leaves behind. Enabling one without a home page is refused outright.
+    const restoreSite = existing
+      ? { is_enabled: existing.is_enabled, home_page_id: existing.home_page_id }
+      : null;
+    await service.site.upsertSiteSettings(room.id, {
+      is_enabled: true,
+      home_page_id: existing?.home_page_id ?? publicPage.id,
     });
-    test.skip(response.status() === 404, 'class-site rewriting is not enabled on this server');
-    expect(response.status()).toBe(200);
 
-    const html = await response.text();
-    const signedImages = imagesFromHtml(html).filter(image => image.signed !== null);
-    test.skip(signedImages.length === 0, 'this public page carries no delivered images');
+    try {
+      // Reached by Host header, not by hostname: there is no DNS for
+      // `{subdomain}.{base}` locally. The site tree is script-less by design,
+      // so the server's own markup is the whole story — which is precisely why
+      // this is the only place the `public` tier is observable.
+      const response = await fetchUntilHtml(
+        async url => {
+          const result = await request.get(url, {
+            headers: { host: `${subdomain}.${baseDomain}` },
+          });
+          return { status: result.status(), body: await result.text() };
+        },
+        `${env.pages}/${publicPage.slug}`,
+        html => html.includes(fixture.sha),
+        // The class site is an anonymous surface, so its page content comes out
+        // of the same 60-second read cache a student gets. Long enough to
+        // outlast it.
+        { attempts: 8, delayMs: 10_000 }
+      );
+      expect(response.status, 'the class site should serve the public page').toBe(200);
 
-    for (const image of signedImages) {
-      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('public');
+      const html = response.body;
+      const images = imagesFromHtml(html);
+      const ours = images.find(image => image.signed?.sha === fixture.sha);
+      expect(ours, 'the fixture image should be on the public page').toBeDefined();
+      if (!ours) return;
+
+      expect(ours.signed?.tier, describeSignedUrl(ours.src)).toBe('public');
+      // The class site sizes from the block's own `previewWidth` exactly as the
+      // editor does — the hint follows the BLOCK, not the surface.
+      expect(ours.sizes).toBe(expectedSizesFor(FIXTURE_PREVIEW_WIDTH));
+      expect(ours.candidates.map(candidate => candidate.width)).toEqual([...EXPECTED_WIDTHS]);
+
+      // No legacy escape hatch left in the markup, and nothing unresolvable.
+      expect(html).not.toContain('raw.githubusercontent.com');
+      expect(html).not.toMatch(/\/c\/[0-9a-f-]{36}\/missing\//i);
+    } finally {
+      if (restoreSite) {
+        await service.site.upsertSiteSettings(room.id, restoreSite).catch(() => undefined);
+      } else {
+        await service.site.deleteSiteForClassroom(room.id).catch(() => undefined);
+      }
     }
-
-    // Not a signature in sight in the markup's own legacy escape hatches.
-    expect(html).not.toContain('raw.githubusercontent.com');
-    expect(html).not.toMatch(/\/c\/[0-9a-f-]{36}\/missing\//i);
   });
 });
 
@@ -484,13 +724,11 @@ test.describe('E2E CD — pages, when a file goes away', () => {
     if (!target) return;
 
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
-    const uploaded = await uploadAsset(
-      page,
-      target.id,
-      fixtureName('png', 'doomed'),
-      pngBytes(1000, 40),
-      'image/png'
-    );
+    // The page KEEPS its reference. That is the whole point: the block is not
+    // what breaks, the file underneath it is, and the resolver has to turn a
+    // reference it can no longer satisfy into something deterministic rather
+    // than into a confidently wrong signature.
+    const uploaded = await withFixtureImage(page, target, 'doomed');
 
     // Remove the file behind the app's back, then run the SAME sync the push
     // webhook would have run. Without this the map has simply not heard the
@@ -525,6 +763,17 @@ test.describe('E2E CD — pages, when a file goes away', () => {
     const response = await request.get(resolved);
     expect(response.status()).toBe(404);
     expect(response.headers()['cache-control']).toContain('no-store');
+
+    // And the page really does render that shape, rather than the resolver
+    // merely being willing to produce it.
+    const rendered = await reloadUntilImages(page, `/${target.classroomSlug}/${target.id}`, seen =>
+      seen.some(image => parseMissingUrl(image.src)?.ref === uploaded.path)
+    );
+    const placeholders = rendered.filter(
+      image => parseMissingUrl(image.src)?.ref === uploaded.path
+    );
+    expect(placeholders.length, 'the page should render the /missing/ placeholder').toBe(1);
+    expect(placeholders[0].srcset, 'a placeholder has no candidates to offer').toBeNull();
   });
 });
 
@@ -536,18 +785,31 @@ test.describe('E2E CD — pages, the gate', () => {
     const room = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
 
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+
     const target = await anyEditablePage(room.id);
     test.skip(target === null, 'no page with a content_path in the test classroom');
     if (!target) return;
 
+    // Put a known image on the page BEFORE flipping the gate, so "nothing is
+    // signed" is a real observation rather than the vacuous truth a page with
+    // no images would give either way.
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    const fixture = await withFixtureImage(page, target, 'gate');
+    // Wait for the write to be visible BEFORE flipping the gate, so "no signed
+    // images" cannot be the consistency window wearing the gate's clothes.
+    await reloadUntilImages(page, `/${target.classroomSlug}/${target.id}`, seen =>
+      seen.some(image => image.signed?.sha === fixture.sha)
+    );
+
     const before = await setDeliveryEnabled(room.id, false);
     try {
-      await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
       const log = trackRequests(page);
       await page.goto(`/${target.classroomSlug}/${target.id}`);
       await page.waitForLoadState('networkidle');
 
       const images = await readImages(page);
+      expect(images.length, 'the fixture image should still be on the page').toBeGreaterThan(0);
       for (const image of images) {
         expect(image.signed, `still signed with the gate off: ${describeSignedUrl(image.src)}`)
           .toBeNull();
@@ -563,7 +825,8 @@ test.describe('E2E CD — pages, the gate', () => {
       await page.waitForLoadState('networkidle');
 
       const signedAgain = (await readImages(page)).filter(image => image.signed !== null);
-      test.skip(signedAgain.length === 0, 'this page carries no images to re-sign');
+      expect(signedAgain.length, 'the gate went back on; the image should sign again')
+        .toBeGreaterThan(0);
       expect(secondLog.delivery().length).toBeGreaterThan(0);
       secondLog.stop();
     } finally {
@@ -578,6 +841,7 @@ test.describe('E2E CD — pages, the gate', () => {
     requireDelivery();
     const room = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
     test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
 
     const target = await anyEditablePage(room.id);
@@ -585,11 +849,13 @@ test.describe('E2E CD — pages, the gate', () => {
     if (!target) return;
 
     await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
-    await page.goto(`/${target.classroomSlug}/${target.id}`);
-    await page.waitForLoadState('networkidle');
+    const fixture = await withFixtureImage(page, target, 'version');
+    const settled = await reloadUntilImages(page, `/${target.classroomSlug}/${target.id}`, seen =>
+      seen.some(image => image.signed?.sha === fixture.sha)
+    );
 
-    const before = (await readImages(page)).filter(image => image.signed !== null);
-    test.skip(before.length === 0, 'this page carries no delivered images to re-version');
+    const before = settled.filter(image => image.signed !== null);
+    expect(before.length, 'the fixture image should be signed before the bump').toBeGreaterThan(0);
     const versionBefore = await keyVersion(room.id);
     expect(before.every(image => image.signed?.keyVersion === versionBefore)).toBe(true);
     const staleUrl = before[0].src;
@@ -610,10 +876,16 @@ test.describe('E2E CD — pages, the gate', () => {
       }
     }
 
-    // The old URL is not merely superseded — it no longer verifies, because the
-    // per-classroom key is derived from the version.
+    // And the part that is easy to get backwards, so it is asserted rather
+    // than assumed: a bump is NOT a revocation. The Worker derives its key from
+    // the `v` carried in the URL, so a link minted under the old version still
+    // verifies, and whoever is holding one keeps their access. What changed is
+    // which URL the app hands out — every cache keyed by URL misses and refills.
+    // If this ever starts returning 403, the bump has quietly become a
+    // revocation and the comment on `bumpContentKeyVersion` is a lie.
     const stale = await request.get(staleUrl);
-    expect(stale.status()).toBe(403);
+    expect(stale.status(), 'a cache bump must not revoke URLs already handed out').toBe(200);
+    expect(parseSignedUrl(staleUrl)?.keyVersion).toBe(versionBefore);
   });
 });
 
@@ -627,16 +899,38 @@ test.describe('E2E CD — the Worker, directly', () => {
    */
   let signedUrl: string | null = null;
 
+  /** Why no URL could be harvested, for the skip message. */
+  let harvestError: string | null = null;
+
   test.beforeAll(async ({ browser }) => {
-    if (deliveryDown !== null || localOnlySkipReason() !== null || !target) return;
+    if (deliveryDown !== null || localOnlySkipReason() !== null || !target) {
+      harvestError = deliveryDown ?? localOnlySkipReason() ?? 'no classroom';
+      return;
+    }
+    if (uploadSkipReason() !== null) {
+      harvestError = uploadSkipReason();
+      return;
+    }
+
     const page = await browser.newPage();
     try {
       const editable = await anyEditablePage(target.id);
-      if (!editable) return;
+      if (!editable) {
+        harvestError = 'no page with a content_path in the test classroom';
+        return;
+      }
+      // Make the image rather than hoping for one. A Worker suite that silently
+      // skipped because the seeded pages happened to carry no images would be
+      // the most expensive kind of nothing: six green-looking refusal tests that
+      // never ran.
       await loginAs(page, 'owner', `/${editable.classroomSlug}/${editable.id}`);
+      await withFixtureImage(page, editable, 'worker');
       await page.goto(`/${editable.classroomSlug}/${editable.id}`);
       await page.waitForLoadState('networkidle');
       signedUrl = (await readImages(page)).find(image => image.signed !== null)?.src ?? null;
+      if (!signedUrl) harvestError = 'the fixture image rendered without a signature';
+    } catch (error) {
+      harvestError = error instanceof Error ? error.message : String(error);
     } finally {
       await page.close();
     }
@@ -644,10 +938,7 @@ test.describe('E2E CD — the Worker, directly', () => {
 
   function requireSignedUrl(): string {
     requireDelivery();
-    test.skip(
-      signedUrl === null,
-      'no signed URL could be harvested from a rendered page — the earlier scenarios say why'
-    );
+    test.skip(signedUrl === null, `no signed URL to work from: ${harvestError}`);
     return signedUrl as string;
   }
 

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -38,6 +38,8 @@ import {
   deleteRepoFile,
   deliverySkipReason,
   describeSignedUrl,
+  e2eTarget,
+  harvestSignedFromHtml,
   FIXTURE_PREVIEW_WIDTH,
   expectedSizesFor,
   extendExpiry,
@@ -607,6 +609,47 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     log.stop();
   });
 
+  /**
+   * The one member-facing surface a DEPLOYED target can be checked on.
+   *
+   * A class site is anonymous and server-rendered, so it needs neither a
+   * session nor a database — which is exactly the pair staging cannot give
+   * this pack. Against staging the site already carries public-tier images, so
+   * the scenario reads what is there; locally it has to make one first,
+   * because a freshly seeded classroom has no public site and no pictures.
+   */
+  test('a public class site serves the public tier, with its ladder', async ({ request }) => {
+    requireDelivery();
+    test.skip(e2eTarget() !== 'staging', 'the local form of this scenario is the next test');
+
+    const response = await request.get(env.classSite);
+    expect(response.status(), `${env.classSite} should serve a class site`).toBe(200);
+
+    const html = await response.text();
+    const images = imagesFromHtml(html).filter(image => image.signed !== null);
+    expect(images.length, 'the staging class site should carry delivered images').toBeGreaterThan(0);
+
+    for (const image of images) {
+      expect(image.signed?.origin).toBe(env.deliveryOrigin);
+      // Anonymous readers, so `public` and nothing else. A `draft` or
+      // `enrolled` URL on an anonymous page would be a tier leak.
+      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('public');
+      expect(image.signed?.w, 'the fallback src carries no width').toBeNull();
+      if (image.candidates.length > 0) {
+        expect(image.candidates.map(candidate => candidate.width)).toEqual([...EXPECTED_WIDTHS]);
+        for (const candidate of image.candidates) {
+          expect(candidate.parsed?.sha).toBe(image.signed?.sha);
+          expect(candidate.parsed?.fmt).toBe('auto');
+          expect(candidate.parsed?.exp).toBe(image.signed?.exp);
+        }
+        expect(image.sizes).toBeTruthy();
+      }
+    }
+
+    expect(html).not.toContain('raw.githubusercontent.com');
+    expect(html).not.toMatch(/\/c\/[0-9a-f-]{36}\/missing\//i);
+  });
+
   test('a public class-site page is served at the public tier, with its ladder', async ({
     page,
     request,
@@ -902,9 +945,32 @@ test.describe('E2E CD — the Worker, directly', () => {
   /** Why no URL could be harvested, for the skip message. */
   let harvestError: string | null = null;
 
-  test.beforeAll(async ({ browser }) => {
-    if (deliveryDown !== null || localOnlySkipReason() !== null || !target) {
-      harvestError = deliveryDown ?? localOnlySkipReason() ?? 'no classroom';
+  test.beforeAll(async ({ browser, request }) => {
+    if (deliveryDown !== null) {
+      harvestError = deliveryDown;
+      return;
+    }
+
+    // Against a deployed target there is no database and no session, so the
+    // signature comes off the public class site — anonymous, server-rendered,
+    // and already carrying current public-tier URLs. This is the whole reason
+    // the Worker's contract is checkable against staging at all.
+    if (e2eTarget() === 'staging') {
+      try {
+        const response = await request.get(env.classSite);
+        const image = await harvestSignedFromHtml(await response.text());
+        signedUrl = image?.src ?? null;
+        if (!signedUrl) {
+          harvestError = `no signed image on ${env.classSite} — is content delivery on for that classroom?`;
+        }
+      } catch (error) {
+        harvestError = error instanceof Error ? error.message : String(error);
+      }
+      return;
+    }
+
+    if (localOnlySkipReason() !== null || !target) {
+      harvestError = localOnlySkipReason() ?? 'no classroom';
       return;
     }
     if (uploadSkipReason() !== null) {
@@ -990,10 +1056,13 @@ test.describe('E2E CD — the Worker, directly', () => {
   });
 
   test('a /missing/ URL is a 404 that is never cached', async ({ request }) => {
-    requireDelivery();
-    const room = requireClassroom();
+    // The classroom id comes from the harvested URL rather than the database,
+    // so this runs against a deployed target too. It is a read of a path that
+    // by construction names no file — nothing is created and nothing is
+    // written, which is what makes it safe to point at staging.
+    const classroomId = parseSignedUrl(requireSignedUrl())!.classroomId;
     const response = await request.get(
-      `${env.deliveryOrigin}/c/${room.id}/missing/${encodeURIComponent('pages/e2e-cd/nope.png')}`
+      `${env.deliveryOrigin}/c/${classroomId}/missing/${encodeURIComponent('pages/e2e-cd/nope.png')}`
     );
     expect(response.status()).toBe(404);
     // Never cached: the reference may become resolvable the moment someone

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -1,0 +1,712 @@
+/**
+ * The content delivery pipeline, end to end, for pages.
+ *
+ * What is under test is a DERIVATION, not a stored value: a page stores a bare
+ * repo path, and the signed URL a viewer loads is computed at render time from
+ * that path, the file's current sha, the viewer's tier and the classroom's key
+ * version. Every claim below is therefore about a relationship between what is
+ * stored, what is rendered, and what the Worker will serve — never about a
+ * literal URL, which would be a claim about the time of day.
+ *
+ * Two rules the whole file obeys:
+ *
+ *   - **Shape, never signature.** A signature is a function of a secret and a
+ *     clock. Assertions match the path and the set of query keys; the `sig`
+ *     value is only ever checked for presence, and never printed.
+ *   - **Skip loudly.** Half of this pack cannot run without a Worker, a
+ *     writable content repo, or a database. A silent pass in those conditions
+ *     is worse than a failure, so every gate names the exact missing piece.
+ *
+ * Fixtures are prefixed `E2E CD` / `e2e-cd` and removed in `afterAll`, because
+ * a run leaves rows in a real database and files in a real GitHub repository.
+ */
+import { expect, test } from './fixtures/test.fixture';
+import {
+  EXPECTED_SIZES,
+  EXPECTED_WIDTHS,
+  FOREIGN_CLASSROOM_ID,
+  type E2EClassroom,
+  type RenderedImage,
+  appendWidth,
+  assetRow,
+  authSkipReason,
+  bumpKeyVersion,
+  classroom as loadClassroom,
+  clearMintedSessions,
+  deleteRepoFile,
+  deliverySkipReason,
+  describeSignedUrl,
+  extendExpiry,
+  fixtureName,
+  gifBytes,
+  imageForSha,
+  imagesFromHtml,
+  keyVersion,
+  loginAs,
+  localOnlySkipReason,
+  parseMissingUrl,
+  parseSignedUrl,
+  pngBytes,
+  readImages,
+  readStoredContent,
+  services,
+  setDeliveryEnabled,
+  storedContentLeaks,
+  swapClassroom,
+  syncMap,
+  tamperSignature,
+  targets,
+  trackRequests,
+  uploadSkipReason,
+} from './helpers';
+
+const env = targets();
+
+/**
+ * Resolved once, in `beforeAll`, and consulted by every gate.
+ *
+ * `test.skip()` inside a test body is what produces a readable reason in the
+ * report; a `describe`-level condition can only say "skipped". These are the
+ * reasons.
+ */
+let deliveryDown: string | null = 'not probed';
+let target: E2EClassroom | null = null;
+let classroomError: string | null = null;
+
+/** Repo paths this run wrote; removed in `afterAll` whatever happened. */
+const uploadedPaths: string[] = [];
+
+test.beforeAll(async () => {
+  deliveryDown = await deliverySkipReason();
+
+  if (localOnlySkipReason() === null) {
+    try {
+      target = await loadClassroom();
+    } catch (error) {
+      classroomError = error instanceof Error ? error.message : String(error);
+    }
+  }
+});
+
+test.afterAll(async () => {
+  await clearMintedSessions();
+
+  if (!target || uploadSkipReason() !== null) return;
+  for (const repoPath of uploadedPaths.splice(0)) {
+    try {
+      await deleteRepoFile(target, repoPath);
+    } catch {
+      // Best effort: a fixture that outlives a killed run is findable by its
+      // `e2e-cd-` marker, and a failed cleanup must not turn the suite red.
+    }
+  }
+});
+
+/** The classroom, or a skip that says why there isn't one. */
+function requireClassroom(): E2EClassroom {
+  test.skip(
+    localOnlySkipReason() !== null,
+    localOnlySkipReason() ?? 'database access is local only'
+  );
+  test.skip(classroomError !== null, `could not load the test classroom: ${classroomError}`);
+  if (!target) throw new Error('unreachable: classroom missing without a skip');
+  return target;
+}
+
+function requireDelivery(): void {
+  test.skip(deliveryDown !== null, deliveryDown ?? 'delivery not configured');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared assertions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A rendered raster image, checked against the whole contract at once.
+ *
+ * Bundled rather than left as loose expects because these five facts only mean
+ * something together: a signed `src` with no `srcset` is a regression, a
+ * `srcset` whose candidates carry a different key version than `src` is a
+ * split-clock bug, and `sizes` without either is meaningless markup.
+ */
+function expectResponsive(
+  image: RenderedImage,
+  expected: { classroomId: string; tier: string; keyVersion?: number }
+): void {
+  const signed = image.signed;
+  expect(signed, `src is not a signed delivery URL: ${describeSignedUrl(image.src)}`).not.toBeNull();
+  if (!signed) return;
+
+  expect(signed.origin).toBe(env.deliveryOrigin);
+  expect(signed.classroomId.toLowerCase()).toBe(expected.classroomId.toLowerCase());
+  expect(signed.tier).toBe(expected.tier);
+  expect(signed.sig.length).toBeGreaterThan(0);
+  expect(signed.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  if (expected.keyVersion !== undefined) expect(signed.keyVersion).toBe(expected.keyVersion);
+
+  // `src` is the untransformed original: the fallback for a browser that
+  // ignores srcset, and the string a caller pairs its candidate list with.
+  expect(signed.w, 'the fallback src must carry no width').toBeNull();
+
+  expect(image.sizes).toBe(EXPECTED_SIZES);
+
+  const widths = image.candidates.map(candidate => candidate.width);
+  expect(widths).toEqual([...EXPECTED_WIDTHS]);
+
+  for (const candidate of image.candidates) {
+    expect(
+      candidate.parsed,
+      `srcset candidate is not signed: ${describeSignedUrl(candidate.url)}`
+    ).not.toBeNull();
+    expect(candidate.parsed?.w).toBe(candidate.width);
+    expect(candidate.parsed?.fmt).toBe('auto');
+    expect(candidate.parsed?.sha).toBe(signed.sha);
+    expect(candidate.parsed?.tier).toBe(signed.tier);
+    // One clock for the batch: a candidate signed in a different expiry bucket
+    // than its own `src` is the bug `resolveDelivery`'s pinned `now` prevents.
+    expect(candidate.parsed?.keyVersion).toBe(signed.keyVersion);
+    expect(candidate.parsed?.exp).toBe(signed.exp);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TestPage {
+  id: string;
+  slug: string;
+  contentPath: string;
+  classroomSlug: string;
+}
+
+/** A staff-editable page in the target classroom, from the seeded content. */
+async function anyEditablePage(classroomId: string): Promise<TestPage | null> {
+  const service = await services();
+  const pages = await service.page.findByClassroomId(classroomId).catch(() => null);
+  const row = pages?.find(
+    (page: { content_path?: string | null }) => typeof page.content_path === 'string'
+  );
+  if (!row) return null;
+  return {
+    id: row.id,
+    slug: row.slug,
+    contentPath: row.content_path,
+    classroomSlug: env.classroomSlug,
+  };
+}
+
+/**
+ * Upload one file through the app's own `/api/upload`, as staff.
+ *
+ * Through the route rather than through `ContentService` directly: the route is
+ * what decides whether the editor is handed a bare repo path or a legacy URL,
+ * and that decision is half of what this pack is checking. Returns the repo
+ * path, which is the thing the block stores.
+ */
+async function uploadAsset(
+  page: import('@playwright/test').Page,
+  pageId: string,
+  filename: string,
+  bytes: Buffer,
+  mimeType: string
+): Promise<{ path: string; url: string; displayUrl: string | null }> {
+  const result = await page.evaluate(
+    async ({ pageId: id, filename: name, base64, mimeType: type }) => {
+      const binary = atob(base64);
+      const buffer = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        buffer[index] = binary.charCodeAt(index);
+      }
+      const form = new FormData();
+      form.append('file', new File([buffer], name, { type }));
+      form.append('pageId', id);
+      const response = await fetch('/api/upload', { method: 'POST', body: form });
+      return { status: response.status, body: await response.text() };
+    },
+    { pageId, filename, base64: bytes.toString('base64'), mimeType }
+  );
+
+  expect(result.status, `upload failed: ${result.body}`).toBe(200);
+  const body = JSON.parse(result.body) as {
+    error?: string;
+    path: string;
+    url: string;
+    displayUrl: string | null;
+  };
+  expect(body.error, `upload rejected: ${body.error}`).toBeUndefined();
+  uploadedPaths.push(body.path);
+  return body;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenarios
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('E2E CD — pages, the editor', () => {
+  test('an uploaded raster image renders as a signed draft src with a three-rung srcset', async ({
+    page,
+  }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+    test.skip(
+      !room.content_delivery_enabled,
+      `content_delivery_enabled is false for '${room.slug}' — see apps/content/README.md, "Local end-to-end"`
+    );
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+
+    const uploaded = await uploadAsset(
+      page,
+      target.id,
+      fixtureName('png', 'editor'),
+      pngBytes(1800, 80),
+      'image/png'
+    );
+
+    // The route hands the editor a BARE REPO PATH when the layer is on. That
+    // is the value the block will store, and the reason storage survives an
+    // expiry: `pages/<slug>/assets/<name>.png`, no scheme, no host.
+    expect(uploaded.path).toMatch(/^[\w.-]+(?:\/[\w.-]+)*\.png$/);
+    expect(uploaded.path).not.toMatch(/^https?:/);
+    expect(uploaded.displayUrl, 'the layer is on, so a display URL was signed').not.toBeNull();
+
+    const displaySigned = parseSignedUrl(uploaded.displayUrl ?? '');
+    expect(displaySigned, `displayUrl is not signed: ${describeSignedUrl(uploaded.displayUrl ?? '')}`)
+      .not.toBeNull();
+    // Staff uploading into an editor is the draft tier by definition.
+    expect(displaySigned?.tier).toBe('draft');
+
+    // The asset map learned about the file as part of the upload — this is what
+    // makes the very first render resolvable rather than a `/missing/`.
+    const row = await assetRow(room.id, uploaded.path);
+    expect(row?.type).toBe('blob');
+    expect(row?.sha).toBe(displaySigned?.sha);
+
+    // Now the render. Watching the network from BEFORE the navigation is the
+    // only way to count: a listener attached afterwards has already missed the
+    // image requests.
+    const log = trackRequests(page);
+    await page.goto(`/${target.classroomSlug}/${target.id}`);
+    await page.waitForLoadState('networkidle');
+
+    const images = await readImages(page);
+    const rendered = imageForSha(images, row!.sha);
+    expect(
+      rendered,
+      `no rendered <img> for the uploaded sha; saw ${images.map(i => describeSignedUrl(i.src)).join(', ')}`
+    ).toBeDefined();
+    if (!rendered) return;
+
+    expectResponsive(rendered, { classroomId: room.id, tier: 'draft' });
+
+    // Exactly one network request for this image. The browser picks ONE
+    // candidate out of the set; a page that fetched two is a page that painted
+    // a `src` and then swapped in a `srcset` after layout, which is precisely
+    // the double-download the block's synchronous attribute wiring prevents.
+    expect(log.forSha(row!.sha).length, 'one image, one fetch').toBe(1);
+    expect(log.missing(), 'nothing should resolve to /missing/').toEqual([]);
+    log.stop();
+  });
+
+  test('the stored block keeps a bare path — no signature, no srcset, no delivery origin', async ({
+    page,
+  }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    const uploaded = await uploadAsset(
+      page,
+      target.id,
+      fixtureName('png', 'stored'),
+      pngBytes(900, 40),
+      'image/png'
+    );
+
+    const stored = await readStoredContent(room, target.contentPath);
+
+    // The invariant is about the RAW text, not a walked object: a signature
+    // could hide in a nested prop, an HTML string, or a key nobody thought to
+    // traverse, and the point is that it is nowhere at all.
+    expect(
+      storedContentLeaks(stored.raw, env.deliveryOrigin),
+      'derived values leaked into stored content'
+    ).toEqual([]);
+
+    // And the path we uploaded is storable as-is: relative, no scheme.
+    expect(uploaded.path.startsWith('http')).toBe(false);
+  });
+
+  test('a GIF gets a plain signed URL and no responsive ladder', async ({ page }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    const uploaded = await uploadAsset(
+      page,
+      target.id,
+      fixtureName('gif', 'animation'),
+      gifBytes(),
+      'image/gif'
+    );
+
+    const signed = parseSignedUrl(uploaded.displayUrl ?? '');
+    expect(signed, 'a gif is still signed — it just gets no ladder').not.toBeNull();
+    expect(signed?.ext).toBe('gif');
+
+    // The whole claim: resizing a GIF would flatten an animation to a still, so
+    // the pipeline declines to offer widths at all.
+    expect(signed?.w, 'a gif must never carry a width').toBeNull();
+    expect(signed?.fmt, 'a gif must never be re-encoded').toBeNull();
+
+    const set = await services().then(service =>
+      service.contentDelivery.resolveAssetSrcSet(
+        {
+          classroom: {
+            id: room.id,
+            content_key_version: room.content_key_version,
+            content_repo: room.content_repo ?? '',
+            git_organization: { login: room.orgLogin },
+            content_delivery_enabled: room.content_delivery_enabled,
+          },
+          tier: 'draft',
+        },
+        uploaded.path
+      )
+    );
+    expect(set, 'a gif must not earn a srcset entry').toBeNull();
+  });
+});
+
+test.describe('E2E CD — pages, what each audience sees', () => {
+  test('a signed-in member gets the enrolled tier on a private page', async ({ page }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(authSkipReason() !== null, authSkipReason() ?? '');
+    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+
+    const service = await services();
+    const pages = await service.page.findByClassroomId(room.id);
+    const privatePage = pages.find(
+      (row: { is_public?: boolean; is_draft?: boolean }) => row.is_public === false && !row.is_draft
+    );
+    test.skip(privatePage === undefined, 'no published non-public page in this classroom');
+    if (!privatePage) return;
+
+    // A STUDENT, deliberately. Staff would be `draft` — the tier is about what
+    // the viewer may see, and only a non-editing member exercises `enrolled`.
+    await loginAs(page, 'student', `/${env.classroomSlug}/${privatePage.id}`);
+
+    const log = trackRequests(page);
+    await page.goto(`/${env.classroomSlug}/${privatePage.id}`);
+    await page.waitForLoadState('networkidle');
+
+    const signedImages = (await readImages(page)).filter(image => image.signed !== null);
+    test.skip(signedImages.length === 0, 'this page carries no delivered images');
+
+    for (const image of signedImages) {
+      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('enrolled');
+    }
+    expect(log.missing()).toEqual([]);
+    expect(log.legacy(), 'a delivered page must not also fetch legacy refs').toEqual([]);
+    log.stop();
+  });
+
+  test('a public class-site page is served at the public tier, with its ladder', async ({
+    request,
+  }) => {
+    requireDelivery();
+    const room = requireClassroom();
+
+    const service = await services();
+    const sites = await service.site.getSiteForClassroom(room.id).catch(() => null);
+    test.skip(
+      !sites?.subdomain,
+      'no class site claimed for this classroom — a public-tier render is only observable on a site host'
+    );
+    const pages = await service.page.findByClassroomId(room.id);
+    const publicPage = pages.find((row: { is_public?: boolean }) => row.is_public === true);
+    test.skip(publicPage === undefined, 'no public page in this classroom');
+    if (!publicPage || !sites?.subdomain) return;
+
+    // The site is reached by Host header, not by hostname: locally there is no
+    // DNS for `{subdomain}.classmoji.io`, and the site tree is script-less, so
+    // the server's own markup is the whole story.
+    const response = await request.get(`${env.pages}/${publicPage.slug}`, {
+      headers: { host: `${sites.subdomain}.classmoji.io` },
+    });
+    test.skip(response.status() === 404, 'class-site rewriting is not enabled on this server');
+    expect(response.status()).toBe(200);
+
+    const html = await response.text();
+    const signedImages = imagesFromHtml(html).filter(image => image.signed !== null);
+    test.skip(signedImages.length === 0, 'this public page carries no delivered images');
+
+    for (const image of signedImages) {
+      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('public');
+    }
+
+    // Not a signature in sight in the markup's own legacy escape hatches.
+    expect(html).not.toContain('raw.githubusercontent.com');
+    expect(html).not.toMatch(/\/c\/[0-9a-f-]{36}\/missing\//i);
+  });
+});
+
+test.describe('E2E CD — pages, when a file goes away', () => {
+  test('deleting the asset from the repo turns its reference into /missing/, and the Worker 404s', async ({
+    page,
+    request,
+  }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    const uploaded = await uploadAsset(
+      page,
+      target.id,
+      fixtureName('png', 'doomed'),
+      pngBytes(1000, 40),
+      'image/png'
+    );
+
+    // Remove the file behind the app's back, then run the SAME sync the push
+    // webhook would have run. Without this the map has simply not heard the
+    // news yet, and the test would be asserting against staleness rather than
+    // against the resolver.
+    await deleteRepoFile(room, uploaded.path);
+    uploadedPaths.splice(uploadedPaths.indexOf(uploaded.path), 1);
+    await syncMap(room.id);
+
+    const service = await services();
+    const resolved = await service.contentDelivery.resolveAssetUrl(
+      {
+        classroom: {
+          id: room.id,
+          content_key_version: room.content_key_version,
+          content_repo: room.content_repo ?? '',
+          git_organization: { login: room.orgLogin },
+          content_delivery_enabled: room.content_delivery_enabled,
+        },
+        tier: 'enrolled',
+      },
+      uploaded.path
+    );
+
+    const missing = parseMissingUrl(resolved);
+    expect(missing, `a dangling reference must resolve to /missing/, got ${resolved}`).not.toBeNull();
+    expect(missing?.classroomId.toLowerCase()).toBe(room.id.toLowerCase());
+    expect(missing?.ref).toBe(uploaded.path);
+
+    // 404, NOT 403. A deleted file is not a tampered URL, and an operator
+    // searching the logs must be able to tell the two apart.
+    const response = await request.get(resolved);
+    expect(response.status()).toBe(404);
+    expect(response.headers()['cache-control']).toContain('no-store');
+  });
+});
+
+test.describe('E2E CD — pages, the gate', () => {
+  test('with content_delivery_enabled false, every reference is legacy and nothing is fetched from the origin', async ({
+    page,
+  }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    const before = await setDeliveryEnabled(room.id, false);
+    try {
+      await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+      const log = trackRequests(page);
+      await page.goto(`/${target.classroomSlug}/${target.id}`);
+      await page.waitForLoadState('networkidle');
+
+      const images = await readImages(page);
+      for (const image of images) {
+        expect(image.signed, `still signed with the gate off: ${describeSignedUrl(image.src)}`)
+          .toBeNull();
+      }
+      expect(log.delivery(), 'the gate is off; the delivery origin must be untouched').toEqual([]);
+      log.stop();
+
+      // Flip it back and the same page signs again — the point of the gate is
+      // that it is reversible, not that it is a one-way migration.
+      await setDeliveryEnabled(room.id, true);
+      const secondLog = trackRequests(page);
+      await page.goto(`/${target.classroomSlug}/${target.id}`);
+      await page.waitForLoadState('networkidle');
+
+      const signedAgain = (await readImages(page)).filter(image => image.signed !== null);
+      test.skip(signedAgain.length === 0, 'this page carries no images to re-sign');
+      expect(secondLog.delivery().length).toBeGreaterThan(0);
+      secondLog.stop();
+    } finally {
+      await setDeliveryEnabled(room.id, before);
+    }
+  });
+
+  test('resetting the content cache bumps v in every signed URL and retires the old ones', async ({
+    page,
+    request,
+  }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
+    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+
+    const target = await anyEditablePage(room.id);
+    test.skip(target === null, 'no page with a content_path in the test classroom');
+    if (!target) return;
+
+    await loginAs(page, 'owner', `/${target.classroomSlug}/${target.id}`);
+    await page.goto(`/${target.classroomSlug}/${target.id}`);
+    await page.waitForLoadState('networkidle');
+
+    const before = (await readImages(page)).filter(image => image.signed !== null);
+    test.skip(before.length === 0, 'this page carries no delivered images to re-version');
+    const versionBefore = await keyVersion(room.id);
+    expect(before.every(image => image.signed?.keyVersion === versionBefore)).toBe(true);
+    const staleUrl = before[0].src;
+
+    // Through the same service the settings action calls, so the assertion is
+    // about the product's own increment rather than a hand-written update.
+    const versionAfter = await bumpKeyVersion(room.id);
+    expect(versionAfter).toBe(versionBefore + 1);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    const after = (await readImages(page)).filter(image => image.signed !== null);
+    expect(after.length).toBeGreaterThan(0);
+    for (const image of after) {
+      expect(image.signed?.keyVersion, describeSignedUrl(image.src)).toBe(versionAfter);
+      for (const candidate of image.candidates) {
+        expect(candidate.parsed?.keyVersion, 'a candidate kept the old version').toBe(versionAfter);
+      }
+    }
+
+    // The old URL is not merely superseded — it no longer verifies, because the
+    // per-classroom key is derived from the version.
+    const stale = await request.get(staleUrl);
+    expect(stale.status()).toBe(403);
+  });
+});
+
+test.describe('E2E CD — the Worker, directly', () => {
+  /**
+   * Every URL below is DERIVED from one the app actually rendered.
+   *
+   * Minting one here would mean re-implementing the canonical string, the key
+   * derivation and the expiry buckets in the test — at which point the test
+   * would be checking its own copy of the algorithm rather than the app's.
+   */
+  let signedUrl: string | null = null;
+
+  test.beforeAll(async ({ browser }) => {
+    if (deliveryDown !== null || localOnlySkipReason() !== null || !target) return;
+    const page = await browser.newPage();
+    try {
+      const editable = await anyEditablePage(target.id);
+      if (!editable) return;
+      await loginAs(page, 'owner', `/${editable.classroomSlug}/${editable.id}`);
+      await page.goto(`/${editable.classroomSlug}/${editable.id}`);
+      await page.waitForLoadState('networkidle');
+      signedUrl = (await readImages(page)).find(image => image.signed !== null)?.src ?? null;
+    } finally {
+      await page.close();
+    }
+  });
+
+  function requireSignedUrl(): string {
+    requireDelivery();
+    test.skip(
+      signedUrl === null,
+      'no signed URL could be harvested from a rendered page — the earlier scenarios say why'
+    );
+    return signedUrl as string;
+  }
+
+  test('/healthz reports a configured Worker', async ({ request }) => {
+    const response = await request.get(`${env.deliveryOrigin}/healthz`);
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as { ok: boolean; configured: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.configured, 'the Worker is missing its signing secrets').toBe(true);
+  });
+
+  test('a valid signed URL serves the image, and HEAD agrees with GET', async ({ request }) => {
+    const url = requireSignedUrl();
+
+    const get = await request.get(url);
+    expect(get.status()).toBe(200);
+    expect(get.headers()['content-type']).toMatch(/^image\//);
+
+    const head = await request.head(url);
+    expect(head.status()).toBe(200);
+    // A HEAD answered from R2 metadata and a GET answered from the origin must
+    // still agree about the size, or a client sizing a download gets it wrong.
+    expect(head.headers()['content-length']).toBe(get.headers()['content-length']);
+  });
+
+  test('a tampered signature is refused', async ({ request }) => {
+    const response = await request.get(tamperSignature(requireSignedUrl()));
+    expect(response.status()).toBe(403);
+  });
+
+  test('a width appended after signing is refused', async ({ request }) => {
+    // The interesting forgery: `w=` is a real, valid parameter — it is just not
+    // one THIS signature covers. Transforms are inside the canonical string
+    // precisely so a client cannot widen an image it was handed.
+    const response = await request.get(appendWidth(requireSignedUrl(), 800));
+    expect(response.status()).toBe(403);
+  });
+
+  test('an extended expiry is refused', async ({ request }) => {
+    const response = await request.get(extendExpiry(requireSignedUrl()));
+    expect(response.status()).toBe(403);
+  });
+
+  test("another classroom's id is refused", async ({ request }) => {
+    // Same sha, same everything else. The classroom is inside the key
+    // derivation, so one classroom's URL cannot be re-pointed at another's.
+    const response = await request.get(swapClassroom(requireSignedUrl(), FOREIGN_CLASSROOM_ID));
+    expect(response.status()).toBe(403);
+  });
+
+  test('a /missing/ URL is a 404 that is never cached', async ({ request }) => {
+    requireDelivery();
+    const room = requireClassroom();
+    const response = await request.get(
+      `${env.deliveryOrigin}/c/${room.id}/missing/${encodeURIComponent('pages/e2e-cd/nope.png')}`
+    );
+    expect(response.status()).toBe(404);
+    // Never cached: the reference may become resolvable the moment someone
+    // re-adds the file, and a cached 404 would outlive the fix.
+    expect(response.headers()['cache-control']).toContain('no-store');
+  });
+});

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -166,7 +166,10 @@ function expectResponsive(
   expected: { classroomId: string; tier: string; keyVersion?: number; sizes?: string }
 ): void {
   const signed = image.signed;
-  expect(signed, `src is not a signed delivery URL: ${describeSignedUrl(image.src)}`).not.toBeNull();
+  expect(
+    signed,
+    `src is not a signed delivery URL: ${describeSignedUrl(image.src)}`
+  ).not.toBeNull();
   if (!signed) return;
 
   expect(signed.origin).toBe(env.deliveryOrigin);
@@ -345,8 +348,10 @@ test.describe('E2E CD — pages, the editor', () => {
     expect(uploaded.displayUrl, 'the layer is on, so a display URL was signed').not.toBeNull();
 
     const displaySigned = parseSignedUrl(uploaded.displayUrl ?? '');
-    expect(displaySigned, `displayUrl is not signed: ${describeSignedUrl(uploaded.displayUrl ?? '')}`)
-      .not.toBeNull();
+    expect(
+      displaySigned,
+      `displayUrl is not signed: ${describeSignedUrl(uploaded.displayUrl ?? '')}`
+    ).not.toBeNull();
     // Staff uploading into an editor is the draft tier by definition.
     expect(displaySigned?.tier).toBe('draft');
 
@@ -495,7 +500,10 @@ test.describe('E2E CD — pages, the editor', () => {
     requireDelivery();
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
-    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+    test.skip(
+      !room.content_delivery_enabled,
+      `content_delivery_enabled is false for '${room.slug}'`
+    );
 
     const target = await anyEditablePage(room.id);
     test.skip(target === null, 'no page with a content_path in the test classroom');
@@ -543,7 +551,10 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     requireDelivery();
     const room = requireClassroom();
     test.skip(authSkipReason() !== null, authSkipReason() ?? '');
-    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+    test.skip(
+      !room.content_delivery_enabled,
+      `content_delivery_enabled is false for '${room.slug}'`
+    );
 
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
 
@@ -627,7 +638,9 @@ test.describe('E2E CD — pages, what each audience sees', () => {
 
     const html = await response.text();
     const images = imagesFromHtml(html).filter(image => image.signed !== null);
-    expect(images.length, 'the staging class site should carry delivered images').toBeGreaterThan(0);
+    expect(images.length, 'the staging class site should carry delivered images').toBeGreaterThan(
+      0
+    );
 
     for (const image of images) {
       expect(image.signed?.origin).toBe(env.deliveryOrigin);
@@ -760,7 +773,10 @@ test.describe('E2E CD — pages, when a file goes away', () => {
     requireDelivery();
     const room = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
-    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+    test.skip(
+      !room.content_delivery_enabled,
+      `content_delivery_enabled is false for '${room.slug}'`
+    );
 
     const target = await anyEditablePage(room.id);
     test.skip(target === null, 'no page with a content_path in the test classroom');
@@ -797,7 +813,10 @@ test.describe('E2E CD — pages, when a file goes away', () => {
     );
 
     const missing = parseMissingUrl(resolved);
-    expect(missing, `a dangling reference must resolve to /missing/, got ${resolved}`).not.toBeNull();
+    expect(
+      missing,
+      `a dangling reference must resolve to /missing/, got ${resolved}`
+    ).not.toBeNull();
     expect(missing?.classroomId.toLowerCase()).toBe(room.id.toLowerCase());
     expect(missing?.ref).toBe(uploaded.path);
 
@@ -854,8 +873,10 @@ test.describe('E2E CD — pages, the gate', () => {
       const images = await readImages(page);
       expect(images.length, 'the fixture image should still be on the page').toBeGreaterThan(0);
       for (const image of images) {
-        expect(image.signed, `still signed with the gate off: ${describeSignedUrl(image.src)}`)
-          .toBeNull();
+        expect(
+          image.signed,
+          `still signed with the gate off: ${describeSignedUrl(image.src)}`
+        ).toBeNull();
       }
       expect(log.delivery(), 'the gate is off; the delivery origin must be untouched').toEqual([]);
       log.stop();
@@ -868,8 +889,10 @@ test.describe('E2E CD — pages, the gate', () => {
       await page.waitForLoadState('networkidle');
 
       const signedAgain = (await readImages(page)).filter(image => image.signed !== null);
-      expect(signedAgain.length, 'the gate went back on; the image should sign again')
-        .toBeGreaterThan(0);
+      expect(
+        signedAgain.length,
+        'the gate went back on; the image should sign again'
+      ).toBeGreaterThan(0);
       expect(secondLog.delivery().length).toBeGreaterThan(0);
       secondLog.stop();
     } finally {
@@ -885,7 +908,10 @@ test.describe('E2E CD — pages, the gate', () => {
     const room = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
-    test.skip(!room.content_delivery_enabled, `content_delivery_enabled is false for '${room.slug}'`);
+    test.skip(
+      !room.content_delivery_enabled,
+      `content_delivery_enabled is false for '${room.slug}'`
+    );
 
     const target = await anyEditablePage(room.id);
     test.skip(target === null, 'no page with a content_path in the test classroom');

--- a/apps/pages/tests/helpers/contentDelivery.helpers.ts
+++ b/apps/pages/tests/helpers/contentDelivery.helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * The content-delivery helpers, re-exported from where pages specs expect them.
+ *
+ * The implementation is shared with `apps/slides` and lives at the repo root
+ * (`tests/content-delivery/`), because both suites have to make IDENTICAL
+ * claims about one URL format — a second copy would drift, and two suites
+ * asserting slightly different shapes would both stay green while the app
+ * emitted neither. This file exists so specs still import from
+ * `tests/helpers`, alongside `auth.helpers` and the rest.
+ */
+export * from '../../../../tests/content-delivery/contentDelivery.helpers';

--- a/apps/pages/tests/helpers/index.ts
+++ b/apps/pages/tests/helpers/index.ts
@@ -1,3 +1,5 @@
 export * from './auth.helpers';
 export * from './env.helpers';
 export * from './prisma.helpers';
+// Content delivery helpers — one implementation, shared with apps/slides.
+export * from './contentDelivery.helpers';

--- a/apps/pages/tests/helpers/prisma.helpers.ts
+++ b/apps/pages/tests/helpers/prisma.helpers.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 // PrismaClient eagerly at module import, so the runtime import MUST happen
 // after DATABASE_URL is resolved (see getTestPrisma's dynamic import).
 import type getPrismaType from '@classmoji/database';
+import { assertWritableDatabase } from '../../../../tests/content-delivery/databaseGuard';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,6 +35,14 @@ export async function getTestPrisma(): Promise<TestPrisma> {
     const url = databaseUrlFromDevContext();
     if (url) process.env.DATABASE_URL = url;
   }
+  // Every suite that reaches the database goes through here, and several of
+  // them write: sessions are minted, fixtures are created, classroom columns
+  // are flipped. Which database that lands in is decided by whatever
+  // DATABASE_URL happened to be exported — a value that is routinely pointed at
+  // a deployed environment for an afternoon's debugging and not put back. The
+  // guard is on the resolved host, so intent (E2E_TARGET, NODE_ENV) cannot vouch
+  // for connectivity.
+  assertWritableDatabase('open a test database connection');
   if (!cached) {
     const { default: getPrisma } = await import('@classmoji/database');
     cached = getPrisma();

--- a/apps/slides/tests/content-pipeline.spec.ts
+++ b/apps/slides/tests/content-pipeline.spec.ts
@@ -29,12 +29,16 @@ import {
   classroom as loadClassroom,
   deliverySkipReason,
   describeSignedUrl,
+  describeUrls,
+  e2eTarget,
   getTestClassroomSlug,
   loginAs,
   localOnlySkipReason,
+  markScenarioRan,
   parseSignedUrl,
   readImages,
   reloadUntilImages,
+  scenariosThatRan,
   services,
   setDeliveryEnabled,
   storedContentLeaks,
@@ -45,6 +49,13 @@ import {
 } from './helpers';
 
 const env = targets();
+
+/**
+ * No trace, no video. Both record full request URLs, and every URL in this pack
+ * is a signed credential; a Playwright report is a CI artifact. See the same
+ * note in the pages pack.
+ */
+test.use({ trace: 'off', video: 'off' });
 
 let deliveryDown: string | null = 'not probed';
 let room: E2EClassroom | null = null;
@@ -130,10 +141,18 @@ function requireClassroom(): E2EClassroom {
  */
 async function keepAllImages(page: import('@playwright/test').Page): Promise<void> {
   const keepAll = page.getByRole('button', { name: 'Keep All' });
-  if (await keepAll.isVisible().catch(() => false)) {
-    await keepAll.click();
-    await keepAll.waitFor({ state: 'hidden' }).catch(() => undefined);
+  // `isVisible()` answers about THIS instant. The modal appears after the save
+  // round-trips, so an immediate check reliably said "not there" and the test
+  // moved on with a destructive dialog still open behind it — where a later
+  // click could land on its delete button. A bounded three-second wait is the
+  // difference between "no modal" and "no modal yet".
+  try {
+    await keepAll.waitFor({ state: 'visible', timeout: 3_000 });
+  } catch {
+    return; // Genuinely absent: this save orphaned nothing.
   }
+  await keepAll.click();
+  await keepAll.waitFor({ state: 'hidden' }).catch(() => undefined);
 }
 
 /** The shared responsive contract, identical to the pages pack's. */
@@ -216,6 +235,10 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
     page,
   }) => {
     requireDelivery();
+    markScenarioRan();
+    // Creates a deck, commits an image and saves, all against a real GitHub
+    // repo. The default 60s budget does not cover it.
+    test.setTimeout(180_000);
     const target = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
     test.skip(
@@ -291,6 +314,10 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
 
   test('deck.json stores no signature, no srcset and no delivery origin', async ({ page }) => {
     requireDelivery();
+    markScenarioRan();
+    // Creates a deck, commits an image and saves, all against a real GitHub
+    // repo. The default 60s budget does not cover it.
+    test.setTimeout(180_000);
     const target = requireClassroom();
     test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
 
@@ -339,6 +366,10 @@ test.describe('E2E CD — slides, the gate', () => {
     page,
   }) => {
     requireDelivery();
+    markScenarioRan();
+    // Creates a deck, commits an image and saves, all against a real GitHub
+    // repo. The default 60s budget does not cover it.
+    test.setTimeout(180_000);
     const target = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
 
@@ -393,10 +424,31 @@ test.describe('E2E CD — slides, the gate', () => {
       // The positive half: they fell back to the legacy proxy form, rather than
       // to nothing at all.
       expect(images.some(image => /\/content\/[^/]+\/[^/]+\//.test(image.src))).toBe(true);
-      expect(log.delivery(), 'the gate is off; the delivery origin must be untouched').toEqual([]);
+      expect(
+        describeUrls(log.delivery()),
+        'the gate is off; the delivery origin must be untouched'
+      ).toEqual([]);
       log.stop();
     } finally {
       await setDeliveryEnabled(target.id, before);
     }
   });
+});
+
+/**
+ * The check that the suite did anything at all — see the note on the pages
+ * pack's copy. A run where every scenario skips is green and worthless, and
+ * that has already happened here once (turbo dropped E2E_CD_CONTENT_REPO).
+ */
+test('E2E CD — at least one slides scenario actually ran', async () => {
+  test.skip(
+    e2eTarget() === 'staging',
+    'the slides pack has no staging form: every scenario here needs an editor session'
+  );
+  expect(
+    scenariosThatRan(),
+    'every slides scenario skipped. The run is green and proved nothing — check the skip reasons ' +
+      'above (a missing Worker, E2E_CD_CONTENT_REPO not reaching Playwright, or a classroom whose ' +
+      'content_delivery_enabled is false).'
+  ).toBeGreaterThan(0);
 });

--- a/apps/slides/tests/content-pipeline.spec.ts
+++ b/apps/slides/tests/content-pipeline.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * The content delivery pipeline, end to end, for slide decks.
+ *
+ * A deck differs from a page in one way that matters here: what it STORES is
+ * not a bare repo path but the legacy absolute reference the upload action
+ * returns — `/content/{org}/{repo}/{path}`. The delivery layer reduces that
+ * back to a repo path at render time (`extractOwnRepoPath`) and signs it. So
+ * the invariant is not "the deck stores a relative path" but the stronger one:
+ * whatever the deck stores, it is never a SIGNED url, never a `srcset`, and
+ * never mentions the delivery origin.
+ *
+ * Same two rules as the pages pack: assert shape, never a signature; and skip
+ * with a reason that names the missing piece rather than passing quietly.
+ *
+ * One safety rule specific to slides. Saving a deck can pop the "Clean Up
+ * Unused Images" modal, whose primary button permanently deletes files from
+ * GitHub. Every save here dismisses it with **Keep All**. Nothing in this file
+ * may ever click the delete button — a test that tidies a real content repo is
+ * a test that can destroy a course.
+ */
+import { expect, test } from './fixtures/test.fixture';
+import {
+  EXPECTED_SIZES,
+  EXPECTED_WIDTHS,
+  type E2EClassroom,
+  type RenderedImage,
+  classroom as loadClassroom,
+  deliverySkipReason,
+  describeSignedUrl,
+  getTestClassroomSlug,
+  loginAs,
+  localOnlySkipReason,
+  parseSignedUrl,
+  readImages,
+  setDeliveryEnabled,
+  storedContentLeaks,
+  targets,
+  trackRequests,
+  uploadSkipReason,
+  waitForReveal,
+} from './helpers';
+
+const env = targets();
+
+let deliveryDown: string | null = 'not probed';
+let room: E2EClassroom | null = null;
+let classroomError: string | null = null;
+
+/** Decks this run created, torn down in `afterAll`. */
+const createdDeckIds: string[] = [];
+
+test.beforeAll(async () => {
+  deliveryDown = await deliverySkipReason();
+  if (localOnlySkipReason() === null) {
+    try {
+      room = await loadClassroom(getTestClassroomSlug());
+    } catch (error) {
+      classroomError = error instanceof Error ? error.message : String(error);
+    }
+  }
+});
+
+test.afterAll(async () => {
+  if (!room || createdDeckIds.length === 0) return;
+  const { getTestPrisma } = await import('./helpers');
+  const prisma = await getTestPrisma();
+  for (const id of createdDeckIds.splice(0)) {
+    // The database row only. The deck's folder in the content repo is left
+    // alone deliberately: deleting a folder from a real course repository to
+    // tidy after a test is exactly the blast radius this file refuses to have.
+    // Everything is prefixed `E2E CD`, so the leftovers are findable.
+    await prisma.slide.delete({ where: { id } }).catch(() => undefined);
+  }
+});
+
+function requireDelivery(): void {
+  test.skip(deliveryDown !== null, deliveryDown ?? 'delivery not configured');
+}
+
+function requireClassroom(): E2EClassroom {
+  test.skip(
+    localOnlySkipReason() !== null,
+    localOnlySkipReason() ?? 'database access is local only'
+  );
+  test.skip(classroomError !== null, `could not load the test classroom: ${classroomError}`);
+  if (!room) throw new Error('unreachable: classroom missing without a skip');
+  return room;
+}
+
+/**
+ * Dismiss the orphan-cleanup modal if a save raised it. **Keep All, always.**
+ *
+ * Its list is computed folder-wide by substring match, so a fixture deck's
+ * pre-existing images can appear in it alongside anything this test added. The
+ * destructive button is never the right answer for an automated run.
+ */
+async function keepAllImages(page: import('@playwright/test').Page): Promise<void> {
+  const keepAll = page.getByRole('button', { name: 'Keep All' });
+  if (await keepAll.isVisible().catch(() => false)) {
+    await keepAll.click();
+    await keepAll.waitFor({ state: 'hidden' }).catch(() => undefined);
+  }
+}
+
+/** The shared responsive contract, identical to the pages pack's. */
+function expectResponsive(image: RenderedImage, expected: { classroomId: string }): void {
+  const signed = image.signed;
+  expect(signed, `src is not signed: ${describeSignedUrl(image.src)}`).not.toBeNull();
+  if (!signed) return;
+
+  expect(signed.origin).toBe(env.deliveryOrigin);
+  expect(signed.classroomId.toLowerCase()).toBe(expected.classroomId.toLowerCase());
+  expect(signed.w, 'the fallback src carries no width').toBeNull();
+  expect(signed.sig.length).toBeGreaterThan(0);
+  expect(image.sizes).toBe(EXPECTED_SIZES);
+  expect(image.candidates.map(candidate => candidate.width)).toEqual([...EXPECTED_WIDTHS]);
+  for (const candidate of image.candidates) {
+    expect(candidate.parsed?.sha).toBe(signed.sha);
+    expect(candidate.parsed?.fmt).toBe('auto');
+    expect(candidate.parsed?.exp).toBe(signed.exp);
+  }
+}
+
+/**
+ * Upload an image into a deck through the editor route's own action.
+ *
+ * The deck editor has no `/api/upload`: it posts `intent=upload-image` to the
+ * deck route itself. Driving that directly rather than through the toolbar
+ * button is deliberate — the toolbar's antd Tooltip means the button carries
+ * no accessible name, and the modal's client-side processor re-encodes the
+ * file, so a UI-driven upload would not put the bytes under test into the repo.
+ * The action, the service and the map row are all still the product's.
+ */
+async function uploadDeckImage(
+  page: import('@playwright/test').Page,
+  slideId: string,
+  filename: string,
+  bytes: Buffer
+): Promise<{ url: string; path: string }> {
+  const result = await page.evaluate(
+    async ({ id, name, base64 }) => {
+      const binary = atob(base64);
+      const buffer = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) {
+        buffer[index] = binary.charCodeAt(index);
+      }
+      const form = new FormData();
+      form.append('intent', 'upload-image');
+      form.append('file', new File([buffer], name, { type: 'image/png' }));
+      const response = await fetch(`/${id}`, { method: 'POST', body: form });
+      return { status: response.status, body: await response.text() };
+    },
+    { id: slideId, name: filename, base64: bytes.toString('base64') }
+  );
+
+  expect(result.status, `deck upload failed: ${result.body}`).toBe(200);
+  const body = JSON.parse(result.body) as { error?: string; url: string; path: string };
+  expect(body.error, `deck upload rejected: ${body.error}`).toBeUndefined();
+  return body;
+}
+
+test.describe('E2E CD — slides, a deck with an uploaded image', () => {
+  test('the viewer and /present both serve a signed src with a three-rung srcset', async ({
+    page,
+  }) => {
+    requireDelivery();
+    const target = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+    test.skip(
+      !target.content_delivery_enabled,
+      `content_delivery_enabled is false for '${target.slug}' — see apps/content/README.md, "Local end-to-end"`
+    );
+
+    const { createSlide, editSlide, saveSlide, presentSlide, fixtureName, pngBytes } = await import(
+      './helpers'
+    );
+
+    await loginAs(page, 'owner', '/');
+    const deckId = await createSlide(page, `E2E CD deck ${Date.now()}`);
+    createdDeckIds.push(deckId);
+
+    await editSlide(page, deckId);
+    const uploaded = await uploadDeckImage(
+      page,
+      deckId,
+      fixtureName('png', 'deck'),
+      pngBytes(1700, 90)
+    );
+
+    // The action returns the LEGACY absolute form. That is what the editor
+    // inserts and what the deck will store — the delivery layer's job is to
+    // reduce it back to a repo path at render time, not to change what is
+    // written down.
+    expect(uploaded.url).toMatch(/^\/content\/[^/]+\/[^/]+\//);
+    expect(parseSignedUrl(uploaded.url), 'a stored deck ref must never be signed').toBeNull();
+
+    // Put the image into the deck's HTML and save.
+    await page.evaluate(url => {
+      const section = document.querySelector('.reveal .slides section');
+      if (!section) throw new Error('no reveal section to insert into');
+      const img = document.createElement('img');
+      img.setAttribute('src', url);
+      img.setAttribute('alt', 'E2E CD fixture');
+      section.appendChild(img);
+    }, uploaded.url);
+    await saveSlide(page);
+    await keepAllImages(page);
+
+    // The viewer.
+    const viewerLog = trackRequests(page);
+    await page.goto(`/${deckId}`);
+    await waitForReveal(page);
+
+    const viewerImages = (await readImages(page, '.reveal img')).filter(
+      image => image.alt === 'E2E CD fixture'
+    );
+    expect(viewerImages.length, 'the fixture image should be on the rendered deck').toBe(1);
+    expectResponsive(viewerImages[0], { classroomId: target.id });
+
+    expect(viewerLog.forSha(viewerImages[0].signed!.sha).length, 'one image, one fetch').toBe(1);
+    expect(viewerLog.missing()).toEqual([]);
+    viewerLog.stop();
+
+    // `/present` is a different render path off the same deck, and it has
+    // regressed independently before — a signed viewer with an unsigned
+    // presentation is exactly the split this asserts against.
+    await presentSlide(page, deckId);
+    await waitForReveal(page);
+    const presentImages = (await readImages(page, '.reveal img')).filter(
+      image => image.alt === 'E2E CD fixture'
+    );
+    expect(presentImages.length).toBe(1);
+    expectResponsive(presentImages[0], { classroomId: target.id });
+  });
+
+  test('deck.json stores no signature, no srcset and no delivery origin', async ({ page }) => {
+    requireDelivery();
+    const target = requireClassroom();
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+
+    const { createSlide, editSlide, saveSlide, fixtureName, pngBytes, getSlideById, readRepoFile } =
+      await import('./helpers');
+
+    await loginAs(page, 'owner', '/');
+    const deckId = await createSlide(page, `E2E CD storage ${Date.now()}`);
+    createdDeckIds.push(deckId);
+
+    await editSlide(page, deckId);
+    const uploaded = await uploadDeckImage(
+      page,
+      deckId,
+      fixtureName('png', 'storage'),
+      pngBytes(800, 40)
+    );
+    await page.evaluate(url => {
+      const section = document.querySelector('.reveal .slides section');
+      const img = document.createElement('img');
+      img.setAttribute('src', url);
+      section?.appendChild(img);
+    }, uploaded.url);
+    await saveSlide(page);
+    await keepAllImages(page);
+
+    const deck = await getSlideById(deckId);
+    test.skip(!deck?.content_path, 'the created deck has no content_path');
+
+    const stored = await readRepoFile(target, `${deck!.content_path}/deck.json`);
+    test.skip(stored === null, 'no deck.json in the repo yet — the save may still be propagating');
+    if (!stored) return;
+
+    expect(
+      storedContentLeaks(stored.content, env.deliveryOrigin),
+      'derived values leaked into deck.json'
+    ).toEqual([]);
+    // And positively: the legacy reference IS what was written down.
+    expect(stored.content).toContain(uploaded.path);
+  });
+});
+
+test.describe('E2E CD — slides, the gate', () => {
+  test('with content_delivery_enabled false the viewer serves legacy /content/ refs and asks the origin for nothing', async ({
+    page,
+  }) => {
+    requireDelivery();
+    const target = requireClassroom();
+    test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
+
+    const { getTestPrisma } = await import('./helpers');
+    const prisma = await getTestPrisma();
+    const deck = await prisma.slide.findFirst({
+      where: { classroom_id: target.id, content_path: { not: null } },
+      select: { id: true },
+    });
+    test.skip(deck === null, 'no deck with a content_path in the test classroom');
+    if (!deck) return;
+
+    const before = await setDeliveryEnabled(target.id, false);
+    try {
+      await loginAs(page, 'owner', '/');
+      const log = trackRequests(page);
+      await page.goto(`/${deck.id}`);
+      await waitForReveal(page);
+
+      const images = await readImages(page, '.reveal img');
+      test.skip(images.length === 0, 'this deck carries no images');
+
+      for (const image of images) {
+        expect(image.signed, `still signed with the gate off: ${describeSignedUrl(image.src)}`)
+          .toBeNull();
+      }
+      // The positive half: they fell back to the legacy proxy form, rather than
+      // to nothing at all.
+      expect(images.some(image => /\/content\/[^/]+\/[^/]+\//.test(image.src))).toBe(true);
+      expect(log.delivery(), 'the gate is off; the delivery origin must be untouched').toEqual([]);
+      log.stop();
+    } finally {
+      await setDeliveryEnabled(target.id, before);
+    }
+  });
+});

--- a/apps/slides/tests/content-pipeline.spec.ts
+++ b/apps/slides/tests/content-pipeline.spec.ts
@@ -32,6 +32,8 @@ import {
   localOnlySkipReason,
   parseSignedUrl,
   readImages,
+  reloadUntilImages,
+  services,
   setDeliveryEnabled,
   storedContentLeaks,
   targets,
@@ -122,41 +124,59 @@ function expectResponsive(image: RenderedImage, expected: { classroomId: string 
 }
 
 /**
- * Upload an image into a deck through the editor route's own action.
+ * Put an image into a deck's images folder and return the reference the
+ * editor's own upload would have produced.
  *
- * The deck editor has no `/api/upload`: it posts `intent=upload-image` to the
- * deck route itself. Driving that directly rather than through the toolbar
- * button is deliberate — the toolbar's antd Tooltip means the button carries
- * no accessible name, and the modal's client-side processor re-encodes the
- * file, so a UI-driven upload would not put the bytes under test into the repo.
- * The action, the service and the map row are all still the product's.
+ * NOT driven through the toolbar, and not through the route action either,
+ * for two concrete reasons rather than convenience:
+ *
+ *   - The toolbar's upload control is an antd `Tooltip`-wrapped button, so it
+ *     carries no accessible name at all, and the modal re-encodes the file
+ *     client-side before sending it. A UI-driven upload would put DIFFERENT
+ *     bytes in the repo than the ones the assertions are about.
+ *   - The deck editor has no `/api/upload`; it posts `intent=upload-image` to
+ *     the deck route and reads the result through a fetcher. A plain `fetch`
+ *     to that route gets the rendered HTML document back, not the action's
+ *     JSON, so there is nothing to read a path out of.
+ *
+ * So the file goes in through `ContentService.upload` — the same call the
+ * action makes, into the same `${content_path}/images` folder — and the
+ * reference is rebuilt in the action's own legacy shape. Everything this pack
+ * actually asserts about (the map row, the render, the storage invariant) is
+ * downstream of here and is entirely the product's.
  */
 async function uploadDeckImage(
-  page: import('@playwright/test').Page,
-  slideId: string,
+  target: E2EClassroom,
+  contentPath: string,
   filename: string,
   bytes: Buffer
 ): Promise<{ url: string; path: string }> {
-  const result = await page.evaluate(
-    async ({ id, name, base64 }) => {
-      const binary = atob(base64);
-      const buffer = new Uint8Array(binary.length);
-      for (let index = 0; index < binary.length; index += 1) {
-        buffer[index] = binary.charCodeAt(index);
-      }
-      const form = new FormData();
-      form.append('intent', 'upload-image');
-      form.append('file', new File([buffer], name, { type: 'image/png' }));
-      const response = await fetch(`/${id}`, { method: 'POST', body: form });
-      return { status: response.status, body: await response.text() };
-    },
-    { id: slideId, name: filename, base64: bytes.toString('base64') }
-  );
+  const { ContentService } = await import('@classmoji/services');
+  const result = await ContentService.upload({
+    orgLogin: target.orgLogin,
+    repo: target.content_repo!,
+    file: bytes,
+    filename,
+    folder: `${contentPath}/images`,
+    message: 'E2E CD: fixture image',
+  });
 
-  expect(result.status, `deck upload failed: ${result.body}`).toBe(200);
-  const body = JSON.parse(result.body) as { error?: string; url: string; path: string };
-  expect(body.error, `deck upload rejected: ${body.error}`).toBeUndefined();
-  return body;
+  // The action's SECOND step, and the one it would be easy to leave out. It
+  // records the map row immediately rather than waiting for the push webhook,
+  // because a deck saved seconds after an upload stores this path and a render
+  // that misses the map produces a `/missing/` URL. Skipping it here would make
+  // this pack fail for a reason that has nothing to do with delivery.
+  const service = await services();
+  await service.contentAssets.recordContentAsset(target.id, {
+    path: result.path,
+    sha: result.sha,
+    size: bytes.length,
+  });
+
+  return {
+    path: result.path,
+    url: `/content/${target.orgLogin}/${target.content_repo}/${result.path}`,
+  };
 }
 
 test.describe('E2E CD — slides, a deck with an uploaded image', () => {
@@ -179,10 +199,14 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
     const deckId = await createSlide(page, `E2E CD deck ${Date.now()}`);
     createdDeckIds.push(deckId);
 
+    const { getSlideById } = await import('./helpers');
+    const deck = await getSlideById(deckId);
+    expect(deck?.content_path, 'a new deck should have a content_path').toBeTruthy();
+
     await editSlide(page, deckId);
     const uploaded = await uploadDeckImage(
-      page,
-      deckId,
+      target,
+      deck!.content_path,
       fixtureName('png', 'deck'),
       pngBytes(1700, 90)
     );
@@ -245,10 +269,13 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
     const deckId = await createSlide(page, `E2E CD storage ${Date.now()}`);
     createdDeckIds.push(deckId);
 
+    const deck = await getSlideById(deckId);
+    expect(deck?.content_path, 'a new deck should have a content_path').toBeTruthy();
+
     await editSlide(page, deckId);
     const uploaded = await uploadDeckImage(
-      page,
-      deckId,
+      target,
+      deck!.content_path,
       fixtureName('png', 'storage'),
       pngBytes(800, 40)
     );
@@ -260,9 +287,6 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
     }, uploaded.url);
     await saveSlide(page);
     await keepAllImages(page);
-
-    const deck = await getSlideById(deckId);
-    test.skip(!deck?.content_path, 'the created deck has no content_path');
 
     const stored = await readRepoFile(target, `${deck!.content_path}/deck.json`);
     test.skip(stored === null, 'no deck.json in the repo yet — the save may still be propagating');
@@ -285,24 +309,47 @@ test.describe('E2E CD — slides, the gate', () => {
     const target = requireClassroom();
     test.skip(localOnlySkipReason() !== null, localOnlySkipReason() ?? '');
 
-    const { getTestPrisma } = await import('./helpers');
-    const prisma = await getTestPrisma();
-    const deck = await prisma.slide.findFirst({
-      where: { classroom_id: target.id, content_path: { not: null } },
-      select: { id: true },
-    });
-    test.skip(deck === null, 'no deck with a content_path in the test classroom');
-    if (!deck) return;
+    test.skip(uploadSkipReason() !== null, uploadSkipReason() ?? '');
+
+    // Its own deck, with its own image. Reaching for whichever deck happens to
+    // be in the classroom makes the result depend on what ran before it, and a
+    // deck with no images would pass this test without exercising the gate at
+    // all — the emptiest possible green.
+    const { createSlide, editSlide, saveSlide, getSlideById, fixtureName, pngBytes } = await import(
+      './helpers'
+    );
+
+    await loginAs(page, 'owner', '/');
+    const deckId = await createSlide(page, `E2E CD gate ${Date.now()}`);
+    createdDeckIds.push(deckId);
+    const deck = await getSlideById(deckId);
+    expect(deck?.content_path).toBeTruthy();
+
+    await editSlide(page, deckId);
+    const uploaded = await uploadDeckImage(
+      target,
+      deck!.content_path,
+      fixtureName('png', 'gate'),
+      pngBytes(900, 40)
+    );
+    await page.evaluate(url => {
+      const section = document.querySelector('.reveal .slides section');
+      const img = document.createElement('img');
+      img.setAttribute('src', url);
+      img.setAttribute('alt', 'E2E CD gate');
+      section?.appendChild(img);
+    }, uploaded.url);
+    await saveSlide(page);
+    await keepAllImages(page);
 
     const before = await setDeliveryEnabled(target.id, false);
     try {
-      await loginAs(page, 'owner', '/');
       const log = trackRequests(page);
-      await page.goto(`/${deck.id}`);
+      await page.goto(`/${deckId}`);
       await waitForReveal(page);
 
       const images = await readImages(page, '.reveal img');
-      test.skip(images.length === 0, 'this deck carries no images');
+      expect(images.length, 'the fixture image should be on the deck').toBeGreaterThan(0);
 
       for (const image of images) {
         expect(image.signed, `still signed with the gate off: ${describeSignedUrl(image.src)}`)

--- a/apps/slides/tests/content-pipeline.spec.ts
+++ b/apps/slides/tests/content-pipeline.spec.ts
@@ -20,6 +20,8 @@
  */
 import { expect, test } from './fixtures/test.fixture';
 import {
+  E2E_PREFIX,
+  E2E_SLUG_PREFIX,
   EXPECTED_SIZES,
   EXPECTED_WIDTHS,
   type E2EClassroom,
@@ -51,6 +53,24 @@ let classroomError: string | null = null;
 /** Decks this run created, torn down in `afterAll`. */
 const createdDeckIds: string[] = [];
 
+/**
+ * Content-repo folders this run created, and the guard on deleting them.
+ *
+ * Deleting a folder from a real course repository is the most destructive thing
+ * this file can do, so it is allowed for exactly one shape: a path this run
+ * created, under `slides/`, whose name carries the `e2e-cd` marker. Anything
+ * else is left alone even if it looks like litter.
+ */
+const createdDeckPaths: string[] = [];
+
+function safeToDelete(contentPath: string): boolean {
+  return (
+    contentPath.startsWith('slides/') &&
+    contentPath.split('/').length === 2 &&
+    contentPath.includes(E2E_SLUG_PREFIX)
+  );
+}
+
 test.beforeAll(async () => {
   deliveryDown = await deliverySkipReason();
   if (localOnlySkipReason() === null) {
@@ -67,11 +87,23 @@ test.afterAll(async () => {
   const { getTestPrisma } = await import('./helpers');
   const prisma = await getTestPrisma();
   for (const id of createdDeckIds.splice(0)) {
-    // The database row only. The deck's folder in the content repo is left
-    // alone deliberately: deleting a folder from a real course repository to
-    // tidy after a test is exactly the blast radius this file refuses to have.
-    // Everything is prefixed `E2E CD`, so the leftovers are findable.
     await prisma.slide.delete({ where: { id } }).catch(() => undefined);
+  }
+
+  // And the folders. Each run creates three decks in a real course repository,
+  // so "the leftovers are findable by their prefix" is not good enough — a few
+  // runs bury the repo in `slides/e2e-cd-*`. `safeToDelete` is what keeps this
+  // from ever being a folder a human made.
+  if (uploadSkipReason() !== null) return;
+  const { ContentService } = await import('@classmoji/services');
+  for (const contentPath of createdDeckPaths.splice(0)) {
+    if (!safeToDelete(contentPath)) continue;
+    await ContentService.deleteFolder({
+      orgLogin: room.orgLogin,
+      repo: room.content_repo!,
+      path: contentPath,
+      message: `${E2E_PREFIX}: remove test deck ${contentPath}`,
+    }).catch(() => undefined);
   }
 });
 
@@ -202,6 +234,7 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
     const { getSlideById } = await import('./helpers');
     const deck = await getSlideById(deckId);
     expect(deck?.content_path, 'a new deck should have a content_path').toBeTruthy();
+    createdDeckPaths.push(deck!.content_path);
 
     await editSlide(page, deckId);
     const uploaded = await uploadDeckImage(
@@ -271,6 +304,7 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
 
     const deck = await getSlideById(deckId);
     expect(deck?.content_path, 'a new deck should have a content_path').toBeTruthy();
+    createdDeckPaths.push(deck!.content_path);
 
     await editSlide(page, deckId);
     const uploaded = await uploadDeckImage(
@@ -324,6 +358,7 @@ test.describe('E2E CD — slides, the gate', () => {
     createdDeckIds.push(deckId);
     const deck = await getSlideById(deckId);
     expect(deck?.content_path).toBeTruthy();
+    createdDeckPaths.push(deck!.content_path);
 
     await editSlide(page, deckId);
     const uploaded = await uploadDeckImage(

--- a/apps/slides/tests/content-pipeline.spec.ts
+++ b/apps/slides/tests/content-pipeline.spec.ts
@@ -223,9 +223,8 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
       `content_delivery_enabled is false for '${target.slug}' — see apps/content/README.md, "Local end-to-end"`
     );
 
-    const { createSlide, editSlide, saveSlide, presentSlide, fixtureName, pngBytes } = await import(
-      './helpers'
-    );
+    const { createSlide, editSlide, saveSlide, presentSlide, fixtureName, pngBytes } =
+      await import('./helpers');
 
     await loginAs(page, 'owner', '/');
     const deckId = await createSlide(page, `E2E CD deck ${Date.now()}`);
@@ -349,9 +348,8 @@ test.describe('E2E CD — slides, the gate', () => {
     // be in the classroom makes the result depend on what ran before it, and a
     // deck with no images would pass this test without exercising the gate at
     // all — the emptiest possible green.
-    const { createSlide, editSlide, saveSlide, getSlideById, fixtureName, pngBytes } = await import(
-      './helpers'
-    );
+    const { createSlide, editSlide, saveSlide, getSlideById, fixtureName, pngBytes } =
+      await import('./helpers');
 
     await loginAs(page, 'owner', '/');
     const deckId = await createSlide(page, `E2E CD gate ${Date.now()}`);
@@ -387,8 +385,10 @@ test.describe('E2E CD — slides, the gate', () => {
       expect(images.length, 'the fixture image should be on the deck').toBeGreaterThan(0);
 
       for (const image of images) {
-        expect(image.signed, `still signed with the gate off: ${describeSignedUrl(image.src)}`)
-          .toBeNull();
+        expect(
+          image.signed,
+          `still signed with the gate off: ${describeSignedUrl(image.src)}`
+        ).toBeNull();
       }
       // The positive half: they fell back to the legacy proxy form, rather than
       // to nothing at all.

--- a/apps/slides/tests/helpers/contentDelivery.helpers.ts
+++ b/apps/slides/tests/helpers/contentDelivery.helpers.ts
@@ -1,0 +1,8 @@
+/**
+ * The content-delivery helpers, re-exported from where slides specs expect them.
+ *
+ * One implementation, shared with `apps/pages`, at the repo root
+ * (`tests/content-delivery/`). See the note in the pages copy of this file for
+ * why it does not live inside either app.
+ */
+export * from '../../../../tests/content-delivery/contentDelivery.helpers';

--- a/apps/slides/tests/helpers/index.ts
+++ b/apps/slides/tests/helpers/index.ts
@@ -8,6 +8,9 @@
 // Authentication helpers
 export { loginAs, logout, isLoggedIn, getSessionToken, type TestRole } from './auth.helpers';
 
+// Content delivery helpers — one implementation, shared with apps/pages.
+export * from './contentDelivery.helpers';
+
 // Environment helpers
 export {
   getDevPort,

--- a/apps/slides/tests/helpers/prisma.helpers.ts
+++ b/apps/slides/tests/helpers/prisma.helpers.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 // after DATABASE_URL is resolved (see getTestPrisma's dynamic import).
 // Mirrors apps/pages/tests/helpers/prisma.helpers.ts.
 import type getPrismaType from '@classmoji/database';
+import { assertWritableDatabase } from '../../../../tests/content-delivery/databaseGuard';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -35,6 +36,14 @@ export async function getTestPrisma(): Promise<TestPrisma> {
     const url = databaseUrlFromDevContext();
     if (url) process.env.DATABASE_URL = url;
   }
+  // Every suite that reaches the database goes through here, and several of
+  // them write: sessions are minted, fixtures are created, classroom columns
+  // are flipped. Which database that lands in is decided by whatever
+  // DATABASE_URL happened to be exported — a value that is routinely pointed at
+  // a deployed environment for an afternoon's debugging and not put back. The
+  // guard is on the resolved host, so intent (E2E_TARGET, NODE_ENV) cannot vouch
+  // for connectivity.
+  assertWritableDatabase('open a test database connection');
   if (!cached) {
     const { default: getPrisma } = await import('@classmoji/database');
     cached = getPrisma();

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "slides:test:ui": "dotenv -e .env -- ./scripts/devport.sh run turbo run test:ui --filter=@classmoji/slides",
     "pages:test": "dotenv -e .env -- ./scripts/devport.sh run turbo run test --filter=@classmoji/pages",
     "pages:test:ui": "dotenv -e .env -- ./scripts/devport.sh run turbo run test:ui --filter=@classmoji/pages",
+    "e2e:content": "dotenv -e .env -- ./scripts/devport.sh run turbo run test --filter=@classmoji/pages --filter=@classmoji/slides --concurrency=1 -- content-pipeline",
     "test": "dotenv -e .env -- ./scripts/devport.sh run turbo run test",
     "test:ai-agent": "dotenv -e .env -- ./scripts/devport.sh run turbo run test --filter=@classmoji/ai-agent",
     "test:ai-agent:integration": "dotenv -e .env -- ./scripts/devport.sh run turbo run test:integration --filter=@classmoji/ai-agent",

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -169,10 +169,21 @@ export async function deliverySkipReason(): Promise<string | null> {
   return null;
 }
 
-/** Scenarios that write to the database or read Prisma directly. */
+/**
+ * Scenarios that need a Prisma client, to read the classroom or to write to it.
+ *
+ * The message says all three things a reader needs, because "local only" on its
+ * own invites the wrong fix. This pack refuses to open a database connection
+ * against a deployed target at all (see `prisma()` below), so the read-side
+ * scenarios have no classroom row to work from; the write-side ones would be
+ * changing a shared environment, where a cache-reset alone rewrites every URL
+ * every real viewer is holding; and the editor scenarios need a session, which
+ * staging cannot mint because `/test-login` does not exist outside development.
+ */
 export function localOnlySkipReason(): string | null {
   return e2eTarget() === 'staging'
-    ? 'local only: this scenario writes to the database (content_delivery_enabled / content_key_version) and must never touch a deployed one'
+    ? 'needs a database and a signed-in session, and this pack opens neither against a deployed target ' +
+        '(no Prisma connection, no /test-login) — run with E2E_TARGET=local for this one'
     : null;
 }
 
@@ -498,6 +509,21 @@ export async function reloadUntilImages(
     if (attempt < attempts - 1) await page.waitForTimeout(delayMs);
   }
   return images;
+}
+
+/**
+ * A signed URL taken off a page, with no database and no session.
+ *
+ * This is what lets the Worker's own contract be checked against a DEPLOYED
+ * environment. Everything else in the pack needs Prisma or an editor session,
+ * neither of which exists against staging — but a public class site is
+ * anonymous, server-rendered and already full of `public`-tier URLs, so one GET
+ * yields a genuine, current signature to probe with. Minting one in the test
+ * instead would mean re-implementing the canonical string and the key
+ * derivation, and would then only ever prove the test agrees with itself.
+ */
+export async function harvestSignedFromHtml(html: string): Promise<RenderedImage | null> {
+  return imagesFromHtml(html).find(image => image.signed !== null) ?? null;
 }
 
 /** The same wait, for a surface only reachable over plain HTTP. */

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -22,7 +22,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as zlib from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import type { Locator, Page, Request } from '@playwright/test';
+import type { BrowserContext, Locator, Page, Request } from '@playwright/test';
+import {
+  assertWritableDatabase,
+  databaseHost,
+  isLocalDatabaseHost,
+  resolvedDatabaseUrl,
+} from './databaseGuard.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, '../..');
@@ -80,6 +86,107 @@ export function devDatabaseUrl(): string | null {
   return match ? match[1] : null;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Fail-open detector
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * How many scenarios got far enough to assert something.
+ *
+ * The failure this exists for has already happened once: `npm run e2e:content`
+ * reported two green tasks while every scenario skipped, because turbo did not
+ * pass `E2E_CD_CONTENT_REPO` through and each skip looked individually
+ * reasonable. A suite whose skips are all "correct" can still be worth nothing,
+ * and nothing in a green summary says so. Each pack ends with a check on this
+ * counter.
+ */
+let scenariosRun = 0;
+
+/** Call once a scenario has reached its first real assertion. */
+export function markScenarioRan(): void {
+  scenariosRun += 1;
+}
+
+export function scenariosThatRan(): number {
+  return scenariosRun;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Origin safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The only content origin a staging run may ever talk to. */
+const STAGING_DELIVERY_ORIGIN = 'https://content-staging.classmoji.io';
+
+/**
+ * Hosts this pack must never be pointed at, however it is configured.
+ *
+ * The pack signs in, uploads, deletes and flips flags. Against production that
+ * is not a bad test run, it is an incident — so production is refused at the
+ * point the origin is resolved rather than trusted to be excluded by whichever
+ * skip happens to fire first. The rule is positive: a `classmoji.io` host has
+ * to SAY `staging` somewhere. `app.` and `content.` are named too, so the error
+ * can be specific about the two that matter most.
+ */
+function assertSafeOrigin(label: string, raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`${label} is not a valid URL: ${JSON.stringify(raw)}`);
+  }
+
+  const host = url.hostname.toLowerCase();
+  if (LOCAL_ORIGIN_HOSTS.has(host)) return raw;
+
+  const named: Record<string, string> = {
+    'app.classmoji.io': 'the production webapp',
+    'content.classmoji.io': 'the production content Worker',
+    'pages.classmoji.io': 'the production pages app',
+    'slides.classmoji.io': 'the production slides app',
+  };
+  if (named[host]) {
+    throw new Error(
+      `${label} points at ${named[host]} (${host}). This pack uploads, deletes and changes ` +
+        'classroom rows; it must never be aimed at production.'
+    );
+  }
+
+  const isClassmoji = host === 'classmoji.io' || host.endsWith('.classmoji.io');
+  if (isClassmoji && !host.includes('staging')) {
+    throw new Error(
+      `${label} points at '${host}', a classmoji.io host that is not a staging one. ` +
+        'Only staging hosts are allowed; use E2E_TARGET=local for a local run.'
+    );
+  }
+
+  return raw;
+}
+
+const LOCAL_ORIGIN_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+/**
+ * The delivery origin for a staging run, ignoring the environment entirely.
+ *
+ * `npm run e2e:content` runs under `dotenv -e .env`, and a local `.env` sets
+ * `CONTENT_DELIVERY_ORIGIN=http://localhost:8787`. Read as an override, that
+ * value silently redirected a staging run at a Worker on the developer's own
+ * machine — which answers, and whose signatures are for a different host, so
+ * the suite would have reported refusals as if staging had produced them. The
+ * staging origin is therefore a constant, and a conflicting env value is
+ * reported rather than obeyed.
+ */
+function stagingDeliveryOrigin(): string {
+  const override = process.env.CONTENT_DELIVERY_ORIGIN;
+  if (override && new URL(override).host !== new URL(STAGING_DELIVERY_ORIGIN).host) {
+    console.warn(
+      `[e2e] IGNORING CONTENT_DELIVERY_ORIGIN=${override} — a staging run always uses ` +
+        `${STAGING_DELIVERY_ORIGIN}. (Your .env sets this for local work; that is expected.)`
+    );
+  }
+  return STAGING_DELIVERY_ORIGIN;
+}
+
 export interface ContentDeliveryTargets {
   target: E2ETarget;
   /** Pages app — the page editor and the private page view. */
@@ -110,24 +217,55 @@ export function targets(): ContentDeliveryTargets {
   if (target === 'staging') {
     return {
       target,
-      pages: process.env.E2E_PAGES_URL ?? 'https://pages.staging.classmoji.io',
-      slides: process.env.E2E_SLIDES_URL ?? 'https://slides.staging.classmoji.io',
-      webapp: process.env.E2E_WEBAPP_URL ?? 'https://staging.classmoji.io',
-      classSite: process.env.E2E_CLASS_SITE_URL ?? 'https://cs98-test.staging.classmoji.io',
-      deliveryOrigin: process.env.CONTENT_DELIVERY_ORIGIN ?? 'https://content-staging.classmoji.io',
+      pages: assertSafeOrigin(
+        'E2E_PAGES_URL',
+        process.env.E2E_PAGES_URL ?? 'https://pages.staging.classmoji.io'
+      ),
+      slides: assertSafeOrigin(
+        'E2E_SLIDES_URL',
+        process.env.E2E_SLIDES_URL ?? 'https://slides.staging.classmoji.io'
+      ),
+      webapp: assertSafeOrigin(
+        'E2E_WEBAPP_URL',
+        process.env.E2E_WEBAPP_URL ?? 'https://staging.classmoji.io'
+      ),
+      classSite: assertSafeOrigin(
+        'E2E_CLASS_SITE_URL',
+        process.env.E2E_CLASS_SITE_URL ?? 'https://cs98-test.staging.classmoji.io'
+      ),
+      // Deliberately NOT read from the environment. See stagingDeliveryOrigin.
+      deliveryOrigin: stagingDeliveryOrigin(),
       classroomSlug: process.env.E2E_CLASSROOM_SLUG ?? 'cs98-test',
     };
   }
 
   return {
     target,
-    pages: process.env.E2E_PAGES_URL ?? devPort('Pages') ?? 'http://localhost:7100',
-    slides: process.env.E2E_SLIDES_URL ?? devPort('Slides') ?? 'http://localhost:6500',
-    webapp: process.env.E2E_WEBAPP_URL ?? devPort('Webapp') ?? 'http://localhost:3000',
+    pages: assertSafeOrigin(
+      'E2E_PAGES_URL',
+      process.env.E2E_PAGES_URL ?? devPort('Pages') ?? 'http://localhost:7100'
+    ),
+    slides: assertSafeOrigin(
+      'E2E_SLIDES_URL',
+      process.env.E2E_SLIDES_URL ?? devPort('Slides') ?? 'http://localhost:6500'
+    ),
+    webapp: assertSafeOrigin(
+      'E2E_WEBAPP_URL',
+      process.env.E2E_WEBAPP_URL ?? devPort('Webapp') ?? 'http://localhost:3000'
+    ),
     // Locally the class site is served by the pages app on a host header it
     // cannot fake from Playwright, so the reachable surface is the same origin.
-    classSite: process.env.E2E_CLASS_SITE_URL ?? devPort('Pages') ?? 'http://localhost:7100',
-    deliveryOrigin: process.env.CONTENT_DELIVERY_ORIGIN ?? 'http://localhost:8787',
+    classSite: assertSafeOrigin(
+      'E2E_CLASS_SITE_URL',
+      process.env.E2E_CLASS_SITE_URL ?? devPort('Pages') ?? 'http://localhost:7100'
+    ),
+    // A local run signs for, and probes, whatever the apps were started with —
+    // but it still may not be a production host: an operator who exported the
+    // production origin and forgot would otherwise aim the refusal probes there.
+    deliveryOrigin: assertSafeOrigin(
+      'CONTENT_DELIVERY_ORIGIN',
+      process.env.CONTENT_DELIVERY_ORIGIN ?? 'http://localhost:8787'
+    ),
     classroomSlug: process.env.E2E_CLASSROOM_SLUG ?? 'classmoji-dev-winter-2025',
   };
 }
@@ -202,6 +340,69 @@ export function authSkipReason(): string | null {
     'staging has no test-login route and no seeded credentials: set E2E_SESSION_COOKIE to a ' +
     '`classmoji.session_token` value for a member of the target classroom, or run with E2E_TARGET=local'
   );
+}
+
+/** The session cookie name better-auth issues, and the one the apps read. */
+const SESSION_COOKIE = 'classmoji.session_token';
+
+/**
+ * Sign a browser context in on a DEPLOYED target, using a real session token.
+ *
+ * Scoped to the three staging origins by URL and to nothing else. A cookie is
+ * a live credential for a real account, so it is set per-origin rather than by
+ * domain: a `.classmoji.io` domain cookie would be attached to production the
+ * moment any redirect crossed over, which is the one thing this pack must never
+ * do. `assertSafeOrigin` has already refused a production host by this point,
+ * so the two checks compound.
+ *
+ * No-op unless the target is staging AND a token was supplied, so a local run
+ * (which mints its own sessions through `/test-login`) is unaffected.
+ */
+export async function applyStagingSession(context: BrowserContext): Promise<boolean> {
+  const token = process.env.E2E_SESSION_COOKIE;
+  if (e2eTarget() !== 'staging' || !token) return false;
+
+  const { pages, slides, classSite } = targets();
+  await context.addCookies(
+    [...new Set([pages, slides, classSite])].map(url => ({
+      name: SESSION_COOKIE,
+      value: token,
+      url,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax' as const,
+    }))
+  );
+  return true;
+}
+
+/** Is a signed-in staging run actually configured? */
+export function hasStagingSession(): boolean {
+  return e2eTarget() === 'staging' && Boolean(process.env.E2E_SESSION_COOKIE);
+}
+
+/**
+ * The first content link on a classroom index, or null.
+ *
+ * Staging has no database to query for "a page this member can see", and
+ * hard-coding an id would rot the first time someone tidied the classroom. The
+ * index is the same list a member browses, so whatever it links to is by
+ * definition something they may open.
+ */
+export async function discoverMemberContentUrl(
+  page: Page,
+  classroomSlug: string
+): Promise<string | null> {
+  await page.goto(`/${classroomSlug}`);
+  await page.waitForLoadState('networkidle');
+  const href = await page
+    .locator(`a[href^="/${classroomSlug}/"]`)
+    .first()
+    .getAttribute('href')
+    .catch(() => null);
+  if (!href) return null;
+  // `/new` is the create form, not content.
+  return href.endsWith('/new') ? null : href;
 }
 
 /**
@@ -393,6 +594,18 @@ export function describeSignedUrl(raw: string): string {
   if (parsed.w !== null) bits.push(`w=${parsed.w}`);
   if (parsed.fmt !== null) bits.push(`fmt=${parsed.fmt}`);
   return `${parsed.origin}/c/${parsed.classroomId}/blob/${parsed.sha}.${parsed.ext}?${bits.join('&')}`;
+}
+
+/**
+ * A list of URLs, reduced to something safe to put in a failure message.
+ *
+ * `expect(log.delivery()).toEqual([])` reads well and, on failure, prints every
+ * signed URL it saw — into a Playwright report that CI uploads as an artifact,
+ * where a `public`-tier signature stays valid for a month. Comparing the
+ * redacted form instead keeps the assertion and loses the credential.
+ */
+export function describeUrls(urls: string[]): string[] {
+  return urls.map(describeSignedUrl);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -755,6 +968,11 @@ async function prisma() {
     const url = devDatabaseUrl();
     if (url) process.env.DATABASE_URL = url;
   }
+  // Reads are harmless, but every write path in this file reaches the database
+  // through here, and the classroom this pack reads is the same one it later
+  // mutates. Checking once, at the connection, is what makes the guard hard to
+  // route around.
+  assertWritableDatabase('open a database connection for the content-delivery e2e pack');
   const { default: getPrisma } = await import('@classmoji/database');
   return getPrisma();
 }
@@ -810,6 +1028,7 @@ export async function classroom(slug = targets().classroomSlug): Promise<E2EClas
  * switch the feature ON in the dev database of anyone who had it off.
  */
 export async function setDeliveryEnabled(classroomId: string, enabled: boolean): Promise<boolean> {
+  assertWritableDatabase(`set content_delivery_enabled on classroom ${classroomId}`);
   const db = await prisma();
   const before = await db.classroom.findUniqueOrThrow({
     where: { id: classroomId },
@@ -841,6 +1060,7 @@ export async function keyVersion(classroomId: string): Promise<number> {
  * relative increment that makes two concurrent clicks safe.
  */
 export async function bumpKeyVersion(classroomId: string): Promise<number> {
+  assertWritableDatabase(`bump content_key_version on classroom ${classroomId}`);
   const service = await services();
   const { content_key_version } = await service.contentDelivery.bumpContentKeyVersion(classroomId);
   return content_key_version;
@@ -868,6 +1088,7 @@ export async function assetRow(
  * looks exactly like the bug it is meant to catch.
  */
 export async function syncMap(classroomId: string): Promise<void> {
+  assertWritableDatabase(`re-sync the asset map for classroom ${classroomId}`);
   const service = await services();
   await service.contentAssets.syncContentAssets(classroomId, { full: true });
 }
@@ -901,6 +1122,11 @@ export async function readRepoFile(
 
 /** Delete a file from the content repo — used to manufacture a dangling ref. */
 export async function deleteRepoFile(target: E2EClassroom, repoPath: string): Promise<void> {
+  // A repo write does not go through Prisma, so it would not be covered by the
+  // connection guard. The database is still the right thing to check: it is
+  // what told us WHICH repo to write to, so a production database means a
+  // production repo even though the write itself is a GitHub call.
+  assertWritableDatabase(`delete ${repoPath} from ${target.content_repo}`);
   const { ContentService } = await import('@classmoji/services');
   if (!target.content_repo) throw new Error(`classroom ${target.slug} has no content_repo`);
   await ContentService.delete({
@@ -936,7 +1162,13 @@ export async function readStoredContent(
  */
 export async function pageWithRepo(pageId: string) {
   const service = await services();
-  return service.page.findById(pageId, { includeClassroom: true });
+  const page = await service.page.findById(pageId, { includeClassroom: true });
+  // `findById` is nullable, and every caller here immediately hands the result
+  // to a content-repo write that dereferences `classroom.git_organization`.
+  // Throwing names the missing page; passing null through produced a
+  // `Cannot read properties of null` from three frames deeper.
+  if (!page) throw new Error(`no page with id '${pageId}'`);
+  return page;
 }
 
 /** A page's blocks, through the product's own reader. */
@@ -957,6 +1189,7 @@ export async function loadPageBlocks(pageId: string): Promise<unknown[]> {
  * meant to prove impossible.
  */
 export async function savePageBlocks(pageId: string, blocks: unknown[]): Promise<void> {
+  assertWritableDatabase(`write page content for ${pageId}`);
   const service = await services();
   const page = await pageWithRepo(pageId);
   await service.pageContent.savePageContent(page, blocks, {

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -200,7 +200,7 @@ export function authSkipReason(): string | null {
   if (process.env.E2E_SESSION_COOKIE) return null;
   return (
     'staging has no test-login route and no seeded credentials: set E2E_SESSION_COOKIE to a ' +
-    "`classmoji.session_token` value for a member of the target classroom, or run with E2E_TARGET=local"
+    '`classmoji.session_token` value for a member of the target classroom, or run with E2E_TARGET=local'
   );
 }
 
@@ -728,10 +728,7 @@ export function pngBytes(width = 1200, height = 60): Buffer {
  * test is about animation.
  */
 export function gifBytes(): Buffer {
-  return Buffer.from(
-    'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=',
-    'base64'
-  );
+  return Buffer.from('R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=', 'base64');
 }
 
 /** A unique, prefixed name for a fixture file. */

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -1,0 +1,854 @@
+/**
+ * Shared helpers for the content-delivery end-to-end pack.
+ *
+ * ONE implementation, used by two Playwright projects. `apps/pages` and
+ * `apps/slides` each own a `tests/helpers/` directory and each own a
+ * `playwright.config.ts` whose `testDir` is its own `./tests`, so neither can
+ * see the other's — and the delivery layer is exactly the thing both of them
+ * have to make identical claims about. A second copy would drift, and the drift
+ * would be invisible: two suites asserting slightly different URL shapes both
+ * stay green while the app emits neither.
+ *
+ * It lives at the repo root rather than inside one app because reaching from
+ * `apps/slides` into `apps/pages/tests` would make one app's internals another
+ * app's dependency, which AGENTS.md rules out. Each app re-exports this from
+ * its own `tests/helpers/index.ts`, so specs still import from the familiar
+ * place.
+ *
+ * Nothing here is collected by either Playwright project (`testDir` is each
+ * app's `./tests`), so this directory holds no specs and never will.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as zlib from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+import type { Locator, Page, Request } from '@playwright/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '../..');
+
+/**
+ * Everything this pack creates is named with this prefix.
+ *
+ * A run leaves rows in a real database and, when a content repo is configured,
+ * files in a real repository. The prefix is what makes the leftovers of a
+ * killed run findable and safe to remove by hand — and what stops a cleanup
+ * from ever matching something a human made.
+ */
+export const E2E_PREFIX = 'E2E CD';
+
+/** A filesystem/repo-safe version of the same marker. */
+export const E2E_SLUG_PREFIX = 'e2e-cd';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Targets
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type E2ETarget = 'local' | 'staging';
+
+/**
+ * Which deployment this run is pointed at. `local` unless asked otherwise.
+ *
+ * The default matters: a developer running `npm run e2e:content` with no env
+ * set must not reach a deployed environment by accident, and a typo in the
+ * variable must fail closed to local rather than open to staging.
+ */
+export function e2eTarget(): E2ETarget {
+  return process.env.E2E_TARGET === 'staging' ? 'staging' : 'local';
+}
+
+/** `.dev-context` is written by `npm run dev`; a devport shifts every port. */
+function devContext(): string | null {
+  try {
+    return fs.readFileSync(path.join(REPO_ROOT, '.dev-context'), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function devPort(label: 'Webapp' | 'Slides' | 'Pages'): string | null {
+  const content = devContext();
+  if (!content) return null;
+  const match = content.match(new RegExp(`${label}:\\s+http://localhost:(\\d+)`));
+  return match ? `http://localhost:${match[1]}` : null;
+}
+
+/** The dev database this checkout is actually using, per `.dev-context`. */
+export function devDatabaseUrl(): string | null {
+  const content = devContext();
+  const match = content?.match(/URL:\s+(postgresql:\/\/\S+)/);
+  return match ? match[1] : null;
+}
+
+export interface ContentDeliveryTargets {
+  target: E2ETarget;
+  /** Pages app — the page editor and the private page view. */
+  pages: string;
+  /** Slides app — the deck editor, viewer and `/present`. */
+  slides: string;
+  /** Webapp — classroom settings, and the Worker's token endpoint. */
+  webapp: string;
+  /** The public class site, where a `public` tier render is observable. */
+  classSite: string;
+  /** Where signed URLs point. MUST match what the apps signed for, port included. */
+  deliveryOrigin: string;
+  /** The classroom the pack works in. */
+  classroomSlug: string;
+}
+
+/**
+ * Resolve every base URL for this run.
+ *
+ * Local reads `.dev-context` so a devport works without configuration, and
+ * every value stays overridable by env for the case `.dev-context` is stale —
+ * which it silently is whenever a different worktree started the dev stack
+ * last.
+ */
+export function targets(): ContentDeliveryTargets {
+  const target = e2eTarget();
+
+  if (target === 'staging') {
+    return {
+      target,
+      pages: process.env.E2E_PAGES_URL ?? 'https://pages.staging.classmoji.io',
+      slides: process.env.E2E_SLIDES_URL ?? 'https://slides.staging.classmoji.io',
+      webapp: process.env.E2E_WEBAPP_URL ?? 'https://staging.classmoji.io',
+      classSite: process.env.E2E_CLASS_SITE_URL ?? 'https://cs98-test.staging.classmoji.io',
+      deliveryOrigin: process.env.CONTENT_DELIVERY_ORIGIN ?? 'https://content-staging.classmoji.io',
+      classroomSlug: process.env.E2E_CLASSROOM_SLUG ?? 'cs98-test',
+    };
+  }
+
+  return {
+    target,
+    pages: process.env.E2E_PAGES_URL ?? devPort('Pages') ?? 'http://localhost:7100',
+    slides: process.env.E2E_SLIDES_URL ?? devPort('Slides') ?? 'http://localhost:6500',
+    webapp: process.env.E2E_WEBAPP_URL ?? devPort('Webapp') ?? 'http://localhost:3000',
+    // Locally the class site is served by the pages app on a host header it
+    // cannot fake from Playwright, so the reachable surface is the same origin.
+    classSite: process.env.E2E_CLASS_SITE_URL ?? devPort('Pages') ?? 'http://localhost:7100',
+    deliveryOrigin: process.env.CONTENT_DELIVERY_ORIGIN ?? 'http://localhost:8787',
+    classroomSlug: process.env.E2E_CLASSROOM_SLUG ?? 'classmoji-dev-winter-2025',
+  };
+}
+
+/** Host of the delivery origin, for request matching. */
+export function deliveryHost(): string {
+  return new URL(targets().deliveryOrigin).host;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Skip gates
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Why this run cannot exercise the delivery layer, or null when it can.
+ *
+ * A skip has to say which of the several ways to be half-configured happened.
+ * "Delivery not configured" is useless when the four causes are a Worker that
+ * is not running, a Worker running without secrets, a classroom whose flag is
+ * off, and apps that were started without `CONTENT_SIGNING_SECRET` — the last
+ * of which looks exactly like the flag being off from the browser's side.
+ */
+export async function deliverySkipReason(): Promise<string | null> {
+  const { deliveryOrigin } = targets();
+
+  const health = await workerHealth(deliveryOrigin);
+  if (!health) {
+    return (
+      `no content Worker answering at ${deliveryOrigin}/healthz — ` +
+      "start one with `npm run cf:dev:local -w apps/content` (see apps/content/README.md, 'Local end-to-end')"
+    );
+  }
+  if (!health.configured) {
+    return (
+      `the Worker at ${deliveryOrigin} reports configured:false — ` +
+      'CONTENT_SIGNING_SECRET / CONTENT_WORKER_SHARED_SECRET are missing from apps/content/.dev.vars'
+    );
+  }
+  return null;
+}
+
+/** Scenarios that write to the database or read Prisma directly. */
+export function localOnlySkipReason(): string | null {
+  return e2eTarget() === 'staging'
+    ? 'local only: this scenario writes to the database (content_delivery_enabled / content_key_version) and must never touch a deployed one'
+    : null;
+}
+
+/**
+ * Why a signed-in scenario cannot run, or null.
+ *
+ * `/test-login` is gated on `ENABLE_TEST_LOGIN` and mints a session by reading
+ * the database, so it exists only where the tests can also reach Postgres.
+ * Against a deployed target there is no such route and no seeded password —
+ * the only way in would be a real session cookie handed to the run.
+ */
+export function authSkipReason(): string | null {
+  if (e2eTarget() !== 'staging') return null;
+  if (process.env.E2E_SESSION_COOKIE) return null;
+  return (
+    'staging has no test-login route and no seeded credentials: set E2E_SESSION_COOKIE to a ' +
+    "`classmoji.session_token` value for a member of the target classroom, or run with E2E_TARGET=local"
+  );
+}
+
+/**
+ * Why an upload scenario cannot run, or null.
+ *
+ * An upload writes a real file to a real GitHub repository through the
+ * classroom's GitHub App installation. The seeded dev classroom points at
+ * `dev-org/content-classmoji-dev-winter-2025`, which does not exist on GitHub,
+ * so an upload there fails at the API call rather than telling you anything
+ * about the delivery layer. `E2E_CD_CONTENT_REPO=1` is the operator's assertion
+ * that the configured classroom's content repo is real and writable.
+ */
+export function uploadSkipReason(): string | null {
+  if (process.env.E2E_CD_CONTENT_REPO === '1') return null;
+  return (
+    "no writable content repo: this scenario uploads to the classroom's GitHub content repo. " +
+    'Point E2E_CLASSROOM_SLUG at a classroom whose repo really exists and whose org has the ' +
+    'GitHub App installed, then set E2E_CD_CONTENT_REPO=1.'
+  );
+}
+
+export interface WorkerHealth {
+  ok: boolean;
+  environment: string;
+  configured: boolean;
+}
+
+/** `/healthz`, or null when nothing answers. Never throws. */
+export async function workerHealth(origin: string): Promise<WorkerHealth | null> {
+  try {
+    const response = await fetch(`${origin.replace(/\/+$/, '')}/healthz`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as WorkerHealth;
+    return typeof body?.configured === 'boolean' ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Signed URL shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type Tier = 'public' | 'enrolled' | 'draft';
+
+/** The three rungs `signSrcSet` emits. Mirrors TRANSFORM_WIDTHS. */
+export const EXPECTED_WIDTHS = [800, 1600, 2560] as const;
+
+/** The `sizes` constant every surface shares. Mirrors IMAGE_SIZES. */
+export const EXPECTED_SIZES = '(max-width: 1024px) 100vw, 1024px';
+
+const UUID = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+/**
+ * `/c/{uuid}/blob/{40-hex}.{ext}` — the path half of a signed blob URL.
+ *
+ * Shape only. NOTHING in this pack may assert a literal signature: a signature
+ * is a function of a secret, a clock and an expiry bucket, so a test that
+ * pinned one would be asserting the time of day. What is actually contractual
+ * is the shape — the path, and which query keys are present.
+ */
+export const SIGNED_BLOB_PATH = new RegExp(`^/c/(${UUID})/blob/([0-9a-f]{40})\\.([a-z0-9]{1,8})$`);
+
+/** `/c/{uuid}/missing/{encodedRef}` — the deterministic unresolvable URL. */
+export const MISSING_PATH = new RegExp(`^/c/(${UUID})/missing/(.+)$`);
+
+export interface SignedUrl {
+  origin: string;
+  classroomId: string;
+  sha: string;
+  ext: string;
+  tier: Tier;
+  keyVersion: number;
+  exp: number;
+  /** Present, never compared to a literal. */
+  sig: string;
+  w: number | null;
+  fmt: string | null;
+}
+
+/** Parse a signed blob URL into its parts, or null when it is not one. */
+export function parseSignedUrl(raw: string): SignedUrl | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  const match = SIGNED_BLOB_PATH.exec(url.pathname);
+  if (!match) return null;
+
+  const tier = url.searchParams.get('p');
+  const keyVersion = url.searchParams.get('v');
+  const exp = url.searchParams.get('exp');
+  const sig = url.searchParams.get('sig');
+  if (!tier || !keyVersion || !exp || !sig) return null;
+  if (tier !== 'public' && tier !== 'enrolled' && tier !== 'draft') return null;
+
+  const w = url.searchParams.get('w');
+  return {
+    origin: url.origin,
+    classroomId: match[1],
+    sha: match[2],
+    ext: match[3],
+    tier,
+    keyVersion: Number(keyVersion),
+    exp: Number(exp),
+    sig,
+    w: w === null ? null : Number(w),
+    fmt: url.searchParams.get('fmt'),
+  };
+}
+
+/** Is this one of the resolver's `/missing/` placeholders? */
+export function parseMissingUrl(raw: string): { classroomId: string; ref: string } | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  const match = MISSING_PATH.exec(url.pathname);
+  if (!match) return null;
+  return { classroomId: match[1], ref: decodeURIComponent(match[2]) };
+}
+
+export interface SrcSetCandidate {
+  url: string;
+  width: number;
+  parsed: SignedUrl | null;
+}
+
+/** Split a `srcset` attribute into its candidates, preserving order. */
+export function parseSrcSet(srcset: string | null): SrcSetCandidate[] {
+  if (!srcset) return [];
+  return srcset
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
+    .map(entry => {
+      const lastSpace = entry.lastIndexOf(' ');
+      const url = lastSpace === -1 ? entry : entry.slice(0, lastSpace);
+      const descriptor = lastSpace === -1 ? '' : entry.slice(lastSpace + 1);
+      return {
+        url,
+        width: Number.parseInt(descriptor.replace(/w$/, ''), 10),
+        parsed: parseSignedUrl(url),
+      };
+    });
+}
+
+/**
+ * A signed URL is a credential, so a failure message must not print one.
+ *
+ * Playwright puts the compared values in the report, the report is uploaded as
+ * a CI artifact, and a `public`-tier signature is good for a month. Everything
+ * this pack asserts on is therefore reduced to a redacted description first.
+ */
+export function describeSignedUrl(raw: string): string {
+  const parsed = parseSignedUrl(raw);
+  if (!parsed) {
+    const missing = parseMissingUrl(raw);
+    if (missing) return `<missing ${missing.classroomId} ${missing.ref}>`;
+    return `<not a signed url: ${raw.split('?')[0]}>`;
+  }
+  const bits = [`p=${parsed.tier}`, `v=${parsed.keyVersion}`, 'exp=<n>', 'sig=<redacted>'];
+  if (parsed.w !== null) bits.push(`w=${parsed.w}`);
+  if (parsed.fmt !== null) bits.push(`fmt=${parsed.fmt}`);
+  return `${parsed.origin}/c/${parsed.classroomId}/blob/${parsed.sha}.${parsed.ext}?${bits.join('&')}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tampering — every mutation re-derives from a real URL, never a literal
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Flip the last character of `sig`, leaving a well-formed but wrong one. */
+export function tamperSignature(raw: string): string {
+  const url = new URL(raw);
+  const sig = url.searchParams.get('sig');
+  if (!sig) throw new Error('tamperSignature: url carries no sig');
+  const last = sig.slice(-1);
+  url.searchParams.set('sig', sig.slice(0, -1) + (last === 'A' ? 'B' : 'A'));
+  return url.toString();
+}
+
+/** Append a transform the signature never covered. */
+export function appendWidth(raw: string, width = 800): string {
+  const url = new URL(raw);
+  url.searchParams.set('w', String(width));
+  return url.toString();
+}
+
+/** Push `exp` further out — the "my link never expires" forgery. */
+export function extendExpiry(raw: string, seconds = 86_400): string {
+  const url = new URL(raw);
+  const exp = Number(url.searchParams.get('exp'));
+  if (!Number.isFinite(exp)) throw new Error('extendExpiry: url carries no numeric exp');
+  url.searchParams.set('exp', String(exp + seconds));
+  return url.toString();
+}
+
+/** Re-point a signed URL at a different classroom, keeping everything else. */
+export function swapClassroom(raw: string, classroomId: string): string {
+  const url = new URL(raw);
+  url.pathname = url.pathname.replace(SIGNED_BLOB_PATH, (_full, _id, sha, ext) => {
+    return `/c/${classroomId}/blob/${sha}.${ext}`;
+  });
+  return url.toString();
+}
+
+/** A UUID that is syntactically a classroom id and belongs to no classroom. */
+export const FOREIGN_CLASSROOM_ID = '00000000-0000-4000-8000-000000000000';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reading rendered images
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RenderedImage {
+  src: string;
+  srcset: string | null;
+  sizes: string | null;
+  /** What the browser actually chose — proof the candidate list is usable. */
+  currentSrc: string;
+  alt: string;
+  signed: SignedUrl | null;
+  candidates: SrcSetCandidate[];
+}
+
+/** Read one `<img>`'s delivery-relevant attributes. */
+export async function readImage(locator: Locator): Promise<RenderedImage> {
+  const raw = await locator.evaluate((node: HTMLImageElement) => ({
+    src: node.src,
+    srcset: node.getAttribute('srcset'),
+    sizes: node.getAttribute('sizes'),
+    currentSrc: node.currentSrc,
+    alt: node.alt,
+  }));
+  return {
+    ...raw,
+    signed: parseSignedUrl(raw.src),
+    candidates: parseSrcSet(raw.srcset),
+  };
+}
+
+/** Read every `<img>` matching a selector, in document order. */
+export async function readImages(page: Page, selector = 'img'): Promise<RenderedImage[]> {
+  const images = page.locator(selector);
+  const count = await images.count();
+  const out: RenderedImage[] = [];
+  for (let index = 0; index < count; index += 1) {
+    out.push(await readImage(images.nth(index)));
+  }
+  return out;
+}
+
+/**
+ * The one `<img>` whose `src` names a given repo path's file, by sha.
+ *
+ * Matching by sha rather than by DOM position: a page has a title image, an
+ * avatar and a logo, and "the first img" silently becomes the wrong one the
+ * moment a layout changes.
+ */
+export function imageForSha(images: RenderedImage[], sha: string): RenderedImage | undefined {
+  return images.find(image => image.signed?.sha === sha);
+}
+
+/**
+ * The same three attributes, read out of SERVER-RENDERED HTML.
+ *
+ * The class site is script-less by design and is reached by a Host header
+ * rather than a hostname a browser can resolve, so the `public` tier is only
+ * observable over plain HTTP. Reading the markup is therefore not a shortcut:
+ * it is the only place where what the server SENT can be separated from what a
+ * client-side pass might have fixed up afterwards.
+ *
+ * `currentSrc` is empty here, because nothing selected a candidate — no
+ * browser ran. Assertions on this shape must not use it.
+ */
+export function imagesFromHtml(html: string): RenderedImage[] {
+  const out: RenderedImage[] = [];
+  for (const [, tag] of html.matchAll(/<img\b([^>]*)>/gi)) {
+    const attr = (name: string): string | null => {
+      const match = new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`, 'i').exec(tag);
+      return match ? decodeHtmlEntities(match[1]) : null;
+    };
+    const src = attr('src') ?? '';
+    const srcset = attr('srcset');
+    out.push({
+      src,
+      srcset,
+      sizes: attr('sizes'),
+      currentSrc: '',
+      alt: attr('alt') ?? '',
+      signed: parseSignedUrl(src),
+      candidates: parseSrcSet(srcset),
+    });
+  }
+  return out;
+}
+
+/** Only the entities an attribute value can carry. */
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Counting requests
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RequestLog {
+  /** Every request to the delivery origin, in order. */
+  delivery(): string[];
+  /** Requests to the delivery origin for one sha (any transform). */
+  forSha(sha: string): string[];
+  /** `/missing/` requests — should be empty on a healthy render. */
+  missing(): string[];
+  /** Legacy content refs: raw.githubusercontent.com, or an app `/content/…`. */
+  legacy(): string[];
+  /** Everything seen, for a failure message. */
+  all(): string[];
+  stop(): void;
+}
+
+const LEGACY_PATTERNS = [/raw\.githubusercontent\.com/i, /\/content\/[^/]+\/[^/]+\//i];
+
+/**
+ * Watch a page's network for delivery and legacy content requests.
+ *
+ * Attach BEFORE the navigation that should produce them; a listener added after
+ * `goto` resolves has already missed the images. Counting is the only way to
+ * tell "the gate is off" from "the gate is on and every URL happens to look
+ * legacy", and the only way to prove an image was fetched exactly once rather
+ * than once per candidate.
+ */
+export function trackRequests(page: Page, origin = targets().deliveryOrigin): RequestLog {
+  const host = new URL(origin).host;
+  const seen: string[] = [];
+
+  const onRequest = (request: Request) => seen.push(request.url());
+  page.on('request', onRequest);
+
+  const isDelivery = (url: string) => {
+    try {
+      return new URL(url).host === host;
+    } catch {
+      return false;
+    }
+  };
+
+  return {
+    all: () => [...seen],
+    delivery: () => seen.filter(isDelivery),
+    forSha: (sha: string) => seen.filter(url => isDelivery(url) && url.includes(sha)),
+    missing: () => seen.filter(url => isDelivery(url) && parseMissingUrl(url) !== null),
+    legacy: () =>
+      seen.filter(url => !isDelivery(url) && LEGACY_PATTERNS.some(pattern => pattern.test(url))),
+    stop: () => page.off('request', onRequest),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Image fixtures, generated rather than committed
+// ─────────────────────────────────────────────────────────────────────────────
+
+function crc32(bytes: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const typed = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(typed));
+  return Buffer.concat([length, typed, crc]);
+}
+
+/**
+ * A real, decodable RGB PNG of the requested size.
+ *
+ * Generated rather than committed for two reasons. A binary fixture in git is
+ * unreviewable — nobody can tell a 40KB PNG from a 40KB anything — and the
+ * width has to be a parameter: the pipeline's `scale-down` fit means a source
+ * narrower than a rung is not upscaled, so a test about the ladder needs an
+ * image wide enough for the ladder to be meaningful.
+ *
+ * The pixels are a deterministic gradient, not noise, so the bytes (and
+ * therefore the git blob sha) are stable across runs — a re-upload of the same
+ * fixture is genuinely the same blob, which is what makes the map's behaviour
+ * observable rather than accidental.
+ */
+export function pngBytes(width = 1200, height = 60): Buffer {
+  const raw = Buffer.alloc((width * 3 + 1) * height);
+  let offset = 0;
+  for (let y = 0; y < height; y += 1) {
+    raw[offset] = 0; // filter: none
+    offset += 1;
+    for (let x = 0; x < width; x += 1) {
+      raw[offset] = (x * 255) / width;
+      raw[offset + 1] = (y * 255) / height;
+      raw[offset + 2] = 0x40;
+      offset += 3;
+    }
+  }
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // colour type: truecolour
+  // 10-12: compression, filter, interlace — all 0.
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', zlib.deflateSync(raw, { level: 9 })),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+/**
+ * A 1x1 GIF87a.
+ *
+ * The point of the GIF case is the EXTENSION, not the pixels: `gif` is excluded
+ * from the responsive ladder because resizing would flatten an animation to a
+ * still. The smallest legal file makes that assertion without pretending the
+ * test is about animation.
+ */
+export function gifBytes(): Buffer {
+  return Buffer.from(
+    'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=',
+    'base64'
+  );
+}
+
+/** A unique, prefixed name for a fixture file. */
+export function fixtureName(kind: 'png' | 'gif', label: string): string {
+  return `${E2E_SLUG_PREFIX}-${label}-${Date.now()}.${kind}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Database access — LOCAL ONLY
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * `@classmoji/database` builds its PrismaClient at module scope, so every
+ * import below is dynamic and happens only after DATABASE_URL is resolved.
+ * A static import at the top of this file would connect to whatever
+ * DATABASE_URL was set when Playwright started — on a devport, the wrong
+ * database, and on a machine with none set, no database at all.
+ */
+async function prisma() {
+  if (e2eTarget() === 'staging') {
+    throw new Error('refusing to open a Prisma client while E2E_TARGET=staging');
+  }
+  if (!process.env.DATABASE_URL) {
+    const url = devDatabaseUrl();
+    if (url) process.env.DATABASE_URL = url;
+  }
+  const { default: getPrisma } = await import('@classmoji/database');
+  return getPrisma();
+}
+
+/** The service layer, loaded the same way and for the same reason. */
+export async function services() {
+  await prisma();
+  const { ClassmojiService } = await import('@classmoji/services');
+  return ClassmojiService;
+}
+
+export interface E2EClassroom {
+  id: string;
+  slug: string;
+  content_repo: string | null;
+  content_key_version: number;
+  content_delivery_enabled: boolean;
+  orgLogin: string;
+}
+
+/** The classroom this run works in, read straight from the database. */
+export async function classroom(slug = targets().classroomSlug): Promise<E2EClassroom> {
+  const db = await prisma();
+  const row = await db.classroom.findFirst({
+    where: { slug },
+    select: {
+      id: true,
+      slug: true,
+      content_repo: true,
+      content_key_version: true,
+      content_delivery_enabled: true,
+      git_organization: { select: { login: true } },
+    },
+  });
+  if (!row) {
+    throw new Error(`no classroom with slug '${slug}' — is the dev database seeded?`);
+  }
+  return {
+    id: row.id,
+    slug: row.slug,
+    content_repo: row.content_repo,
+    content_key_version: row.content_key_version,
+    content_delivery_enabled: row.content_delivery_enabled,
+    orgLogin: row.git_organization?.login ?? '',
+  };
+}
+
+/**
+ * Flip the per-classroom gate and hand back the previous value.
+ *
+ * Returning the old value rather than assuming `true` is what lets a scenario
+ * restore whatever it found. A pack that always restored `true` would silently
+ * switch the feature ON in the dev database of anyone who had it off.
+ */
+export async function setDeliveryEnabled(classroomId: string, enabled: boolean): Promise<boolean> {
+  const db = await prisma();
+  const before = await db.classroom.findUniqueOrThrow({
+    where: { id: classroomId },
+    select: { content_delivery_enabled: true },
+  });
+  await db.classroom.update({
+    where: { id: classroomId },
+    data: { content_delivery_enabled: enabled },
+  });
+  return before.content_delivery_enabled;
+}
+
+export async function keyVersion(classroomId: string): Promise<number> {
+  const db = await prisma();
+  const row = await db.classroom.findUniqueOrThrow({
+    where: { id: classroomId },
+    select: { content_key_version: true },
+  });
+  return row.content_key_version;
+}
+
+/**
+ * Bump the cache-bust version through the SAME service the settings action
+ * calls, rather than a hand-written update.
+ *
+ * The assertion is about the product's behaviour — "reset content cache changes
+ * every URL" — so the test has to go through the product's own increment. A
+ * `{ set: n + 1 }` here would also pass while proving nothing about the
+ * relative increment that makes two concurrent clicks safe.
+ */
+export async function bumpKeyVersion(classroomId: string): Promise<number> {
+  const service = await services();
+  const { content_key_version } = await service.contentDelivery.bumpContentKeyVersion(classroomId);
+  return content_key_version;
+}
+
+/** The asset map's row for one repo path, or null. */
+export async function assetRow(
+  classroomId: string,
+  repoPath: string
+): Promise<{ sha: string; type: string } | null> {
+  const db = await prisma();
+  const row = await db.contentAsset.findFirst({
+    where: { classroom_id: classroomId, path: repoPath },
+    select: { sha: true, type: true },
+  });
+  return row;
+}
+
+/**
+ * Re-read the repo tree into the asset map, the way the app does.
+ *
+ * The push webhook normally keeps the map current; a test that changes the repo
+ * behind the app's back has to trigger the same sync explicitly, or it is
+ * asserting against a map that simply has not heard the news yet — a flake that
+ * looks exactly like the bug it is meant to catch.
+ */
+export async function syncMap(classroomId: string): Promise<void> {
+  const service = await services();
+  await service.contentAssets.syncContentAssets({ classroomId, full: true });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Content repo access — never a hardcoded token
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read a file out of the classroom's content repo, through the app's own
+ * ContentService.
+ *
+ * ContentService resolves the org's GitHub App installation from the database
+ * and mints an installation token per call — the same credential path the
+ * product uses. No token is ever read from a literal here, and none should be:
+ * a token in a spec is a token in the git history.
+ */
+export async function readRepoFile(
+  target: E2EClassroom,
+  repoPath: string
+): Promise<{ content: string; sha: string } | null> {
+  const { ContentService } = await import('@classmoji/services');
+  if (!target.content_repo) throw new Error(`classroom ${target.slug} has no content_repo`);
+  return ContentService.getContent({
+    orgLogin: target.orgLogin,
+    repo: target.content_repo,
+    path: repoPath,
+    skipCache: true,
+  });
+}
+
+/** Delete a file from the content repo — used to manufacture a dangling ref. */
+export async function deleteRepoFile(target: E2EClassroom, repoPath: string): Promise<void> {
+  const { ContentService } = await import('@classmoji/services');
+  if (!target.content_repo) throw new Error(`classroom ${target.slug} has no content_repo`);
+  await ContentService.delete({
+    orgLogin: target.orgLogin,
+    repo: target.content_repo,
+    path: repoPath,
+    message: `${E2E_PREFIX}: remove test asset ${repoPath}`,
+  });
+}
+
+/**
+ * A page's stored `content.json`, parsed.
+ *
+ * The whole storage contract — no signature, no srcset, no delivery origin, a
+ * bare repo-relative path — is a claim about THIS file, so it has to be read
+ * from the repo rather than inferred from what the editor showed.
+ */
+export async function readStoredContent(
+  target: E2EClassroom,
+  contentPath: string
+): Promise<{ raw: string; json: unknown }> {
+  const file = await readRepoFile(target, `${contentPath.replace(/\/+$/, '')}/content.json`);
+  if (!file) throw new Error(`no content.json at ${contentPath} in ${target.content_repo}`);
+  return { raw: file.content, json: JSON.parse(file.content) };
+}
+
+/**
+ * The three things that must never appear in stored content.
+ *
+ * Asserted on the RAW text, not the parsed object: a signature could be hiding
+ * in a nested prop, an HTML string, or a key nobody thought to walk, and the
+ * point of the invariant is that it holds everywhere rather than in the places
+ * a traversal remembered to look.
+ */
+export function storedContentLeaks(raw: string, deliveryOrigin: string): string[] {
+  const leaks: string[] = [];
+  if (raw.includes('sig=')) leaks.push('sig=');
+  if (/srcset/i.test(raw)) leaks.push('srcset');
+  if (raw.includes(new URL(deliveryOrigin).host)) leaks.push(new URL(deliveryOrigin).host);
+  return leaks;
+}

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -241,8 +241,27 @@ export type Tier = 'public' | 'enrolled' | 'draft';
 /** The three rungs `signSrcSet` emits. Mirrors TRANSFORM_WIDTHS. */
 export const EXPECTED_WIDTHS = [800, 1600, 2560] as const;
 
-/** The `sizes` constant every surface shares. Mirrors IMAGE_SIZES. */
+/**
+ * The `sizes` FALLBACK — mirrors `IMAGE_SIZES`.
+ *
+ * Not "the sizes constant every surface uses", which is the tempting and wrong
+ * reading. It is what a surface emits when it does not know how wide the image
+ * will be laid out. A block that carries `previewWidth` produces a better hint
+ * from it (see `expectedSizesFor`), and that applies to the editor, the viewer
+ * AND the class site — the difference is the BLOCK, not the surface.
+ */
 export const EXPECTED_SIZES = '(max-width: 1024px) 100vw, 1024px';
+
+/** The `sizes` a block with this preview width should emit. Mirrors `imageSizesFor`. */
+export function expectedSizesFor(previewWidth?: number | null): string {
+  if (typeof previewWidth !== 'number' || !Number.isFinite(previewWidth) || previewWidth <= 0) {
+    return EXPECTED_SIZES;
+  }
+  return `min(100vw, ${Math.round(previewWidth)}px)`;
+}
+
+/** The preview width `imageBlock` writes, so assertions can derive `sizes`. */
+export const FIXTURE_PREVIEW_WIDTH = 512;
 
 const UUID = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
 
@@ -447,6 +466,54 @@ export async function readImages(page: Page, selector = 'img'): Promise<Rendered
     out.push(await readImage(images.nth(index)));
   }
   return out;
+}
+
+/**
+ * Reload until the page's images satisfy a predicate, or give up.
+ *
+ * NOT a flake workaround — a real property of the system being tested. Page and
+ * deck content lives in a git repository, and GitHub's contents API is
+ * eventually consistent: a read issued immediately after a write can legally
+ * return the previous commit. The app itself is built around this (the slides
+ * suite has its own `reloadUntil` for the same reason), so a spec that saved
+ * and then asserted on one render would be asserting that GitHub is strongly
+ * consistent, and would fail perhaps one run in five.
+ *
+ * The predicate is about the CONTENT, never a timeout: the loop ends the moment
+ * the expected state is visible, and a failure after the last attempt is a real
+ * failure rather than a slow success.
+ */
+export async function reloadUntilImages(
+  page: Page,
+  url: string,
+  predicate: (images: RenderedImage[]) => boolean,
+  { selector = 'img', attempts = 6, delayMs = 2_000 } = {}
+): Promise<RenderedImage[]> {
+  let images: RenderedImage[] = [];
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    await page.goto(url);
+    await page.waitForLoadState('networkidle');
+    images = await readImages(page, selector);
+    if (predicate(images)) return images;
+    if (attempt < attempts - 1) await page.waitForTimeout(delayMs);
+  }
+  return images;
+}
+
+/** The same wait, for a surface only reachable over plain HTTP. */
+export async function fetchUntilHtml(
+  fetcher: (url: string) => Promise<{ status: number; body: string }>,
+  url: string,
+  predicate: (html: string) => boolean,
+  { attempts = 6, delayMs = 2_000 } = {}
+): Promise<{ status: number; body: string }> {
+  let last = { status: 0, body: '' };
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    last = await fetcher(url);
+    if (last.status === 200 && predicate(last.body)) return last;
+    if (attempt < attempts - 1) await new Promise(resolve => setTimeout(resolve, delayMs));
+  }
+  return last;
 }
 
 /**
@@ -779,7 +846,7 @@ export async function assetRow(
  */
 export async function syncMap(classroomId: string): Promise<void> {
   const service = await services();
-  await service.contentAssets.syncContentAssets({ classroomId, full: true });
+  await service.contentAssets.syncContentAssets(classroomId, { full: true });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -835,6 +902,68 @@ export async function readStoredContent(
   const file = await readRepoFile(target, `${contentPath.replace(/\/+$/, '')}/content.json`);
   if (!file) throw new Error(`no content.json at ${contentPath} in ${target.content_repo}`);
   return { raw: file.content, json: JSON.parse(file.content) };
+}
+
+/**
+ * A page row with the classroom and git organization a content write needs.
+ *
+ * `contentRepoFor` in the page-content service refuses anything less, and the
+ * refusal is a thrown Error rather than a typed one — so the include list is
+ * part of the contract, not an optimization.
+ */
+export async function pageWithRepo(pageId: string) {
+  const service = await services();
+  return service.page.findById(pageId, { includeClassroom: true });
+}
+
+/** A page's blocks, through the product's own reader. */
+export async function loadPageBlocks(pageId: string): Promise<unknown[]> {
+  const service = await services();
+  const page = await pageWithRepo(pageId);
+  const content = await service.pageContent.loadPageContent(page, { skipCache: true });
+  return Array.isArray(content?.blocks) ? content.blocks : [];
+}
+
+/**
+ * Write a page's blocks through the product's own save path.
+ *
+ * Through `savePageContent` rather than a hand-rolled `ContentService.put`,
+ * because the save path is where `canonicalizeAssetRef` runs — the pass that
+ * keeps a rendered signature from being written back into storage. A fixture
+ * that bypassed it would set up the very state the storage assertions are
+ * meant to prove impossible.
+ */
+export async function savePageBlocks(pageId: string, blocks: unknown[]): Promise<void> {
+  const service = await services();
+  const page = await pageWithRepo(pageId);
+  await service.pageContent.savePageContent(page, blocks, {
+    message: `${E2E_PREFIX}: fixture write`,
+  });
+}
+
+/** The BlockNote image block the editor itself would have inserted. */
+export function imageBlock(repoPath: string, caption: string): Record<string, unknown> {
+  return {
+    id: `${E2E_SLUG_PREFIX}-${Math.random().toString(36).slice(2, 10)}`,
+    type: 'image',
+    props: {
+      // The STORED value: a bare repo path. The signed URL is derived from it
+      // at render time and never written back.
+      url: repoPath,
+      caption,
+      previewWidth: FIXTURE_PREVIEW_WIDTH,
+      backgroundColor: 'default',
+      textAlignment: 'left',
+      name: '',
+    },
+    content: undefined,
+    children: [],
+  };
+}
+
+/** Does any block still reference this repo path, anywhere in its props? */
+export function blocksReference(blocks: unknown[], repoPath: string): boolean {
+  return JSON.stringify(blocks).includes(repoPath);
 }
 
 /**

--- a/tests/content-delivery/databaseGuard.ts
+++ b/tests/content-delivery/databaseGuard.ts
@@ -1,0 +1,136 @@
+/**
+ * One question, asked before anything writes: is this database local?
+ *
+ * The guard this replaces keyed on `E2E_TARGET`, which describes INTENT and
+ * not connectivity. A developer whose `.env` DATABASE_URL points at Neon —
+ * ordinary when debugging production data — running the documented command
+ * `E2E_CD_CONTENT_REPO=1 npm run e2e:content` would have had `E2E_TARGET`
+ * unset, therefore "local", therefore permission to upload fixtures to a live
+ * content repo, delete a file out of it, flip a real classroom's
+ * `content_delivery_enabled`, and bump its `content_key_version` — which
+ * rewrites every signed URL every real viewer is holding.
+ *
+ * So the gate is the resolved DATABASE_URL's HOST, checked at the moment of the
+ * write. It lives in its own module because the pack is not the only caller:
+ * `getTestPrisma` in both apps' `tests/helpers/` opens the same client for
+ * other suites, and a guard the shared client does not enforce is a guard with
+ * a way around it.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '../..');
+
+/** The escape hatch. Long and unpleasant to type, deliberately. */
+const OVERRIDE = 'E2E_ALLOW_REMOTE_DB_I_KNOW_WHAT_I_AM_DOING';
+
+/** Loopback in the three spellings a connection string actually uses. */
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0']);
+
+/**
+ * Hosts the override may NOT unlock.
+ *
+ * The point of an escape hatch is a docker host or a colleague's box on the
+ * LAN, never production. Neon is matched by provider domain rather than by
+ * project name because the project name is the part that changes; the
+ * `prod`/`production` words catch a self-hosted equivalent.
+ */
+const NEVER_WRITABLE = [
+  // Not end-anchored: these are matched against `host/database`, so a `$` here
+  // would stop matching the moment the database name was appended — which is
+  // how the Neon rule silently stopped firing when the name was added.
+  /\.neon\.tech\//i,
+  /\.supabase\.co\//i,
+  /\.rds\.amazonaws\.com\//i,
+  /\bprod(uction)?\b/i,
+];
+
+/** DATABASE_URL as the pack will actually use it: env first, then `.dev-context`. */
+export function resolvedDatabaseUrl(): string | null {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  try {
+    const content = fs.readFileSync(path.join(REPO_ROOT, '.dev-context'), 'utf-8');
+    const match = content.match(/URL:\s+(postgresql:\/\/\S+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Host of a postgres connection string, lowercased, or null if unparseable. */
+export function databaseHost(url: string | null): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function isLocalDatabaseHost(host: string | null): boolean {
+  return host !== null && LOCAL_HOSTS.has(host);
+}
+
+/**
+ * The identity the never-writable patterns are matched against.
+ *
+ * Host AND database name, because production hides in either one. A managed
+ * provider announces itself in the host (`…aws.neon.tech`), but a self-hosted
+ * production database is usually `db.internal.example.com/prod` — an ordinary
+ * host holding the database everyone cares about. Matching the host alone let
+ * the override through on exactly that shape.
+ */
+function databaseIdentity(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.hostname}/${parsed.pathname.replace(/^\//, '')}`.toLowerCase();
+  } catch {
+    return url.toLowerCase();
+  }
+}
+
+/**
+ * Refuse the write unless the database is one it is safe to damage.
+ *
+ * Throws rather than skipping. A skip is the right answer to "this environment
+ * cannot show me the thing"; this is "this environment must not be touched",
+ * and a run that quietly skipped would leave the operator believing the guard
+ * had approved something. `action` names the specific write so the message
+ * says what was stopped.
+ */
+export function assertWritableDatabase(action: string): void {
+  const url = resolvedDatabaseUrl();
+  const host = databaseHost(url);
+
+  if (isLocalDatabaseHost(host)) return;
+
+  if (host === null) {
+    throw new Error(
+      `refusing to ${action}: no DATABASE_URL could be resolved, so there is no way to tell ` +
+        'which database this would write to. Set DATABASE_URL, or run from a checkout with a .dev-context.'
+    );
+  }
+
+  const identity = databaseIdentity(url as string);
+  if (NEVER_WRITABLE.some(pattern => pattern.test(identity))) {
+    throw new Error(
+      `refusing to ${action}: DATABASE_URL points at '${identity}', which looks like a managed or ` +
+        `production database. ${OVERRIDE} does not unlock this one.`
+    );
+  }
+
+  if (process.env[OVERRIDE] === '1') {
+    console.warn(
+      `[e2e] ${OVERRIDE}=1 — allowing "${action}" against the non-local database at '${host}'.`
+    );
+    return;
+  }
+
+  throw new Error(
+    `refusing to ${action}: DATABASE_URL points at '${host}', not a local database. ` +
+      'This pack creates and deletes files in a real GitHub content repo and changes classroom ' +
+      `rows, so it only runs against localhost. Set ${OVERRIDE}=1 if you are certain.`
+  );
+}

--- a/turbo.json
+++ b/turbo.json
@@ -115,6 +115,7 @@
         "E2E_CLASSROOM_SLUG",
         "E2E_CD_CONTENT_REPO",
         "E2E_SESSION_COOKIE",
+        "E2E_ALLOW_REMOTE_DB_I_KNOW_WHAT_I_AM_DOING",
         "TEST_CLASSROOM_SLUG"
       ],
       "outputs": ["test-results/**", "playwright-report/**"]

--- a/turbo.json
+++ b/turbo.json
@@ -99,6 +99,24 @@
     "db:dev": {},
     "test": {
       "cache": false,
+      // turbo hands a task only the environment it has been told about, so an
+      // E2E_* variable set on the command line simply does not reach Playwright
+      // unless it is named here. The failure mode is quiet and expensive: the
+      // content-delivery pack reads these to decide what it can exercise, so a
+      // missing name turns into every scenario skipping and a green run that
+      // tested nothing. Declared on the task rather than in globalEnv because
+      // these steer tests only — they are not part of any build's identity.
+      "env": [
+        "E2E_TARGET",
+        "E2E_PAGES_URL",
+        "E2E_SLIDES_URL",
+        "E2E_WEBAPP_URL",
+        "E2E_CLASS_SITE_URL",
+        "E2E_CLASSROOM_SLUG",
+        "E2E_CD_CONTENT_REPO",
+        "E2E_SESSION_COOKIE",
+        "TEST_CLASSROOM_SLUG"
+      ],
       "outputs": ["test-results/**", "playwright-report/**"]
     },
     "test:integration": {


### PR DESCRIPTION
## What
A Playwright pack that exercises the content delivery layer end to end, plus what's needed to run it:

- **Scenarios** (`apps/pages/tests/content-pipeline.spec.ts`, `apps/slides/tests/content-pipeline.spec.ts`, shared helpers under `tests/content-delivery/`): upload → signed draft `src` + 3-rung `srcset` + `sizes` with exactly one delivery request; stored block is a bare path and `content.json`/`deck.json` contain no signature, srcset, or delivery origin; block removal; GIF passthrough; `enrolled` on a private page and `public` on the class site; deleted asset → `/missing/` form → Worker 404 `no-store`; gate off → legacy refs and zero delivery requests, back on → signed; reset content cache bumps `v` everywhere (old URL still serves: a bust, not a revoke); Worker direct: `/healthz`, 200 + HEAD length parity, four tamper 403s; deck upload → viewer and `/present` signed, `deck.json` clean, Clean Up modal kept-all; deck gate off. A final test per pack fails if no scenario actually ran.
- **Targets:** `E2E_TARGET=local` (dev stack + `wrangler dev --env dev`) and `E2E_TARGET=staging` (read-only by default; `E2E_SESSION_COOKIE` unlocks signed-in reads, origin-scoped; uploads need `E2E_CD_CONTENT_REPO=1`). Writes to the database or a content repo are refused unless `DATABASE_URL` is local; production hostnames are refused outright; staging ignores `.env`'s delivery origin.
- **Worker `dev` env** in `wrangler.jsonc` (`cf:dev:local`), README "Local end-to-end", root `e2e:content`, `turbo.json` `E2E_*` vars (env-gated tests otherwise skip to green under turbo), dispatch-only `.github/workflows/e2e-content.yml`, and `apps/content/.dev.vars` git-ignored (it wasn't).

## Test
Local: pages 17 passed / 2 staging-only skips, slides 4 passed; tsc 0 on both apps. Staging (read-only, no creds): 8 passed / 11 skipped with reasons. Dispatch `e2e-content.yml` against staging to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA