### PR TITLE
feat(content): serve deck and page text through the Worker

### DIFF
--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -46,6 +46,43 @@ is no separate version field. Anything else is a 404. An unsigned, tampered, or
 long-expired URL is a 403 with `Cache-Control: no-store` — a refusal is never
 cached.
 
+### Text blobs
+
+`{ext}` is not only an image extension. A deck's `index.html` and `deck.json`, a
+page's `content.json`, a theme's css/js/fonts and any `.md`/`.txt` in a content
+repo go through the SAME blob route — sha-addressed, signed the same way. That
+is what makes them fresh by construction rather than by waiting out a GitHub
+Pages rebuild. There is no separate text scheme and no per-extension allowlist:
+the extension is a FIELD of the canonical string, so a signature minted for
+`.json` can never serve the same sha as `.html`.
+
+| Extension | Content-Type |
+| --- | --- |
+| `html`, `htm` | `text/html; charset=utf-8` |
+| `css` | `text/css; charset=utf-8` |
+| `js`, `mjs` | `text/javascript; charset=utf-8` |
+| `json` | `application/json; charset=utf-8` |
+| `md` | `text/markdown; charset=utf-8` |
+| `txt` | `text/plain; charset=utf-8` |
+| `svg` | `image/svg+xml` — an image, but never transformed |
+| `woff`, `woff2`, `ttf`, `otf` | the matching `font/*` |
+
+Two rules hold for all of them:
+
+- **The type comes from the extension, never from the bytes.** Nothing here
+  sniffs, and `X-Content-Type-Options: nosniff` tells the browser not to either.
+- **A served `.html` is inert.** `Content-Security-Policy: default-src 'none';
+  sandbox` drops it into an opaque origin with no script execution, so opening
+  one as a top-level navigation cannot run script on the `.classmoji.io`
+  session-cookie domain — the same reason the CSP was there for SVG. No
+  response from this Worker carries a cookie.
+
+`w=`/`fmt=` stay raster-only. A text URL carrying one (a stale link, a caller
+mistake) is served untransformed from `blobs/{sha}`: the transform gate is
+`isRasterExtension`, and `svg`, `html` and `json` all fall outside it. Cache
+lifetimes are decided by the tier alone, so text gets exactly the `immutable`
+an image gets, and exactly the `no-store` on `draft`.
+
 ## Behaviour worth knowing
 
 - **Bytes stream.** A miss is piped to the browser while a tee'd copy goes to R2

--- a/apps/content/src/blob.ts
+++ b/apps/content/src/blob.ts
@@ -35,8 +35,24 @@ interface ServeOptions {
   head?: boolean;
 }
 
-function storedHeaders(object: R2Object, fallbackType: string, cacheControl: string): Headers {
-  const headers = contentHeaders(object.httpMetadata?.contentType ?? fallbackType, cacheControl);
+/**
+ * Headers for an object served out of R2.
+ *
+ * `contentType` is the type the SIGNED EXTENSION says, and the stored
+ * `httpMetadata.contentType` is deliberately ignored. R2 keys are
+ * content-addressed — `blobs/{sha}`, no classroom in the key — so one object is
+ * shared by every classroom and every path that holds those bytes, and whatever
+ * extension happened to be fetched FIRST wrote the stored type. A stylesheet
+ * whose bytes also live at a `.txt` path anywhere in the fleet would then be
+ * served `text/plain` to everyone, and `nosniff` (correctly) makes the browser
+ * refuse it as a stylesheet.
+ *
+ * The signed extension is per-request and inside the signature, so it is both
+ * correct for this caller and unforgeable. The stored value can only ever be a
+ * different caller's answer to a different question.
+ */
+function storedHeaders(object: R2Object, contentType: string, cacheControl: string): Headers {
+  const headers = contentHeaders(contentType, cacheControl);
   headers.set('ETag', object.httpEtag);
   // R2 knows the length without reading a byte, so there is no reason to make a
   // client guess at download progress.
@@ -44,12 +60,8 @@ function storedHeaders(object: R2Object, fallbackType: string, cacheControl: str
   return headers;
 }
 
-function storedResponse(
-  object: R2ObjectBody,
-  fallbackType: string,
-  cacheControl: string
-): Response {
-  return new Response(object.body, { headers: storedHeaders(object, fallbackType, cacheControl) });
+function storedResponse(object: R2ObjectBody, contentType: string, cacheControl: string): Response {
+  return new Response(object.body, { headers: storedHeaders(object, contentType, cacheControl) });
 }
 
 /**
@@ -60,12 +72,12 @@ function storedResponse(
 async function storedHead(
   env: Env,
   key: string,
-  fallbackType: string,
+  contentType: string,
   cacheControl: string
 ): Promise<Response | null> {
   const object = await env.CACHE.head(key);
   if (!object) return null;
-  return new Response(null, { headers: storedHeaders(object, fallbackType, cacheControl) });
+  return new Response(null, { headers: storedHeaders(object, contentType, cacheControl) });
 }
 
 /**

--- a/apps/content/src/content-type.ts
+++ b/apps/content/src/content-type.ts
@@ -1,4 +1,22 @@
-/** Extension → Content-Type. Anything unmapped is served as an opaque download. */
+/**
+ * Extension → Content-Type. Anything unmapped is served as an opaque download.
+ *
+ * The type comes from the EXTENSION and from nothing else — the bytes are never
+ * inspected. That is deliberate, and it is what makes serving TEXT here safe:
+ * a `.html` blob is `text/html; charset=utf-8` because the URL said `.html`,
+ * and a signature covers the extension, so a caller cannot re-label one file as
+ * another. `nosniff` plus the sandboxing CSP on every response (see cache.ts)
+ * does the rest: an `.html` opened directly is an inert document in an opaque
+ * origin, not script running on a cookie-bearing domain.
+ *
+ * Text types carry `charset=utf-8` explicitly. Without it a browser falls back
+ * to its own locale default and a deck's smart quotes come out as mojibake on
+ * exactly the machines nobody tests on.
+ *
+ * `svg` stays an image and stays OUT of `RASTER_EXTENSIONS` below: it is
+ * resolution-independent, so rasterizing it is a downgrade rather than a
+ * variant.
+ */
 const BY_EXTENSION: Readonly<Record<string, string>> = {
   png: 'image/png',
   jpg: 'image/jpeg',
@@ -7,8 +25,11 @@ const BY_EXTENSION: Readonly<Record<string, string>> = {
   webp: 'image/webp',
   avif: 'image/avif',
   svg: 'image/svg+xml',
+  html: 'text/html; charset=utf-8',
+  htm: 'text/html; charset=utf-8',
   css: 'text/css; charset=utf-8',
   js: 'text/javascript; charset=utf-8',
+  mjs: 'text/javascript; charset=utf-8',
   woff: 'font/woff',
   woff2: 'font/woff2',
   ttf: 'font/ttf',

--- a/apps/content/src/content-type.ts
+++ b/apps/content/src/content-type.ts
@@ -1,8 +1,11 @@
 /**
  * Extension → Content-Type. Anything unmapped is served as an opaque download.
  *
- * The type comes from the EXTENSION and from nothing else — the bytes are never
- * inspected. That is deliberate, and it is what makes serving TEXT here safe:
+ * The type comes from the SIGNED EXTENSION and from nothing else — the bytes
+ * are never inspected, and neither is the type R2 has stored against the object
+ * (see `storedHeaders` in blob.ts: R2 keys are content-addressed, so a stored
+ * type is whatever extension reached that sha first, across all classrooms).
+ * That is deliberate, and it is what makes serving TEXT here safe:
  * a `.html` blob is `text/html; charset=utf-8` because the URL said `.html`,
  * and a signature covers the extension, so a caller cannot re-label one file as
  * another. `nosniff` plus the sandboxing CSP on every response (see cache.ts)

--- a/apps/content/tests/content-type.test.ts
+++ b/apps/content/tests/content-type.test.ts
@@ -16,8 +16,11 @@ describe('content type mapping', () => {
     ['webp', 'image/webp'],
     ['avif', 'image/avif'],
     ['svg', 'image/svg+xml'],
+    ['html', 'text/html; charset=utf-8'],
+    ['htm', 'text/html; charset=utf-8'],
     ['css', 'text/css; charset=utf-8'],
     ['js', 'text/javascript; charset=utf-8'],
+    ['mjs', 'text/javascript; charset=utf-8'],
     ['woff', 'font/woff'],
     ['woff2', 'font/woff2'],
     ['ttf', 'font/ttf'],
@@ -39,6 +42,14 @@ describe('content type mapping', () => {
 
   it('is case-insensitive', () => {
     expect(contentTypeForExtension('PNG')).toBe('image/png');
+  });
+
+  it('gives every text type an explicit charset', () => {
+    // Without one a browser falls back to its own locale default, and a deck's
+    // smart quotes come out as mojibake on machines nobody tests on.
+    for (const ext of ['html', 'htm', 'css', 'js', 'mjs', 'json', 'txt', 'md']) {
+      expect(contentTypeForExtension(ext)).toMatch(/; charset=utf-8$/);
+    }
   });
 });
 
@@ -63,7 +74,10 @@ describe('isRasterExtension', () => {
     for (const ext of ['png', 'jpg', 'jpeg', 'webp', 'avif', 'gif']) {
       expect(isRasterExtension(ext)).toBe(true);
     }
-    for (const ext of ['svg', 'pdf', 'css', 'mp4']) {
+    // svg is in this list on purpose: it IS an image, but a
+    // resolution-independent one, so rasterizing it to a `w=` rung is a
+    // downgrade rather than a variant. Text never reaches a transform at all.
+    for (const ext of ['svg', 'pdf', 'css', 'mp4', 'html', 'json', 'md', 'woff2']) {
       expect(isRasterExtension(ext)).toBe(false);
     }
   });

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -497,6 +497,49 @@ describe('blob delivery', () => {
     expect(response.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
   });
 
+  it('ignores the type R2 stored and trusts the signed extension', async () => {
+    // R2 keys are content-addressed — `blobs/{sha}`, no classroom — so ONE
+    // object is shared by every classroom and every path holding those bytes,
+    // and whichever extension was fetched first wrote the stored type. Trusting
+    // it means a stylesheet whose bytes also live at a `.txt` path anywhere in
+    // the fleet is served `text/plain` to everyone, and `nosniff` then makes
+    // the browser refuse it as a stylesheet. The signed extension is
+    // per-request and unforgeable; the stored type is someone else's answer.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: {
+        body: 'body { color: red }',
+        contentType: 'text/plain; charset=utf-8',
+      },
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css', tier: 'enrolled' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.headers.get('Content-Type')).toBe('text/css; charset=utf-8');
+  });
+
+  it('answers HEAD from the signed extension too', async () => {
+    // Same object, same trap — a HEAD is answered straight from R2 metadata,
+    // which is exactly where the wrong stored type lives.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: { body: '<!doctype html>', contentType: 'application/octet-stream' },
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'enrolled' });
+
+    const response = await worker.fetch(
+      new Request(url, { method: 'HEAD' }),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+  });
+
   it('serves a draft html blob no-store, exactly like a draft image', async () => {
     // The per-tier cache lifetimes are decided by `cacheControlFor` on the
     // tier alone; text takes the same answer images take, unchanged.

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -445,6 +445,130 @@ describe('blob delivery', () => {
     expect(await response.text()).toBe('');
   });
 
+  // ── Text blobs ─────────────────────────────────────────────────────────────
+  //
+  // A deck's index.html, a page's content.json and a theme's css are served by
+  // exactly the same path as an image: sha-addressed, signed, immutable. The
+  // only thing that changes is the content type — and the guarantee that an
+  // .html served from here is INERT if a browser opens it directly.
+
+  it('serves an html blob as inert text/html', async () => {
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: {
+        body: '<!doctype html><script>alert(document.cookie)</script>',
+        contentType: 'text/html; charset=utf-8',
+      },
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'enrolled' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    // The three headers that make the script above harmless. Production serves
+    // from content.classmoji.io, inside the app's session-cookie domain, so a
+    // top-level navigation to this document must land in an opaque origin.
+    expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'none'; sandbox");
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(response.headers.get('Set-Cookie')).toBeNull();
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Cache-Control')).toMatch(/^public, max-age=\d+, immutable$/);
+  });
+
+  it('types a text blob from its extension alone, never from its bytes', async () => {
+    // The object in R2 has no stored content type at all, and its body is
+    // plainly html. The reply is still json, because the SIGNED extension said
+    // json — sniffing is what would let one file be re-labelled as another.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: { body: '<!doctype html><p>not json</p>' },
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'json', tier: 'enrolled' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
+  });
+
+  it('serves a draft html blob no-store, exactly like a draft image', async () => {
+    // The per-tier cache lifetimes are decided by `cacheControlFor` on the
+    // tier alone; text takes the same answer images take, unchanged.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: { body: '<!doctype html>', contentType: 'text/html; charset=utf-8' },
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'draft' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('ignores a width on a text blob and serves the original', async () => {
+    // `w=` is signed, so it cannot be added by a client — but a stale URL or a
+    // caller mistake must not reach the Images binding with a json body. The
+    // transform gate is raster-only, and everything else falls through to the
+    // plain blob path.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}`]: {
+        body: '{"version":1}',
+        contentType: 'application/json; charset=utf-8',
+      },
+    });
+    const url = await signedBlobUrl({
+      sha: BLOB_SHA,
+      ext: 'json',
+      tier: 'enrolled',
+      transform: { w: 800, fmt: 'auto' },
+    });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
+    // The original key, not `blobs/{sha}/w800.webp` — no variant was consulted.
+    expect(bucket.gets).toEqual([`blobs/${BLOB_SHA}`]);
+    expect(await response.text()).toBe('{"version":1}');
+  });
+
+  it('pulls an html miss from the origin and caches it under the text type', async () => {
+    const bucket = fakeBucket();
+    const ctx = fakeContext();
+    stubUpstreams();
+
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'enrolled' });
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('origin-bytes');
+    await ctx.settled();
+    expect(bucket.puts).toEqual([
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'text/html; charset=utf-8',
+        bytes: 'origin-bytes'.length,
+      },
+    ]);
+  });
+
   it('marks draft content no-store, but still writes it to R2', async () => {
     // Deliberate: `no-store` governs the SHARED caches in front of the Worker,
     // which must never hold draft bytes. R2 sits behind the signature gate and

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -116,13 +116,21 @@ export const loader = async ({
   // Staff asked for a preview but no branch exists → render main with a notice.
   const previewMissing = Boolean(canEdit && wantsPreview && !previewStatus?.exists);
 
-  // Load content from GitHub (page includes classroom.git_organization via
-  // includeClassroom). Staff loads bypass the 60s per-process cache: for
-  // canEdit users this read IS the edit surface (the editor mounts inline) and
-  // seeds the save conflict token, so a cached read on another Fly instance
-  // could silently revert an MCP write (4b parity with slides). It also keeps
-  // the post-accept redirect (`?notice=preview-accepted`, staff-only) from
-  // showing pre-accept cached content under the success toast.
+  // Load content. This loader serves two surfaces, and they read differently.
+  //
+  // The EDITOR (canEdit, and any preview-branch read) goes to GitHub: this read
+  // IS the edit surface — the editor mounts inline — and it seeds the save
+  // conflict token, which must be the sha of the file on the branch being
+  // written. `skipCache` for the same reason: the 60s per-process cache has no
+  // cross-instance invalidation, so a cached read on another Fly instance could
+  // silently revert an MCP write (4b parity with slides). It also keeps the
+  // post-accept redirect (`?notice=preview-accepted`) from showing pre-accept
+  // content under the success toast. Preview branches have no map rows at all,
+  // which is the other reason this side cannot use the layer.
+  //
+  // The VIEWER reads by sha through the delivery layer, so a student sees a
+  // save the moment it returns rather than up to a minute later, and a page
+  // view costs no GitHub call.
   const {
     format,
     content,
@@ -130,7 +138,11 @@ export const loader = async ({
     sha: contentFileSha,
   } = await loadPageContent(
     pageForContent,
-    previewActive ? { ref: previewBranch, skipCache: true } : { skipCache: canEdit }
+    previewActive
+      ? { ref: previewBranch, skipCache: true }
+      : canEdit
+        ? { skipCache: true }
+        : { viaWorker: true }
   );
 
   let viewerContent: unknown;

--- a/apps/pages/app/site/content.server.ts
+++ b/apps/pages/app/site/content.server.ts
@@ -61,12 +61,20 @@ export type SiteContentPage = {
   content_path: string;
 };
 
-/** The classroom fields a content read needs (the narrow site select). */
+/**
+ * The classroom fields a content read needs (the narrow site select).
+ *
+ * The delivery fields are REQUIRED, matching `ResolveClassroom`'s reasoning:
+ * a site select that quietly stopped carrying `content_delivery_enabled` would
+ * read as `undefined`, which means "off" — and the class site would fall back
+ * to reading GitHub on every render for a classroom that had been switched on,
+ * with nothing failing to say so. Typed required so the compiler names the
+ * select instead.
+ */
 export type SiteContentClassroom = {
-  /** Present on the site select; absent only in older test fixtures. */
-  id?: string;
-  content_key_version?: number;
-  content_delivery_enabled?: boolean | null;
+  id: string;
+  content_key_version: number;
+  content_delivery_enabled: boolean | null;
   content_repo: string | null;
   git_organization: { login: string | null } | null;
 };
@@ -99,22 +107,20 @@ async function readContentFile(
   // and this module exists precisely because that distinction decides between
   // an empty page and a 503. So the map either answers or gets out of the way,
   // and the typed read below keeps owning the failure semantics.
-  if (classroom.id) {
-    const viaMap = await ClassmojiService.contentDelivery.fetchContentText(
-      {
-        classroom: {
-          id: classroom.id,
-          content_key_version: classroom.content_key_version ?? 0,
-          content_repo: repo,
-          content_delivery_enabled: classroom.content_delivery_enabled === true,
-          git_organization: { login: orgLogin },
-        },
+  const viaMap = await ClassmojiService.contentDelivery.fetchContentText(
+    {
+      classroom: {
+        id: classroom.id,
+        content_key_version: classroom.content_key_version,
+        content_repo: repo,
+        content_delivery_enabled: classroom.content_delivery_enabled === true,
+        git_organization: { login: orgLogin },
       },
-      path,
-      { label: 'site', workerOnly: true }
-    );
-    if (viaMap) return { content: viaMap.text, sha: viaMap.sha };
-  }
+    },
+    path,
+    { label: 'site', workerOnly: true }
+  );
+  if (viaMap) return { content: viaMap.text, sha: viaMap.sha };
 
   try {
     return await ContentService.getContent({

--- a/apps/pages/app/site/content.server.ts
+++ b/apps/pages/app/site/content.server.ts
@@ -1,4 +1,4 @@
-import { ContentService } from '@classmoji/services';
+import { ClassmojiService, ContentService } from '@classmoji/services';
 
 import { migrateHtmlToBlockNote } from '~/utils/migration.server.ts';
 import { schema } from '~/components/editor/blocks/index.tsx';
@@ -63,6 +63,10 @@ export type SiteContentPage = {
 
 /** The classroom fields a content read needs (the narrow site select). */
 export type SiteContentClassroom = {
+  /** Present on the site select; absent only in older test fixtures. */
+  id?: string;
+  content_key_version?: number;
+  content_delivery_enabled?: boolean | null;
   content_repo: string | null;
   git_organization: { login: string | null } | null;
 };
@@ -79,10 +83,39 @@ const statusOf = (error: unknown): number | null => {
  * unavailability so it can never be mistaken for "no content".
  */
 async function readContentFile(
+  classroom: SiteContentClassroom,
   orgLogin: string,
   repo: string,
   path: string
-): Promise<{ content: string; sha: string } | null> {
+): Promise<{ content: string; sha: string | null } | null> {
+  // The delivery layer first, by sha. A save is then visible to the site the
+  // moment it returns rather than after the five-minute cache below — and the
+  // read costs no GitHub call at all, which matters on the one surface with
+  // anonymous readers and no upper bound on traffic.
+  //
+  // `workerOnly` is what makes this safe to put in front of the read below:
+  // `fetchContentText` swallows every failure into `null`, which would collapse
+  // "this page has no content.json" and "GitHub is down" into the same answer —
+  // and this module exists precisely because that distinction decides between
+  // an empty page and a 503. So the map either answers or gets out of the way,
+  // and the typed read below keeps owning the failure semantics.
+  if (classroom.id) {
+    const viaMap = await ClassmojiService.contentDelivery.fetchContentText(
+      {
+        classroom: {
+          id: classroom.id,
+          content_key_version: classroom.content_key_version ?? 0,
+          content_repo: repo,
+          content_delivery_enabled: classroom.content_delivery_enabled === true,
+          git_organization: { login: orgLogin },
+        },
+      },
+      path,
+      { label: 'site', workerOnly: true }
+    );
+    if (viaMap) return { content: viaMap.text, sha: viaMap.sha };
+  }
+
   try {
     return await ContentService.getContent({
       orgLogin,
@@ -119,7 +152,12 @@ export async function loadSitePageContent(
     return { format: 'none', blocks: [], coverImage: null };
   }
 
-  const jsonFile = await readContentFile(orgLogin, repo, `${page.content_path}/content.json`);
+  const jsonFile = await readContentFile(
+    classroom,
+    orgLogin,
+    repo,
+    `${page.content_path}/content.json`
+  );
 
   if (jsonFile?.content) {
     let parsed: unknown;
@@ -155,7 +193,12 @@ export async function loadSitePageContent(
     };
   }
 
-  const htmlFile = await readContentFile(orgLogin, repo, `${page.content_path}/index.html`);
+  const htmlFile = await readContentFile(
+    classroom,
+    orgLogin,
+    repo,
+    `${page.content_path}/index.html`
+  );
 
   if (htmlFile?.content) {
     // The migration builds its own ServerBlockNoteEditor, so it contends for

--- a/apps/pages/app/site/content.server.ts
+++ b/apps/pages/app/site/content.server.ts
@@ -118,7 +118,7 @@ async function readContentFile(
       },
     },
     path,
-    { label: 'site', workerOnly: true }
+    { label: 'site', fallback: 'none' }
   );
   if (viaMap) return { content: viaMap.text, sha: viaMap.sha };
 

--- a/apps/pages/app/utils/content.server.ts
+++ b/apps/pages/app/utils/content.server.ts
@@ -39,10 +39,14 @@ interface PageContentResult {
  * @param options.ref - Git ref to read from (e.g. the page's preview branch).
  * @param options.skipCache - Bypass the 60s ContentService cache (sha-bearing
  *   reads that seed an expectedSha MUST pass true).
+ * @param options.viaWorker - Read by SHA through the delivery layer. For
+ *   RENDER reads only: it makes a save visible the moment it returns and costs
+ *   no GitHub call, but a preview branch has no map rows and the editor's own
+ *   load must see the branch it will write to.
  */
 export async function loadPageContent(
   page: PageForContent,
-  options: { ref?: string; skipCache?: boolean } = {}
+  options: { ref?: string; skipCache?: boolean; viaWorker?: boolean } = {}
 ): Promise<PageContentResult> {
   const { format, blocks, coverImage, sha } = await ClassmojiService.pageContent.loadPageContent(
     page,

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -334,28 +334,39 @@ export const loader = async ({
   // with it, and the three surfaces stop being able to disagree about what the
   // current deck is.
   //
-  // Cost moves in the right direction on every one of them. Staff no longer
-  // spend an installation-token API call per view. Students no longer wait out
-  // a Pages build. Thumbnails — a staff landing page renders ~20 at once, which
-  // is why they were pinned to the CDN to avoid an API fan-out — are served
-  // from the edge for two DB reads apiece (the map row, and the freshness stamp
-  // `ensureContentAssets` checks). The fan-out they were protected from is now
-  // two separate things, and both are handled: a map MISS falls back to the
-  // API, which the save-time write-through is what prevents; and a stale map
-  // would have had all twenty start their own full sync, which
-  // `ensureContentAssets` collapses into one.
+  // Cost moves in the right direction on every one of them: no GitHub call for
+  // the deck TEXT on any of the three, where staff used to spend an
+  // installation-token read per view and students waited out a Pages build.
+  // Deck text only — a deck on a shared theme still resolves its theme URLs
+  // through `getThemeUrls`, which does reach GitHub (pre-existing, and its own
+  // follow-up).
+  //
+  // THUMBNAILS keep their own rule, and it is the one the CDN pinning was
+  // for. A staff landing page renders ~20 at once; when the map answers they
+  // all come from the edge, but a map MISS on the default ladder would put
+  // twenty authenticated reads against the org installation's shared limit in
+  // one page load. So a thumbnail that misses goes to the CDN and stops there:
+  // a thumbnail is a picture of a deck, three minutes stale is invisible on
+  // one, and a rate limit is not. (The other half of that fan-out — twenty
+  // concurrent map refreshes on a stale classroom — is collapsed into one
+  // inside `ensureContentAssets`.)
   if (!contentResult) {
     contentResult = await readDeckText(
       slide,
       gitOrgLogin,
       repo,
       filePath,
-      isThumbnail ? 'thumbnail' : 'viewer'
+      isThumbnail ? 'thumbnail' : 'viewer',
+      isThumbnail ? { fallback: 'cdn-only' } : {}
     );
   }
 
   if (contentResult) {
     slideContent = contentResult.content;
+    // Kept for the client-side fallback's own bookkeeping. It now means "the
+    // delivery layer could not answer and GitHub did", which is a narrower
+    // thing than it used to be — `worker` is the ordinary case and `cdn` is
+    // the thumbnail one.
     usedApiFallback = contentResult.source === 'api';
 
     // Sign the deck's image references — but never for the document the editor
@@ -508,6 +519,23 @@ async function recordThemeFile(
     sha,
     size: Buffer.byteLength(String(content)),
   });
+}
+
+/**
+ * Forget `.slidesthemes/` paths the repo no longer has.
+ *
+ * The mirror of `recordThemeFile`, and needed for the same reason: blobs are
+ * content-addressed and immutable, so a row that outlives its file keeps
+ * serving that file's last bytes out of R2. A renamed snippet would answer
+ * under BOTH names until the next full sweep, and a deleted theme would go on
+ * resolving.
+ */
+async function forgetThemeFiles(
+  slide: { classroom_id?: string | null },
+  paths: string[]
+): Promise<void> {
+  if (!slide.classroom_id) return;
+  await ClassmojiService.contentAssets.removeContentAssets(slide.classroom_id, paths);
 }
 
 export const action = async ({
@@ -970,6 +998,7 @@ export const action = async ({
         message: `Update snippet: ${name}`,
       });
       await recordThemeFile(slide, newPath, written.sha, content);
+      if (id !== newFilename) await forgetThemeFiles(slide, [oldPath]);
 
       return {
         intent: 'update-snippet',
@@ -1002,6 +1031,7 @@ export const action = async ({
         path: `.slidesthemes/snippets/${id}`,
         message: `Delete snippet: ${id}`,
       });
+      await forgetThemeFiles(slide, [`.slidesthemes/snippets/${id}`]);
 
       return {
         intent: 'delete-snippet',
@@ -1103,6 +1133,7 @@ export const action = async ({
         message: `Update CSS theme: ${name} (${type})`,
       });
       await recordThemeFile(slide, newPath, written.sha, content);
+      if (id !== newFilename) await forgetThemeFiles(slide, [oldPath]);
 
       return {
         intent: 'update-theme',
@@ -1136,6 +1167,7 @@ export const action = async ({
         path: `.slidesthemes/${id}`,
         message: `Delete CSS theme: ${id}`,
       });
+      await forgetThemeFiles(slide, [`.slidesthemes/${id}`]);
 
       return {
         intent: 'delete-theme',
@@ -1164,6 +1196,16 @@ export const action = async ({
         paths,
         message: `Clean up unused images from slides: ${slide.title}`,
       });
+
+      // Only the ones that actually went. `deleteMultiple` reports per-path
+      // errors and keeps going, so forgetting the whole list would drop rows
+      // for images still in the repo — which is a dangling URL, the failure
+      // this map exists to prevent.
+      const failed = new Set(result.errors.map(entry => entry.split(':')[0]));
+      await forgetThemeFiles(
+        slide,
+        (paths as string[]).filter(path => !failed.has(path))
+      );
 
       return {
         intent: 'delete-images',

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -337,10 +337,13 @@ export const loader = async ({
   // Cost moves in the right direction on every one of them. Staff no longer
   // spend an installation-token API call per view. Students no longer wait out
   // a Pages build. Thumbnails — a staff landing page renders ~20 at once, which
-  // is why they were pinned to the CDN to avoid the API fan-out — now cost one
-  // indexed map read each and are served from the edge; the API fan-out they
-  // were protected from only happens if the map misses, which a save's own
-  // write-through is what prevents.
+  // is why they were pinned to the CDN to avoid an API fan-out — are served
+  // from the edge for two DB reads apiece (the map row, and the freshness stamp
+  // `ensureContentAssets` checks). The fan-out they were protected from is now
+  // two separate things, and both are handled: a map MISS falls back to the
+  // API, which the save-time write-through is what prevents; and a stale map
+  // would have had all twenty start their own full sync, which
+  // `ensureContentAssets` collapses into one.
   if (!contentResult) {
     contentResult = await readDeckText(
       slide,
@@ -477,6 +480,36 @@ export const loader = async ({
 };
 
 // Action to save slide content or fetch fresh content from GitHub API
+/**
+ * Record a just-written `.slidesthemes/` file in the asset map.
+ *
+ * These four writes used to need nothing: the map only served IMAGES, and a
+ * theme's css reached the browser through the `/content/...` proxy, which read
+ * GitHub directly. Text goes through the map now, so a snippet or custom theme
+ * saved here and not recorded serves its PREVIOUS bytes until the push webhook
+ * lands — the author edits a theme, reloads, and sees the old one.
+ *
+ * `themeService.saveSharedTheme` handles the folder case differently, and has
+ * to: a shared theme is addressed by its FOLDER's tree sha, so it runs a full
+ * sync. These paths are flat files, so their own blob sha is the whole answer.
+ *
+ * Never throws — the file is already committed, and the next sync writes the
+ * same row.
+ */
+async function recordThemeFile(
+  slide: { classroom_id?: string | null },
+  path: string,
+  sha: string,
+  content: FormDataEntryValue
+): Promise<void> {
+  if (!slide.classroom_id) return;
+  await ClassmojiService.contentAssets.recordContentAsset(slide.classroom_id, {
+    path,
+    sha,
+    size: Buffer.byteLength(String(content)),
+  });
+}
+
 export const action = async ({
   request,
   params,
@@ -868,13 +901,14 @@ export const action = async ({
           .replace(/\s+/g, '-')
           .replace(/[^a-z0-9-]/g, '') + '.html';
 
-      await ContentService.put({
+      const written = await ContentService.put({
         orgLogin: gitOrgLogin,
         repo,
         path: `.slidesthemes/snippets/${filename}`,
         content: String(content),
         message: `Add snippet: ${name}`,
       });
+      await recordThemeFile(slide, `.slidesthemes/snippets/${filename}`, written.sha, content);
 
       return {
         intent: 'save-snippet',
@@ -928,13 +962,14 @@ export const action = async ({
       }
 
       // Save the updated content
-      await ContentService.put({
+      const written = await ContentService.put({
         orgLogin: gitOrgLogin,
         repo,
         path: newPath,
         content: String(content),
         message: `Update snippet: ${name}`,
       });
+      await recordThemeFile(slide, newPath, written.sha, content);
 
       return {
         intent: 'update-snippet',
@@ -997,13 +1032,14 @@ export const action = async ({
         .replace(/[^a-z0-9-]/g, '');
       const filename = `${baseName}-${type}.css`;
 
-      await ContentService.put({
+      const written = await ContentService.put({
         orgLogin: gitOrgLogin,
         repo,
         path: `.slidesthemes/${filename}`,
         content: String(content),
         message: `Add custom CSS theme: ${name} (${type})`,
       });
+      await recordThemeFile(slide, `.slidesthemes/${filename}`, written.sha, content);
 
       return {
         intent: 'save-theme',
@@ -1059,13 +1095,14 @@ export const action = async ({
       }
 
       // Save the updated content
-      await ContentService.put({
+      const written = await ContentService.put({
         orgLogin: gitOrgLogin,
         repo,
         path: newPath,
         content: String(content),
         message: `Update CSS theme: ${name} (${type})`,
       });
+      await recordThemeFile(slide, newPath, written.sha, content);
 
       return {
         intent: 'update-theme',

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -30,12 +30,12 @@ import {
 } from '@classmoji/services/slides';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import { useUser } from '~/hooks';
-import { fetchContent } from '~/utils/contentProxy';
 import { diffDeckSnapshots, extractDeckSnapshot, type DeckSnapshot } from '~/utils/deckOpsDiff';
 import { getThemeUrls } from '~/utils/themeService.server';
 import {
   deckAccessFor,
   deckDeliveryContext,
+  readDeckText,
   resolveDeckAssets,
   resolveDeliveryThemeUrls,
   resolveReadThemeUrls,
@@ -184,12 +184,21 @@ export const loader = async ({
   // preview branch names contain slashes).
   const diffUrl = `https://github.com/${gitOrgLogin}/${repo}/compare/main...${encodeURIComponent(previewBranch)}`;
 
-  // Fetch content: API-first for edit mode (freshness), CDN-first for view mode (speed)
-  // CDN has ~3 minute propagation delay after saves, so edit mode needs fresh API data
+  // Two reads, and the split is deliberate.
+  //
+  // EDIT mode keeps the contents API (skipCache), and must: it reads a PREVIEW
+  // BRANCH when one is active, and preview branches are not in the asset map at
+  // all — nothing there has a sha to sign. It also seeds the save conflict
+  // token, which has to be the sha of the file on the branch being written.
+  // Staff-only and low volume, so the API call per open is affordable.
+  //
+  // VIEW mode reads through the delivery layer by sha (see below), which is
+  // what makes a save visible the moment it returns instead of whenever GitHub
+  // Pages finishes rebuilding.
   let slideContent: string | null = null;
   let contentError: string | null = null;
   let usedApiFallback = false;
-  let contentResult: { content: string | Buffer; source: string } | null = null;
+  let contentResult: { content: string; source: string } | null = null;
 
   // Conflict token for the editor (Phase 4b): the sha of the deck's SOURCE OF
   // TRUTH — deck.json once it exists (materialized by the first dual-write
@@ -316,40 +325,34 @@ export const loader = async ({
     }
   }
 
-  // Staff view mode: API-first. The CDN (GitHub Pages) lags saves by minutes —
-  // and rapid consecutive saves can ERROR its builds, extending the lag — so a
-  // hard reload right after saving showed stale content to the very person who
-  // saved. Staff read the committed truth from the API; students keep the
-  // cheap CDN path (eventual consistency is fine for them). Thumbnails
-  // (?preview=true) stay CDN — a staff landing page renders ~20 at once and
-  // must not fan out API reads (the D4 amplification).
-  if (!contentResult && canEdit && !isThumbnail) {
-    try {
-      const result = await ContentService.getContent({
-        orgLogin: gitOrgLogin,
-        repo,
-        path: filePath,
-      });
-      if (result) {
-        contentResult = { content: result.content, source: 'api' };
-      }
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : String(e);
-      console.warn('[Loader] Staff view API read failed, falling back to CDN:', message);
-    }
-  }
-
-  // CDN-first for student/anonymous view mode, or as fallback if API failed
+  // Live deck, for everyone: read by SHA through the delivery layer.
+  //
+  // This replaces a three-way split — staff read the contents API, students
+  // read the CDN, thumbnails read the CDN — that existed entirely because
+  // GitHub Pages lags a save by minutes and rapid saves can ERROR its builds.
+  // Addressing the file by sha makes that question go away, so the split goes
+  // with it, and the three surfaces stop being able to disagree about what the
+  // current deck is.
+  //
+  // Cost moves in the right direction on every one of them. Staff no longer
+  // spend an installation-token API call per view. Students no longer wait out
+  // a Pages build. Thumbnails — a staff landing page renders ~20 at once, which
+  // is why they were pinned to the CDN to avoid the API fan-out — now cost one
+  // indexed map read each and are served from the edge; the API fan-out they
+  // were protected from only happens if the map misses, which a save's own
+  // write-through is what prevents.
   if (!contentResult) {
-    contentResult = await fetchContent({
-      org: gitOrgLogin,
+    contentResult = await readDeckText(
+      slide,
+      gitOrgLogin,
       repo,
-      path: filePath,
-    });
+      filePath,
+      isThumbnail ? 'thumbnail' : 'viewer'
+    );
   }
 
   if (contentResult) {
-    slideContent = contentResult.content as string;
+    slideContent = contentResult.content;
     usedApiFallback = contentResult.source === 'api';
 
     // Sign the deck's image references — but never for the document the editor

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -4,10 +4,10 @@ import getPrisma from '@classmoji/database';
 import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
-import { fetchContent } from '~/utils/contentProxy';
 import {
   deckAccessFor,
   deckDeliveryContext,
+  readDeckText,
   resolveDeckDelivery,
 } from '~/utils/deckDelivery.server';
 
@@ -69,18 +69,18 @@ export const loader = async ({
   const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
-  // Build the content URL using content proxy (CDN-first + API fallback)
+  // Legacy proxy URL, kept as the client-side fallback when the server-side
+  // read below fails entirely.
   const contentUrl = `/content/${gitOrgLogin}/${repo}/${filePath}`;
 
-  // Fetch content using shared utility (CDN first, API fallback)
+  // Read the deck by SHA through the delivery layer. This is the highest-fanout
+  // deck read in the app — a lecture hall opens it at once — and it is now the
+  // cheapest: one signed URL per sha, served from the edge, and zero GitHub
+  // calls per viewer.
   let slideContent: string | null = null;
   let contentError: string | null = null;
 
-  const contentResult = await fetchContent({
-    org: gitOrgLogin,
-    repo,
-    path: filePath,
-  });
+  const contentResult = await readDeckText(slide, gitOrgLogin, repo, filePath, 'follow');
 
   if (contentResult) {
     // Same read-side delivery pass the deck viewer runs. A follower is usually
@@ -89,7 +89,7 @@ export const loader = async ({
     // The `preview` local above is this route's THUMBNAIL flag and is
     // deliberately not part of the access shape; `deckAccessFor` cannot see it.
     const { html } = await resolveDeckDelivery(
-      contentResult.content as string,
+      contentResult.content,
       deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('follow', { canEdit }, slide))
     );
     slideContent = html;

--- a/apps/slides/app/routes/$slideId_.present/route.tsx
+++ b/apps/slides/app/routes/$slideId_.present/route.tsx
@@ -4,10 +4,10 @@ import getPrisma from '@classmoji/database';
 import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
-import { fetchContent } from '~/utils/contentProxy';
 import {
   deckAccessFor,
   deckDeliveryContext,
+  readDeckText,
   resolveDeckDelivery,
 } from '~/utils/deckDelivery.server';
 
@@ -54,19 +54,18 @@ export const loader = async ({
   const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
-  // Build the content URL using content proxy (CDN-first + API fallback)
-  // Used as client-side fallback if server-side fetch fails
+  // Legacy proxy URL, kept as the client-side fallback when the server-side
+  // read below fails entirely.
   const contentUrl = `/content/${gitOrgLogin}/${repo}/${filePath}`;
 
-  // Fetch content using shared utility (CDN first, API fallback)
+  // Read the deck by SHA through the delivery layer. This route is the reason
+  // that matters: the presenter is opened seconds after a save, and the CDN
+  // path this replaces lagged a push by minutes — so a deck saved at the
+  // lectern showed the version from before the fix.
   let slideContent: string | null = null;
   let contentError: string | null = null;
 
-  const contentResult = await fetchContent({
-    org: gitOrgLogin,
-    repo,
-    path: filePath,
-  });
+  const contentResult = await readDeckText(slide, gitOrgLogin, repo, filePath, 'present');
 
   if (contentResult) {
     // Same read-side delivery pass the deck viewer runs: the stored document
@@ -74,7 +73,7 @@ export const loader = async ({
     // private content repo shows them nothing. `deckAccessFor` deliberately
     // does NOT hand this surface the draft tier — see its comment.
     const { html } = await resolveDeckDelivery(
-      contentResult.content as string,
+      contentResult.content,
       deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('present', { canEdit }, slide))
     );
     slideContent = html;

--- a/apps/slides/app/routes/$slideId_.speaker/route.tsx
+++ b/apps/slides/app/routes/$slideId_.speaker/route.tsx
@@ -2,8 +2,12 @@ import { useLoaderData } from 'react-router';
 import getPrisma from '@classmoji/database';
 import { assertSlideAccess } from '@classmoji/auth/server';
 import SpeakerView from '~/components/SpeakerView';
-import { fetchContent } from '~/utils/contentProxy';
-import { deckAccessFor, deckDeliveryContext, resolveDeckAssets } from '~/utils/deckDelivery.server';
+import {
+  deckAccessFor,
+  deckDeliveryContext,
+  readDeckText,
+  resolveDeckAssets,
+} from '~/utils/deckDelivery.server';
 
 /**
  * Speaker route - Remote speaker notes view
@@ -57,15 +61,13 @@ export const loader = async ({
   const repo = slide.classroom.content_repo;
   const filePath = `${slide.content_path}/index.html`;
 
-  // Fetch content using shared utility (CDN first, API fallback)
+  // Read the deck by SHA through the delivery layer — the same read the
+  // presenter makes, and for the same reason: this view is opened alongside a
+  // live presentation, where showing the pre-save deck is worse than useless.
   let slideContent: string | null = null;
   let contentError: string | null = null;
 
-  const contentResult = await fetchContent({
-    org: gitOrgLogin,
-    repo,
-    path: filePath,
-  });
+  const contentResult = await readDeckText(slide, gitOrgLogin, repo, filePath, 'speaker');
 
   if (contentResult) {
     // Sign the deck's references BEFORE the fragment is cut out: the speaker
@@ -74,7 +76,7 @@ export const loader = async ({
     // `.slides` fragment and throws the document's <head> away, so resolving a
     // theme base here would be a lookup for an answer nobody reads.
     const html = await resolveDeckAssets(
-      contentResult.content as string,
+      contentResult.content,
       deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('speaker', { canEdit }, slide))
     );
 

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -230,10 +230,16 @@ export const action = async ({ request }: { request: Request }) => {
       });
 
       // Both rewrites below record what they wrote. index.html and deck.json
-      // are READ through the asset map now (fetchContentText), and a duplicate
-      // that skipped this would render as the ORIGINAL deck's content — the
-      // copy's paths are new, so the map has no row for them at all until the
-      // push webhook lands.
+      // are READ through the asset map now (fetchContentText), and the copy's
+      // paths are new, so the map has no row for them until the push webhook
+      // lands.
+      //
+      // Only what the REWRITES write, though: `copyFolder` above is what puts
+      // the files there, and it reports no shas, so a deck whose content had no
+      // self-referencing paths to rewrite gets no rows here. That is a missing
+      // row, not a wrong one — the read falls back to the contents API and
+      // serves the right bytes — so it costs one GitHub call per view until the
+      // webhook arrives rather than showing the wrong deck.
       const written: Array<{ path: string; sha: string }> = [];
 
       if (indexFile?.content && slide.content_path !== newContentPath) {

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -229,17 +229,25 @@ export const action = async ({ request }: { request: Request }) => {
         skipCache: true,
       });
 
+      // Both rewrites below record what they wrote. index.html and deck.json
+      // are READ through the asset map now (fetchContentText), and a duplicate
+      // that skipped this would render as the ORIGINAL deck's content — the
+      // copy's paths are new, so the map has no row for them at all until the
+      // push webhook lands.
+      const written: Array<{ path: string; sha: string }> = [];
+
       if (indexFile?.content && slide.content_path !== newContentPath) {
         const updatedContent = indexFile.content.replaceAll(slide.content_path, newContentPath);
 
         if (updatedContent !== indexFile.content) {
-          await ContentService.put({
+          const result = await ContentService.put({
             gitOrganization,
             repo,
             path: indexPath,
             content: updatedContent,
             message: `Rewrite content paths for duplicated slides: ${slide.title}`,
           });
+          written.push({ path: indexPath, sha: result.sha });
         }
       }
 
@@ -258,14 +266,21 @@ export const action = async ({ request }: { request: Request }) => {
         const updatedDeck = deckFile.content.replaceAll(slide.content_path, newContentPath);
 
         if (updatedDeck !== deckFile.content) {
-          await ContentService.put({
+          const result = await ContentService.put({
             gitOrganization,
             repo,
             path: deckPath,
             content: updatedDeck,
             message: `Rewrite content paths for duplicated slides: ${slide.title}`,
           });
+          written.push({ path: deckPath, sha: result.sha });
         }
+      }
+
+      // Never throws: the copy is already committed, and the next sync writes
+      // the same rows.
+      if (slide.classroom_id) {
+        await ClassmojiService.contentAssets.recordContentAssets(slide.classroom_id, written);
       }
 
       // Create new database record

--- a/apps/slides/app/routes/content.$org.$repo.$/route.tsx
+++ b/apps/slides/app/routes/content.$org.$repo.$/route.tsx
@@ -1,7 +1,18 @@
 /**
- * Content Proxy Route
+ * Content Proxy Route — LEGACY, kept for links already in the wild.
  *
- * Proxies content from GitHub repositories with CDN-first strategy.
+ * Everything new goes through the delivery Worker: signed, sha-addressed URLs
+ * minted at render time. This route survives because stored documents, browser
+ * bookmarks and shared slide links still carry `/content/{org}/{repo}/{path}`,
+ * and because it is the client-side fallback the deck surfaces hand their
+ * presenter component.
+ *
+ * TEXT served from here now goes through the same map-first read the loaders
+ * use (`fetchContentText`), so an old link is not a stale link. Binary files
+ * keep the legacy `fetchContent` ladder: the delivery layer serves those as
+ * signed URLs at the point of render, and there is nothing to gain from
+ * re-plumbing a path nothing new points at.
+ *
  * Serves CSS, fonts, and other assets with correct MIME types.
  *
  * URL pattern: /content/:org/:repo/*path
@@ -29,11 +40,15 @@
 
 import { fetchContent, getMimeType, isBinaryFile } from '~/utils/contentProxy';
 import { getAuthSession } from '@classmoji/auth/server';
+import { ClassmojiService } from '@classmoji/services';
 import { getContentRepoName } from '@classmoji/utils';
 import getPrisma from '@classmoji/database';
 
 interface ContentRouteMembership {
   classroom?: {
+    id?: string;
+    content_key_version?: number;
+    content_delivery_enabled?: boolean | null;
     content_repo?: string | null;
     git_organization?: {
       login: string;
@@ -41,6 +56,9 @@ interface ContentRouteMembership {
     } | null;
   } | null;
 }
+
+/** The classroom this request was authorized against, for the text read below. */
+type MatchedClassroom = NonNullable<ContentRouteMembership['classroom']>;
 
 // In-memory cache for user classroom memberships
 // Avoids DB hit on every asset request (CSS, fonts, images, etc.)
@@ -83,6 +101,41 @@ async function getCachedMemberships(userId: string) {
   return memberships;
 }
 
+/**
+ * The map-first text read, degrading to the legacy ladder.
+ *
+ * `matched` is null only when access was granted by a branch that did not
+ * resolve a classroom row — there is nothing to sign against then, and the
+ * legacy ladder is the whole answer.
+ */
+async function fetchProxyText(
+  matched: MatchedClassroom | null,
+  org: string,
+  repo: string,
+  path: string
+): Promise<{ content: string; source: string } | null> {
+  if (matched?.id) {
+    const text = await ClassmojiService.contentDelivery.fetchContentText(
+      {
+        classroom: {
+          id: matched.id,
+          content_key_version: matched.content_key_version ?? 0,
+          content_repo: repo,
+          content_delivery_enabled: matched.content_delivery_enabled === true,
+          git_organization: { login: org },
+        },
+      },
+      path,
+      { label: 'proxy' }
+    );
+    if (text) return { content: text.text, source: text.source };
+    return null;
+  }
+
+  const legacy = await fetchContent({ org, repo, path });
+  return legacy ? { content: legacy.content as string, source: legacy.source } : null;
+}
+
 export const loader = async ({
   params,
   request,
@@ -102,6 +155,9 @@ export const loader = async ({
   // Try authentication first
   const authData = await getAuthSession(request);
   let hasAccess = false;
+  // Kept from whichever branch granted access: the text read below needs the
+  // classroom's id and cache version to sign, and its org/repo to fall back.
+  let matched: MatchedClassroom | null = null;
 
   // Path 1: Authenticated user - check classroom memberships
   if (authData) {
@@ -111,7 +167,7 @@ export const loader = async ({
     // The classroom's content repo is STORED and user-editable — never re-derived.
     // Legacy classrooms without one fall back to the ORG-level content repo
     // (organization.settings.content_repo_name).
-    hasAccess = memberships.some((m: ContentRouteMembership) => {
+    const match = memberships.find((m: ContentRouteMembership) => {
       const gitOrg = m.classroom?.git_organization;
       if (!gitOrg || gitOrg.login !== org) return false;
 
@@ -125,6 +181,8 @@ export const loader = async ({
 
       return repo === expectedRepo; // EXACT match only
     });
+    hasAccess = Boolean(match);
+    matched = match?.classroom ?? null;
   }
 
   // Path 2: Public slide access - validate slideId points to a public slide
@@ -156,6 +214,7 @@ export const loader = async ({
 
           if (isSlideContent || isSharedAsset) {
             hasAccess = true;
+            matched = slide.classroom;
           }
         }
       }
@@ -166,9 +225,17 @@ export const loader = async ({
     throw new Response('Forbidden - no access to this content', { status: 403 });
   }
 
-  // 4. Proceed with fetch
+  // 4. Proceed with fetch.
+  //
+  // Text goes through the asset map like every other read now, so an old
+  // `/content/...` link serves the same bytes the loaders do rather than
+  // whatever GitHub Pages last built. Binary falls through to the legacy
+  // ladder — the delivery layer hands those out as signed URLs at render time,
+  // so nothing new arrives here for them.
   const binary = isBinaryFile(path);
-  const result = await fetchContent({ org, repo, path, binary });
+  const result = binary
+    ? await fetchContent({ org, repo, path, binary })
+    : await fetchProxyText(matched, org, repo, path);
 
   if (!result) {
     throw new Response('Not found', { status: 404 });

--- a/apps/slides/app/routes/content.$org.$repo.$/route.tsx
+++ b/apps/slides/app/routes/content.$org.$repo.$/route.tsx
@@ -167,7 +167,7 @@ export const loader = async ({
     // The classroom's content repo is STORED and user-editable — never re-derived.
     // Legacy classrooms without one fall back to the ORG-level content repo
     // (organization.settings.content_repo_name).
-    const match = memberships.find((m: ContentRouteMembership) => {
+    const matches = memberships.filter((m: ContentRouteMembership) => {
       const gitOrg = m.classroom?.git_organization;
       if (!gitOrg || gitOrg.login !== org) return false;
 
@@ -181,8 +181,21 @@ export const loader = async ({
 
       return repo === expectedRepo; // EXACT match only
     });
-    hasAccess = Boolean(match);
-    matched = match?.classroom ?? null;
+    hasAccess = matches.length > 0;
+
+    // ONE match, or none — never "the first of several".
+    //
+    // Access is settled by `hasAccess` above and is unaffected by this. What
+    // this decides is which classroom's ROLLOUT GATE and key version the text
+    // read below signs under, and several of a user's classrooms can legitimately
+    // share one content repo (the org-level `content_repo_name` fallback is
+    // org-wide). Picking the first would let a classroom whose
+    // `content_delivery_enabled` is still false have its text served through the
+    // Worker because a sibling classroom on the same repo is switched on — which
+    // is exactly the per-classroom rollout the flag exists to control.
+    //
+    // Ambiguity therefore reads as "no classroom", and the legacy ladder answers.
+    matched = matches.length === 1 ? (matches[0].classroom ?? null) : null;
   }
 
   // Path 2: Public slide access - validate slideId points to a public slide
@@ -244,11 +257,15 @@ export const loader = async ({
   // Get MIME type - pass content for magic byte detection on extensionless files
   const mimeType = getMimeType(path, binary ? (result.content as Buffer) : undefined);
 
-  // Set cache headers - assets are versioned by path (hash-based filenames)
-  // so they can be cached aggressively. 1 hour browser + CDN caching.
+  // Binary is versioned by path (hash-based filenames) and can be cached hard.
+  // TEXT cannot: a deck's index.html lives at a stable path and changes on every
+  // save, so an hour of browser caching here would put the staleness straight
+  // back — in a bookmarked `/content/...` link and in the presenter's own
+  // client-side fallback, which is the one place a stale deck is worst. A
+  // minute keeps the proxy cheap without outliving a save by much.
   const headers = {
     'Content-Type': mimeType,
-    'Cache-Control': 'public, max-age=3600', // 1 hour
+    'Cache-Control': binary ? 'public, max-age=3600' : 'public, max-age=60',
     'X-Content-Source': result.source, // Debug header
   };
 

--- a/apps/slides/app/routes/content.$org.$repo.$/route.tsx
+++ b/apps/slides/app/routes/content.$org.$repo.$/route.tsx
@@ -132,6 +132,9 @@ async function fetchProxyText(
     return null;
   }
 
+  // No classroom to sign against — the legacy ladder is the whole answer, and
+  // it stays API-first because this is TEXT, where staleness is the expensive
+  // failure (see fetchContent's header).
   const legacy = await fetchContent({ org, repo, path });
   return legacy ? { content: legacy.content as string, source: legacy.source } : null;
 }
@@ -246,8 +249,17 @@ export const loader = async ({
   // ladder — the delivery layer hands those out as signed URLs at render time,
   // so nothing new arrives here for them.
   const binary = isBinaryFile(path);
+  // Binary keeps CDN-first for a classroom the layer is NOT switched on for.
+  // Every image and font of every deck in such a classroom comes through here,
+  // and those bytes never change once uploaded — so a few minutes of CDN
+  // staleness is free where an authenticated read per image spends the org
+  // installation's shared limit. An opted-in classroom serves its assets as
+  // signed URLs and barely reaches this route at all, so API-first is right
+  // there. Unknown classroom reads as "not opted in": the safe direction is
+  // the one that cannot exhaust a rate limit.
+  const preferCdn = matched?.content_delivery_enabled !== true;
   const result = binary
-    ? await fetchContent({ org, repo, path, binary })
+    ? await fetchContent({ org, repo, path, binary, preferCdn })
     : await fetchProxyText(matched, org, repo, path);
 
   if (!result) {

--- a/apps/slides/app/utils/contentProxy.ts
+++ b/apps/slides/app/utils/contentProxy.ts
@@ -10,18 +10,27 @@
  * proxy — plus the last-resort path for a request that could not be tied to a
  * classroom.
  *
- * Fallback order, and it is NOT the one this used to have:
- * 1. GitHub Contents API (authenticated, always the current commit, 1MB cap)
- * 2. GitHub Git Blobs API (authenticated, up to 100MB — binary only)
- * 3. GitHub Pages CDN — LAST, and **slated for deletion in Phase 4**
+ * Fallback order, and it depends on `preferCdn`:
  *
- * The CDN used to be first, and that is the bug this whole change exists to
- * close: GitHub Pages lags a push by minutes, and rapid consecutive saves can
- * ERROR its build and stretch that further, so an instructor who saved a deck
- * and opened the presenter was served the previous version of their own slides.
- * A stale answer arriving quickly is worse than a correct one arriving a beat
- * later, so the authenticated read goes first and the CDN is only what answers
- * when nothing else can.
+ *   preferCdn=false — Contents API → Git Blobs API → Pages CDN
+ *   preferCdn=true  — Pages CDN → Contents API → Git Blobs API
+ *
+ * API-first is the fix this change is about: GitHub Pages lags a push by
+ * minutes, and rapid consecutive saves can ERROR its build and stretch that
+ * further, so an instructor who saved a deck and opened the presenter was
+ * served the previous version of their own slides.
+ *
+ * But API-first is only right where staleness is the expensive failure. For a
+ * classroom the delivery layer is NOT switched on for, every image and font of
+ * every deck still comes through this proxy — and putting those on the
+ * authenticated read spends the org installation's shared 5,000/h limit on
+ * files whose bytes have not changed since they were uploaded. There, the CDN
+ * being three minutes behind costs nothing and a rate limit costs everything,
+ * so those keep the old order. The caller decides, because only the caller
+ * knows the classroom's gate.
+ *
+ * The CDN tier is slated for deletion in Phase 4 either way: a private content
+ * repo serves nothing from `github.io`.
  *
  * Note: raw.githubusercontent.com is blocked/rate-limited from Fly.io IPs,
  * so we use the authenticated Git Blobs API for large files instead.
@@ -30,13 +39,22 @@
 import { ContentService } from '@classmoji/content';
 
 /**
- * Fetch content from GitHub: authenticated first, CDN last.
+ * A hung origin must not hold a render open. Mirrors the delivery layer's own
+ * bound (`TEXT_FETCH_TIMEOUT_MS` in contentDelivery.service).
+ */
+const CONTENT_FETCH_TIMEOUT_MS = 6000;
+
+/**
+ * Fetch content from GitHub.
  *
  * @param {Object} options
  * @param {string} options.org - GitHub organization login
  * @param {string} options.repo - Repository name
  * @param {string} options.path - File path within the repo
  * @param {boolean} [options.binary=false] - If true, returns Buffer instead of string
+ * @param {boolean} [options.preferCdn=false] - Try the Pages CDN first. For
+ *   assets of a classroom the delivery layer is not switched on for, where a
+ *   few minutes of staleness is free and an API call per image is not.
  * @returns {Promise<{content: string | Buffer, source: 'cdn' | 'api' | 'blob'} | null>}
  */
 export async function fetchContent({
@@ -44,13 +62,41 @@ export async function fetchContent({
   repo,
   path,
   binary = false,
+  preferCdn = false,
 }: {
   org: string;
   repo: string;
   path: string;
   binary?: boolean;
+  preferCdn?: boolean;
 }): Promise<{ content: string | Buffer; source: 'cdn' | 'api' | 'blob' } | null> {
-  // The authenticated read first: it always sees the current commit.
+  /**
+   * The Pages CDN leg. Bounded: this runs on a render path, and an unreachable
+   * github.io must cost a fallback rather than a held-open request.
+   */
+  const readCdn = async (): Promise<{ content: string | Buffer; source: 'cdn' } | null> => {
+    try {
+      const response = await fetch(`https://${org}.github.io/${repo}/${path}`, {
+        signal: AbortSignal.timeout(CONTENT_FETCH_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        const content = binary ? Buffer.from(await response.arrayBuffer()) : await response.text();
+        return { content, source: 'cdn' };
+      }
+    } catch (err: unknown) {
+      // Network error (likely ECONNRESET from Fly.io IPs) or the timeout above.
+      const message = err instanceof Error ? err.message : String(err);
+      console.log(`CDN fetch failed for ${path}: ${message}`);
+    }
+    return null;
+  };
+
+  if (preferCdn) {
+    const cdn = await readCdn();
+    if (cdn) return cdn;
+  }
+
+  // The authenticated read: it always sees the current commit.
   try {
     const result = await ContentService.getContent({
       orgLogin: org,
@@ -91,23 +137,10 @@ export async function fetchContent({
     }
   }
 
-  // LAST RESORT, and DEPRECATED — Phase 4 removes this tier along with GitHub
-  // Pages itself. It lags a push by minutes and it stops existing entirely the
-  // moment a content repo goes private, so it can only ever be what answers
-  // when the authenticated reads above could not.
-  try {
-    const response = await fetch(`https://${org}.github.io/${repo}/${path}`);
-    if (response.ok) {
-      const content = binary ? Buffer.from(await response.arrayBuffer()) : await response.text();
-      return { content, source: 'cdn' };
-    }
-  } catch (err: unknown) {
-    // Network error (likely ECONNRESET from Fly.io IPs).
-    const message = err instanceof Error ? err.message : String(err);
-    console.log(`CDN fetch failed for ${path}: ${message}`);
-  }
-
-  return null;
+  // DEPRECATED — Phase 4 removes this tier along with GitHub Pages itself. When
+  // `preferCdn` is set it already ran above; here it is the last resort after
+  // the authenticated reads could not answer.
+  return preferCdn ? null : await readCdn();
 }
 
 /**

--- a/apps/slides/app/utils/contentProxy.ts
+++ b/apps/slides/app/utils/contentProxy.ts
@@ -1,24 +1,36 @@
 /**
- * Content Proxy Utility
+ * Content Proxy Utility — the LEGACY read, for what the delivery layer does not
+ * carry yet.
  *
- * Unified system for fetching content from GitHub repositories.
- * Uses a three-tier fallback strategy:
- * 1. GitHub Pages CDN (fast, but may get ECONNRESET from some cloud providers)
- * 2. GitHub Contents API (authenticated, immediate, but 1MB file size limit)
- * 3. GitHub Git Blobs API (authenticated, supports files up to 100MB)
+ * Anything that can be addressed by sha goes through
+ * `ClassmojiService.contentDelivery.fetchContentText` instead: it resolves a
+ * repo path to a blob sha through the asset map and fetches it from the Worker,
+ * so a save is visible the instant it returns. What is left here is the binary
+ * tail — fonts and images reached through the old `/content/{org}/{repo}/…`
+ * proxy — plus the last-resort path for a request that could not be tied to a
+ * classroom.
+ *
+ * Fallback order, and it is NOT the one this used to have:
+ * 1. GitHub Contents API (authenticated, always the current commit, 1MB cap)
+ * 2. GitHub Git Blobs API (authenticated, up to 100MB — binary only)
+ * 3. GitHub Pages CDN — LAST, and **slated for deletion in Phase 4**
+ *
+ * The CDN used to be first, and that is the bug this whole change exists to
+ * close: GitHub Pages lags a push by minutes, and rapid consecutive saves can
+ * ERROR its build and stretch that further, so an instructor who saved a deck
+ * and opened the presenter was served the previous version of their own slides.
+ * A stale answer arriving quickly is worse than a correct one arriving a beat
+ * later, so the authenticated read goes first and the CDN is only what answers
+ * when nothing else can.
  *
  * Note: raw.githubusercontent.com is blocked/rate-limited from Fly.io IPs,
  * so we use the authenticated Git Blobs API for large files instead.
- *
- * Used by:
- * - HTML slide content (loader)
- * - CSS/font assets (content proxy route)
  */
 
 import { ContentService } from '@classmoji/content';
 
 /**
- * Fetch content from GitHub with CDN-first strategy
+ * Fetch content from GitHub: authenticated first, CDN last.
  *
  * @param {Object} options
  * @param {string} options.org - GitHub organization login
@@ -38,23 +50,7 @@ export async function fetchContent({
   path: string;
   binary?: boolean;
 }): Promise<{ content: string | Buffer; source: 'cdn' | 'api' | 'blob' } | null> {
-  // Try GitHub Pages CDN first (may fail from some cloud providers due to IP blocking)
-  const cdnUrl = `https://${org}.github.io/${repo}/${path}`;
-
-  try {
-    const response = await fetch(cdnUrl);
-    if (response.ok) {
-      const content = binary ? Buffer.from(await response.arrayBuffer()) : await response.text();
-      return { content, source: 'cdn' };
-    }
-    // CDN returned error (404, 500, etc.) - fall through to API
-  } catch (err: unknown) {
-    // Network error (likely ECONNRESET from Fly.io) - fall through to API
-    const message = err instanceof Error ? err.message : String(err);
-    console.log(`CDN fetch failed for ${path}: ${message}`);
-  }
-
-  // Fallback to GitHub API
+  // The authenticated read first: it always sees the current commit.
   try {
     const result = await ContentService.getContent({
       orgLogin: org,
@@ -71,12 +67,12 @@ export async function fetchContent({
     }
   } catch (apiErr: unknown) {
     const message = apiErr instanceof Error ? apiErr.message : String(apiErr);
-    console.error(`API fallback failed for ${path}:`, message);
+    console.error(`API read failed for ${path}:`, message);
   }
 
-  // Try Git Blobs API for large binary files (> 1MB Contents API limit)
-  // Uses authenticated GitHub API which works from Fly.io (unlike raw.githubusercontent.com)
-  // Git Blobs API supports files up to 100MB
+  // Git Blobs API for large binary files (> the 1MB Contents API limit).
+  // Authenticated, works from Fly.io (unlike raw.githubusercontent.com), and
+  // supports files up to 100MB.
   if (binary) {
     try {
       const result = await ContentService.getLargeContent({
@@ -93,6 +89,22 @@ export async function fetchContent({
       const message = blobErr instanceof Error ? blobErr.message : String(blobErr);
       console.log(`Git Blob fetch failed for ${path}: ${message}`);
     }
+  }
+
+  // LAST RESORT, and DEPRECATED — Phase 4 removes this tier along with GitHub
+  // Pages itself. It lags a push by minutes and it stops existing entirely the
+  // moment a content repo goes private, so it can only ever be what answers
+  // when the authenticated reads above could not.
+  try {
+    const response = await fetch(`https://${org}.github.io/${repo}/${path}`);
+    if (response.ok) {
+      const content = binary ? Buffer.from(await response.arrayBuffer()) : await response.text();
+      return { content, source: 'cdn' };
+    }
+  } catch (err: unknown) {
+    // Network error (likely ECONNRESET from Fly.io IPs).
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(`CDN fetch failed for ${path}: ${message}`);
   }
 
   return null;

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -138,6 +138,52 @@ export function deckDeliveryContext(
 
 export type DeliveryContext = ReturnType<typeof deckDeliveryContext>;
 
+/**
+ * Read a deck's stored TEXT — `index.html`, `deck.json` — through the map.
+ *
+ * The read-side twin of `deckDeliveryContext`, and deliberately NOT gated the
+ * way that one is. `deckDeliveryContext` refuses a context when the layer is
+ * off, because a rewrite pass that cannot sign anything is a cheerio parse for
+ * a byte-identical result. This one still has work to do in that case: the
+ * fallback ladder inside `fetchContentText` (contents API, then the Pages CDN)
+ * is how a classroom that has not been opted in keeps reading its own decks,
+ * and it needs the org and repo to do it.
+ *
+ * Why it exists at all: `/present`, `/follow` and `/speaker` read `index.html`
+ * CDN-first, and GitHub Pages lags a push by minutes — so an instructor who
+ * saved a deck and opened the presenter was shown the previous version of
+ * their own slides. Reading by sha removes the question.
+ *
+ * The shape matches what `fetchContent` returned, so the call sites keep their
+ * existing branching; `source` now also carries `'worker'`.
+ */
+export async function readDeckText(
+  slide: DeliverySlide,
+  gitOrgLogin: string,
+  repo: string,
+  path: string,
+  label: string
+): Promise<{ content: string; source: 'worker' | 'api' | 'cdn' } | null> {
+  const classroom = slide.classroom;
+  if (!classroom?.id) return null;
+
+  const result = await ClassmojiService.contentDelivery.fetchContentText(
+    {
+      classroom: {
+        id: classroom.id,
+        content_key_version: classroom.content_key_version ?? 0,
+        content_repo: repo,
+        content_delivery_enabled: classroom.content_delivery_enabled === true,
+        git_organization: { login: gitOrgLogin },
+      },
+    },
+    path,
+    { label }
+  );
+
+  return result ? { content: result.text, source: result.source } : null;
+}
+
 /** The `shared:` theme a rendered deck declares, or null. */
 export function sharedThemeName(html: string | null | undefined): string | null {
   if (!html) return null;

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -162,7 +162,8 @@ export async function readDeckText(
   gitOrgLogin: string,
   repo: string,
   path: string,
-  label: string
+  label: string,
+  opts: { fallback?: 'api-then-cdn' | 'cdn-only' } = {}
 ): Promise<{ content: string; source: 'worker' | 'api' | 'cdn' } | null> {
   const classroom = slide.classroom;
   if (!classroom?.id) return null;
@@ -178,7 +179,7 @@ export async function readDeckText(
       },
     },
     path,
-    { label }
+    { label, ...(opts.fallback ? { fallback: opts.fallback } : {}) }
   );
 
   return result ? { content: result.text, source: result.source } : null;

--- a/apps/slides/app/utils/slidesComImporter.server.ts
+++ b/apps/slides/app/utils/slidesComImporter.server.ts
@@ -814,7 +814,7 @@ export async function processZipImport({
   // 13. Batch upload all files in single commit
   onProgress({ type: 'step', step: 'uploading_github', current: 0, total: files.length });
   try {
-    await ContentService.uploadBatch({
+    const result = await ContentService.uploadBatch({
       orgLogin: org,
       repo: repoName,
       files,
@@ -823,6 +823,10 @@ export async function processZipImport({
         onProgress({ type: 'step', step: 'uploading_github', current, total, filename });
       },
     });
+    // Write-through: an imported deck is opened the moment the import finishes,
+    // and its index.html is read through the asset map. Without this the first
+    // views fall back to the contents API until the push webhook lands.
+    await ClassmojiService.contentAssets.recordContentAssets(classroom.id, result.files);
   } catch (uploadError: unknown) {
     console.log(uploadError);
     // If upload fails, clean up slide record and Cloudinary videos

--- a/packages/content-signing/src/__tests__/urls.test.ts
+++ b/packages/content-signing/src/__tests__/urls.test.ts
@@ -134,6 +134,30 @@ describe('signBlobUrl', () => {
     ).rejects.toThrow(TypeError);
   });
 
+  it('signs the text extensions the delivery layer serves', async () => {
+    // Root content — a deck's index.html, a page's content.json, a theme's css
+    // and fonts — is signed by exactly the same call an image is. There is no
+    // separate text scheme and no per-extension allowlist: the extension is a
+    // FIELD of the canonical string, so a signature for one extension can
+    // never serve another.
+    for (const ext of ['html', 'json', 'css', 'js', 'md', 'txt', 'svg', 'woff', 'woff2', 'ttf']) {
+      const url = await signBlobUrl(ORIGIN, ctx('enrolled'), { sha: SHA, ext });
+      expect(url.startsWith(`${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.${ext}?`)).toBe(true);
+      const parsed = parseContentUrl(url);
+      expect(parsed).toMatchObject({ kind: 'blob', sha: SHA, ext });
+    }
+  });
+
+  it('gives one blob a different signature per extension', async () => {
+    // The guarantee behind "never sniff" on the Worker: re-labelling a signed
+    // .json as .html is not a URL edit, it is a forgery.
+    const asJson = await signBlobUrl(ORIGIN, ctx('enrolled'), { sha: SHA, ext: 'json' });
+    const asHtml = await signBlobUrl(ORIGIN, ctx('enrolled'), { sha: SHA, ext: 'html' });
+    expect(new URL(asJson).searchParams.get('sig')).not.toBe(
+      new URL(asHtml).searchParams.get('sig')
+    );
+  });
+
   it('rejects a nonsense now or keyVersion at mint', async () => {
     for (const now of [Number.NaN, -1, 1.5, Infinity]) {
       await expect(

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -21,6 +21,7 @@ const classroomFindFirst = vi.fn();
 const classroomUpdate = vi.fn();
 const classroomUpdateMany = vi.fn();
 const contentAssetFindMany = vi.fn();
+const executeRaw = vi.fn();
 const transaction = vi.fn();
 
 vi.mock('@classmoji/database', () => ({
@@ -39,8 +40,26 @@ vi.mock('@classmoji/database', () => ({
       findUnique: contentAssetFindUnique,
     },
     $transaction: transaction,
+    $executeRaw: executeRaw,
   }),
 }));
+
+/**
+ * The sync writes its whole batch as ONE tagged-template statement, so the mock
+ * receives `(strings, ...params)`. These read the batch back out positionally,
+ * in the order `upsertManyOp` interpolates them.
+ *
+ * Positional and therefore brittle by design: the parameter order is part of
+ * the statement, and a reordering that these did not notice would be a silent
+ * column swap in production.
+ */
+type RawCall = [TemplateStringsArray, string, Date, string[], string[], string[], number[]];
+const rawCall = (n = 0) => executeRaw.mock.calls[n] as RawCall;
+const upsertSql = (n = 0) => rawCall(n)[0].join('?');
+const upsertedPathsOf = (n = 0) => rawCall(n)[3];
+const upsertedShasOf = (n = 0) => rawCall(n)[4];
+const upsertedSizesOf = (n = 0) => rawCall(n)[6];
+const upsertStampOf = (n = 0) => rawCall(n)[2];
 
 const getTree = vi.fn();
 const getDefaultBranch = vi.fn();
@@ -61,6 +80,8 @@ const {
   lookupContentAssetsBySha,
   ensureContentAssets,
   recordContentAsset,
+  removeContentAssets,
+  removeContentAssetFolder,
   lookupContentAsset,
   lookupContentTree,
   lookupContentAssetBySha,
@@ -92,6 +113,7 @@ const syncedAgo = (ms: number) => ({
  */
 const setupTransaction = (deletedCount = 0, casCount = 1) => {
   contentAssetUpsert.mockImplementation(args => ({ op: 'upsert', args }));
+  executeRaw.mockImplementation(() => ({ op: 'upsertMany' }));
   contentAssetDeleteMany.mockImplementation(args => ({ op: 'deleteMany', args }));
   classroomUpdate.mockImplementation(args => ({ op: 'classroomUpdate', args }));
   classroomUpdateMany.mockImplementation(args => ({ op: 'classroomUpdateMany', args }));
@@ -137,12 +159,12 @@ describe('contentAssets.service', () => {
       expect(getDefaultBranch).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101');
       expect(getLatestCommitSHA).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', 'main');
       expect(getTree).toHaveBeenCalledWith('dartmouth-cs', 'content-cs101', HEAD_COMMIT, true);
-      expect(contentAssetUpsert).toHaveBeenCalledTimes(3);
+      // ONE statement for the whole tree, not one per entry.
+      expect(executeRaw).toHaveBeenCalledTimes(1);
 
       // Directories are rows too — theme folders are addressed by tree SHA, so
       // dropping them would make themes unresolvable.
-      const upsertedPaths = contentAssetUpsert.mock.calls.map(([args]) => args.create.path);
-      expect(upsertedPaths).toEqual(['images', 'images/a.png', 'images/b.png']);
+      expect(upsertedPathsOf()).toEqual(['images', 'images/a.png', 'images/b.png']);
 
       // The sweep is what deletes paths removed from the repo. Every row
       // written this run carries the same stamp, so `lt` matches only rows an
@@ -153,9 +175,42 @@ describe('contentAssets.service', () => {
       expect(sweep.where.classroom_id).toBe('class-1');
       expect(sweep.where.synced_at.lt).toBeInstanceOf(Date);
 
-      const stamps = contentAssetUpsert.mock.calls.map(([args]) => args.create.synced_at.getTime());
-      expect(new Set(stamps).size).toBe(1);
-      expect(stamps[0]).toBe(sweep.where.synced_at.lt.getTime());
+      // One stamp for the batch — the same instant the sweep measures against.
+      expect(upsertStampOf().getTime()).toBe(sweep.where.synced_at.lt.getTime());
+    });
+
+    it('never moves a row BACKWARDS onto the sha the tree reported', async () => {
+      // THE regression. `syncedAt` is taken before the tree read so the sweep
+      // keeps a row written while it was in flight — but the write itself used
+      // to be unconditional, so the same ordering that saved that row from the
+      // DELETE handed it to the UPDATE. A save that landed mid-sync had its sha
+      // replaced by the pre-save one, and `/present` served the old deck until
+      // the next webhook. Surviving-and-wrong is worse than not surviving.
+      getTree.mockResolvedValue({
+        sha: 'r',
+        truncated: false,
+        entries: [{ path: 'slides/a/index.html', sha: 'pre-save-sha', type: 'blob', size: 1 }],
+      });
+
+      await syncContentAssets('class-1');
+
+      // The guard is in the statement, not in application code: only Postgres
+      // knows which rows a concurrent writer moved while this batch was built.
+      expect(upsertSql()).toContain('WHERE content_assets.synced_at < EXCLUDED.synced_at');
+      // …and it is on the UPDATE branch of the conflict, so a brand-new path is
+      // still inserted.
+      expect(upsertSql()).toContain('ON CONFLICT (classroom_id, path) DO UPDATE');
+    });
+
+    it('sends no statement at all for an empty tree', async () => {
+      getTree.mockResolvedValue({ sha: 'r', truncated: false, entries: [] });
+
+      await syncContentAssets('class-1');
+
+      expect(executeRaw).not.toHaveBeenCalled();
+      // The stamp and the sweep still run: an emptied repo must still sweep.
+      expect(classroomUpdate).toHaveBeenCalledTimes(1);
+      expect(contentAssetDeleteMany).toHaveBeenCalledTimes(1);
     });
 
     it('does NOT sweep when GitHub truncated the tree', async () => {
@@ -226,7 +281,7 @@ describe('contentAssets.service', () => {
 
       await syncContentAssets('class-1');
 
-      expect(contentAssetUpsert.mock.calls[0][0].create.size).toBe(0);
+      expect(upsertedSizesOf()[0]).toBe(0);
     });
 
     it('stamps the classroom with the run, inside the same transaction', async () => {
@@ -250,8 +305,7 @@ describe('contentAssets.service', () => {
       // measured against it.
       expect(stamp.data.content_assets_synced_commit).toBe(HEAD_COMMIT);
       // The run's one stamp — the same instant every row it wrote carries.
-      const rowStamp = contentAssetUpsert.mock.calls[0][0].create.synced_at;
-      expect(stamp.data.content_assets_synced_at).toEqual(rowStamp);
+      expect(stamp.data.content_assets_synced_at).toEqual(upsertStampOf());
 
       const ops = transaction.mock.calls[0][0] as { op: string }[];
       expect(ops).toContainEqual({ op: 'classroomUpdate', args: stamp });
@@ -360,8 +414,7 @@ describe('contentAssets.service', () => {
 
       // Still incremental: the tree is only the source of SHAs here, so the
       // untouched path must not be rewritten and nothing must be swept.
-      const upsertedPaths = contentAssetUpsert.mock.calls.map(([args]) => args.create.path);
-      expect(upsertedPaths).not.toContain('images/untouched.png');
+      expect(upsertedPathsOf()).not.toContain('images/untouched.png');
       expect(contentAssetDeleteMany.mock.calls[0][0].where.path).toEqual({ in: [] });
     });
 
@@ -814,6 +867,72 @@ describe('contentAssets.service', () => {
       await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
 
       expect(classroomFindUnique).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('removeContentAssets', () => {
+    it('forgets exactly the paths it is given', async () => {
+      // Blobs are content-addressed and immutable, so a row that outlives its
+      // file keeps serving that file's last bytes out of R2 — a deleted page
+      // that still renders.
+      contentAssetDeleteMany.mockResolvedValue({ count: 2 });
+
+      await expect(
+        removeContentAssets('class-1', ['pages/gone/content.json', 'pages/gone/index.html'])
+      ).resolves.toBe(true);
+
+      expect(contentAssetDeleteMany).toHaveBeenCalledWith({
+        where: {
+          classroom_id: 'class-1',
+          path: { in: ['pages/gone/content.json', 'pages/gone/index.html'] },
+        },
+      });
+    });
+
+    it('sends nothing for an empty list', async () => {
+      await expect(removeContentAssets('class-1', [])).resolves.toBe(true);
+      expect(contentAssetDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('never throws — the sweep is the backstop', async () => {
+      contentAssetDeleteMany.mockRejectedValue(new Error('connection terminated'));
+      await expect(removeContentAssets('class-1', ['a.png'])).resolves.toBe(false);
+    });
+  });
+
+  describe('removeContentAssetFolder', () => {
+    it('matches the folder itself and everything under it', async () => {
+      // The folder row matters: theme folders are addressed by their TREE sha,
+      // so leaving one keeps a deleted theme resolvable.
+      contentAssetDeleteMany.mockResolvedValue({ count: 5 });
+
+      await removeContentAssetFolder('class-1', 'slides/lecture-1');
+
+      expect(contentAssetDeleteMany).toHaveBeenCalledWith({
+        where: {
+          classroom_id: 'class-1',
+          OR: [{ path: 'slides/lecture-1' }, { path: { startsWith: 'slides/lecture-1/' } }],
+        },
+      });
+    });
+
+    it('refuses a prefix that would match the whole map', async () => {
+      // The failure mode is not subtle: an empty prefix empties the classroom.
+      for (const folder of ['', '/', '///']) {
+        expect(await removeContentAssetFolder('class-1', folder)).toBe(false);
+      }
+      expect(contentAssetDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('does not let a trailing slash widen the match', async () => {
+      contentAssetDeleteMany.mockResolvedValue({ count: 0 });
+
+      await removeContentAssetFolder('class-1', 'pages/lab-1/');
+
+      expect(contentAssetDeleteMany.mock.calls[0][0].where.OR).toEqual([
+        { path: 'pages/lab-1' },
+        { path: { startsWith: 'pages/lab-1/' } },
+      ]);
     });
   });
 

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -679,6 +679,33 @@ describe('contentAssets.service', () => {
   });
 
   describe('ensureContentAssets', () => {
+    it('collapses a concurrent burst into ONE sync', async () => {
+      // A staff landing page renders ~20 deck thumbnails at once, and each now
+      // reads through the map. The freshness stamp is written at the END of a
+      // sync, so without this guard all twenty read the same stale value and
+      // all start their own — sixty GitHub calls to compute one answer, on
+      // exactly the classroom that was already behind.
+      classroomFindUnique.mockResolvedValue(syncedAgo(10 * 60_000));
+
+      const results = await Promise.all(
+        Array.from({ length: 20 }, () => ensureContentAssets('class-1', { maxAgeMs: 60_000 }))
+      );
+
+      expect(getTree).toHaveBeenCalledTimes(1);
+      // Every caller still gets the answer — they waited on the one sync.
+      for (const result of results) expect(result).toEqual(results[0]);
+    });
+
+    it('does not hold the in-flight entry past the sync', async () => {
+      // A stampede guard, not a cache: the next stale read must sync again.
+      classroomFindUnique.mockResolvedValue(syncedAgo(10 * 60_000));
+
+      await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
+      await ensureContentAssets('class-1', { maxAgeMs: 60_000 });
+
+      expect(getTree).toHaveBeenCalledTimes(2);
+    });
+
     it('no-ops when the last FULL sync is fresher than maxAgeMs', async () => {
       classroomFindUnique.mockResolvedValue(syncedAgo(1000));
 

--- a/packages/services/src/classmoji/__tests__/contentDelivery.canonicalizeSave.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.canonicalizeSave.test.ts
@@ -58,6 +58,7 @@ vi.mock('../../content/ContentService.ts', () => ({
 vi.mock('../contentAssets.service.ts', () => ({
   ensureContentAssets: async () => null,
   recordContentAsset: async () => null,
+  recordContentAssets: async () => null,
   lookupContentAsset: async (_id: string, path: string) => ({
     sha: path === DECK_PATH_REF ? DECK_SHA : BLOB_SHA,
     type: 'blob',

--- a/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
@@ -258,6 +258,33 @@ describe('fetchContentText fallbacks', () => {
   });
 });
 
+describe('fetchContentText workerOnly', () => {
+  it('answers from the map and nothing else', async () => {
+    const calls = stubFetch({ worker: () => new Response('worker-bytes') });
+
+    const result = await fetchContentText(ctx, DECK_PATH, { workerOnly: true });
+
+    expect(result?.source).toBe('worker');
+    expect(calls).toHaveLength(1);
+    expect(getContent).not.toHaveBeenCalled();
+  });
+
+  it('returns null rather than falling back, so the caller can tell why', async () => {
+    // The class site needs "no content.json" and "GitHub is down" to be
+    // different answers — one is an empty page, the other a 503 — and the
+    // ordinary fallback collapses both into null. So the map gets out of the
+    // way and the caller runs its own typed read.
+    lookupContentAsset.mockResolvedValue(null);
+    const calls = stubFetch({});
+
+    const result = await fetchContentText(ctx, DECK_PATH, { workerOnly: true });
+
+    expect(result).toBeNull();
+    expect(getContent).not.toHaveBeenCalled();
+    expect(calls).toEqual([]);
+  });
+});
+
 describe('fetchContentText path handling', () => {
   it('collapses a relative path to the form the map is keyed by', async () => {
     stubFetch({});

--- a/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Reading a repo's TEXT through the delivery layer.
+ *
+ * The bug this was built for: an instructor saved a deck on staging, opened
+ * `/present`, and saw the previous version of their own slides. Images went
+ * through the Worker by blob sha; deck HTML did not — it was read CDN-first
+ * from `{org}.github.io`, which lags a push by minutes.
+ *
+ * So what these guard is freshness by ADDRESS. The map holds the sha the last
+ * save produced, a signed URL names that sha, and a sha-addressed URL cannot
+ * return anything else. The rest is the fallback ladder and its order, which is
+ * inverted from what it replaces (API before CDN) precisely because the case
+ * that reaches it — a map briefly behind a save — is the case where the CDN is
+ * stalest.
+ *
+ * Prisma, the asset map and ContentService are mocked; `fetch` is stubbed. The
+ * signature is real, minted by @classmoji/content-signing and verified here
+ * with the same package the Worker uses.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const ensureContentAssets = vi.fn();
+const lookupContentAsset = vi.fn();
+const getContent = vi.fn();
+
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+vi.mock('../contentAssets.service.ts', () => ({
+  ensureContentAssets: (...args: unknown[]) => ensureContentAssets(...args),
+  lookupContentAsset: (...args: unknown[]) => lookupContentAsset(...args),
+  lookupContentAssetBySha: vi.fn(),
+  lookupContentAssets: vi.fn(),
+  lookupContentTree: vi.fn(),
+}));
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: { getContent: (...args: unknown[]) => getContent(...args) },
+}));
+
+const { fetchContentText } = await import('../contentDelivery.service.ts');
+const { verifyContentUrl } = await import('@classmoji/content-signing');
+
+const ORIGIN = 'https://cdn.classmoji.test';
+const MASTER = 'test-master-secret';
+const CLASSROOM_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+const ORG = 'dartmouth-cs52';
+const REPO = 'content-dartmouth-cs52-cs52-25s';
+const DECK_SHA = 'a'.repeat(40);
+
+const DECK_PATH = 'slides/lecture-1/index.html';
+const CDN_URL = `https://${ORG}.github.io/${REPO}/${DECK_PATH}`;
+
+const ctx = {
+  classroom: {
+    id: CLASSROOM_ID,
+    content_key_version: 7,
+    content_repo: REPO,
+    content_delivery_enabled: true,
+    git_organization: { login: ORG },
+  },
+};
+
+const offCtx = { classroom: { ...ctx.classroom, content_delivery_enabled: false } };
+
+/** Every fetch this module can make, routed by URL. Anything else is a failure. */
+function stubFetch(handlers: { worker?: () => Response; cdn?: () => Response }) {
+  const calls: string[] = [];
+  const stub = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.startsWith(ORIGIN)) {
+      return handlers.worker?.() ?? new Response('worker-bytes');
+    }
+    if (url === CDN_URL) {
+      return handlers.cdn?.() ?? new Response('cdn-bytes');
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', stub);
+  return calls;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  ensureContentAssets.mockResolvedValue(null);
+  lookupContentAsset.mockResolvedValue({ sha: DECK_SHA, type: 'blob', size: 4096 });
+  getContent.mockResolvedValue({ content: 'api-bytes', sha: 'b'.repeat(40) });
+  process.env.CONTENT_DELIVERY_ORIGIN = ORIGIN;
+  process.env.CONTENT_SIGNING_SECRET = MASTER;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.CONTENT_DELIVERY_ORIGIN;
+  delete process.env.CONTENT_SIGNING_SECRET;
+});
+
+describe('fetchContentText through the Worker', () => {
+  it('signs the sha the map holds and returns the bytes behind it', async () => {
+    const calls = stubFetch({ worker: () => new Response('<!doctype html>deck') });
+
+    const result = await fetchContentText(ctx, DECK_PATH, { label: 'present' });
+
+    expect(result).toEqual({ text: '<!doctype html>deck', sha: DECK_SHA, source: 'worker' });
+    expect(calls).toHaveLength(1);
+
+    // The URL is a real signature, checked by the code the Worker runs.
+    const verified = await verifyContentUrl([MASTER], calls[0]);
+    expect(verified).toMatchObject({
+      ok: true,
+      kind: 'blob',
+      classroomId: CLASSROOM_ID,
+      sha: DECK_SHA,
+      ext: 'html',
+      keyVersion: 7,
+    });
+
+    // Neither fallback was consulted.
+    expect(getContent).not.toHaveBeenCalled();
+  });
+
+  it('always mints the enrolled tier, whoever is reading', async () => {
+    // This is a server-to-server fetch: the bytes go to a loader that has
+    // already authorized its viewer, and the URL is never handed to a browser.
+    // The tier here picks an expiry bucket and a Cache-Control, nothing else.
+    const calls = stubFetch({});
+    await fetchContentText(ctx, DECK_PATH);
+
+    expect(new URL(calls[0]).searchParams.get('p')).toBe('enrolled');
+  });
+
+  it('follows the sha, so a save is visible the moment its row lands', async () => {
+    const NEW_SHA = 'c'.repeat(40);
+    stubFetch({ worker: () => new Response('the new deck') });
+    lookupContentAsset.mockResolvedValue({ sha: NEW_SHA, type: 'blob', size: 5000 });
+
+    const result = await fetchContentText(ctx, DECK_PATH);
+
+    // No cache to wait out and no rebuild to wait for: the address changed, so
+    // the answer changed. This is the whole reason text moved off the CDN.
+    expect(result?.sha).toBe(NEW_SHA);
+    expect(result?.source).toBe('worker');
+  });
+
+  it('refreshes a stale asset map before looking a path up', async () => {
+    stubFetch({});
+    await fetchContentText(ctx, DECK_PATH);
+    expect(ensureContentAssets).toHaveBeenCalledWith(CLASSROOM_ID, expect.anything());
+  });
+});
+
+describe('fetchContentText fallbacks', () => {
+  it('reads the API, then the CDN, when the classroom gate is off', async () => {
+    const calls = stubFetch({});
+
+    const result = await fetchContentText(offCtx, DECK_PATH);
+
+    expect(result).toEqual({ text: 'api-bytes', sha: 'b'.repeat(40), source: 'api' });
+    // The map was never touched — the gate is checked before anything else.
+    expect(lookupContentAsset).not.toHaveBeenCalled();
+    expect(calls).toEqual([]);
+  });
+
+  it('falls back when the deployment cannot sign', async () => {
+    delete process.env.CONTENT_SIGNING_SECRET;
+    stubFetch({});
+
+    const result = await fetchContentText(ctx, DECK_PATH);
+
+    expect(result?.source).toBe('api');
+  });
+
+  it('falls back when the map has no row for the path', async () => {
+    lookupContentAsset.mockResolvedValue(null);
+    stubFetch({});
+
+    const result = await fetchContentText(ctx, DECK_PATH);
+
+    expect(result?.source).toBe('api');
+  });
+
+  it('refuses to sign a TREE row as a blob', async () => {
+    // A directory is not a file. Signing its tree sha as a blob would mint a
+    // confidently-wrong URL the Worker cannot serve.
+    lookupContentAsset.mockResolvedValue({ sha: DECK_SHA, type: 'tree', size: 0 });
+    stubFetch({});
+
+    const result = await fetchContentText(ctx, 'slides/lecture-1');
+
+    expect(result?.source).toBe('api');
+  });
+
+  it('prefers the API over the CDN — the inverted order', async () => {
+    // The old read was CDN-first, which is exactly what showed an instructor
+    // their previous slides. The case that reaches this ladder is a map briefly
+    // behind a save, and that is when the CDN is stalest, so the authenticated
+    // read that always sees the current commit goes first.
+    const calls = stubFetch({});
+
+    const result = await fetchContentText(offCtx, DECK_PATH);
+
+    expect(result?.source).toBe('api');
+    expect(calls).not.toContain(CDN_URL);
+  });
+
+  it('reaches the CDN only when the API has nothing', async () => {
+    getContent.mockResolvedValue(null);
+    const calls = stubFetch({});
+
+    const result = await fetchContentText(offCtx, DECK_PATH);
+
+    expect(result).toEqual({ text: 'cdn-bytes', sha: null, source: 'cdn' });
+    expect(calls).toEqual([CDN_URL]);
+  });
+
+  it('falls back rather than failing when the Worker refuses', async () => {
+    const calls = stubFetch({ worker: () => new Response('nope', { status: 403 }) });
+
+    const result = await fetchContentText(ctx, DECK_PATH);
+
+    expect(result?.source).toBe('api');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('falls back rather than failing when the Worker cannot be reached', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).startsWith(ORIGIN)) throw new Error('ECONNRESET');
+        return new Response('cdn-bytes');
+      })
+    );
+
+    const result = await fetchContentText(ctx, DECK_PATH);
+
+    expect(result?.source).toBe('api');
+  });
+
+  it('never throws, whatever the map does', async () => {
+    // It sits on the render path of every deck and page. A database hiccup must
+    // cost a tier, not a 500.
+    lookupContentAsset.mockRejectedValue(new Error('connection terminated'));
+    stubFetch({});
+
+    await expect(fetchContentText(ctx, DECK_PATH)).resolves.toMatchObject({ source: 'api' });
+  });
+
+  it('returns null when nothing can answer', async () => {
+    getContent.mockResolvedValue(null);
+    stubFetch({
+      worker: () => new Response('', { status: 502 }),
+      cdn: () => new Response('', { status: 404 }),
+    });
+
+    await expect(fetchContentText(ctx, DECK_PATH)).resolves.toBeNull();
+  });
+});
+
+describe('fetchContentText path handling', () => {
+  it('collapses a relative path to the form the map is keyed by', async () => {
+    stubFetch({});
+    await fetchContentText(ctx, './slides//lecture-1/index.html');
+    expect(lookupContentAsset).toHaveBeenCalledWith(CLASSROOM_ID, DECK_PATH);
+  });
+
+  it('refuses a path that escapes the repo', async () => {
+    stubFetch({});
+    await expect(fetchContentText(ctx, '../secrets/.env')).resolves.toBeNull();
+    expect(lookupContentAsset).not.toHaveBeenCalled();
+    expect(getContent).not.toHaveBeenCalled();
+  });
+
+  it('reports the source it used, for the staging log', async () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    stubFetch({});
+
+    await fetchContentText(ctx, DECK_PATH, { label: 'present' });
+
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('source=worker'));
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('present'));
+  });
+});

--- a/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../content/ContentService.ts', () => ({
   ContentService: { getContent: (...args: unknown[]) => getContent(...args) },
 }));
 
-const { fetchContentText } = await import('../contentDelivery.service.ts');
+const { fetchContentText, textReadBudget } = await import('../contentDelivery.service.ts');
 const { verifyContentUrl } = await import('@classmoji/content-signing');
 
 const ORIGIN = 'https://cdn.classmoji.test';
@@ -258,11 +258,11 @@ describe('fetchContentText fallbacks', () => {
   });
 });
 
-describe('fetchContentText workerOnly', () => {
+describe("fetchContentText fallback: 'none'", () => {
   it('answers from the map and nothing else', async () => {
     const calls = stubFetch({ worker: () => new Response('worker-bytes') });
 
-    const result = await fetchContentText(ctx, DECK_PATH, { workerOnly: true });
+    const result = await fetchContentText(ctx, DECK_PATH, { fallback: 'none' });
 
     expect(result?.source).toBe('worker');
     expect(calls).toHaveLength(1);
@@ -277,11 +277,84 @@ describe('fetchContentText workerOnly', () => {
     lookupContentAsset.mockResolvedValue(null);
     const calls = stubFetch({});
 
-    const result = await fetchContentText(ctx, DECK_PATH, { workerOnly: true });
+    const result = await fetchContentText(ctx, DECK_PATH, { fallback: 'none' });
 
     expect(result).toBeNull();
     expect(getContent).not.toHaveBeenCalled();
     expect(calls).toEqual([]);
+  });
+});
+
+describe("fetchContentText fallback: 'cdn-only'", () => {
+  it('skips the API leg entirely on a map miss', async () => {
+    // The thumbnail rule. A staff landing page renders ~20 decks at once, and
+    // twenty authenticated reads against the org installation's shared limit in
+    // one page load is the amplification the CDN pinning existed to prevent.
+    // Three minutes stale is invisible on a thumbnail; a rate limit is not.
+    lookupContentAsset.mockResolvedValue(null);
+    const calls = stubFetch({});
+
+    const result = await fetchContentText(ctx, DECK_PATH, { fallback: 'cdn-only' });
+
+    expect(result).toEqual({ text: 'cdn-bytes', sha: null, source: 'cdn' });
+    expect(getContent).not.toHaveBeenCalled();
+    expect(calls).toEqual([CDN_URL]);
+  });
+
+  it('still prefers the map when it has the row', async () => {
+    const calls = stubFetch({ worker: () => new Response('the current deck') });
+
+    const result = await fetchContentText(ctx, DECK_PATH, { fallback: 'cdn-only' });
+
+    expect(result?.source).toBe('worker');
+    expect(calls).not.toContain(CDN_URL);
+  });
+});
+
+describe('fetchContentText transport circuit', () => {
+  it('stops probing the Worker for this render once it is unreachable', async () => {
+    // A page probes content.json then index.html. A dead origin is about the
+    // ORIGIN, not the file, so paying the timeout twice only turns one stalled
+    // render into two.
+    const attempts: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith(ORIGIN)) {
+          attempts.push(url);
+          throw new Error('ETIMEDOUT');
+        }
+        return new Response('cdn-bytes');
+      })
+    );
+
+    const budget = textReadBudget();
+    await fetchContentText(ctx, DECK_PATH, { budget });
+    await fetchContentText(ctx, 'slides/lecture-1/deck.json', { budget });
+
+    expect(attempts).toHaveLength(1);
+    expect(budget.workerUnavailable).toBe(true);
+  });
+
+  it('does NOT trip on a plain map miss', async () => {
+    // This path having no row says nothing about the next path.
+    lookupContentAsset.mockResolvedValue(null);
+    stubFetch({});
+
+    const budget = textReadBudget();
+    await fetchContentText(ctx, DECK_PATH, { budget });
+
+    expect(budget.workerUnavailable).toBe(false);
+  });
+
+  it('does NOT trip on a Worker refusal — that is an answer, not a dead origin', async () => {
+    stubFetch({ worker: () => new Response('nope', { status: 403 }) });
+
+    const budget = textReadBudget();
+    await fetchContentText(ctx, DECK_PATH, { budget });
+
+    expect(budget.workerUnavailable).toBe(false);
   });
 });
 

--- a/packages/services/src/classmoji/__tests__/contentDelivery.textFreshness.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.textFreshness.test.ts
@@ -1,0 +1,209 @@
+/**
+ * The staleness proof: a save, then a read, with a real map between them.
+ *
+ * Every other suite mocks one side of this. This one runs both against an
+ * in-memory asset map, because the bug being closed lived precisely in the
+ * seam: `saveDeck` committed new bytes, the map still held the previous sha,
+ * and `/present` faithfully served what the map pointed at.
+ *
+ * So the assertion is end to end and deliberately literal — save, look at the
+ * row, read, and check the URL the read signed names the sha the save returned.
+ * If the write-through is ever dropped, or the read stops consulting the map,
+ * one of these fails rather than a deck quietly going stale on staging.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const slideUpdateMock = vi.fn();
+vi.mock('@classmoji/database', () => ({
+  default: () => ({ slide: { update: (...args: unknown[]) => slideUpdateMock(...args) } }),
+}));
+
+const getContentMock = vi.fn();
+const getMetaMock = vi.fn();
+const uploadBatchMock = vi.fn();
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    getContent: (...args: unknown[]) => getContentMock(...args),
+    getMeta: (...args: unknown[]) => getMetaMock(...args),
+    uploadBatch: (...args: unknown[]) => uploadBatchMock(...args),
+    put: vi.fn(),
+  },
+}));
+
+/**
+ * The asset map, in memory.
+ *
+ * Not a spy: the point of this suite is that what the save WRITES is what the
+ * read LOOKS UP, and a pair of independent mocks could agree on nothing and
+ * still both be "called correctly".
+ */
+const rows = new Map<string, { sha: string; type: string; size: number }>();
+const key = (classroomId: string, path: string) => `${classroomId}:${path}`;
+
+vi.mock('../contentAssets.service.ts', () => ({
+  ensureContentAssets: async () => null,
+  recordContentAsset: async (
+    classroomId: string,
+    entry: { path: string; sha: string; size?: number }
+  ) => {
+    rows.set(key(classroomId, entry.path), {
+      sha: entry.sha,
+      type: 'blob',
+      size: entry.size ?? 0,
+    });
+    return true;
+  },
+  recordContentAssets: async (
+    classroomId: string,
+    entries: Array<{ path: string; sha: string; size?: number }>
+  ) => {
+    for (const entry of entries) {
+      rows.set(key(classroomId, entry.path), {
+        sha: entry.sha,
+        type: 'blob',
+        size: entry.size ?? 0,
+      });
+    }
+    return true;
+  },
+  lookupContentAsset: async (classroomId: string, path: string) =>
+    rows.get(key(classroomId, path)) ?? null,
+  lookupContentAssets: async (classroomId: string, paths: string[]) =>
+    new Map(
+      paths
+        .map(path => [path, rows.get(key(classroomId, path))] as const)
+        .filter((entry): entry is readonly [string, { sha: string; type: string; size: number }] =>
+          Boolean(entry[1])
+        )
+    ),
+  lookupContentAssetBySha: async () => null,
+  lookupContentTree: async () => null,
+  resolveContentBranch: async () => 'main',
+}));
+
+const { fetchContentText } = await import('../contentDelivery.service.ts');
+const { saveDeck } = await import('../../slides/slideContent.service.ts');
+
+const ORIGIN = 'https://cdn.classmoji.test';
+const MASTER = 'test-master-secret';
+const CLASSROOM_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+const CONTENT_PATH = 'slides/lecture-1';
+const DECK_PATH = `${CONTENT_PATH}/deck.json`;
+const HTML_PATH = `${CONTENT_PATH}/index.html`;
+
+/** Real 40-hex shas — the signer refuses anything else. */
+const OLD_HTML_SHA = 'a'.repeat(40);
+const NEW_HTML_SHA = 'd'.repeat(40);
+const NEW_DECK_SHA = 'e'.repeat(40);
+
+const slide = {
+  id: 'slide-1',
+  title: 'Lecture 1',
+  content_path: CONTENT_PATH,
+  classroom: {
+    id: CLASSROOM_ID,
+    content_repo: 'content-test-org-cs101',
+    content_key_version: 3,
+    content_delivery_enabled: true,
+    git_organization: { provider: 'GITHUB', login: 'test-org' },
+  },
+};
+
+const readCtx = {
+  classroom: {
+    id: CLASSROOM_ID,
+    content_key_version: 3,
+    content_repo: 'content-test-org-cs101',
+    content_delivery_enabled: true,
+    git_organization: { login: 'test-org' },
+  },
+};
+
+const deck = {
+  version: 1 as const,
+  theme: 'white',
+  slides: [{ id: 's1', html: '<h1>Take two</h1>' }],
+};
+
+/** What the Worker would answer, keyed by the sha in the URL it is asked for. */
+function stubWorker(bodyBySha: Record<string, string>) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      const sha = new URL(url).pathname.split('/').pop()?.split('.')[0] ?? '';
+      const body = bodyBySha[sha];
+      if (body === undefined) return new Response('not found', { status: 404 });
+      return new Response(body);
+    })
+  );
+  return calls;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rows.clear();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  uploadBatchMock.mockImplementation(async ({ files }: { files: Array<{ path: string }> }) => ({
+    commit: 'commit-1',
+    filesUploaded: files.length,
+    files: files.map(file => ({
+      path: file.path,
+      sha: file.path === DECK_PATH ? NEW_DECK_SHA : NEW_HTML_SHA,
+    })),
+  }));
+  process.env.CONTENT_DELIVERY_ORIGIN = ORIGIN;
+  process.env.CONTENT_SIGNING_SECRET = MASTER;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.CONTENT_DELIVERY_ORIGIN;
+  delete process.env.CONTENT_SIGNING_SECRET;
+});
+
+describe('a deck save is visible to the next read', () => {
+  it('moves the map to the shas the commit returned, and the read follows', async () => {
+    // The map starts on the PREVIOUS deck — the state that produced the bug.
+    rows.set(key(CLASSROOM_ID, HTML_PATH), { sha: OLD_HTML_SHA, type: 'blob', size: 100 });
+    const calls = stubWorker({ [OLD_HTML_SHA]: 'the old deck', [NEW_HTML_SHA]: 'the new deck' });
+
+    const saved = await saveDeck({ slide, deck, message: 'Save deck' });
+
+    // Both files the commit carried, at the shas it reported.
+    expect(rows.get(key(CLASSROOM_ID, HTML_PATH))?.sha).toBe(NEW_HTML_SHA);
+    expect(rows.get(key(CLASSROOM_ID, DECK_PATH))?.sha).toBe(NEW_DECK_SHA);
+    expect(saved.sha).toBe(NEW_DECK_SHA);
+
+    // …and the read that /present makes now signs the new one. No cache to wait
+    // out, no Pages build to wait for — the address moved, so the answer did.
+    const read = await fetchContentText(readCtx, HTML_PATH, { label: 'present' });
+
+    expect(read).toEqual({ text: 'the new deck', sha: NEW_HTML_SHA, source: 'worker' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain(`/blob/${NEW_HTML_SHA}.html`);
+    // Nothing fell through to GitHub: a save costs one API round trip, a view
+    // costs none.
+    expect(getContentMock).not.toHaveBeenCalled();
+  });
+
+  it('records nothing for a preview-branch save', async () => {
+    // Preview branches carry deck.json only and are not in the map. A row here
+    // would publish an unaccepted draft to every reader of the live deck.
+    getMetaMock.mockResolvedValue({ sha: NEW_DECK_SHA });
+
+    await saveDeck({
+      slide,
+      deck,
+      message: 'Save preview',
+      branch: `preview/${CONTENT_PATH}`,
+    });
+
+    expect(rows.size).toBe(0);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/contentDelivery.textFreshness.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.textFreshness.test.ts
@@ -123,6 +123,7 @@ const readCtx = {
 const deck = {
   version: 1 as const,
   theme: 'white',
+  codeTheme: 'github-dark',
   slides: [{ id: 's1', html: '<h1>Take two</h1>' }],
 };
 

--- a/packages/services/src/classmoji/__tests__/contentImport.slugConflict.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.slugConflict.test.ts
@@ -55,6 +55,12 @@ vi.mock('../../git/index.ts', () => ({
 }));
 
 vi.mock('../contentManifest.service.ts', () => ({ saveManifest: vi.fn() }));
+// The import records what it wrote into the asset map; stubbed so this suite
+// stays about slug allocation and nothing reaches Prisma.
+vi.mock('../contentAssets.service.ts', () => ({
+  lookupContentAssetsBySha: async () => new Map(),
+  recordContentAssets: async () => true,
+}));
 vi.mock('../notification.service.ts', () => ({
   runSafely: vi.fn(),
   getStudentsInClassroom: vi.fn(),
@@ -128,7 +134,13 @@ beforeEach(() => {
       write(title.toLowerCase().replace(/ /g, '-'))
   );
   pageCreate.mockImplementation(async () => ({ id: 'new-page' }));
-  uploadBatch.mockResolvedValue(undefined);
+  // `files` is part of uploadBatch's real return shape — each written file's
+  // blob sha, which the import records into the asset map on the way out.
+  uploadBatch.mockImplementation(async ({ files }: { files: Array<{ path: string }> }) => ({
+    commit: 'c1',
+    filesUploaded: files.length,
+    files: files.map((file, index) => ({ path: file.path, sha: `sha-${index}` })),
+  }));
   ensureContentRepo.mockResolvedValue(undefined);
 });
 

--- a/packages/services/src/classmoji/__tests__/page.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/page.service.test.ts
@@ -60,8 +60,10 @@ vi.mock('../contentManifest.service.ts', () => ({
 // it (fetchContentText), so a create that does not record its shas is a page
 // that renders empty until the push webhook lands.
 const recordContentAssetsMock = vi.fn();
+const removeContentAssetFolderMock = vi.fn();
 vi.mock('../contentAssets.service.ts', () => ({
   recordContentAssets: (...args: unknown[]) => recordContentAssetsMock(...args),
+  removeContentAssetFolder: (...args: unknown[]) => removeContentAssetFolderMock(...args),
 }));
 
 vi.mock('../notification.service.ts', () => ({
@@ -433,6 +435,11 @@ describe('page.deletePage', () => {
     );
     expect(pageDeleteMock).toHaveBeenCalledWith({ where: { id: 'page-1' } });
     expect(saveManifestMock).toHaveBeenCalledWith('class-1');
+    // …and the map rows. Blobs are content-addressed and immutable, so a row
+    // that outlives the folder keeps serving the deleted page's last
+    // content.json out of R2 — a deleted page that still renders, until the
+    // next full sync sweeps it.
+    expect(removeContentAssetFolderMock).toHaveBeenCalledWith('class-1', 'pages/doomed');
     expect(result.success).toBe(true);
   });
 

--- a/packages/services/src/classmoji/__tests__/page.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/page.service.test.ts
@@ -56,6 +56,14 @@ vi.mock('../contentManifest.service.ts', () => ({
   saveManifest: (...args: unknown[]) => saveManifestMock(...args),
 }));
 
+// The asset map. A created page's index.html and content.json are READ through
+// it (fetchContentText), so a create that does not record its shas is a page
+// that renders empty until the push webhook lands.
+const recordContentAssetsMock = vi.fn();
+vi.mock('../contentAssets.service.ts', () => ({
+  recordContentAssets: (...args: unknown[]) => recordContentAssetsMock(...args),
+}));
+
 vi.mock('../notification.service.ts', () => ({
   runSafely: vi.fn(),
   getStudentsInClassroom: vi.fn(),
@@ -96,7 +104,14 @@ describe('page.createPage', () => {
     pageFindFirstMock.mockResolvedValue(null); // no content-path collision
     repositoryExistsMock.mockResolvedValue(true);
     putMock.mockResolvedValue({ sha: 'abc', commit: 'c1' });
-    uploadBatchMock.mockResolvedValue({ commit: 'c2', filesUploaded: 2 });
+    // `files` is part of uploadBatch's real return shape — each file's blob
+    // sha, which is exactly what the write-through records.
+    uploadBatchMock.mockImplementation(async ({ files }: { files: Array<{ path: string }> }) => ({
+      commit: 'c2',
+      filesUploaded: files.length,
+      files: files.map((file, index) => ({ path: file.path, sha: `sha-${index}` })),
+    }));
+    recordContentAssetsMock.mockResolvedValue(true);
     pageCreateMock.mockImplementation((args: { data: Record<string, unknown> }) => ({
       id: 'page-1',
       ...args.data,
@@ -349,6 +364,31 @@ describe('page.createPage', () => {
     );
     expect(((failure as Error).cause as { code?: string })?.code).toBe('P2002');
     expect(saveManifestMock).not.toHaveBeenCalled();
+  });
+
+  it('records both created files in the asset map', async () => {
+    // index.html and content.json are READ through the map (fetchContentText),
+    // so a create that skips this is a brand-new page that renders empty until
+    // the push webhook lands — on the one surface where the author is watching.
+    await createPage({ classroomId: 'class-1', title: 'My New Page', createdBy: 'user-1' });
+
+    expect(recordContentAssetsMock).toHaveBeenCalledWith('class-1', [
+      { path: 'pages/my-new-page/index.html', sha: 'sha-0' },
+      { path: 'pages/my-new-page/content.json', sha: 'sha-1' },
+    ]);
+  });
+
+  it('records the single-file create too', async () => {
+    await createPage({
+      classroomId: 'class-1',
+      title: 'Imported',
+      createdBy: 'user-1',
+      html: '<h1>Imported</h1>',
+    });
+
+    expect(recordContentAssetsMock).toHaveBeenCalledWith('class-1', [
+      { path: 'pages/imported/index.html', sha: 'abc' },
+    ]);
   });
 });
 

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -44,6 +44,10 @@ vi.mock('../contentAssets.service.ts', () => ({
 const fetchContentTextMock = vi.fn();
 vi.mock('../contentDelivery.service.ts', () => ({
   fetchContentText: (...args: unknown[]) => fetchContentTextMock(...args),
+  // Real, not a stub: the two probes sharing ONE budget object is the thing
+  // being asserted, and a mock that handed out a fresh object each call would
+  // make that assertion vacuous.
+  textReadBudget: () => ({ workerUnavailable: false }),
   canonicalizeMany: async (_ctx: unknown, refs: string[]) => new Map(refs.map(r => [r, r])),
 }));
 
@@ -329,17 +333,24 @@ describe('pageContent.loadPageContent viaWorker', () => {
 
   it('asks the map only, so a miss does not read GitHub twice', async () => {
     // `fetchContentText` has its own API-then-CDN ladder, and the caller's own
-    // GitHub read is sitting right behind this one — without workerOnly every
-    // map miss would pay two contents-API reads and a CDN fetch for one page.
+    // GitHub read is sitting right behind this one — without fallback:'none'
+    // every map miss would pay two contents-API reads and a CDN fetch for one
+    // page. Both probes also share one circuit breaker, so an unreachable
+    // Worker costs one timeout for the render rather than one per file.
     getContentMock.mockResolvedValue(null);
 
     await loadPageContent(keyedPage, { viaWorker: true });
 
     for (const call of fetchContentTextMock.mock.calls) {
-      expect(call[2]).toMatchObject({ workerOnly: true });
+      expect(call[2]).toMatchObject({ fallback: 'none' });
     }
     // content.json + index.html, from the caller's read — not four.
     expect(getContentMock).toHaveBeenCalledTimes(2);
+    // One budget object, shared by both probes.
+    const budgets = fetchContentTextMock.mock.calls.map(
+      call => (call[2] as { budget: unknown }).budget
+    );
+    expect(budgets[0]).toBe(budgets[1]);
   });
 
   it('is ignored for a preview-branch read', async () => {

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -256,6 +256,50 @@ describe('pageContent.savePageContent', () => {
   });
 });
 
+// ─── savePageContent write-through ───────────────────────────────────────────
+
+describe('pageContent.savePageContent write-through', () => {
+  const blocks = [{ id: 'b1', type: 'paragraph', content: [] }];
+  // The fixture above deliberately has no classroom id (several callers have
+  // none); this one does, because the map row is keyed on it.
+  const keyedPage = { ...page, classroom: { ...page.classroom, id: 'class-1' } };
+
+  beforeEach(() => {
+    recordContentAssetMock.mockResolvedValue(true);
+  });
+
+  it('records content.json at the sha the commit returned', async () => {
+    // This is what makes a save VISIBLE. content.json is read through the map
+    // now, so a row one save behind is the previous version of the page on a
+    // student's screen — not merely a stale cache.
+    await savePageContent(keyedPage, blocks, { coverImage: null });
+
+    expect(recordContentAssetMock).toHaveBeenCalledWith('class-1', {
+      path: 'pages/syllabus/content.json',
+      sha: 'new-sha',
+    });
+  });
+
+  it('records nothing for a preview-branch save', async () => {
+    // A preview branch is not in the map. Recording its sha would publish an
+    // unaccepted draft to every reader.
+    getContentMock.mockResolvedValueOnce(null);
+
+    await savePageContent(keyedPage, blocks, { branch: 'preview/pages/syllabus' });
+
+    expect(recordContentAssetMock).not.toHaveBeenCalled();
+  });
+
+  it('still returns the save when the map write cannot be keyed', async () => {
+    // A page assembled without its classroom id has nothing to key a row on.
+    // The commit stands; the next sync picks it up.
+    const result = await savePageContent(page, blocks, { coverImage: null });
+
+    expect(result).toEqual({ sha: 'new-sha', commit: 'commit-1' });
+    expect(recordContentAssetMock).not.toHaveBeenCalled();
+  });
+});
+
 // ─── uploadPageAsset ─────────────────────────────────────────────────────────
 
 describe('pageContent.uploadPageAsset', () => {

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -375,7 +375,25 @@ describe('pageContent.savePageContent write-through', () => {
     expect(recordContentAssetMock).toHaveBeenCalledWith('class-1', {
       path: 'pages/syllabus/content.json',
       sha: 'new-sha',
+      // The real byte length of what was committed — a writer that has the
+      // bytes must not hand the map a size it made up, because `size ?? 0`
+      // would overwrite one an earlier sync actually measured.
+      size: Buffer.byteLength(callArg(putMock).content as string),
     });
+  });
+
+  it('still records a save aimed explicitly at the default branch', async () => {
+    // The guard tests the `preview/` prefix rather than the absence of a
+    // branch: a caller naming main would otherwise write it and silently lose
+    // the map row, which is the stale read this whole path exists to close.
+    getContentMock.mockResolvedValueOnce(null);
+
+    await savePageContent(keyedPage, blocks, { branch: 'main' });
+
+    expect(recordContentAssetMock).toHaveBeenCalledWith(
+      'class-1',
+      expect.objectContaining({ path: 'pages/syllabus/content.json', sha: 'new-sha' })
+    );
   });
 
   it('records nothing for a preview-branch save', async () => {

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -327,6 +327,21 @@ describe('pageContent.loadPageContent viaWorker', () => {
     expect(result.sha).toBe('github-sha');
   });
 
+  it('asks the map only, so a miss does not read GitHub twice', async () => {
+    // `fetchContentText` has its own API-then-CDN ladder, and the caller's own
+    // GitHub read is sitting right behind this one — without workerOnly every
+    // map miss would pay two contents-API reads and a CDN fetch for one page.
+    getContentMock.mockResolvedValue(null);
+
+    await loadPageContent(keyedPage, { viaWorker: true });
+
+    for (const call of fetchContentTextMock.mock.calls) {
+      expect(call[2]).toMatchObject({ workerOnly: true });
+    }
+    // content.json + index.html, from the caller's read — not four.
+    expect(getContentMock).toHaveBeenCalledTimes(2);
+  });
+
   it('is ignored for a preview-branch read', async () => {
     // Preview branches have no map rows at all; signing against one would serve
     // main's bytes under a preview URL.

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -37,6 +37,16 @@ vi.mock('../contentAssets.service.ts', () => ({
   resolveContentBranch: (...args: unknown[]) => resolveContentBranchMock(...args),
 }));
 
+// The map-first read (`viaWorker`). Mocked at the module seam so this suite
+// stays about page-content shapes; contentDelivery.text.test.ts owns the read
+// itself. `canonicalizeMany` is passed through unchanged — the save path calls
+// it and this suite is not testing canonicalization.
+const fetchContentTextMock = vi.fn();
+vi.mock('../contentDelivery.service.ts', () => ({
+  fetchContentText: (...args: unknown[]) => fetchContentTextMock(...args),
+  canonicalizeMany: async (_ctx: unknown, refs: string[]) => new Map(refs.map(r => [r, r])),
+}));
+
 const {
   loadPageContent,
   savePageContent,
@@ -253,6 +263,79 @@ describe('pageContent.savePageContent', () => {
     expect(arg.content).toBe(
       JSON.stringify({ blocks }, null, 2) // 2-space pretty wrapper, null cover omitted
     );
+  });
+});
+
+// ─── loadPageContent via the delivery layer ──────────────────────────────────
+
+describe('pageContent.loadPageContent viaWorker', () => {
+  // The map-first read only has a context to work with when the page carries
+  // its classroom id and repo — the resolver's own requirement.
+  const keyedPage = {
+    ...page,
+    classroom: { ...page.classroom, id: '3f2504e0-4f89-41d3-9a0c-0305e82c3301' },
+  };
+
+  beforeEach(() => {
+    fetchContentTextMock.mockResolvedValue(null);
+  });
+
+  it('reads content.json through the map, and never touches GitHub on a hit', async () => {
+    // The whole point: a page view costs no GitHub call, and the sha the map
+    // signed is the sha the reader gets.
+    fetchContentTextMock.mockResolvedValueOnce({
+      text: JSON.stringify({ blocks: [{ id: 'b1' }], coverImage: cover }),
+      sha: 'map-sha',
+      source: 'worker',
+    });
+
+    const result = await loadPageContent(keyedPage, { viaWorker: true });
+
+    expect(result).toEqual({
+      format: 'json',
+      blocks: [{ id: 'b1' }],
+      coverImage: cover,
+      sha: 'map-sha',
+    });
+    expect(getContentMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to index.html for a legacy page', async () => {
+    fetchContentTextMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ text: '<h1>Legacy</h1>', sha: 'html-sha', source: 'worker' });
+
+    const result = await loadPageContent(keyedPage, { viaWorker: true });
+
+    expect(result).toEqual({
+      format: 'html',
+      blocks: '<h1>Legacy</h1>',
+      coverImage: null,
+      sha: 'html-sha',
+    });
+  });
+
+  it('falls back to the GitHub read when the map has nothing', async () => {
+    // The layer is an accelerator, never the reason a page fails to load.
+    getContentMock.mockResolvedValueOnce({
+      content: JSON.stringify({ blocks: [], coverImage: null }),
+      sha: 'github-sha',
+    });
+
+    const result = await loadPageContent(keyedPage, { viaWorker: true });
+
+    expect(result.sha).toBe('github-sha');
+  });
+
+  it('is ignored for a preview-branch read', async () => {
+    // Preview branches have no map rows at all; signing against one would serve
+    // main's bytes under a preview URL.
+    getContentMock.mockResolvedValueOnce({ content: '{"blocks":[]}', sha: 'branch-sha' });
+
+    await loadPageContent(keyedPage, { viaWorker: true, ref: 'preview/pages/syllabus' });
+
+    expect(fetchContentTextMock).not.toHaveBeenCalled();
+    expect(callArg(getContentMock).ref).toBe('preview/pages/syllabus');
   });
 });
 

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -627,6 +627,52 @@ export async function ensureContentAssets(
 }
 
 /**
+ * Record several just-written blobs in the map in one pass.
+ *
+ * The batch form of `recordContentAsset`, and the one every TEXT save uses: a
+ * deck save commits `deck.json` and `index.html` together, so recording them
+ * one at a time would load the classroom twice to answer the same question.
+ *
+ * Same contract as the single form in every other respect — never throws, and
+ * a classroom the delivery layer does not serve is a quiet `false`. Partial
+ * success is reported as failure: the caller's only use for the answer is a
+ * log line, and "some rows landed" is not a state worth a second return shape.
+ */
+export async function recordContentAssets(
+  classroomId: string,
+  entries: Array<{ path: string; sha: string; size?: number }>
+): Promise<boolean> {
+  if (entries.length === 0) return true;
+
+  try {
+    const classroom = await loadClassroomRaw(classroomId);
+    if (!isDeliverable(classroom)) return false;
+
+    // One stamp for the batch. These files were committed together, and a sync
+    // sweep compares against this value — giving them separate `now`s would be
+    // a distinction the repo does not make.
+    const syncedAt = new Date();
+    await Promise.all(
+      entries.map(entry =>
+        upsertOp(
+          classroomId,
+          { path: entry.path, sha: entry.sha, type: 'blob', size: entry.size },
+          syncedAt
+        )
+      )
+    );
+    return true;
+  } catch (error: unknown) {
+    console.warn(
+      `[contentAssets] Could not record ${entries.length} path(s) for ${classroomId}; ` +
+        'the next sync will pick them up:',
+      error
+    );
+    return false;
+  }
+}
+
+/**
  * Record ONE just-uploaded blob in the map, now, without waiting for a sync.
  *
  * The map is otherwise filled by a push webhook or by `ensureContentAssets`'
@@ -635,6 +681,12 @@ export async function ensureContentAssets(
  * up, misses, and the resolver emits its "dangling" URL. The upload already
  * knows everything a row needs — path, blob sha, size — so writing it here
  * removes the round trip entirely.
+ *
+ * The same reasoning applies to the TEXT a save writes — `content.json`,
+ * `deck.json`, the generated `index.html` — for a sharper reason: those are
+ * read THROUGH the map now (see `fetchContentText`), so a missing row is not a
+ * dangling image, it is `/present` showing the previous version of the deck
+ * that was just saved. Multi-file saves use `recordContentAssets` above.
  *
  * A later full sync overwrites this row with identical values and its sweep
  * keeps it (the stamp is `now`), so this is only an early write of what the

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -231,6 +231,30 @@ function upsertOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
 }
 
 /**
+ * `upsertOp` for a writer that may not know the file's SIZE.
+ *
+ * A tree read always carries one, so `upsertOp` above writes it
+ * unconditionally. A write-through often cannot: an accept learns its sha by
+ * reading a file's metadata rather than its bytes, and `size ?? 0` would then
+ * ZERO a real size an earlier sync had measured. On an update the column is
+ * left alone; a new row starts at 0 and the next full sync fills it in.
+ */
+function upsertKnownOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
+  const changed = {
+    sha: entry.sha,
+    type: entry.type,
+    synced_at: syncedAt,
+    ...(entry.size === undefined ? {} : { size: entry.size }),
+  };
+
+  return getPrisma().contentAsset.upsert({
+    where: { classroom_id_path: { classroom_id: classroomId, path: entry.path } },
+    create: { classroom_id: classroomId, path: entry.path, size: 0, ...changed },
+    update: changed,
+  });
+}
+
+/**
  * Rebuild the whole map from the repo's tree.
  *
  * Stamp-and-sweep: every row written this run carries the same `syncedAt`, and
@@ -583,6 +607,37 @@ export async function ensureContentAssets(
   classroomId: string,
   { maxAgeMs }: { maxAgeMs: number }
 ): Promise<SyncContentAssetsResult | null> {
+  // One refresh per classroom at a time, per process.
+  //
+  // The stamp that makes this cheap is written at the END of a sync, so N
+  // concurrent callers all read the same stale value and all start their own —
+  // and a staff landing page renders ~20 deck thumbnails at once, each of which
+  // now reads through the map. Twenty full syncs is sixty GitHub calls to
+  // compute one answer, on exactly the classroom that was already behind.
+  //
+  // Sharing the in-flight promise costs nothing when the map is fresh (the
+  // fast path below returns before this ever holds anything for long) and turns
+  // that burst into one sync the other nineteen wait on.
+  const inFlight = ensuring.get(classroomId);
+  if (inFlight) return inFlight;
+
+  const run = ensureOnce(classroomId, maxAgeMs).finally(() => ensuring.delete(classroomId));
+  ensuring.set(classroomId, run);
+  return run;
+}
+
+/**
+ * In-flight refreshes, keyed by classroom. Per-process and deliberately so:
+ * this is a stampede guard, not a lock. Two Fly instances syncing the same
+ * classroom at once is harmless — `fullSync` is one transaction and idempotent —
+ * and a real lock would need a table nobody wants to operate.
+ */
+const ensuring = new Map<string, Promise<SyncContentAssetsResult | null>>();
+
+async function ensureOnce(
+  classroomId: string,
+  maxAgeMs: number
+): Promise<SyncContentAssetsResult | null> {
   // THIS FUNCTION DOES NOT THROW. It is the one entry point meant to sit on a
   // render path, so every way it can fail has to degrade to "the page renders
   // through the legacy path" — which is exactly what it did before any of this
@@ -654,7 +709,7 @@ export async function recordContentAssets(
     const syncedAt = new Date();
     await Promise.all(
       entries.map(entry =>
-        upsertOp(
+        upsertKnownOp(
           classroomId,
           { path: entry.path, sha: entry.sha, type: 'blob', size: entry.size },
           syncedAt
@@ -708,7 +763,7 @@ export async function recordContentAsset(
     const classroom = await loadClassroomRaw(classroomId);
     if (!isDeliverable(classroom)) return false;
 
-    await upsertOp(
+    await upsertKnownOp(
       classroomId,
       { path: entry.path, sha: entry.sha, type: 'blob', size: entry.size },
       new Date()

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -72,6 +72,12 @@ export interface SyncContentAssetsOptions {
 
 export interface SyncContentAssetsResult {
   mode: 'full' | 'incremental';
+  /**
+   * Entries this run APPLIED, which is not always the number of rows it
+   * changed: the upsert skips any row a newer write-through already holds (see
+   * `upsertManyOp`). The difference is a save that landed mid-sync, so it is
+   * the count being right rather than the write being wrong.
+   */
   upserted: number;
   deleted: number;
   truncated: boolean;
@@ -215,19 +221,65 @@ async function readRepoTree(
   return { entries: tree.entries, truncated: tree.truncated, commit };
 }
 
-function upsertOp(classroomId: string, entry: TreeEntry, syncedAt: Date) {
-  const row = {
-    sha: entry.sha,
-    type: entry.type,
-    size: entry.size ?? 0,
-    synced_at: syncedAt,
-  };
+/**
+ * A whole tree's worth of rows, in ONE statement, that never moves a row
+ * BACKWARDS.
+ *
+ * Two problems, one fix.
+ *
+ * ── The correctness one ────────────────────────────────────────────────────
+ * `fullSync` takes its `syncedAt` BEFORE reading the tree, which is what makes
+ * the sweep safe (see the header). But the write it fed was unconditional, so
+ * the same ordering that protected a fresh row from the DELETE handed it
+ * straight to the UPDATE: a save whose write-through landed while the tree read
+ * was in flight got its sha replaced by the pre-save one the tree had reported.
+ * The row survived and was wrong, which is worse than not surviving — the
+ * renderer signs a URL for the previous deck and `/present` serves it until the
+ * next webhook or the 24-hour refresh.
+ *
+ * `WHERE content_assets.synced_at < EXCLUDED.synced_at` is the whole fix. A row
+ * stamped at or after this run keeps everything it has; every other row is
+ * brought level with the tree.
+ *
+ * Deliberately NOT a Prisma upsert with an extra `where`: Prisma has no
+ * conditional-update upsert, and the shapes that look like one degrade to
+ * read-then-create, which inside `$transaction` surfaces as a P2002 on the
+ * primary key rather than as a skip.
+ *
+ * ── The size one ───────────────────────────────────────────────────────────
+ * A repo of a few thousand files became a few thousand statements in a single
+ * transaction — the plan's "chunk the upserts" follow-up. One `INSERT … SELECT
+ * FROM UNNEST` is not a chunked version of that, it is the whole batch as a
+ * single round trip, so the follow-up is closed rather than deferred.
+ *
+ * `synced_at` and `classroom_id` are scalars rather than parallel arrays on
+ * purpose: they are the same for every row, and an array of `Date` would put
+ * timestamp serialization between the driver and a `TIMESTAMP(3)` column for no
+ * gain. Their types come from the INSERT target columns, so neither is cast;
+ * the four arrays are cast because `UNNEST` has nothing else to infer from.
+ *
+ * Returns null for an empty batch — `UNNEST` of empty arrays is a valid no-op,
+ * but there is no reason to send it.
+ */
+function upsertManyOp(classroomId: string, entries: TreeEntry[], syncedAt: Date) {
+  if (entries.length === 0) return null;
 
-  return getPrisma().contentAsset.upsert({
-    where: { classroom_id_path: { classroom_id: classroomId, path: entry.path } },
-    create: { classroom_id: classroomId, path: entry.path, ...row },
-    update: row,
-  });
+  return getPrisma().$executeRaw`
+    INSERT INTO content_assets (classroom_id, path, sha, type, size, synced_at)
+    SELECT ${classroomId}, entry.path, entry.sha, entry.type, entry.size, ${syncedAt}
+    FROM UNNEST(
+      ${entries.map(entry => entry.path)}::text[],
+      ${entries.map(entry => entry.sha)}::text[],
+      ${entries.map(entry => entry.type)}::text[],
+      ${entries.map(entry => entry.size ?? 0)}::int[]
+    ) AS entry(path, sha, type, size)
+    ON CONFLICT (classroom_id, path) DO UPDATE
+      SET sha = EXCLUDED.sha,
+          type = EXCLUDED.type,
+          size = EXCLUDED.size,
+          synced_at = EXCLUDED.synced_at
+      WHERE content_assets.synced_at < EXCLUDED.synced_at
+  `;
 }
 
 /**
@@ -313,7 +365,10 @@ async function fullSync(classroom: ResolvedClassroom): Promise<SyncContentAssets
     data: { content_assets_synced_at: syncedAt, content_assets_synced_commit: commit },
   });
 
-  const operations = entries.map(entry => upsertOp(classroom.id, entry, syncedAt));
+  // One statement for the whole tree, and one that refuses to move a row
+  // backwards — see `upsertManyOp`.
+  const upsert = upsertManyOp(classroom.id, entries, syncedAt);
+  const operations = upsert ? [upsert] : [];
 
   let deleted = 0;
 
@@ -404,7 +459,8 @@ async function incrementalSync(
   const toDelete = truncated ? unique(removed) : unique([...removed, ...vanished]);
 
   const syncedAt = new Date();
-  const operations = entries.map(entry => upsertOp(classroom.id, entry, syncedAt));
+  const upsert = upsertManyOp(classroom.id, entries, syncedAt);
+  const operations = upsert ? [upsert] : [];
 
   // The commit this diff lands the map on — and ONLY the commit. The freshness
   // timestamp deliberately stays untouched (see `ensureContentAssets`): this run
@@ -649,7 +705,18 @@ async function ensureOnce(
   //   CONFIGURATION — GitLab-backed, the mock org behind an example classroom,
   //   or simply no content repo. Known before any API call, so it is checked
   //   rather than caught.
-  const classroom = await loadClassroomRaw(classroomId);
+  //
+  //   The DB read itself is inside the try, though, which it did not used to
+  //   be: the doc above promises this never throws, and a Postgres blip on the
+  //   render path would have broken that promise in the one place a caller is
+  //   least equipped to handle it.
+  let classroom: ClassroomRecord;
+  try {
+    classroom = await loadClassroomRaw(classroomId);
+  } catch (error: unknown) {
+    console.warn(`[contentAssets] Could not load classroom ${classroomId}; serving stale:`, error);
+    return null;
+  }
   if (!isDeliverable(classroom)) {
     return null;
   }
@@ -678,6 +745,86 @@ async function ensureOnce(
   } catch (error: unknown) {
     console.warn(`[contentAssets] sync failed for ${classroomId}; serving stale/legacy:`, error);
     return null;
+  }
+}
+
+/**
+ * Forget paths the repo no longer has, now, without waiting for a sweep.
+ *
+ * The mirror image of `recordContentAssets`, and it exists for the same reason:
+ * the map is read on the render path, so a row that outlives its file is not a
+ * stale cache entry, it is WRONG CONTENT. A deleted page whose row survives
+ * keeps serving its last bytes from R2 — the blob is content-addressed and
+ * immutable, so it is still perfectly servable — and a renamed snippet serves
+ * its pre-rename bytes under the old name until the next full sync.
+ *
+ * `paths` is explicit. A folder delete has `removeContentAssetFolder` below,
+ * which is the only prefix match on offer and is guarded — "delete everything
+ * under this folder" is one empty string away from emptying a classroom's map.
+ *
+ * NEVER THROWS, like its counterpart — a delete that reached the repo must not
+ * be reported as failed because a cache row could not be cleared. The next full
+ * sync's sweep is the backstop either way; this only shortens the window.
+ */
+export async function removeContentAssets(classroomId: string, paths: string[]): Promise<boolean> {
+  const unique = [...new Set(paths.filter(path => typeof path === 'string' && path.length > 0))];
+  if (unique.length === 0) return true;
+
+  try {
+    await getPrisma().contentAsset.deleteMany({
+      where: { classroom_id: classroomId, path: { in: unique } },
+    });
+    return true;
+  } catch (error: unknown) {
+    console.warn(
+      `[contentAssets] Could not remove ${unique.length} path(s) for ${classroomId}; ` +
+        "the next full sync's sweep will:",
+      error
+    );
+    return false;
+  }
+}
+
+/**
+ * Forget every row under a folder the repo no longer has.
+ *
+ * The companion to `ContentService.deleteFolder`, which reports how many files
+ * it removed but not which — and the map is the only thing that still knows.
+ * Matches the folder itself (theme folders are rows too, addressed by their
+ * tree sha) and everything beneath it.
+ *
+ * GUARDED, because the failure mode is not subtle: an empty or `/` prefix would
+ * match every row this classroom has. A refusal is logged rather than thrown —
+ * the folder is already gone from the repo, and the sweep is the backstop.
+ */
+export async function removeContentAssetFolder(
+  classroomId: string,
+  folder: string
+): Promise<boolean> {
+  const prefix = folder.replace(/^\/+|\/+$/g, '');
+  if (prefix.length === 0) {
+    console.warn(
+      `[contentAssets] Refusing to clear the whole map for ${classroomId} ` +
+        `(empty folder prefix "${folder}")`
+    );
+    return false;
+  }
+
+  try {
+    await getPrisma().contentAsset.deleteMany({
+      where: {
+        classroom_id: classroomId,
+        OR: [{ path: prefix }, { path: { startsWith: `${prefix}/` } }],
+      },
+    });
+    return true;
+  } catch (error: unknown) {
+    console.warn(
+      `[contentAssets] Could not remove ${prefix}/ for ${classroomId}; ` +
+        "the next full sync's sweep will:",
+      error
+    );
+    return false;
   }
 }
 

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -9,6 +9,7 @@ import {
   type TransformFormat,
   type TransformWidth,
 } from '@classmoji/content-signing';
+import { ContentService } from '../content/ContentService.ts';
 import {
   ensureContentAssets,
   lookupContentAsset,
@@ -90,6 +91,24 @@ export async function bumpContentKeyVersion(
  * Everything here is therefore pure derivation, and the save paths run
  * `canonicalizeAssetRef` to make sure the derivation never leaks back into
  * storage.
+ *
+ * ## Referenced content, and root content
+ *
+ * Everything above is about REFERENCED content — the images a document points
+ * at. The plan's other half is ROOT content: `content.json`, `deck.json`, the
+ * generated `index.html`. Nothing points at those, so for a long time nothing
+ * could address them by sha and they were read straight from GitHub — the Pages
+ * CDN first, the App token's contents API behind it.
+ *
+ * That is no longer true, and `fetchContentText` below is where it stopped
+ * being true. A save records the sha its commit returned (`recordContentAsset`),
+ * so the map answers "what is current?" for root files exactly as it does for
+ * referenced ones, and a read signs that sha like any other blob. The pointer
+ * the reference graph was missing is the map row.
+ *
+ * What that buys is not bandwidth — these files are small. It is that GitHub is
+ * touched once per SAVE instead of once per VIEW, and that a `/present` opened
+ * a second after a save shows the deck that was just saved.
  */
 
 /** Access tier a render mints URLs for. See @classmoji/content-signing. */
@@ -687,6 +706,224 @@ export async function resolveMany(
 ): Promise<Map<string, string>> {
   const { urls } = await resolveDelivery(ctx, refs);
   return urls;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reading a repo's TEXT
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Where a repo file's bytes actually came from. Logged, and returned so a
+ * caller (and a staging log) can see the mix rather than guess at it.
+ */
+export type ContentTextSource = 'worker' | 'api' | 'cdn';
+
+export interface ContentText {
+  text: string;
+  /**
+   * The git blob sha the bytes came from, or null.
+   *
+   * Null is only ever the CDN's answer: GitHub Pages serves a path and reports
+   * no object id, so there is nothing honest to put here. The Worker path takes
+   * the sha it signed and the API path takes the one the contents API returned,
+   * both of which name the exact object.
+   */
+  sha: string | null;
+  source: ContentTextSource;
+}
+
+/**
+ * What a text read needs to know. A `ResolveContext` satisfies it structurally,
+ * so a caller that already built one for images can pass it straight through;
+ * the tier on it is ignored (see below).
+ */
+export interface TextReadContext {
+  classroom: ResolveClassroom;
+}
+
+/**
+ * A hung origin must not hold a render open.
+ *
+ * The Worker answers an R2 hit in milliseconds and a cold miss in the time
+ * GitHub takes, so anything past this is a network that has stopped rather than
+ * a slow file — and the API fallback below is still a correct answer. Short
+ * enough that the fallback is not itself a timeout, long enough that a cold
+ * blob on a bad day still wins.
+ */
+const TEXT_FETCH_TIMEOUT_MS = 6000;
+
+/**
+ * One repo file's TEXT, through the delivery layer when it can be.
+ *
+ * ## The problem this exists for
+ *
+ * Images have gone through the Worker by blob sha for a while; text had not.
+ * A deck's `index.html` was read CDN-first from `{org}.github.io`, which lags a
+ * push by minutes (a rapid second save can ERROR the Pages build and stretch
+ * that further) — so an instructor saved a deck, opened `/present`, and was
+ * shown the previous version of their own slides.
+ *
+ * Reading it by SHA removes the question. The asset map holds the sha the last
+ * write produced, the Worker is keyed by content, and a URL naming a sha can
+ * only ever return that sha's bytes. Freshness stops being a cache policy and
+ * becomes a property of the address — which is why the save paths write the
+ * returned sha into the map (`recordContentAsset`) the moment a commit lands.
+ *
+ * ## The tiers
+ *
+ * Always `enrolled`, whoever is reading. This is a server-to-server fetch: the
+ * bytes are handed to a loader that has already done its own authorization, and
+ * they are never given to a browser as a URL. The tier here therefore decides
+ * nothing about access — it only picks an expiry bucket and a `Cache-Control`,
+ * and `enrolled`'s week is the right middle: long enough that one signature
+ * serves a lecture hall's worth of `/follow` reads out of the edge, short
+ * enough not to mint the 30-day public bucket for content nobody published.
+ *
+ * ## The fallback, and why its order is INVERTED
+ *
+ * When the classroom's gate is off, the deployment cannot sign, or the map has
+ * no row for this path, the read falls back — API first, CDN last. That is the
+ * opposite of the order this replaces, and deliberately so: the map being
+ * briefly behind (a save whose row has not landed, a path a sync has not seen)
+ * is exactly the case where the CDN is stalest, so the authenticated read that
+ * always sees the current commit has to go first. The CDN survives only as the
+ * answer of last resort, and Phase 4 deletes it.
+ *
+ * ## Never throws
+ *
+ * This sits on the render path of every deck and page. Every failure — a 502
+ * from the Worker, a GitHub rate limit, a DNS blip — degrades to the next tier
+ * and finally to `null`, which callers already render as "content unavailable".
+ * An exception here would be a 500 on a page whose bytes are one tier away.
+ */
+export async function fetchContentText(
+  ctx: TextReadContext,
+  repoPath: string,
+  opts: { label?: string; skipCache?: boolean } = {}
+): Promise<ContentText | null> {
+  const path = normalizeRepoRelative(repoPath);
+  if (!path) return null;
+
+  const result =
+    (await readTextThroughWorker(ctx, path)) ?? (await readTextFromGitHub(ctx, path, opts));
+
+  // Debug, not warn: one line per file per render is a lot of lines, and the
+  // question they answer — "is this deployment actually serving text from the
+  // Worker, and for which classrooms?" — is one you go looking for during a
+  // rollout rather than one that should interrupt you. The repo's no-console
+  // rule allows only warn/error precisely so that ordinary chatter does not
+  // land at a level an operator is told to search; this is the exception that
+  // proves it, and it stays below that line on purpose.
+  // eslint-disable-next-line no-console
+  console.debug(
+    `[contentDelivery] text ${opts.label ?? 'read'} source=${result?.source ?? 'none'} ` +
+      `path=${path} classroom=${ctx.classroom.id}`
+  );
+
+  return result;
+}
+
+/** The map lookup + signed fetch. Null means "not through the Worker" — never an error. */
+async function readTextThroughWorker(
+  ctx: TextReadContext,
+  path: string
+): Promise<ContentText | null> {
+  if (!isContentDeliveryEnabled(ctx.classroom)) return null;
+  const env = deliveryEnv();
+  if (!env) return null;
+
+  const ext = extensionOf(path);
+  if (!ext) return null;
+
+  try {
+    await ensureMap(ctx.classroom.id);
+    const asset = await lookupContentAsset(ctx.classroom.id, path);
+    // No row, or a TREE row — a directory is not a file. Either way there is no
+    // blob to sign, and the fallback is the honest answer rather than a
+    // confidently-wrong URL.
+    if (!asset || asset.type !== 'blob') return null;
+
+    const url = await signBlobUrl(
+      env.origin,
+      // Server-to-server: `enrolled` names the cache bucket, not the reader.
+      {
+        master: env.master,
+        classroomId: ctx.classroom.id,
+        keyVersion: ctx.classroom.content_key_version,
+        tier: 'enrolled',
+      },
+      { sha: asset.sha, ext }
+    );
+
+    const response = await fetch(url, { signal: AbortSignal.timeout(TEXT_FETCH_TIMEOUT_MS) });
+    if (!response.ok) {
+      console.warn(
+        `[contentDelivery] Worker returned ${response.status} for ${path} ` +
+          `(classroom ${ctx.classroom.id}); falling back to the API`
+      );
+      return null;
+    }
+
+    return { text: await response.text(), sha: asset.sha, source: 'worker' };
+  } catch (error) {
+    console.warn(
+      `[contentDelivery] Worker text read failed for ${path} (classroom ${ctx.classroom.id}):`,
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
+}
+
+/**
+ * The fallback pair, in the order that favours freshness: contents API, then
+ * the Pages CDN.
+ *
+ * The API read is authenticated and always sees the current commit; the CDN is
+ * a build artifact minutes behind it. Marked for deletion with the rest of the
+ * CDN tier in Phase 4 — by then every classroom is on the layer and a repo that
+ * has gone private serves nothing from `github.io` anyway.
+ */
+async function readTextFromGitHub(
+  ctx: TextReadContext,
+  path: string,
+  opts: { skipCache?: boolean }
+): Promise<ContentText | null> {
+  const orgLogin = ctx.classroom.git_organization.login;
+  const repo = ctx.classroom.content_repo;
+  if (!orgLogin || !repo) return null;
+
+  try {
+    const file = await ContentService.getContent({
+      orgLogin,
+      repo,
+      path,
+      ...(opts.skipCache ? { skipCache: true } : {}),
+    });
+    if (file?.content) return { text: file.content, sha: file.sha ?? null, source: 'api' };
+  } catch (error) {
+    console.warn(
+      `[contentDelivery] API text read failed for ${repo}/${path}:`,
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  // DEPRECATED — Phase 4 removes this tier entirely. It is last rather than
+  // first (which is how this read used to be ordered) because GitHub Pages lags
+  // a push by minutes, and the whole point of the map-first path above is that
+  // a save is visible the instant it returns.
+  try {
+    const response = await fetch(`https://${orgLogin}.github.io/${repo}/${path}`, {
+      signal: AbortSignal.timeout(TEXT_FETCH_TIMEOUT_MS),
+    });
+    if (response.ok) return { text: await response.text(), sha: null, source: 'cdn' };
+  } catch (error) {
+    console.warn(
+      `[contentDelivery] CDN text read failed for ${repo}/${path}:`,
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  return null;
 }
 
 /**

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -795,17 +795,24 @@ const TEXT_FETCH_TIMEOUT_MS = 6000;
  * from the Worker, a GitHub rate limit, a DNS blip — degrades to the next tier
  * and finally to `null`, which callers already render as "content unavailable".
  * An exception here would be a 500 on a page whose bytes are one tier away.
+ *
+ * Which is also why `workerOnly` exists. Swallowing failures collapses "this
+ * file does not exist" and "GitHub is down" into the same `null`, and a caller
+ * that must tell those apart — the class site, which answers the first with an
+ * empty page and the second with a 503, because a blank page cached for a
+ * minute in front of anonymous readers is the worse outcome — passes it and
+ * runs its own typed read when the map has nothing.
  */
 export async function fetchContentText(
   ctx: TextReadContext,
   repoPath: string,
-  opts: { label?: string; skipCache?: boolean } = {}
+  opts: { label?: string; skipCache?: boolean; workerOnly?: boolean } = {}
 ): Promise<ContentText | null> {
   const path = normalizeRepoRelative(repoPath);
   if (!path) return null;
 
-  const result =
-    (await readTextThroughWorker(ctx, path)) ?? (await readTextFromGitHub(ctx, path, opts));
+  const viaWorker = await readTextThroughWorker(ctx, path);
+  const result = viaWorker ?? (opts.workerOnly ? null : await readTextFromGitHub(ctx, path, opts));
 
   // Debug, not warn: one line per file per render is a lot of lines, and the
   // question they answer — "is this deployment actually serving text from the

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -11,6 +11,7 @@ import {
 } from '@classmoji/content-signing';
 import { ContentService } from '../content/ContentService.ts';
 import {
+  type ContentAssetRecord,
   ensureContentAssets,
   lookupContentAsset,
   lookupContentAssetBySha,
@@ -742,15 +743,84 @@ export interface TextReadContext {
 }
 
 /**
+ * Which fallbacks a text read may use when the map cannot answer.
+ *
+ *   - `api-then-cdn` — the default, and the only ordering that is right for a
+ *     single document a person is waiting on: the authenticated read always
+ *     sees the current commit, and the case that reaches it (a map briefly
+ *     behind a save) is exactly when the CDN is stalest.
+ *   - `cdn-only` — for a FAN-OUT. A staff landing page renders ~20 deck
+ *     thumbnails at once, and twenty authenticated reads is the amplification
+ *     the CDN pinning existed to prevent. A thumbnail is a picture of a deck;
+ *     three minutes stale is invisible there and a rate limit is not.
+ *   - `none` — the map answers or it does not. For a caller that must tell "no
+ *     such file" from "GitHub is down", because swallowing failures makes both
+ *     of them `null`. The class site is the one that must: the first is an
+ *     empty page, the second a 503, and a blank page cached for a minute in
+ *     front of anonymous readers is the worse outcome.
+ */
+export type TextFallback = 'api-then-cdn' | 'cdn-only' | 'none';
+
+/**
+ * One render's worth of probes, and whether the Worker has already failed.
+ *
+ * Not a rate limiter — a circuit breaker with a lifetime of one render. A read
+ * that probes several paths (a page tries `content.json`, then `index.html`)
+ * would otherwise pay the full timeout on EVERY probe when the Worker is
+ * unreachable, turning one stalled render into several. A transport failure is
+ * about the origin, not the file, so the first one answers for all of them.
+ *
+ * A MISS is not a failure and never trips this: the map genuinely not having a
+ * row for `content.json` says nothing about `index.html`.
+ */
+export interface TextReadBudget {
+  workerUnavailable: boolean;
+}
+
+export function textReadBudget(): TextReadBudget {
+  return { workerUnavailable: false };
+}
+
+/**
  * A hung origin must not hold a render open.
  *
  * The Worker answers an R2 hit in milliseconds and a cold miss in the time
  * GitHub takes, so anything past this is a network that has stopped rather than
- * a slow file — and the API fallback below is still a correct answer. Short
+ * a slow file — and the fallbacks below are still a correct answer. Short
  * enough that the fallback is not itself a timeout, long enough that a cold
  * blob on a bad day still wins.
  */
 const TEXT_FETCH_TIMEOUT_MS = 6000;
+
+/**
+ * The bound on the map refresh a read may trigger.
+ *
+ * `ensureMap` can reach GitHub for a default branch, a head commit and a whole
+ * tree — three round trips, on the render path, for a classroom whose map has
+ * gone stale. It already degrades to "serve what the map has" on failure, but
+ * only after GitHub has finished being slow. This puts a ceiling on that.
+ */
+const ENSURE_MAP_TIMEOUT_MS = 4000;
+
+/**
+ * Reject after `ms`, so a call with no cancellation of its own cannot hold a
+ * render open.
+ *
+ * The losing promise is NOT cancelled — `ContentService.getContent` takes no
+ * `AbortSignal`, so the underlying request keeps running to completion and its
+ * result is discarded. That is the honest trade: the render stops waiting, the
+ * socket does not. Its rejection is swallowed so a late failure cannot surface
+ * as an unhandled rejection after the caller has moved on.
+ */
+function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T> {
+  work.catch(() => {});
+  return Promise.race([
+    work,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${what} exceeded ${ms}ms`)), ms).unref?.()
+    ),
+  ]);
+}
 
 /**
  * One repo file's TEXT, through the delivery layer when it can be.
@@ -779,77 +849,87 @@ const TEXT_FETCH_TIMEOUT_MS = 6000;
  * serves a lecture hall's worth of `/follow` reads out of the edge, short
  * enough not to mint the 30-day public bucket for content nobody published.
  *
- * ## The fallback, and why its order is INVERTED
+ * ## When the map cannot answer
  *
- * When the classroom's gate is off, the deployment cannot sign, or the map has
- * no row for this path, the read falls back — API first, CDN last. That is the
- * opposite of the order this replaces, and deliberately so: the map being
- * briefly behind (a save whose row has not landed, a path a sync has not seen)
- * is exactly the case where the CDN is stalest, so the authenticated read that
- * always sees the current commit has to go first. The CDN survives only as the
- * answer of last resort, and Phase 4 deletes it.
+ * See `TextFallback`. The default inverts the order this replaces; a fan-out
+ * asks for `cdn-only`; a caller that needs its own error semantics asks for
+ * `none`.
  *
  * ## Never throws
  *
  * This sits on the render path of every deck and page. Every failure — a 502
- * from the Worker, a GitHub rate limit, a DNS blip — degrades to the next tier
- * and finally to `null`, which callers already render as "content unavailable".
- * An exception here would be a 500 on a page whose bytes are one tier away.
- *
- * Which is also why `workerOnly` exists. Swallowing failures collapses "this
- * file does not exist" and "GitHub is down" into the same `null`, and a caller
- * that must tell those apart — the class site, which answers the first with an
- * empty page and the second with a 503, because a blank page cached for a
- * minute in front of anonymous readers is the worse outcome — passes it and
- * runs its own typed read when the map has nothing.
+ * from the Worker, a GitHub rate limit, a DNS blip, a timeout — degrades to the
+ * next tier and finally to `null`, which callers already render as "content
+ * unavailable". An exception here would be a 500 on a page whose bytes are one
+ * tier away.
  */
 export async function fetchContentText(
   ctx: TextReadContext,
   repoPath: string,
-  opts: { label?: string; skipCache?: boolean; workerOnly?: boolean } = {}
+  opts: {
+    label?: string;
+    skipCache?: boolean;
+    fallback?: TextFallback;
+    budget?: TextReadBudget;
+  } = {}
 ): Promise<ContentText | null> {
   const path = normalizeRepoRelative(repoPath);
   if (!path) return null;
 
-  const viaWorker = await readTextThroughWorker(ctx, path);
-  const result = viaWorker ?? (opts.workerOnly ? null : await readTextFromGitHub(ctx, path, opts));
+  const fallback = opts.fallback ?? 'api-then-cdn';
+  const viaWorker = await readTextThroughWorker(ctx, path, opts.budget);
+  const result =
+    viaWorker ?? (fallback === 'none' ? null : await readTextFromGitHub(ctx, path, fallback, opts));
 
-  // Debug, not warn: one line per file per render is a lot of lines, and the
-  // question they answer — "is this deployment actually serving text from the
-  // Worker, and for which classrooms?" — is one you go looking for during a
-  // rollout rather than one that should interrupt you. The repo's no-console
-  // rule allows only warn/error precisely so that ordinary chatter does not
-  // land at a level an operator is told to search; this is the exception that
-  // proves it, and it stays below that line on purpose.
-  // eslint-disable-next-line no-console
-  console.debug(
-    `[contentDelivery] text ${opts.label ?? 'read'} source=${result?.source ?? 'none'} ` +
-      `path=${path} classroom=${ctx.classroom.id}`
-  );
-
+  logTextRead(opts.label, path, ctx.classroom.id, result?.source ?? 'none');
   return result;
 }
 
 /** The map lookup + signed fetch. Null means "not through the Worker" — never an error. */
 async function readTextThroughWorker(
   ctx: TextReadContext,
-  path: string
+  path: string,
+  budget?: TextReadBudget
 ): Promise<ContentText | null> {
   if (!isContentDeliveryEnabled(ctx.classroom)) return null;
+  // A previous probe in this render already found the Worker unreachable.
+  // Paying the timeout again would only make one stalled render into several.
+  if (budget?.workerUnavailable) return null;
   const env = deliveryEnv();
   if (!env) return null;
 
   const ext = extensionOf(path);
   if (!ext) return null;
 
+  let asset: ContentAssetRecord | null;
   try {
-    await ensureMap(ctx.classroom.id);
-    const asset = await lookupContentAsset(ctx.classroom.id, path);
-    // No row, or a TREE row — a directory is not a file. Either way there is no
-    // blob to sign, and the fallback is the honest answer rather than a
-    // confidently-wrong URL.
-    if (!asset || asset.type !== 'blob') return null;
+    // Bounded: a stale map turns this into three GitHub calls, and a slow
+    // GitHub must cost a fallback rather than a held-open render.
+    await withDeadline(ensureMap(ctx.classroom.id), ENSURE_MAP_TIMEOUT_MS, 'map refresh').catch(
+      error => {
+        console.warn(
+          `[contentDelivery] Map refresh gave up for classroom ${ctx.classroom.id}:`,
+          error instanceof Error ? error.message : error
+        );
+      }
+    );
+    asset = await lookupContentAsset(ctx.classroom.id, path);
+  } catch (error) {
+    // The map itself is unreachable, which is not the Worker's fault — do not
+    // trip the circuit, just fall back for this path.
+    console.warn(
+      `[contentDelivery] Map lookup failed for ${path} (classroom ${ctx.classroom.id}):`,
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
 
+  // No row, or a TREE row — a directory is not a file. Either way there is no
+  // blob to sign. A MISS, deliberately not a circuit trip: this path having no
+  // row says nothing about the next path the caller probes.
+  if (!asset || asset.type !== 'blob') return null;
+
+  try {
     const url = await signBlobUrl(
       env.origin,
       // Server-to-server: `enrolled` names the cache bucket, not the reader.
@@ -864,17 +944,24 @@ async function readTextThroughWorker(
 
     const response = await fetch(url, { signal: AbortSignal.timeout(TEXT_FETCH_TIMEOUT_MS) });
     if (!response.ok) {
+      // A refusal is an ANSWER, not a dead origin: the Worker is up and said
+      // no. Fall back for this path and leave the circuit closed.
       console.warn(
         `[contentDelivery] Worker returned ${response.status} for ${path} ` +
-          `(classroom ${ctx.classroom.id}); falling back to the API`
+          `(classroom ${ctx.classroom.id}); falling back`
       );
       return null;
     }
 
     return { text: await response.text(), sha: asset.sha, source: 'worker' };
   } catch (error) {
+    // A throw here is transport — a timeout, a DNS failure, a refused socket —
+    // and it is about the ORIGIN rather than this file. Trip the circuit so the
+    // rest of this render does not queue up behind the same dead connection.
+    if (budget) budget.workerUnavailable = true;
     console.warn(
-      `[contentDelivery] Worker text read failed for ${path} (classroom ${ctx.classroom.id}):`,
+      `[contentDelivery] Worker text read failed for ${path} (classroom ${ctx.classroom.id}); ` +
+        'skipping the Worker for the rest of this read:',
       error instanceof Error ? error.message : error
     );
     return null;
@@ -882,36 +969,46 @@ async function readTextThroughWorker(
 }
 
 /**
- * The fallback pair, in the order that favours freshness: contents API, then
- * the Pages CDN.
+ * The fallbacks, in the order that favours freshness: contents API, then the
+ * Pages CDN.
  *
  * The API read is authenticated and always sees the current commit; the CDN is
- * a build artifact minutes behind it. Marked for deletion with the rest of the
- * CDN tier in Phase 4 — by then every classroom is on the layer and a repo that
- * has gone private serves nothing from `github.io` anyway.
+ * a build artifact minutes behind it. `cdn-only` skips the API leg entirely —
+ * see `TextFallback`.
+ *
+ * The CDN tier is marked for deletion with the rest of Phase 4: by then every
+ * classroom is on the layer, and a repo that has gone private serves nothing
+ * from `github.io` anyway.
  */
 async function readTextFromGitHub(
   ctx: TextReadContext,
   path: string,
+  fallback: TextFallback,
   opts: { skipCache?: boolean }
 ): Promise<ContentText | null> {
   const orgLogin = ctx.classroom.git_organization.login;
   const repo = ctx.classroom.content_repo;
   if (!orgLogin || !repo) return null;
 
-  try {
-    const file = await ContentService.getContent({
-      orgLogin,
-      repo,
-      path,
-      ...(opts.skipCache ? { skipCache: true } : {}),
-    });
-    if (file?.content) return { text: file.content, sha: file.sha ?? null, source: 'api' };
-  } catch (error) {
-    console.warn(
-      `[contentDelivery] API text read failed for ${repo}/${path}:`,
-      error instanceof Error ? error.message : error
-    );
+  if (fallback !== 'cdn-only') {
+    try {
+      const file = await withDeadline(
+        ContentService.getContent({
+          orgLogin,
+          repo,
+          path,
+          ...(opts.skipCache ? { skipCache: true } : {}),
+        }),
+        TEXT_FETCH_TIMEOUT_MS,
+        'contents API read'
+      );
+      if (file?.content) return { text: file.content, sha: file.sha ?? null, source: 'api' };
+    } catch (error) {
+      console.warn(
+        `[contentDelivery] API text read failed for ${repo}/${path}:`,
+        error instanceof Error ? error.message : error
+      );
+    }
   }
 
   // DEPRECATED — Phase 4 removes this tier entirely. It is last rather than
@@ -931,6 +1028,58 @@ async function readTextFromGitHub(
   }
 
   return null;
+}
+
+/**
+ * Where a render's text came from, one line per render rather than per file.
+ *
+ * The question these answer — "is this deployment actually serving text from
+ * the Worker, and for which classrooms?" — is asked of a rollout, not of a
+ * file, and a page that probes three paths should not write three lines to
+ * answer it once. Consecutive reads carrying the same label, classroom and
+ * source are folded into one line with a count, flushed when any of the three
+ * changes.
+ *
+ * Debug, not warn: the repo's `no-console` rule allows only warn and error
+ * precisely so that ordinary chatter does not land at a level an operator is
+ * told to search. This stays below that line on purpose.
+ */
+let pendingLog: {
+  key: string;
+  label: string;
+  classroomId: string;
+  source: string;
+  n: number;
+} | null = null;
+
+function logTextRead(
+  label: string | undefined,
+  path: string,
+  classroomId: string,
+  source: string
+): void {
+  const name = label ?? 'read';
+  const key = `${name}|${classroomId}|${source}`;
+  if (pendingLog && pendingLog.key === key) {
+    pendingLog.n += 1;
+    return;
+  }
+  flushTextReadLog();
+  pendingLog = { key, label: name, classroomId, source, n: 1 };
+  // Emitted on the next tick so a render's remaining probes can fold into it;
+  // a render is a handful of awaits, so this always lands within the request.
+  queueMicrotask(flushTextReadLog);
+  void path;
+}
+
+function flushTextReadLog(): void {
+  if (!pendingLog) return;
+  const { label, classroomId, source, n } = pendingLog;
+  pendingLog = null;
+  // eslint-disable-next-line no-console
+  console.debug(
+    `[contentDelivery] text ${label} source=${source} files=${n} classroom=${classroomId}`
+  );
 }
 
 /**

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -22,7 +22,7 @@
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
 import { contentProxyBase, isCommitRef, pagesContentBase, splitRawRef } from './contentRefs.ts';
-import { lookupContentAssetsBySha } from './contentAssets.service.ts';
+import { lookupContentAssetsBySha, recordContentAssets } from './contentAssets.service.ts';
 import { getGitProvider } from '../git/index.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import { createWithUniquePageSlug, ensureContentRepo, isPageSlugConflict } from './page.service.ts';
@@ -878,13 +878,18 @@ async function importPages({
 
   // ONE commit for all page files.
   try {
-    await ContentService.uploadBatch({
+    const result = await ContentService.uploadBatch({
       gitOrganization: target.gitOrganization,
       repo: target.repo,
       files: written.flatMap(w => w.files),
       branch: 'main',
       message: commitMessage,
     });
+    // Write-through: imported `content.json` is read through the asset map, and
+    // an import is followed immediately by someone opening what they imported.
+    // Without this the first views fall back to the contents API until the push
+    // webhook lands — correct, but a GitHub call per view for no reason.
+    await recordContentAssets(target.classroomId, result.files);
   } catch (error: unknown) {
     warn('pages', `page content commit failed: ${errText(error)}`);
     return 0;
@@ -1057,13 +1062,17 @@ async function importSlides({
   // ONE commit for all slide files (deck.json + generated index.html copied
   // verbatim — never regenerated).
   try {
-    await ContentService.uploadBatch({
+    const result = await ContentService.uploadBatch({
       gitOrganization: target.gitOrganization,
       repo: target.repo,
       files,
       branch: 'main',
       message: commitMessage,
     });
+    // Write-through, for the same reason as the page batch above: `deck.json`
+    // and `index.html` are read through the map, and an imported deck is
+    // usually opened straight away.
+    await recordContentAssets(target.classroomId, result.files);
   } catch (error: unknown) {
     warn('slides', `slide content commit failed: ${errText(error)}`);
     return 0;

--- a/packages/services/src/classmoji/page.service.ts
+++ b/packages/services/src/classmoji/page.service.ts
@@ -2,7 +2,7 @@ import getPrisma from '@classmoji/database';
 import { titleToIdentifier, RESERVED_PAGE_SLUGS } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import { getGitProvider } from '../git/index.ts';
-import { recordContentAssets } from './contentAssets.service.ts';
+import { recordContentAssets, removeContentAssetFolder } from './contentAssets.service.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import * as notificationService from './notification.service.ts';
 import { blankPageContentJson, previewBranchName } from './pageContent.service.ts';
@@ -748,6 +748,11 @@ export async function deletePage(pageId: string) {
       console.error('Failed to delete page content from GitHub:', error);
       // Continue with database deletion even if GitHub fails
     }
+
+    // Forget the map rows too. The blobs are content-addressed and immutable,
+    // so a surviving row keeps serving the deleted page's last bytes out of R2
+    // — a deleted page that still renders, until the next sweep.
+    await removeContentAssetFolder(classroomId, page.content_path);
 
     // Drop any pending preview branch alongside the folder — a stale
     // preview/<content_path> ref would retarget a future page reusing the slug.

--- a/packages/services/src/classmoji/page.service.ts
+++ b/packages/services/src/classmoji/page.service.ts
@@ -460,6 +460,11 @@ export async function createPage({
 
   // Never throws, and its failure is not this caller's problem: the files are
   // already committed, and the next sync writes the same rows.
+  //
+  // No sizes: the import branch's `files` carry base64 for binary uploads, so a
+  // byte length taken here would be the encoding's, not the file's — and a
+  // wrong size overwrites a right one a tree sync measured. Omitted rather than
+  // guessed; the next full sync fills the column in.
   await recordContentAssets(
     ctx.classroom.id,
     written.map(file => ({ path: file.path, sha: file.sha }))

--- a/packages/services/src/classmoji/page.service.ts
+++ b/packages/services/src/classmoji/page.service.ts
@@ -2,6 +2,7 @@ import getPrisma from '@classmoji/database';
 import { titleToIdentifier, RESERVED_PAGE_SLUGS } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import { getGitProvider } from '../git/index.ts';
+import { recordContentAssets } from './contentAssets.service.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import * as notificationService from './notification.service.ts';
 import { blankPageContentJson, previewBranchName } from './pageContent.service.ts';
@@ -382,10 +383,17 @@ export async function createPage({
 
   const htmlPath = `${contentPath}/index.html`;
 
+  // Every branch below records what it committed. `content.json` and
+  // `index.html` are READ through the asset map now (see `fetchContentText`),
+  // so a page created without rows is a page that renders as empty until the
+  // push webhook lands — a fresh page, blank for a minute, on the one surface
+  // where the author is watching.
+  let written: Array<{ path: string; sha: string }> = [];
+
   if (files.length > 0) {
     // Import flow: assets + index.html in a single batch commit.
     try {
-      await ContentService.uploadBatch({
+      const result = await ContentService.uploadBatch({
         gitOrganization: ctx.classroom.git_organization!,
         repo: ctx.repoName,
         files: [
@@ -395,6 +403,7 @@ export async function createPage({
         branch: 'main',
         message: commitMessage ?? `Import page: ${title}`,
       });
+      written = result.files;
     } catch (uploadError) {
       console.error('Failed to upload files to GitHub:', uploadError);
       throw new Error(
@@ -405,13 +414,14 @@ export async function createPage({
   } else if (html != null) {
     // Import/markdown flow without extra assets: single-file commit.
     try {
-      await ContentService.put({
+      const result = await ContentService.put({
         gitOrganization: ctx.classroom.git_organization!,
         repo: ctx.repoName,
         path: htmlPath,
         content: html,
         message: commitMessage ?? `Create page: ${title}`,
       });
+      written = [{ path: htmlPath, sha: result.sha }];
     } catch (uploadError) {
       console.error('Failed to upload file to GitHub:', uploadError);
       throw new Error(
@@ -424,7 +434,7 @@ export async function createPage({
     // BlockNote content.json wrapper in ONE commit, so fresh pages are
     // json-first for the granular content tools from birth.
     try {
-      await ContentService.uploadBatch({
+      const result = await ContentService.uploadBatch({
         gitOrganization: ctx.classroom.git_organization!,
         repo: ctx.repoName,
         files: [
@@ -438,6 +448,7 @@ export async function createPage({
         branch: 'main',
         message: commitMessage ?? `Create page: ${title}`,
       });
+      written = result.files;
     } catch (uploadError) {
       console.error('Failed to upload files to GitHub:', uploadError);
       throw new Error(
@@ -446,6 +457,13 @@ export async function createPage({
       );
     }
   }
+
+  // Never throws, and its failure is not this caller's problem: the files are
+  // already committed, and the next sync writes the same rows.
+  await recordContentAssets(
+    ctx.classroom.id,
+    written.map(file => ({ path: file.path, sha: file.sha }))
+  );
 
   try {
     const page = await create({

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -4,7 +4,11 @@ import { z } from 'zod';
 import { collectBlockAssetRefs, mapBlockAssetRefs } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
 import { recordContentAsset, resolveContentBranch } from './contentAssets.service.ts';
-import { canonicalizeMany, type ResolveContext } from './contentDelivery.service.ts';
+import {
+  canonicalizeMany,
+  fetchContentText,
+  type ResolveContext,
+} from './contentDelivery.service.ts';
 import {
   dedupeMergedTreeIds,
   indexResolutions,
@@ -98,12 +102,26 @@ function contentRepoFor(page: PageWithContentRepo) {
  *   reads that will be used as expectedSha MUST pass true).
  * @param options.ref - Git ref (branch/sha) to read from — e.g. the page's
  *   preview branch. Ref-bearing reads always bypass the cache.
+ * @param options.viaWorker - Read by SHA through the delivery layer
+ *   (`fetchContentText`) rather than straight from GitHub. For RENDER reads: a
+ *   save is visible the moment it returns, and a page view costs no GitHub call
+ *   at all. Ignored when `ref` is set — a preview branch has no map rows to
+ *   sign against, which is also why the editor's own load leaves this off.
  */
 export async function loadPageContent(
   page: PageWithContentRepo,
-  { skipCache = false, ref }: { skipCache?: boolean; ref?: string } = {}
+  {
+    skipCache = false,
+    ref,
+    viaWorker = false,
+  }: { skipCache?: boolean; ref?: string; viaWorker?: boolean } = {}
 ): Promise<PageContentResult> {
   const { gitOrganization, repo } = contentRepoFor(page);
+
+  if (viaWorker && !ref) {
+    const viaMap = await loadPageContentViaWorker(page);
+    if (viaMap) return viaMap;
+  }
 
   // Try JSON first (BlockNote format)
   try {
@@ -169,6 +187,52 @@ export async function loadPageContent(
   }
 
   return { format: 'none', blocks: null, coverImage: null, sha: null };
+}
+
+/**
+ * The map-first form of the load above: same precedence, same shapes.
+ *
+ * Null means "the delivery layer had nothing to say" — the classroom is not
+ * opted in, the deployment cannot sign, or the map has no row for either file.
+ * The caller then runs its ordinary GitHub read, so this is purely an
+ * accelerator that can never be the reason a page fails to load.
+ *
+ * `fetchContentText` does its own API-then-CDN fallback, so a hit here has
+ * already exhausted the alternatives for that path; a null on `content.json`
+ * genuinely means the file is not there, and the `index.html` probe below is
+ * the legacy-page case rather than a retry.
+ */
+async function loadPageContentViaWorker(
+  page: PageWithContentRepo
+): Promise<PageContentResult | null> {
+  const ctx = pageResolveContext(page);
+  if (!ctx) return null;
+
+  const json = await fetchContentText(ctx, `${page.content_path}/content.json`, { label: 'page' });
+  if (json) {
+    try {
+      const parsed = JSON.parse(json.text);
+      // Two stored shapes: the `{ blocks, coverImage? }` wrapper, and a bare
+      // blocks array from before the wrapper existed.
+      if (parsed && !Array.isArray(parsed) && Array.isArray(parsed.blocks)) {
+        return {
+          format: 'json',
+          blocks: parsed.blocks,
+          coverImage: parsed.coverImage || null,
+          sha: json.sha,
+        };
+      }
+      return { format: 'json', blocks: parsed, coverImage: null, sha: json.sha };
+    } catch {
+      // Malformed JSON falls through to the HTML probe, exactly as the GitHub
+      // path does — a corrupt content.json must not hide a legacy index.html.
+    }
+  }
+
+  const html = await fetchContentText(ctx, `${page.content_path}/index.html`, { label: 'page' });
+  if (html) return { format: 'html', blocks: html.text, coverImage: null, sha: html.sha };
+
+  return null;
 }
 
 // ─── Canonicalize on save ────────────────────────────────────────────────────

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -7,6 +7,7 @@ import { recordContentAsset, resolveContentBranch } from './contentAssets.servic
 import {
   canonicalizeMany,
   fetchContentText,
+  textReadBudget,
   type ResolveContext,
 } from './contentDelivery.service.ts';
 import {
@@ -213,7 +214,10 @@ async function loadPageContentViaWorker(
   const ctx = pageResolveContext(page);
   if (!ctx) return null;
 
-  const opts = { label: 'page', workerOnly: true } as const;
+  // One circuit for both probes: if the Worker is unreachable, the second probe
+  // must not pay the timeout again to learn the same thing.
+  const budget = textReadBudget();
+  const opts = { label: 'page', fallback: 'none', budget } as const;
   const json = await fetchContentText(ctx, `${page.content_path}/content.json`, opts);
   if (json) {
     try {

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -197,10 +197,12 @@ export async function loadPageContent(
  * The caller then runs its ordinary GitHub read, so this is purely an
  * accelerator that can never be the reason a page fails to load.
  *
- * `fetchContentText` does its own API-then-CDN fallback, so a hit here has
- * already exhausted the alternatives for that path; a null on `content.json`
- * genuinely means the file is not there, and the `index.html` probe below is
- * the legacy-page case rather than a retry.
+ * `workerOnly`, and it matters: `fetchContentText` would otherwise run its own
+ * API-then-CDN fallback, and the caller's GitHub read is sitting right behind
+ * this call — so every map miss would pay TWO contents-API reads and a CDN
+ * fetch to answer one page. The caller's read is also the better of the two:
+ * it carries the full `gitOrganization` record, where the fallback can only
+ * pass a login and re-resolve it as GitHub.
  */
 async function loadPageContentViaWorker(
   page: PageWithContentRepo
@@ -208,7 +210,8 @@ async function loadPageContentViaWorker(
   const ctx = pageResolveContext(page);
   if (!ctx) return null;
 
-  const json = await fetchContentText(ctx, `${page.content_path}/content.json`, { label: 'page' });
+  const opts = { label: 'page', workerOnly: true } as const;
+  const json = await fetchContentText(ctx, `${page.content_path}/content.json`, opts);
   if (json) {
     try {
       const parsed = JSON.parse(json.text);
@@ -229,7 +232,7 @@ async function loadPageContentViaWorker(
     }
   }
 
-  const html = await fetchContentText(ctx, `${page.content_path}/index.html`, { label: 'page' });
+  const html = await fetchContentText(ctx, `${page.content_path}/index.html`, opts);
   if (html) return { format: 'html', blocks: html.text, coverImage: null, sha: html.sha };
 
   return null;

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -77,6 +77,9 @@ interface BlockNode {
   [key: string]: unknown;
 }
 
+/** Singleton preview branch per page: `preview/<content_path>`. */
+export const PAGE_PREVIEW_BRANCH_PREFIX = 'preview/';
+
 // ─── Repo resolution ─────────────────────────────────────────────────────────
 
 function contentRepoFor(page: PageWithContentRepo) {
@@ -402,11 +405,12 @@ export async function savePageContent(
     wrapper.coverImage = coverImage;
   }
 
+  const content = JSON.stringify(wrapper, null, 2);
   const result = await ContentService.put({
     gitOrganization,
     repo,
     path,
-    content: JSON.stringify(wrapper, null, 2),
+    content,
     message: message ?? `Update page: ${page.title}`,
     ...(expectedSha ? { expectedSha } : {}),
     ...(branch ? { branch } : {}),
@@ -420,8 +424,13 @@ export async function savePageContent(
   //
   // Default branch only. A preview branch is not in the map, and recording its
   // sha would publish an unaccepted draft to every reader.
-  if (!branch) {
-    await recordPageFile(page, path, result.sha);
+  //
+  // The test is on the PREFIX, not on `branch` being absent, and deliberately
+  // so — it matches `saveDeck`'s. No caller passes `branch: 'main'` today, but
+  // one that did would otherwise write the default branch and silently lose its
+  // map row, which is exactly the stale read this path exists to close.
+  if (!branch || !branch.startsWith(PAGE_PREVIEW_BRANCH_PREFIX)) {
+    await recordPageFile(page, path, result.sha, content);
   }
 
   return result;
@@ -434,10 +443,22 @@ export async function savePageContent(
  * the one branch it cannot: a page assembled without its classroom id has
  * nothing to key a row on. The commit still stands; the next sync picks it up.
  */
-async function recordPageFile(page: PageWithContentRepo, path: string, sha: string): Promise<void> {
+async function recordPageFile(
+  page: PageWithContentRepo,
+  path: string,
+  sha: string,
+  content?: string
+): Promise<void> {
   const classroomId = (page.classroom as { id?: unknown }).id;
   if (typeof classroomId !== 'string') return;
-  await recordContentAsset(classroomId, { path, sha });
+  await recordContentAsset(classroomId, {
+    path,
+    sha,
+    // The real byte length, but only where the writer actually has the bytes.
+    // A row is a cache of what the repo holds; handing it a size it does not
+    // know would overwrite a good one an earlier sync had measured.
+    ...(content === undefined ? {} : { size: Buffer.byteLength(content) }),
+  });
 }
 
 /**
@@ -936,7 +957,7 @@ export function applyBlockOps(
 
 /** The singleton preview branch for a content path (e.g. `preview/pages/syllabus`). */
 export function previewBranchName(contentPath: string): string {
-  return `preview/${contentPath}`;
+  return `${PAGE_PREVIEW_BRANCH_PREFIX}${contentPath}`;
 }
 
 export interface PreviewStatus {

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -335,7 +335,7 @@ export async function savePageContent(
     wrapper.coverImage = coverImage;
   }
 
-  return ContentService.put({
+  const result = await ContentService.put({
     gitOrganization,
     repo,
     path,
@@ -344,6 +344,33 @@ export async function savePageContent(
     ...(expectedSha ? { expectedSha } : {}),
     ...(branch ? { branch } : {}),
   });
+
+  // Write-through: `content.json` is READ through the map now (see
+  // `fetchContentText`), so a row that is one save behind is not a stale cache,
+  // it is the previous version of the page on a student's screen. The contents
+  // API just told us the new blob sha; recording it here is what makes the save
+  // visible the moment it returns, rather than when the push webhook lands.
+  //
+  // Default branch only. A preview branch is not in the map, and recording its
+  // sha would publish an unaccepted draft to every reader.
+  if (!branch) {
+    await recordPageFile(page, path, result.sha);
+  }
+
+  return result;
+}
+
+/**
+ * Put a just-committed page file into the asset map.
+ *
+ * Never throws — `recordContentAsset` swallows its own failures, and this adds
+ * the one branch it cannot: a page assembled without its classroom id has
+ * nothing to key a row on. The commit still stands; the next sync picks it up.
+ */
+async function recordPageFile(page: PageWithContentRepo, path: string, sha: string): Promise<void> {
+  const classroomId = (page.classroom as { id?: unknown }).id;
+  if (typeof classroomId !== 'string') return;
+  await recordContentAsset(classroomId, { path, sha });
 }
 
 /**
@@ -1054,6 +1081,14 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
         error instanceof Error ? error.message : String(error)
       );
     }
+
+    // Write-through, same as an ordinary save. A git-level merge produces a
+    // commit nobody in this process wrote, so there is no put() result to take
+    // a sha from — but the read above already fetched it at the merge commit,
+    // which is the same value. Without this, accepting a preview would publish
+    // content the read side keeps serving the pre-accept version of until the
+    // webhook lands.
+    if (newSha) await recordPageFile(page, path, newSha);
 
     // Concurrent-stacking guard: a stacking apply may have committed to the
     // preview branch AFTER the merge snapshot GitHub used. If the branch now

--- a/packages/services/src/classmoji/site.service.ts
+++ b/packages/services/src/classmoji/site.service.ts
@@ -75,8 +75,10 @@ export class SiteError extends Error {
  * never be in it. Only `theme` is pulled through, by explicit select.
  *
  * `git_organization` likewise selects identity only — `access_token` is a
- * GitLab/Gitea credential. Content reads on the public site go to the GitHub
- * Pages CDN (getContentUrl), which needs nothing but the login and repo name.
+ * GitLab/Gitea credential. Site content reads need nothing more than the login
+ * and repo name: they resolve a path to a blob sha through the asset map and
+ * fetch it from the delivery Worker, and the contents API behind that runs on
+ * the installation token the service looks up for itself.
  */
 const SITE_CLASSROOM_SELECT = {
   id: true,

--- a/packages/services/src/slides/__tests__/slide.service.test.ts
+++ b/packages/services/src/slides/__tests__/slide.service.test.ts
@@ -15,9 +15,13 @@ const slideDeleteMock = vi.fn();
 const slideUpdateMock = vi.fn();
 const gitOrgFindFirstMock = vi.fn();
 
+const classroomFindManyMock = vi.fn();
 vi.mock('@classmoji/database', () => ({
   default: () => ({
-    classroom: { findUnique: (...args: unknown[]) => classroomFindUniqueMock(...args) },
+    classroom: {
+      findUnique: (...args: unknown[]) => classroomFindUniqueMock(...args),
+      findMany: (...args: unknown[]) => classroomFindManyMock(...args),
+    },
     slide: {
       findUnique: (...args: unknown[]) => slideFindUniqueMock(...args),
       findFirst: (...args: unknown[]) => slideFindFirstMock(...args),
@@ -27,6 +31,8 @@ vi.mock('@classmoji/database', () => ({
       update: (...args: unknown[]) => slideUpdateMock(...args),
     },
     gitOrganization: { findFirst: (...args: unknown[]) => gitOrgFindFirstMock(...args) },
+    // The shared-theme delete asks which classrooms share the repo, so it can
+    // clear each one's rows for the folder it just removed.
   }),
 }));
 
@@ -54,6 +60,15 @@ vi.mock('../../classmoji/contentManifest.service.ts', () => ({
 const ensureContentRepoMock = vi.fn();
 vi.mock('../../classmoji/page.service.ts', () => ({
   ensureContentRepo: (...args: unknown[]) => ensureContentRepoMock(...args),
+}));
+
+// A delete has to forget the map rows too: blobs are content-addressed and
+// immutable, so a row that outlives its folder keeps serving the deleted deck's
+// last index.html out of R2.
+const removeContentAssetFolderMock = vi.fn();
+vi.mock('../../classmoji/contentAssets.service.ts', () => ({
+  removeContentAssetFolder: (...args: unknown[]) => removeContentAssetFolderMock(...args),
+  recordContentAssets: vi.fn(),
 }));
 
 const {
@@ -92,6 +107,8 @@ function seededIdGen(): () => string {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Repo→classrooms lookup for the shared-theme delete's map cleanup.
+  classroomFindManyMock.mockResolvedValue([]);
   classroomFindUniqueMock.mockResolvedValue(classroom);
   slideFindFirstMock.mockResolvedValue(null);
   ensureContentRepoMock.mockResolvedValue({ repoName: 'content-test-org-26w' });

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -315,6 +315,15 @@ export async function acceptDeckPreview(
     return null;
   };
 
+  /**
+   * index.html's sha from whichever regenerate actually landed, or null.
+   *
+   * Written by `regenerateFrom` rather than returned from it because the retry
+   * path below calls it twice and only the successful call's sha is the one the
+   * map should hold.
+   */
+  let htmlSha: string | null = null;
+
   // Render + commit the artifact, CAS-pinned on the deck.json sha it was
   // generated from: if a concurrent save moves deck.json, the write aborts
   // (DeckConflictError) instead of publishing a stale artifact.
@@ -342,15 +351,6 @@ export async function acceptDeckPreview(
     });
     htmlSha = written.files.find(file => file.path === htmlPath)?.sha ?? null;
   };
-
-  /**
-   * index.html's sha from whichever regenerate actually landed, or null.
-   *
-   * Written by `regenerateFrom` rather than returned from it because the retry
-   * path below calls it twice and only the successful call's sha is the one the
-   * map should hold.
-   */
-  let htmlSha: string | null = null;
 
   let mergedSha: string | null = null;
   let htmlRegenerated = false;

--- a/packages/services/src/slides/deckPreview.service.ts
+++ b/packages/services/src/slides/deckPreview.service.ts
@@ -20,6 +20,7 @@
 
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
+import { recordContentAssets } from '../classmoji/contentAssets.service.ts';
 import { generateDeckHtml, type DeckThemeUrls } from './deckHtml.ts';
 import {
   indexResolutions,
@@ -324,7 +325,7 @@ export async function acceptDeckPreview(
       themeUrls,
       includeNotes: true,
     });
-    await ContentService.uploadBatch({
+    const written = await ContentService.uploadBatch({
       gitOrganization,
       repo,
       files: [{ path: htmlPath, content: html, encoding: 'utf-8' as const }],
@@ -339,7 +340,17 @@ export async function acceptDeckPreview(
         }
       },
     });
+    htmlSha = written.files.find(file => file.path === htmlPath)?.sha ?? null;
   };
+
+  /**
+   * index.html's sha from whichever regenerate actually landed, or null.
+   *
+   * Written by `regenerateFrom` rather than returned from it because the retry
+   * path below calls it twice and only the successful call's sha is the one the
+   * map should hold.
+   */
+  let htmlSha: string | null = null;
 
   let mergedSha: string | null = null;
   let htmlRegenerated = false;
@@ -387,6 +398,19 @@ export async function acceptDeckPreview(
     // Preview never wrote deck.json (nothing but the branch point) — the
     // merge was a no-op for content; there is nothing to regenerate.
     console.warn(`[deckPreview] No deck.json on main after merge for ${deckPath}`);
+  }
+
+  // Write-through. A git merge produces a commit nobody in this process wrote,
+  // so there is no put() result to take shas from — but both are already in
+  // hand: `mergedSha` came from reading deck.json at the merge commit, and
+  // `htmlSha` from the regenerate's own batch. Without this, accepting a
+  // preview would publish a deck that `/present` keeps serving the pre-accept
+  // version of until the push webhook lands.
+  if (slide.classroom?.id) {
+    const written: Array<{ path: string; sha: string }> = [];
+    if (mergedSha) written.push({ path: deckPath, sha: mergedSha });
+    if (htmlSha) written.push({ path: htmlPath, sha: htmlSha });
+    await recordContentAssets(slide.classroom.id, written);
   }
 
   // Concurrent-stacking guard: a stacking apply may have committed to the

--- a/packages/services/src/slides/slide.service.ts
+++ b/packages/services/src/slides/slide.service.ts
@@ -12,6 +12,7 @@
 
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
+import { removeContentAssetFolder } from '../classmoji/contentAssets.service.ts';
 import * as contentManifestService from '../classmoji/contentManifest.service.ts';
 import { ensureContentRepo } from '../classmoji/page.service.ts';
 import { mintSlideId, type IdGenerator } from './deckHtml.ts';
@@ -469,6 +470,19 @@ export async function deleteSharedTheme(
     path: `${THEMES_FOLDER}/${themeName}`,
     message: `Delete shared theme: ${themeName}`,
   });
+
+  // And the map rows. A theme folder is addressed by its TREE sha, so a
+  // surviving row keeps a deleted theme resolvable and its css servable from
+  // R2 long after the folder is gone.
+  const classrooms = await getPrisma().classroom.findMany({
+    where: { content_repo: contentRepo, git_organization: { login: gitOrgLogin } },
+    select: { id: true },
+  });
+  await Promise.all(
+    classrooms.map(classroom =>
+      removeContentAssetFolder(classroom.id, `${THEMES_FOLDER}/${themeName}`)
+    )
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -546,6 +560,11 @@ export async function deleteSlide({
     console.error('Failed to delete slide content from GitHub:', error);
     // Continue with database deletion even if GitHub fails.
   }
+
+  // Forget the map rows too. Blobs are content-addressed and immutable, so a
+  // surviving row keeps serving the deleted deck's last index.html out of R2 —
+  // a deleted deck that still presents, until the next sweep.
+  await removeContentAssetFolder(slide.classroom_id, slide.content_path);
 
   // Drop any pending preview branch alongside the folder — a stale
   // preview/<content_path> ref would retarget a future deck reusing the slug.

--- a/packages/services/src/slides/slideContent.service.ts
+++ b/packages/services/src/slides/slideContent.service.ts
@@ -18,7 +18,7 @@ import {
 } from './deckHtml.ts';
 import type { DeckJson } from './deckTypes.ts';
 import { canonicalizeDeckAssets } from './deckAssets.ts';
-import { recordContentAssets } from '../classmoji/contentAssets.service.ts';
+import { recordContentAssets, resolveContentBranch } from '../classmoji/contentAssets.service.ts';
 import {
   canonicalizeMany,
   isOwnAssetRef,
@@ -312,6 +312,20 @@ export async function saveDeck({
   deck = await canonicalizeDeckForSave(slide, deck);
 
   const isPreviewBranch = branch != null && branch.startsWith(PREVIEW_BRANCH_PREFIX);
+  // ASSUMED `main`, where `uploadPageAsset` ASKS — and the asymmetry is
+  // deliberate, not an oversight.
+  //
+  // `resolveContentBranch` is an uncached GitHub call. An upload pays it gladly:
+  // it happens when a teacher drops a file into the editor, which is rare. A
+  // deck save is the editor's hot path, and putting a default-branch lookup in
+  // front of every one of them spends the org installation's shared limit on a
+  // question whose answer has not changed since the repo was created — classmoji
+  // creates content repos on `main`.
+  //
+  // The gap this leaves is a content repo imported from an older org that is on
+  // `master`: deck saves there fail on a missing ref, exactly as they did before
+  // this layer existed. Worth fixing WITH a cache rather than with a call per
+  // save — tracked, not done here.
   const targetBranch = branch ?? 'main';
   // Ref for conflict checks: the branch being written (main when absent) —
   // §3b: expected_sha refers to the file on the branch being written.

--- a/packages/services/src/slides/slideContent.service.ts
+++ b/packages/services/src/slides/slideContent.service.ts
@@ -427,7 +427,7 @@ export async function saveDeck({
   // Main writes only. A preview branch is not in the map, and recording its
   // shas would point every reader at unpublished content.
   if (!isPreviewBranch) {
-    await recordDeckFiles(slide, result.files);
+    await recordDeckFiles(slide, result.files, files);
   }
 
   // Bump updated_at for main writes (a preview-branch commit changes nothing
@@ -446,18 +446,31 @@ export async function saveDeck({
  * Put a just-committed deck's files into the asset map.
  *
  * Never throws — `recordContentAssets` swallows its own failures, and this adds
- * the one branch it cannot: a target with no classroom id (createSlide's
- * starter deck, the importer's synthetic target) has nothing to key a row on.
- * Such a save is still committed; the map picks it up on the next sync.
+ * the one branch it cannot: a target assembled without the classroom join (the
+ * importer's synthetic target) has nothing to key a row on. Such a save is
+ * still committed; the map picks it up on the next sync. `createSlide` DOES
+ * reach here — it passes the whole classroom row.
+ *
+ * Sizes come from the bytes that were actually committed, which this caller
+ * still has in hand. Guessing one would be worse than omitting it: the map's
+ * size column is written by tree syncs that measured it, and an invented value
+ * would overwrite a measured one.
  */
 async function recordDeckFiles(
   slide: SlideContentTarget,
-  files: Array<{ path: string; sha: string }>
+  committed: Array<{ path: string; sha: string }>,
+  written: Array<{ path: string; content: string }>
 ): Promise<void> {
   const classroomId = slide.classroom?.id;
   if (!classroomId) return;
+
+  const bytes = new Map(written.map(file => [file.path, Buffer.byteLength(file.content)]));
   await recordContentAssets(
     classroomId,
-    files.map(file => ({ path: file.path, sha: file.sha }))
+    committed.map(file => ({
+      path: file.path,
+      sha: file.sha,
+      ...(bytes.has(file.path) ? { size: bytes.get(file.path) } : {}),
+    }))
   );
 }

--- a/packages/services/src/slides/slideContent.service.ts
+++ b/packages/services/src/slides/slideContent.service.ts
@@ -18,6 +18,7 @@ import {
 } from './deckHtml.ts';
 import type { DeckJson } from './deckTypes.ts';
 import { canonicalizeDeckAssets } from './deckAssets.ts';
+import { recordContentAssets } from '../classmoji/contentAssets.service.ts';
 import {
   canonicalizeMany,
   isOwnAssetRef,
@@ -417,6 +418,18 @@ export async function saveDeck({
     throw new Error('uploadBatch did not return a sha for deck.json');
   }
 
+  // Write-through: the map learns this commit's shas NOW rather than when the
+  // push webhook arrives, which is what makes `/present` fresh the instant a
+  // save returns. The read side signs whatever sha the map holds, so a row that
+  // is one save behind IS the previous deck on screen — the exact bug this
+  // whole path exists to close.
+  //
+  // Main writes only. A preview branch is not in the map, and recording its
+  // shas would point every reader at unpublished content.
+  if (!isPreviewBranch) {
+    await recordDeckFiles(slide, result.files);
+  }
+
   // Bump updated_at for main writes (a preview-branch commit changes nothing
   // students or the live viewer can see).
   if (slide.id && !isPreviewBranch) {
@@ -427,4 +440,24 @@ export async function saveDeck({
   }
 
   return { sha: newDeckSha, commit: result.commit, html };
+}
+
+/**
+ * Put a just-committed deck's files into the asset map.
+ *
+ * Never throws — `recordContentAssets` swallows its own failures, and this adds
+ * the one branch it cannot: a target with no classroom id (createSlide's
+ * starter deck, the importer's synthetic target) has nothing to key a row on.
+ * Such a save is still committed; the map picks it up on the next sync.
+ */
+async function recordDeckFiles(
+  slide: SlideContentTarget,
+  files: Array<{ path: string; sha: string }>
+): Promise<void> {
+  const classroomId = slide.classroom?.id;
+  if (!classroomId) return;
+  await recordContentAssets(
+    classroomId,
+    files.map(file => ({ path: file.path, sha: file.sha }))
+  );
 }

--- a/packages/tasks/src/scripts/migrate-pages-to-blocknote.ts
+++ b/packages/tasks/src/scripts/migrate-pages-to-blocknote.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { ContentService } from '@classmoji/content';
+import { ClassmojiService } from '@classmoji/services';
 import { migrateHtmlToBlockNote } from '../../../../apps/pages/app/utils/migration.server.ts';
 import { BlockNoteSchema, defaultBlockSpecs, createCodeBlockSpec } from '@blocknote/core';
 import { multiColumnSchema } from '@blocknote/xl-multi-column';
@@ -167,12 +168,24 @@ async function migratePagesToBlockNote(): Promise<void> {
         const blockNoteContent = await migrateHtmlToBlockNote(htmlContent, schema);
 
         // Save as content.json to GitHub
-        await ContentService.put({
+        const contentJson = JSON.stringify(blockNoteContent, null, 2);
+        const written = await ContentService.put({
           gitOrganization: effectiveGitOrg,
           repo,
           path: `${page.content_path}/content.json`,
-          content: JSON.stringify(blockNoteContent, null, 2),
+          content: contentJson,
           message: `Migrate ${page.slug} from HTML to BlockNote format`,
+        });
+
+        // Record the row like any other save. `content.json` is READ through
+        // the asset map, and a migration that skipped this would leave every
+        // page it converted falling back to the contents API — one GitHub call
+        // per view, across a whole classroom at once — until the push webhook
+        // caught up. Never throws.
+        await ClassmojiService.contentAssets.recordContentAsset(page.classroom.id, {
+          path: `${page.content_path}/content.json`,
+          sha: written.sha,
+          size: Buffer.byteLength(contentJson),
         });
 
         console.log(`✅ Converted ${page.slug}`);

--- a/packages/tasks/src/scripts/migrate-slides-to-deck.ts
+++ b/packages/tasks/src/scripts/migrate-slides-to-deck.ts
@@ -33,7 +33,7 @@
  */
 
 import getPrisma from '@classmoji/database';
-import { ContentService } from '@classmoji/services';
+import { ClassmojiService, ContentService } from '@classmoji/services';
 import { DeckParseError, parseDeckHtml } from '@classmoji/services/slides';
 
 // Small inter-item pause so a large classroom doesn't hammer the GitHub API —
@@ -274,13 +274,23 @@ async function migrateSlidesToDeck(options: CliOptions): Promise<void> {
           continue;
         }
         try {
-          await ContentService.put({
+          const written = await ContentService.put({
             gitOrganization,
             repo,
             path: deckPath,
             content: deckJson,
             message: 'Migrate deck to deck.json',
             createOnly: true,
+          });
+
+          // Record the row like any other save — `deck.json` is read through
+          // the asset map, and a migration that skipped this would leave every
+          // deck it converted falling back to the contents API until the push
+          // webhook caught up. Never throws.
+          await ClassmojiService.contentAssets.recordContentAsset(classroom.id, {
+            path: deckPath,
+            sha: written.sha,
+            size: Buffer.byteLength(deckJson),
           });
         } catch (writeError: unknown) {
           const status = (writeError as { status?: number }).status;


### PR DESCRIPTION
## What
The last piece of the delivery layer: repo **text** (`index.html`, `deck.json`, `content.json`, theme CSS) now goes through the Worker like images do, content-addressed by blob SHA. Trigger: saving a deck on staging and opening `/present` showed the previous slide, because deck HTML still read CDN-first from `github.io` (~3 min Pages delay).

- **Read:** `fetchContentText` resolves the path through the asset map, signs the SHA at the `enrolled` tier, fetches from the Worker (R2/edge). Fallback order worker → API → CDN only when the classroom's gate is off or the map has no row; thumbnails fall back CDN-only (no API fan-out); the class site keeps its 404-vs-503 distinction. Editor edit mode and `fetch-latest` stay API-only (preview branches aren't in the map).
- **Write-through:** every default-branch text save records the returned SHA (page/deck saves, preview accepts, create, imports, theme/snippet saves, migration scripts), so present mode is fresh the instant a save returns. Deletes and renames now remove map rows.
- **Freshness is by construction:** a new save is a new SHA, a new URL, a guaranteed first-read miss. A full sync can no longer revert a save it raced: rows are applied with one `INSERT … ON CONFLICT … DO UPDATE … WHERE synced_at < EXCLUDED.synced_at` (verified against Postgres), which also collapses the thousand-statement sync transaction into one.
- **Cost:** zero GitHub API calls per view for deck/page text; one Worker origin pull per new SHA. A 150-student `/follow` burst mints one bucket-stable URL and costs no API calls.
- **Worker:** Content-Type for html/htm/mjs; text served with `charset=utf-8`, `nosniff`, CSP `default-src 'none'; sandbox`, no cookies, type always from the signed extension (never from a shared cache entry). Timeouts on every read leg; a per-render circuit so a hung Worker costs one timeout, not one per file.

Known, documented: `saveDeck` still targets `main` (a cached default-branch resolve is the right fix, not a call per save); `copyFolder` reports no SHAs so a duplicated deck's images wait for the webhook.

## Test
services 1558 passed / 13 known; Worker 144; signing 92; pages 489; slides 95; mcp 559; typechecks clean except the 16 known GitLabProvider. On staging: edit a `cs98-test` deck, save, open `/present` immediately → new content; Workers Logs show a text blob pull once per save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA