### PR TITLE
fix(slides): enrolled tier for speaker panes, and reload the viewer after a save

### DIFF
--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -40,6 +40,7 @@ import {
   resolveDeliveryThemeUrls,
   resolveReadThemeUrls,
 } from '~/utils/deckDelivery.server';
+import { displayDeckContent, settleSaveRefresh } from '~/utils/deckViewContent';
 import RevealSlides, { type RevealSlidesHandle } from '~/components/RevealSlides';
 import SlideToolbar from '~/components/SlideToolbar';
 import SlideNotesPanel from '~/components/SlideNotesPanel';
@@ -757,8 +758,16 @@ export const action = async ({
 
   // ─────────────────────────────────────────────────────────────────────────
 
-  // Fetch latest content from GitHub API (bypasses CDN cache)
-  // Used when entering edit mode to ensure we're editing the current version
+  // Read the deck straight from the GitHub API for the EDITOR.
+  //
+  // Not a CDN-lag workaround any more — the loader reads the deck text through
+  // the delivery Worker by sha, so it is not behind. This exists for the two
+  // things the loader's view-mode read deliberately cannot give the editor: a
+  // conflict token (the sha of the file about to be written, read skipCache so
+  // a per-process cache cannot hand back a token that would silently revert a
+  // concurrent write), and a document whose image refs are still the stored
+  // `/content/...` ones — a signed URL that round-tripped through the editor
+  // would be committed into deck.json.
   if (intent === 'fetch-latest') {
     try {
       // Phase 4c: deck.json-first, mirroring the edit-mode loader. skipCache:
@@ -1672,7 +1681,10 @@ export const action = async ({
       console.error('Failed to detect orphaned images:', err);
     }
 
-    // Return the full HTML so UI can update without waiting for CDN.
+    // Return the full HTML: it is the editor's next-session document and the
+    // baseline the next save diffs against, and it stays UNSIGNED for that.
+    // View mode no longer renders it once the loader's revalidation lands —
+    // that read is by sha through the Worker, so it is not behind this one.
     // sha is the DECK sha (+ sha_source 'deck') — deck.json now exists, so the
     // client's conflict token must point at it for the next save.
     // merged_with_concurrent (present iff the merge path committed) → the
@@ -1829,8 +1841,30 @@ export default function SlideViewer() {
   // token over the stale DOM, would clobber the folded-in concurrent changes.
   const [editorEpoch, setEditorEpoch] = useState(0);
   const [autoEditTriggered, setAutoEditTriggered] = useState(false);
-  // Track editable content separately from CDN content
+  // Track editable content separately from the loader's content
   const [editableContent, setEditableContent] = useState<string | null>(null);
+  // VIEW mode renders the LOADER's copy of the deck, not the editor's.
+  //
+  // They are the same document with one difference that matters: the loader's
+  // has been through `resolveDeckAssets`, so its images are signed
+  // `content-*.classmoji.io` URLs, while the editor's is the stored document
+  // with raw `/content/...` refs — which is exactly what must NOT be signed
+  // (a signed URL that round-tripped through the editor would be committed
+  // into deck.json, freezing one viewer's expiring signature into the deck).
+  //
+  // So view mode preferred `editableContent` only because the loader used to
+  // be BEHIND after a save: it read the Pages CDN, which lags a push by
+  // minutes. It no longer does — the loader reads the deck text through the
+  // Worker by sha — and React Router revalidates this route's loader
+  // automatically when the save fetcher's action returns. This flag is what
+  // says that refresh has landed; until it does, view mode keeps showing the
+  // copy we just saved rather than flashing the pre-save deck.
+  const [viewFromLoader, setViewFromLoader] = useState(false);
+  // Armed on a save's success, disarmed when its loader refresh settles.
+  const awaitingSaveRefreshRef = useRef(false);
+  // `slideContent` as it stood when that save returned — how we tell a landed
+  // refresh from a loader that never re-ran.
+  const preSaveContentRef = useRef<string | null>(null);
   // Orphaned images cleanup
   const [orphanedImages, setOrphanedImages] = useState<
     Array<{ path: string; name: string; url: string }>
@@ -1985,6 +2019,12 @@ export default function SlideViewer() {
     if (fetcher.data?.intent === 'fetch-latest' && fetcher.data?.content) {
       // Got fresh content from GitHub API - enter edit mode with it
       setEditableContent(fetcher.data.content);
+      // This read is skipCache and can be AHEAD of the loader (someone else
+      // saved since this page loaded), so it becomes the freshest thing we
+      // hold. Hand view mode back to it until the next save's refresh lands.
+      awaitingSaveRefreshRef.current = false;
+      preSaveContentRef.current = null;
+      setViewFromLoader(false);
       // Refresh the conflict token (also the recovery path after a 409:
       // fresh content + fresh token, unsaved changes discarded)
       if (fetcher.data.content_sha) {
@@ -2141,9 +2181,18 @@ export default function SlideViewer() {
       }
       fetcher.submit(payload, { method: 'post' });
     } else if (fetcher.data?.savedContent) {
-      // After save, update our local content to match what was saved
-      // This prevents stale content when CDN hasn't updated yet
+      // After save, update our local content to match what was saved. This is
+      // the EDITOR's copy: it seeds the next edit session and is what the next
+      // save diffs against, and it must stay unsigned for that round trip.
       setEditableContent(fetcher.data.savedContent);
+      // View mode wants the loader's signed copy instead — but not yet. The
+      // action has only just returned; the loader revalidation React Router
+      // fires off the back of it is still in flight, so `slideContent` still
+      // holds the PRE-save deck. Showing it now would flash the old slides.
+      // Fall back to what we just saved until that refresh lands (below).
+      preSaveContentRef.current = slideContent;
+      awaitingSaveRefreshRef.current = true;
+      setViewFromLoader(false);
       // The save materialized deck.json — future saves must key on ITS sha
       if (fetcher.data.sha) {
         setContentToken({
@@ -2210,6 +2259,34 @@ export default function SlideViewer() {
       );
     }
   }, [fetcher.data]);
+
+  // Settle the post-save loader refresh armed above.
+  //
+  // React Router revalidates this route's loader off the back of the save
+  // fetcher's action, so there is nothing to trigger here — only something to
+  // WAIT for, and the wait has to be told apart from a loader that never came
+  // back with anything new. New `slideContent` is that signal: it is the
+  // committed deck, resolved through the delivery layer, and view mode can
+  // switch to it. Anything else — a no-op save, or a route that later opts out
+  // of revalidation — settles on the copy we saved locally, which is what this
+  // shipped with before, so the failure mode here is "no worse than before".
+  //
+  // Deliberately NOT gated on `isEditing`: this only ever moves what VIEW mode
+  // renders. `editableContent` — the editor's document, its diff baseline and
+  // its conflict token — is never touched from here, so an edit session in
+  // progress (an auto-save keeps one open) cannot be clobbered by a refresh.
+  useEffect(() => {
+    if (!awaitingSaveRefreshRef.current) return;
+    const outcome = settleSaveRefresh({
+      loaderContent: slideContent,
+      preSaveContent: preSaveContentRef.current,
+      fetcherIdle: fetcher.state === 'idle',
+    });
+    if (!outcome.settled) return;
+    awaitingSaveRefreshRef.current = false;
+    preSaveContentRef.current = null;
+    if (outcome.viewFromLoader) setViewFromLoader(true);
+  }, [fetcher.state, slideContent]);
 
   // Handle image upload - returns a promise that resolves with the image URL
   const handleImageUpload = useCallback(
@@ -2450,9 +2527,17 @@ export default function SlideViewer() {
   }, []);
 
   // Determine which content to show
-  // - When editing: use editableContent (fresh from API or after save)
-  // - When viewing: use CDN content (slideContent) or editableContent if we have it
-  const displayContent = isEditing ? editableContent : editableContent || slideContent;
+  // - When editing: editableContent, the editor's own unsigned round-trip copy
+  // - When viewing: the loader's copy once a save's revalidation has landed
+  //   (see `viewFromLoader`) — same document, but with its images resolved
+  //   through the delivery layer. Before that, and on a page that has not
+  //   saved anything, the pre-existing order stands.
+  const displayContent = displayDeckContent({
+    isEditing,
+    viewFromLoader,
+    editableContent,
+    loaderContent: slideContent,
+  });
 
   // Save a new snippet
   const handleSaveSnippet = useCallback(

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -39,6 +39,7 @@ import {
   resolveDeckAssets,
   resolveDeliveryThemeUrls,
   resolveReadThemeUrls,
+  gitBlobSha,
 } from '~/utils/deckDelivery.server';
 import { displayDeckContent, settleSaveRefresh } from '~/utils/deckViewContent';
 import RevealSlides, { type RevealSlidesHandle } from '~/components/RevealSlides';
@@ -199,7 +200,13 @@ export const loader = async ({
   let slideContent: string | null = null;
   let contentError: string | null = null;
   let usedApiFallback = false;
-  let contentResult: { content: string; source: string } | null = null;
+  let contentResult: { content: string; source: string; sha?: string | null } | null = null;
+  // The IDENTITY of the deck the VIEW-MODE read resolved, and only that read.
+  // Edit mode and the preview branch generate their document from deck.json, so
+  // they name no index.html object and leave this null — as does the CDN
+  // fallback, which serves a path and reports no object id. Null therefore
+  // means "cannot tell what this is", which is what the client must assume.
+  let deckSha: string | null = null;
 
   // Conflict token for the editor (Phase 4b): the sha of the deck's SOURCE OF
   // TRUTH — deck.json once it exists (materialized by the first dual-write
@@ -364,6 +371,7 @@ export const loader = async ({
 
   if (contentResult) {
     slideContent = contentResult.content;
+    deckSha = contentResult.sha ?? null;
     // Kept for the client-side fallback's own bookkeeping. It now means "the
     // delivery layer could not answer and GitHub did", which is a narrower
     // thing than it used to be — `worker` is the ordinary case and `cdn` is
@@ -461,6 +469,10 @@ export const loader = async ({
     autoEdit: mode === 'edit',
     // Indicate if we fell back to API (CDN wasn't available yet)
     usedApiFallback,
+    // index.html's blob sha for the view-mode read (null when this read could
+    // not name an object). The client matches it against the sha a save just
+    // committed to know its loader refresh has actually landed.
+    deckSha,
     // Conflict token (edit mode only; null in view mode): sha of the deck's
     // source of truth + which file it came from. The client echoes it back on
     // every save so saveDeck can 409 instead of clobbering a concurrent write.
@@ -760,8 +772,11 @@ export const action = async ({
 
   // Read the deck straight from the GitHub API for the EDITOR.
   //
-  // Not a CDN-lag workaround any more — the loader reads the deck text through
-  // the delivery Worker by sha, so it is not behind. This exists for the two
+  // Not a CDN-lag workaround any more — where the delivery layer answers (the
+  // classroom's flag on, the signing env set, and a map row for the path) the
+  // loader reads the deck text by sha through the Worker and is not behind; on
+  // the fallback paths it still reaches the contents API and then the lagging
+  // CDN. Either way that is not what this is for now. It exists for the two
   // things the loader's view-mode read deliberately cannot give the editor: a
   // conflict token (the sha of the file about to be written, read skipCache so
   // a per-process cache cannot hand back a token that would silently revert a
@@ -1500,6 +1515,11 @@ export const action = async ({
         sha: result.sha,
         sha_source: 'deck' as const,
         savedContent: result.html,
+        // The committed index.html's IDENTITY. `sha` above is deck.json's, and
+        // the viewer's read is of index.html — comparing those two would never
+        // match. Hashed from the bytes just committed, which is the same object
+        // git stored, so no extra API call buys it.
+        html_sha: gitBlobSha(result.html),
         orphanedImages,
         adoption_required: result.adoption_required,
         ...(result.concurrent > 0 ? { merged_with_concurrent: result.concurrent } : {}),
@@ -1695,6 +1715,8 @@ export const action = async ({
       sha: saved.sha,
       sha_source: 'deck' as const,
       savedContent: saved.html,
+      // index.html's identity — see the ops path above for why it is not `sha`.
+      html_sha: gitBlobSha(saved.html),
       orphanedImages,
       ...(mergedSave ? { merged_with_concurrent: mergedWithConcurrent } : {}),
     };
@@ -1736,6 +1758,7 @@ export default function SlideViewer() {
     isPro,
     contentUrl,
     slideContent,
+    deckSha,
     contentError,
     snippets: initialSnippets,
     cssThemes: initialCssThemes,
@@ -1854,17 +1877,21 @@ export default function SlideViewer() {
   //
   // So view mode preferred `editableContent` only because the loader used to
   // be BEHIND after a save: it read the Pages CDN, which lags a push by
-  // minutes. It no longer does — the loader reads the deck text through the
-  // Worker by sha — and React Router revalidates this route's loader
-  // automatically when the save fetcher's action returns. This flag is what
-  // says that refresh has landed; until it does, view mode keeps showing the
-  // copy we just saved rather than flashing the pre-save deck.
+  // minutes. Usually it no longer is — but only when the classroom's delivery
+  // flag is on, the signing env is set and the asset map has a row for the
+  // path does the loader read by sha through the Worker; otherwise it still
+  // falls back to the contents API and then that same lagging CDN. React
+  // Router revalidates this route's loader automatically when the save
+  // fetcher's action returns, and this flag says that refresh landed AND
+  // named the object we committed. Until then view mode keeps showing the copy
+  // we just saved rather than flashing the pre-save deck.
   const [viewFromLoader, setViewFromLoader] = useState(false);
   // Armed on a save's success, disarmed when its loader refresh settles.
   const awaitingSaveRefreshRef = useRef(false);
-  // `slideContent` as it stood when that save returned — how we tell a landed
-  // refresh from a loader that never re-ran.
-  const preSaveContentRef = useRef<string | null>(null);
+  // The blob sha of the index.html that save committed. The loader naming the
+  // SAME object is the only proof its read caught up — see `settleSaveRefresh`
+  // for why comparing the rendered documents cannot work.
+  const savedShaRef = useRef<string | null>(null);
   // Orphaned images cleanup
   const [orphanedImages, setOrphanedImages] = useState<
     Array<{ path: string; name: string; url: string }>
@@ -1908,12 +1935,27 @@ export default function SlideViewer() {
 
   // Store returnUrl in sessionStorage and clean the URL on mount
   useEffect(() => {
+    const url = new URL(window.location.href);
+    let cleaned = false;
     // Check if we have a returnUrl from query params
     if (returnUrl) {
       sessionStorage.setItem('slidesReturnUrl', returnUrl);
       // Clean the URL by removing the returnUrl param
-      const url = new URL(window.location.href);
       url.searchParams.delete('returnUrl');
+      cleaned = true;
+    }
+    // `?mode=edit` is a ONE-SHOT instruction: it exists so the new-slide path
+    // can land in the editor, and `autoEditTriggered` already makes sure it
+    // fires once. Leaving it in the URL makes every later revalidation take
+    // the loader's EDIT branch, whose document is deliberately unsigned — so
+    // a post-save refresh would hand view mode raw `/content/...` refs and
+    // call it fresh. The editor gets its own document from `fetch-latest`, so
+    // dropping the param costs it nothing.
+    if (url.searchParams.has('mode')) {
+      url.searchParams.delete('mode');
+      cleaned = true;
+    }
+    if (cleaned) {
       window.history.replaceState({}, '', url.toString());
     }
     // Set backUrl from sessionStorage (or fall back to webappUrl)
@@ -2023,7 +2065,7 @@ export default function SlideViewer() {
       // saved since this page loaded), so it becomes the freshest thing we
       // hold. Hand view mode back to it until the next save's refresh lands.
       awaitingSaveRefreshRef.current = false;
-      preSaveContentRef.current = null;
+      savedShaRef.current = null;
       setViewFromLoader(false);
       // Refresh the conflict token (also the recovery path after a 409:
       // fresh content + fresh token, unsaved changes discarded)
@@ -2189,8 +2231,9 @@ export default function SlideViewer() {
       // action has only just returned; the loader revalidation React Router
       // fires off the back of it is still in flight, so `slideContent` still
       // holds the PRE-save deck. Showing it now would flash the old slides.
-      // Fall back to what we just saved until that refresh lands (below).
-      preSaveContentRef.current = slideContent;
+      // Fall back to what we just saved until the loader comes back naming the
+      // index.html this save committed (below).
+      savedShaRef.current = fetcher.data.html_sha ?? null;
       awaitingSaveRefreshRef.current = true;
       setViewFromLoader(false);
       // The save materialized deck.json — future saves must key on ITS sha
@@ -2278,15 +2321,27 @@ export default function SlideViewer() {
   useEffect(() => {
     if (!awaitingSaveRefreshRef.current) return;
     const outcome = settleSaveRefresh({
-      loaderContent: slideContent,
-      preSaveContent: preSaveContentRef.current,
+      loaderSha: deckSha,
+      savedSha: savedShaRef.current,
       fetcherIdle: fetcher.state === 'idle',
     });
     if (!outcome.settled) return;
     awaitingSaveRefreshRef.current = false;
-    preSaveContentRef.current = null;
+    if (!outcome.viewFromLoader) {
+      // The loader settled on something other than what we committed: a read
+      // that has not caught up, or one that cannot name what it fetched. Stay
+      // on the saved copy — correct content, legacy image URLs — and say so,
+      // because this is the branch that would otherwise be invisible.
+      console.debug(
+        '[slides] Post-save loader refresh did not name the committed deck; ' +
+          `keeping the locally saved copy (loader=${deckSha ?? 'null'}, saved=${
+            savedShaRef.current ?? 'null'
+          })`
+      );
+    }
+    savedShaRef.current = null;
     if (outcome.viewFromLoader) setViewFromLoader(true);
-  }, [fetcher.state, slideContent]);
+  }, [fetcher.state, deckSha]);
 
   // Handle image upload - returns a promise that resolves with the image URL
   const handleImageUpload = useCallback(

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -86,11 +86,19 @@ export const loader = async ({
     // Same read-side delivery pass the deck viewer runs. A follower is usually
     // a student or a shareCode guest, so the tier lands on `enrolled`/`public`
     // rather than the staff `draft` bucket — `tierFor` decides, not this route.
-    // The `preview` local above is this route's THUMBNAIL flag and is
-    // deliberately not part of the access shape; `deckAccessFor` cannot see it.
+    // The `preview` local above is this route's THUMBNAIL flag, and it reaches
+    // `deckAccessFor` as `thumbnail` — never as the viewer's preview-BRANCH
+    // flag. It marks the read-only iframe form (the speaker view's panes), so
+    // staff get the long-lived tier there instead of a 4h `draft` signature
+    // that expires part-way through a long lecture.
     const { html } = await resolveDeckDelivery(
       contentResult.content,
-      deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('follow', { canEdit }, slide))
+      deckDeliveryContext(
+        slide,
+        gitOrgLogin,
+        repo,
+        deckAccessFor('follow', { canEdit }, slide, { thumbnail: preview })
+      )
     );
     slideContent = html;
 

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -5,8 +5,9 @@ import { assertSlideAccess } from '@classmoji/auth/server';
 import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
 import {
-  deckAccessFor,
   deckDeliveryContext,
+  followDeckAccess,
+  isThumbnailRequest,
   readDeckText,
   resolveDeckDelivery,
 } from '~/utils/deckDelivery.server';
@@ -30,7 +31,7 @@ export const loader = async ({
   if (!slideId) throw new Response('Missing slideId', { status: 400 });
   const url = new URL(request.url);
   const shareCode = url.searchParams.get('shareCode');
-  const preview = url.searchParams.get('preview') === 'true';
+  const preview = isThumbnailRequest(url);
 
   const slide = await getPrisma().slide.findUnique({
     where: { id: slideId },
@@ -86,19 +87,14 @@ export const loader = async ({
     // Same read-side delivery pass the deck viewer runs. A follower is usually
     // a student or a shareCode guest, so the tier lands on `enrolled`/`public`
     // rather than the staff `draft` bucket — `tierFor` decides, not this route.
-    // The `preview` local above is this route's THUMBNAIL flag, and it reaches
-    // `deckAccessFor` as `thumbnail` — never as the viewer's preview-BRANCH
-    // flag. It marks the read-only iframe form (the speaker view's panes), so
-    // staff get the long-lived tier there instead of a 4h `draft` signature
-    // that expires part-way through a long lecture.
+    // `followDeckAccess` re-reads this route's THUMBNAIL flag off the URL and
+    // hands it to `deckAccessFor` as `thumbnail` — never as the viewer's
+    // preview-BRANCH flag. It marks the read-only iframe form (the speaker
+    // view's panes), so staff get the long-lived tier there instead of a 4h
+    // `draft` signature that expires part-way through a long lecture.
     const { html } = await resolveDeckDelivery(
       contentResult.content,
-      deckDeliveryContext(
-        slide,
-        gitOrgLogin,
-        repo,
-        deckAccessFor('follow', { canEdit }, slide, { thumbnail: preview })
-      )
+      deckDeliveryContext(slide, gitOrgLogin, repo, followDeckAccess(url, { canEdit }, slide))
     );
     slideContent = html;
 

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -78,19 +78,34 @@ export interface SlideAccessResultLike {
  *     for presenting.
  *   - only `viewer` honours `previewActive`. `follow` has a `?preview=true`
  *     query param of its own that means "thumbnail render", and letting that
- *     reach `tierFor` would mint draft URLs for a hall full of students.
+ *     reach `tierFor` would mint draft URLs for a hall full of students. It
+ *     arrives as `opts.thumbnail`, and is never allowed to become `preview`.
+ *   - a THUMBNAIL `follow` is read-only, and gets the same treatment as
+ *     `present`/`speaker` for the same reason. The speaker view embeds
+ *     `/follow?preview=true` in its current and next panes, so staff opening
+ *     `/speaker` were signing those iframes into the 4-hour `draft` bucket —
+ *     and a lecture that runs longer than four hours 403s a lazily-loaded
+ *     Reveal background mid-talk. Nobody edits through a thumbnail, so
+ *     `canEdit` is pinned false and the tier lands on `enrolled` (or `public`
+ *     for a public deck): the same immutable sha-addressed bytes, with an
+ *     expiry that outlives the class.
  */
 export function deckAccessFor(
   surface: DeckSurface,
   access: SlideAccessResultLike,
-  slide: { is_public?: boolean | null }
+  slide: { is_public?: boolean | null },
+  opts: { thumbnail?: boolean } = {}
 ): DeliveryAccess {
   const isPublicSite = Boolean(slide.is_public);
   if (surface === 'present' || surface === 'speaker') {
     return { canEdit: false, isPublicSite };
   }
+  // The read-only iframe form of `/follow`. Only `follow` has one here: the
+  // deck viewer's `?preview=true` landing-page thumbnail is a different
+  // surface with a different lifetime, and is deliberately left alone.
+  const isReadOnlyThumbnail = surface === 'follow' && Boolean(opts.thumbnail);
   return {
-    canEdit: access.canEdit,
+    canEdit: isReadOnlyThumbnail ? false : access.canEdit,
     preview: surface === 'viewer' ? Boolean(access.previewActive) : false,
     isPublicSite,
   };

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -23,6 +23,7 @@
  * content proxy. Nothing here is allowed to break a deck read.
  */
 
+import { createHash } from 'node:crypto';
 import { ClassmojiService } from '@classmoji/services';
 import {
   rewriteDeckAssetUrls,
@@ -112,6 +113,36 @@ export function deckAccessFor(
 }
 
 /**
+ * `/follow`'s THUMBNAIL flag, read from the request URL.
+ *
+ * `?preview=true` on this route means "render me as a thumbnail" — the speaker
+ * view's current/next panes and nothing else. It is a different parameter from
+ * the deck viewer's `?preview=1`, which means "read the preview BRANCH", and
+ * the two must never be confused: one is a read-only iframe, the other is a
+ * staff read that legitimately earns draft URLs.
+ *
+ * Exported so the route reads the parameter in exactly one place, and so the
+ * param → flag → tier chain can be pinned without a database behind it.
+ */
+export function isThumbnailRequest(url: URL): boolean {
+  return url.searchParams.get('preview') === 'true';
+}
+
+/**
+ * The `/follow` route's whole tier decision, from its request URL.
+ *
+ * The route's own wiring, hoisted out of the loader so it is testable: the
+ * loader around it needs Prisma and a session, this does not.
+ */
+export function followDeckAccess(
+  url: URL,
+  access: SlideAccessResultLike,
+  slide: { is_public?: boolean | null }
+): DeliveryAccess {
+  return deckAccessFor('follow', access, slide, { thumbnail: isThumbnailRequest(url) });
+}
+
+/**
  * The classroom shape the content resolver needs, or null when this deck's
  * classroom cannot be served by the delivery layer at all.
  *
@@ -171,6 +202,11 @@ export type DeliveryContext = ReturnType<typeof deckDeliveryContext>;
  *
  * The shape matches what `fetchContent` returned, so the call sites keep their
  * existing branching; `source` now also carries `'worker'`.
+ *
+ * `sha` is the git blob sha the bytes came from — the file's IDENTITY, and the
+ * only honest way to ask "is this read the deck that was just saved?". It is
+ * null on the CDN path (GitHub Pages serves a path and names no object), so a
+ * caller comparing identities must read null as "cannot tell", never as a match.
  */
 export async function readDeckText(
   slide: DeliverySlide,
@@ -179,7 +215,7 @@ export async function readDeckText(
   path: string,
   label: string,
   opts: { fallback?: 'api-then-cdn' | 'cdn-only' } = {}
-): Promise<{ content: string; source: 'worker' | 'api' | 'cdn' } | null> {
+): Promise<{ content: string; source: 'worker' | 'api' | 'cdn'; sha: string | null } | null> {
   const classroom = slide.classroom;
   if (!classroom?.id) return null;
 
@@ -197,7 +233,25 @@ export async function readDeckText(
     { label, ...(opts.fallback ? { fallback: opts.fallback } : {}) }
   );
 
-  return result ? { content: result.text, source: result.source } : null;
+  return result ? { content: result.text, source: result.source, sha: result.sha } : null;
+}
+
+/**
+ * The git blob sha of a string, as git itself computes it.
+ *
+ * `sha1("blob " + byteLength + "\0" + bytes)`. This is not a hash we invented:
+ * it is the object id GitHub will report for those exact bytes, so a writer can
+ * name what it just committed without spending an API call to ask.
+ *
+ * Used to give a save the IDENTITY of the index.html it wrote, so the viewer can
+ * tell its own commit from a stale read. Comparing rendered HTML instead cannot
+ * work: the read side signs asset URLs, and the `draft` tier's expiry is an
+ * exact `now + 4h` rather than a bucket, so a staff read of an UNCHANGED deck
+ * comes back with different bytes every second.
+ */
+export function gitBlobSha(content: string): string {
+  const bytes = Buffer.from(content, 'utf8');
+  return createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex');
 }
 
 /** The `shared:` theme a rendered deck declares, or null. */

--- a/apps/slides/app/utils/deckViewContent.ts
+++ b/apps/slides/app/utils/deckViewContent.ts
@@ -14,12 +14,16 @@
  *     into the deck forever. It is also the next save's diff baseline.
  *
  * View mode used to prefer the editor's copy, and had to: the loader read the
- * Pages CDN, which lags a push by minutes, so after a save it was BEHIND. It no
- * longer is — the loader reads the deck text through the delivery Worker by
- * sha, and React Router revalidates it automatically off the back of the save
- * fetcher's action. So view mode goes back to the loader's copy as soon as that
- * refresh lands, and shows the legacy `/content/...` document only in the gap
- * before it does.
+ * Pages CDN, which lags a push by minutes, so after a save it was BEHIND.
+ * Usually it no longer is — WHEN the classroom's delivery flag is on, the
+ * signing env is configured and the asset map has a row for the path, the
+ * loader reads the deck text through the Worker by sha; otherwise it still
+ * falls back to the contents API and then that same lagging CDN. React Router
+ * revalidates the loader automatically off the back of the save fetcher's
+ * action either way. So view mode goes back to the loader's copy once that
+ * refresh is CONFIRMED — by sha, see `settleSaveRefresh`, because on the
+ * fallback paths it may well not be fresh — and otherwise stays on the
+ * document the client saved.
  *
  * Pure, and separated from the route so the choice can be pinned without a
  * browser or the dev stack.
@@ -56,10 +60,14 @@ export function displayDeckContent({
 
 /** What the viewer knows while it waits for a save's loader refresh. */
 export interface SaveRefreshInputs {
-  /** The loader's content as it stands now. */
-  loaderContent: string | null;
-  /** The loader's content at the moment the save's action returned. */
-  preSaveContent: string | null;
+  /**
+   * The git blob sha of the index.html the loader's view-mode read resolved,
+   * or null when that read could not name an object (the CDN fallback, or an
+   * edit/preview-branch render generated from deck.json).
+   */
+  loaderSha: string | null;
+  /** The git blob sha of the index.html the save just committed. */
+  savedSha: string | null;
   /** The save fetcher has finished — action AND its revalidation. */
   fetcherIdle: boolean;
 }
@@ -77,21 +85,29 @@ export interface SaveRefreshOutcome {
  *
  * There is nothing to trigger — the revalidation is already in flight when the
  * action returns — only something to wait for, and the wait has to be told
- * apart from a loader that never came back with anything new. NEW loader
- * content is that signal, and it is checked before the fetcher's idle state on
- * purpose: the two can arrive in either order, and settling on "idle" first
- * would give up one render before the answer showed up.
+ * apart from a loader that came back with a STALE deck.
  *
- * Everything else settles on the copy the client saved locally — the behaviour
- * that shipped before this — so a no-op save, or a route that later opts out of
- * revalidation, degrades to "no worse than before" rather than to stale slides.
+ * The test is IDENTITY, not bytes. Comparing rendered HTML cannot work here:
+ * the read side signs asset URLs per viewer, and the `draft` tier anyone with
+ * edit access gets is an exact `now + 4h` rather than a bucketed expiry, so two
+ * reads of an unchanged deck differ every second. "The document changed" would
+ * be true on every single read, and a stale one — a map row not yet updated, a
+ * Worker 502 falling back to another instance's <60s API cache — would settle
+ * as if it were fresh and put the PRE-save deck on screen. Worse than the bug
+ * this set out to fix.
+ *
+ * So: the loader must name the very object the save committed. A different sha
+ * is a read that has not caught up; a null sha is a read that cannot say what
+ * it fetched. Both settle on the copy the client saved locally — the behaviour
+ * that shipped before this — so every uncertain case degrades to "no worse than
+ * before" rather than to stale slides.
  */
 export function settleSaveRefresh({
-  loaderContent,
-  preSaveContent,
+  loaderSha,
+  savedSha,
   fetcherIdle,
 }: SaveRefreshInputs): SaveRefreshOutcome {
-  if (loaderContent && loaderContent !== preSaveContent) {
+  if (savedSha && loaderSha === savedSha) {
     return { settled: true, viewFromLoader: true };
   }
   return { settled: fetcherIdle, viewFromLoader: false };

--- a/apps/slides/app/utils/deckViewContent.ts
+++ b/apps/slides/app/utils/deckViewContent.ts
@@ -1,0 +1,98 @@
+/**
+ * deckViewContent.ts — which copy of a deck the viewer route renders.
+ *
+ * The deck viewer holds TWO copies of the same document and they are not
+ * interchangeable:
+ *
+ *   - the LOADER's (`slideContent`), which has been through
+ *     `resolveDeckAssets`, so its images are signed `content-*.classmoji.io`
+ *     URLs. This is the one a reader should see.
+ *   - the EDITOR's (`editableContent`), the stored document with raw
+ *     `/content/...` refs. It has to stay unsigned: the editor posts its
+ *     document back on save, and a signed URL that made that round trip would
+ *     be committed into deck.json, freezing one viewer's expiring signature
+ *     into the deck forever. It is also the next save's diff baseline.
+ *
+ * View mode used to prefer the editor's copy, and had to: the loader read the
+ * Pages CDN, which lags a push by minutes, so after a save it was BEHIND. It no
+ * longer is — the loader reads the deck text through the delivery Worker by
+ * sha, and React Router revalidates it automatically off the back of the save
+ * fetcher's action. So view mode goes back to the loader's copy as soon as that
+ * refresh lands, and shows the legacy `/content/...` document only in the gap
+ * before it does.
+ *
+ * Pure, and separated from the route so the choice can be pinned without a
+ * browser or the dev stack.
+ */
+
+/** The two documents plus the two flags that choose between them. */
+export interface DeckDisplayInputs {
+  /** True while the live editor is mounted. */
+  isEditing: boolean;
+  /** A save's loader refresh has landed — see `settleSaveRefresh`. */
+  viewFromLoader: boolean;
+  /** The editor's copy: unsigned, and the next save's baseline. */
+  editableContent: string | null;
+  /** The loader's copy: signed through the delivery layer. */
+  loaderContent: string | null;
+}
+
+/**
+ * The document to render.
+ *
+ * Edit mode is absolute: the editor renders its OWN copy or nothing at all.
+ * Substituting the loader's signed document there is the one thing this module
+ * must never do — it would put signed URLs in front of the save round trip.
+ */
+export function displayDeckContent({
+  isEditing,
+  viewFromLoader,
+  editableContent,
+  loaderContent,
+}: DeckDisplayInputs): string | null {
+  if (isEditing) return editableContent;
+  return viewFromLoader ? loaderContent || editableContent : editableContent || loaderContent;
+}
+
+/** What the viewer knows while it waits for a save's loader refresh. */
+export interface SaveRefreshInputs {
+  /** The loader's content as it stands now. */
+  loaderContent: string | null;
+  /** The loader's content at the moment the save's action returned. */
+  preSaveContent: string | null;
+  /** The save fetcher has finished — action AND its revalidation. */
+  fetcherIdle: boolean;
+}
+
+/** Whether to keep waiting, and what view mode should render once we stop. */
+export interface SaveRefreshOutcome {
+  /** False while the refresh is still outstanding. */
+  settled: boolean;
+  /** True only when the loader actually came back with the committed deck. */
+  viewFromLoader: boolean;
+}
+
+/**
+ * Decide whether a save's loader refresh has landed.
+ *
+ * There is nothing to trigger — the revalidation is already in flight when the
+ * action returns — only something to wait for, and the wait has to be told
+ * apart from a loader that never came back with anything new. NEW loader
+ * content is that signal, and it is checked before the fetcher's idle state on
+ * purpose: the two can arrive in either order, and settling on "idle" first
+ * would give up one render before the answer showed up.
+ *
+ * Everything else settles on the copy the client saved locally — the behaviour
+ * that shipped before this — so a no-op save, or a route that later opts out of
+ * revalidation, degrades to "no worse than before" rather than to stale slides.
+ */
+export function settleSaveRefresh({
+  loaderContent,
+  preSaveContent,
+  fetcherIdle,
+}: SaveRefreshInputs): SaveRefreshOutcome {
+  if (loaderContent && loaderContent !== preSaveContent) {
+    return { settled: true, viewFromLoader: true };
+  }
+  return { settled: fetcherIdle, viewFromLoader: false };
+}

--- a/apps/slides/tests/unit/deck-delivery.spec.ts
+++ b/apps/slides/tests/unit/deck-delivery.spec.ts
@@ -21,6 +21,9 @@ import { test, expect } from '@playwright/test';
 import {
   deckAccessFor,
   deckDeliveryContext,
+  followDeckAccess,
+  gitBlobSha,
+  isThumbnailRequest,
   isThemeRef,
   rebaseThemeRef,
   resolveDeckAssets,
@@ -421,6 +424,62 @@ test.describe('deckAccessFor — the tier inputs, per surface', () => {
     expect(tierOf('follow', OWNER, SLIDE, { thumbnail: true })).toBe('enrolled');
     expect(tierOf('follow', OWNER, PUBLIC_SLIDE, { thumbnail: true })).toBe('public');
     expect(tierOf('follow', STUDENT, SLIDE, { thumbnail: true })).toBe('enrolled');
+  });
+});
+
+test.describe('the /follow route\'s own wiring', () => {
+  const followUrl = (query: string) => new URL(`https://slides.classmoji.io/deck-1/follow${query}`);
+
+  test('only `preview=true` is the thumbnail form', () => {
+    expect(isThumbnailRequest(followUrl('?preview=true'))).toBe(true);
+    expect(isThumbnailRequest(followUrl(''))).toBe(false);
+    // `?preview=1` is the deck VIEWER's preview-BRANCH gate, a different
+    // parameter on a different route. It is not a thumbnail.
+    expect(isThumbnailRequest(followUrl('?preview=1'))).toBe(false);
+    expect(isThumbnailRequest(followUrl('?preview=false'))).toBe(false);
+    expect(isThumbnailRequest(followUrl('?shareCode=abc123'))).toBe(false);
+  });
+
+  test('the URL alone decides the tier the speaker panes get', () => {
+    // The whole chain the route runs: query param → thumbnail flag → access
+    // shape → tier. This is what `/speaker` embeds, and it must not be draft.
+    const tierOf = (url: URL, access: typeof OWNER, slide = SLIDE) =>
+      deckDeliveryContext(slide, ORG, REPO, followDeckAccess(url, access, slide))?.tier;
+
+    expect(tierOf(followUrl('?preview=true'), OWNER)).toBe('enrolled');
+    expect(tierOf(followUrl('?preview=true'), OWNER, PUBLIC_SLIDE)).toBe('public');
+    // Plain /follow is untouched — staff editing along still get draft.
+    expect(tierOf(followUrl(''), OWNER)).toBe('draft');
+    // And a follower is a follower either way.
+    expect(tierOf(followUrl('?preview=true'), STUDENT)).toBe('enrolled');
+    expect(tierOf(followUrl(''), STUDENT)).toBe('enrolled');
+  });
+
+  test('a thumbnail never claims edit access', () => {
+    expect(followDeckAccess(followUrl('?preview=true'), OWNER, SLIDE)).toEqual({
+      canEdit: false,
+      preview: false,
+      isPublicSite: false,
+    });
+    expect(followDeckAccess(followUrl(''), OWNER, SLIDE).canEdit).toBe(true);
+  });
+});
+
+test.describe('gitBlobSha — naming what a save committed', () => {
+  test('agrees with git hash-object', () => {
+    // Pinned against `printf 'hello world\n' | git hash-object --stdin`. If
+    // this drifts, a save can no longer recognise its own commit in the
+    // loader's read and the viewer silently stops refreshing after a save.
+    expect(gitBlobSha('hello world\n')).toBe('3b18e512dba79e4c8300dd08aeb37f8e728b8dad');
+    // The empty blob, the other value git documents.
+    expect(gitBlobSha('')).toBe('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391');
+  });
+
+  test('hashes BYTES, not characters', () => {
+    // The length in the header is the byte length — a deck full of typographic
+    // quotes and em dashes would otherwise hash to something git never stored.
+    expect(gitBlobSha('é')).toBe(gitBlobSha('\u00e9'));
+    expect(gitBlobSha('a')).not.toBe(gitBlobSha('é'));
   });
 });
 

--- a/apps/slides/tests/unit/deck-delivery.spec.ts
+++ b/apps/slides/tests/unit/deck-delivery.spec.ts
@@ -373,12 +373,42 @@ test.describe('deckAccessFor — the tier inputs, per surface', () => {
     expect(deckAccessFor('follow', OWNER, SLIDE).canEdit).toBe(true);
   });
 
+  test('the thumbnail form of follow is read-only, even for an owner', () => {
+    // `/speaker` embeds `/follow?preview=true` in its current and next panes.
+    // Signed as `draft`, those iframes expire four hours in — mid-lecture for
+    // a long class — and the lazily-loaded backgrounds start 403ing.
+    expect(deckAccessFor('follow', OWNER, SLIDE, { thumbnail: true })).toEqual({
+      canEdit: false,
+      preview: false,
+      isPublicSite: false,
+    });
+    // The thumbnail flag still never becomes the viewer's preview-BRANCH flag.
+    expect(
+      deckAccessFor('follow', { canEdit: true, previewActive: true }, SLIDE, { thumbnail: true })
+        .preview
+    ).toBe(false);
+    // Plain `/follow` is untouched: staff still edit there.
+    expect(deckAccessFor('follow', OWNER, SLIDE, { thumbnail: false }).canEdit).toBe(true);
+    expect(deckAccessFor('follow', OWNER, SLIDE).canEdit).toBe(true);
+    // A student was already read-only, and the flag changes nothing for them.
+    expect(deckAccessFor('follow', STUDENT, SLIDE, { thumbnail: true })).toEqual(
+      deckAccessFor('follow', STUDENT, SLIDE)
+    );
+    // Only `follow` has a thumbnail form — the other surfaces ignore the flag.
+    for (const surface of ['viewer', 'present', 'speaker'] as const) {
+      expect(deckAccessFor(surface, OWNER, SLIDE, { thumbnail: true })).toEqual(
+        deckAccessFor(surface, OWNER, SLIDE)
+      );
+    }
+  });
+
   test('the tiers those shapes actually produce', () => {
     const tierOf = (
       surface: Parameters<typeof deckAccessFor>[0],
       access: typeof OWNER,
-      slide = SLIDE
-    ) => deckDeliveryContext(slide, ORG, REPO, deckAccessFor(surface, access, slide))?.tier;
+      slide = SLIDE,
+      opts: Parameters<typeof deckAccessFor>[3] = {}
+    ) => deckDeliveryContext(slide, ORG, REPO, deckAccessFor(surface, access, slide, opts))?.tier;
 
     expect(tierOf('viewer', OWNER)).toBe('draft');
     expect(tierOf('present', OWNER)).toBe('enrolled');
@@ -387,6 +417,10 @@ test.describe('deckAccessFor — the tier inputs, per surface', () => {
     expect(tierOf('follow', STUDENT)).toBe('enrolled');
     expect(tierOf('follow', STUDENT, PUBLIC_SLIDE)).toBe('public');
     expect(tierOf('follow', OWNER)).toBe('draft');
+    // The speaker view's panes: an owner, but not the 4h bucket.
+    expect(tierOf('follow', OWNER, SLIDE, { thumbnail: true })).toBe('enrolled');
+    expect(tierOf('follow', OWNER, PUBLIC_SLIDE, { thumbnail: true })).toBe('public');
+    expect(tierOf('follow', STUDENT, SLIDE, { thumbnail: true })).toBe('enrolled');
   });
 });
 

--- a/apps/slides/tests/unit/deck-view-content.spec.ts
+++ b/apps/slides/tests/unit/deck-view-content.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for `deckViewContent` — which copy of a deck the viewer renders,
+ * and when a save's loader refresh counts as landed.
+ *
+ * The regression: after a save, view mode kept rendering the EDITOR's copy —
+ * the stored document, with raw `/content/...` image refs — until a full page
+ * reload. That preference was correct once, because the loader read the Pages
+ * CDN and was minutes behind a push. It is not any more: the loader reads the
+ * deck text through the delivery Worker by sha, and React Router revalidates it
+ * automatically off the back of the save fetcher's action.
+ *
+ * Runs in the Playwright runner WITHOUT a browser — both functions are pure.
+ */
+
+import { test, expect } from '@playwright/test';
+import { displayDeckContent, settleSaveRefresh } from '../../app/utils/deckViewContent.ts';
+
+/** The loader's copy: images resolved to signed delivery URLs. */
+const SIGNED = '<section><img src="https://content-staging.classmoji.io/c/abc/blob/sha1"></section>';
+/** The editor's copy of the SAME deck: stored refs, and it must stay that way. */
+const STORED = '<section><img src="/content/cs98-org/cs98-content/slides/w1/hero.jpeg"></section>';
+
+test.describe('displayDeckContent — which document is on screen', () => {
+  test('edit mode renders the editor copy, and only ever that', () => {
+    // Handing the editor the signed document is the one thing this must never
+    // do: the editor posts its document back on save, so a signed URL that made
+    // that round trip would be committed into deck.json.
+    expect(
+      displayDeckContent({
+        isEditing: true,
+        viewFromLoader: false,
+        editableContent: STORED,
+        loaderContent: SIGNED,
+      })
+    ).toBe(STORED);
+    // Even once view mode has switched over to the loader.
+    expect(
+      displayDeckContent({
+        isEditing: true,
+        viewFromLoader: true,
+        editableContent: STORED,
+        loaderContent: SIGNED,
+      })
+    ).toBe(STORED);
+    // And with nothing to edit yet, the editor gets nothing — not the loader's.
+    expect(
+      displayDeckContent({
+        isEditing: true,
+        viewFromLoader: true,
+        editableContent: null,
+        loaderContent: SIGNED,
+      })
+    ).toBe(null);
+  });
+
+  test('a page that has saved nothing is unchanged', () => {
+    // First render: no editor copy exists, so the loader's is what shows.
+    expect(
+      displayDeckContent({
+        isEditing: false,
+        viewFromLoader: false,
+        editableContent: null,
+        loaderContent: SIGNED,
+      })
+    ).toBe(SIGNED);
+  });
+
+  test('view mode switches to the loader copy once the refresh has landed', () => {
+    const inputs = { isEditing: false, editableContent: STORED, loaderContent: SIGNED };
+    // Before: the save has returned but its revalidation has not, so `SIGNED`
+    // is still the PRE-save deck. Showing it would flash the old slides.
+    expect(displayDeckContent({ ...inputs, viewFromLoader: false })).toBe(STORED);
+    // After: the loader has the committed deck, signed. This is the fix — it
+    // used to stay on STORED until a full page reload.
+    expect(displayDeckContent({ ...inputs, viewFromLoader: true })).toBe(SIGNED);
+  });
+
+  test('a missing loader document always falls back to the editor copy', () => {
+    // `contentError` in the loader → nothing to render from it. Never blank the
+    // deck when we are holding a perfectly good copy of it.
+    expect(
+      displayDeckContent({
+        isEditing: false,
+        viewFromLoader: true,
+        editableContent: STORED,
+        loaderContent: null,
+      })
+    ).toBe(STORED);
+  });
+});
+
+test.describe('settleSaveRefresh — has the save’s loader refresh landed', () => {
+  test('new loader content settles it, whatever the fetcher is doing', () => {
+    // Checked BEFORE the idle state on purpose: the two can arrive in either
+    // order, and settling on idle first would give up one render too early.
+    expect(
+      settleSaveRefresh({ loaderContent: SIGNED, preSaveContent: 'old', fetcherIdle: false })
+    ).toEqual({ settled: true, viewFromLoader: true });
+    expect(
+      settleSaveRefresh({ loaderContent: SIGNED, preSaveContent: 'old', fetcherIdle: true })
+    ).toEqual({ settled: true, viewFromLoader: true });
+  });
+
+  test('an in-flight refresh keeps waiting', () => {
+    expect(
+      settleSaveRefresh({ loaderContent: 'old', preSaveContent: 'old', fetcherIdle: false })
+    ).toEqual({ settled: false, viewFromLoader: false });
+  });
+
+  test('a loader that never came back with anything new keeps the saved copy', () => {
+    // A no-op save, or a route that later opts out of revalidation: stop
+    // waiting, but stay on what the client saved locally — the behaviour that
+    // shipped before this. Degrading to stale slides would be worse.
+    expect(
+      settleSaveRefresh({ loaderContent: 'old', preSaveContent: 'old', fetcherIdle: true })
+    ).toEqual({ settled: true, viewFromLoader: false });
+    // Same for a loader with no content at all.
+    expect(
+      settleSaveRefresh({ loaderContent: null, preSaveContent: null, fetcherIdle: true })
+    ).toEqual({ settled: true, viewFromLoader: false });
+  });
+});

--- a/apps/slides/tests/unit/deck-view-content.spec.ts
+++ b/apps/slides/tests/unit/deck-view-content.spec.ts
@@ -90,33 +90,67 @@ test.describe('displayDeckContent — which document is on screen', () => {
 });
 
 test.describe('settleSaveRefresh — has the save’s loader refresh landed', () => {
-  test('new loader content settles it, whatever the fetcher is doing', () => {
-    // Checked BEFORE the idle state on purpose: the two can arrive in either
-    // order, and settling on idle first would give up one render too early.
-    expect(
-      settleSaveRefresh({ loaderContent: SIGNED, preSaveContent: 'old', fetcherIdle: false })
-    ).toEqual({ settled: true, viewFromLoader: true });
-    expect(
-      settleSaveRefresh({ loaderContent: SIGNED, preSaveContent: 'old', fetcherIdle: true })
-    ).toEqual({ settled: true, viewFromLoader: true });
+  const SAVED = 'a'.repeat(40);
+  const OLDER = 'b'.repeat(40);
+
+  test('the loader naming the committed deck settles it, fetcher or no fetcher', () => {
+    // Checked BEFORE the idle state on purpose: the loader data and the
+    // fetcher's idle transition can arrive in either order, and settling on
+    // idle first would give up one render before the answer showed up.
+    expect(settleSaveRefresh({ loaderSha: SAVED, savedSha: SAVED, fetcherIdle: false })).toEqual({
+      settled: true,
+      viewFromLoader: true,
+    });
+    expect(settleSaveRefresh({ loaderSha: SAVED, savedSha: SAVED, fetcherIdle: true })).toEqual({
+      settled: true,
+      viewFromLoader: true,
+    });
   });
 
   test('an in-flight refresh keeps waiting', () => {
-    expect(
-      settleSaveRefresh({ loaderContent: 'old', preSaveContent: 'old', fetcherIdle: false })
-    ).toEqual({ settled: false, viewFromLoader: false });
+    expect(settleSaveRefresh({ loaderSha: OLDER, savedSha: SAVED, fetcherIdle: false })).toEqual({
+      settled: false,
+      viewFromLoader: false,
+    });
   });
 
-  test('a loader that never came back with anything new keeps the saved copy', () => {
-    // A no-op save, or a route that later opts out of revalidation: stop
-    // waiting, but stay on what the client saved locally — the behaviour that
-    // shipped before this. Degrading to stale slides would be worse.
-    expect(
-      settleSaveRefresh({ loaderContent: 'old', preSaveContent: 'old', fetcherIdle: true })
-    ).toEqual({ settled: true, viewFromLoader: false });
-    // Same for a loader with no content at all.
-    expect(
-      settleSaveRefresh({ loaderContent: null, preSaveContent: null, fetcherIdle: true })
-    ).toEqual({ settled: true, viewFromLoader: false });
+  test('a loader read that has not caught up never wins', () => {
+    // The map row is not updated yet, or a Worker 502 fell back to another
+    // instance's <60s API cache. The bytes WILL differ from the last read —
+    // `draft` expiries are an exact now+4h, so every signed URL in the document
+    // changes every second — which is exactly why identity is the test and
+    // "the document changed" is not. Settling true here would put the PRE-save
+    // deck on screen: worse than the bug this fixes.
+    expect(settleSaveRefresh({ loaderSha: OLDER, savedSha: SAVED, fetcherIdle: true })).toEqual({
+      settled: true,
+      viewFromLoader: false,
+    });
+  });
+
+  test('a read that cannot name what it fetched never wins', () => {
+    // The CDN fallback serves a path and reports no object id, and so does an
+    // edit/preview-branch render generated from deck.json. Null is "cannot
+    // tell", and must never be read as agreement — including with itself.
+    expect(settleSaveRefresh({ loaderSha: null, savedSha: SAVED, fetcherIdle: false })).toEqual({
+      settled: false,
+      viewFromLoader: false,
+    });
+    expect(settleSaveRefresh({ loaderSha: null, savedSha: SAVED, fetcherIdle: true })).toEqual({
+      settled: true,
+      viewFromLoader: false,
+    });
+    expect(settleSaveRefresh({ loaderSha: null, savedSha: null, fetcherIdle: true })).toEqual({
+      settled: true,
+      viewFromLoader: false,
+    });
+  });
+
+  test('a save that reported no sha keeps the locally saved copy', () => {
+    // Nothing to match against — an older server, or a path that did not
+    // return one. Degrade to the behaviour that shipped before this.
+    expect(settleSaveRefresh({ loaderSha: SAVED, savedSha: null, fetcherIdle: true })).toEqual({
+      settled: true,
+      viewFromLoader: false,
+    });
   });
 });


### PR DESCRIPTION
## What
Two decided follow-ups:

- **Speaker panes get the `enrolled` tier.** `/speaker` embeds `/follow?preview=true` iframes; `/follow` signed by role, so staff got the 4-hour `draft` tier inside the speaker view and a lecture running past four hours would 403 lazily-loaded backgrounds. The thumbnail/iframe form of `/follow` is now a read-only surface (`canEdit: false`), like `/present`. Plain `/follow`, the viewer, and the preview-branch flag are unchanged.
- **The viewer switches to the loader's resolved deck after a save** instead of showing the raw, unsigned copy until reload. React Router already revalidates the loader after the save action; this adds the wait: the save returns the committed `index.html` blob SHA (computed from the exact bytes, verified against `git hash-object`), the loader returns the SHA its view-mode read resolved through the Worker, and view mode flips to loader content only when they match. A stale read (map lagging, Worker down, CDN fallback) settles on the locally saved copy, never on the pre-save deck. Edit mode is never handed a signed document. Also strips `?mode=edit` from the URL after use so later revalidations don't take the unsigned edit branch.

## Test
slides unit 110 passed (was 95), typecheck 0. Revert-tested: dropping the thumbnail flag fails 2 tests; loosening the settle rule fails 4. On staging: open a `cs98-test` deck, edit, save, stay in view mode → images signed and fresh without a reload; open `/speaker` → pane image URLs carry `p=enrolled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA