### PR TITLE
fix(content-worker): cache text blobs whose origin length is unknown

### DIFF
--- a/apps/content/src/blob.ts
+++ b/apps/content/src/blob.ts
@@ -19,6 +19,14 @@ import {
 } from './transform.ts';
 import { cacheControlFor, nowSeconds, type BlobVerification } from './verify.ts';
 
+/**
+ * What a caught rejection actually says. Workers Logs renders a thrown object
+ * as a bare stack, so every cache warning logs this instead.
+ */
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /** The success half of the verification union. */
 type VerifiedBlob = Extract<BlobVerification, { ok: true }>;
 
@@ -103,9 +111,66 @@ function declaredLength(headers: Headers): number | null {
 }
 
 /**
- * Stream an origin body to the client while a tee'd copy lands in R2. Bytes are
- * never buffered here — this is the path every untransformed miss takes, and
- * the one the transform path falls back to when its source is too big to hold.
+ * Ceiling on a cache copy we have to hold in memory because the origin never
+ * said how long it was. Text blobs — `content.json`, `index.html`, css — are
+ * kilobytes, and images arrive identity-encoded with a length, so nothing on
+ * the normal path comes near this. It is here so a pathological body cannot
+ * trade a cache write for the isolate's memory.
+ */
+export const MAX_UNKNOWN_LENGTH_CACHE_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Put the tee'd cache branch into R2, buffering it only when we must.
+ *
+ * R2 accepts a `ReadableStream` only when the runtime knows its length up
+ * front, which it does from the origin's `Content-Length` — and only when the
+ * origin sent one it did not encode. GitHub gzips text, so every
+ * `content.json`, `index.html` and stylesheet arrives with the length of the
+ * ENCODED body while `tee()` hands us the decoded bytes: length unknown, and
+ * the streaming put rejects. That failure is silent to the client (the write is
+ * in `waitUntil`), so text was served correctly and re-pulled from GitHub on
+ * every single read, never landing in R2 or at the edge.
+ *
+ * With no length there is nothing to declare up front, so the only way to write
+ * it is to hold it. `readBounded` caps how much — past the ceiling the copy is
+ * dropped rather than cached, which costs a re-fetch and never the isolate.
+ */
+async function putCacheBranch(
+  env: Env,
+  key: string,
+  toCache: ReadableStream<Uint8Array>,
+  contentType: string,
+  contentLength: number | null
+): Promise<void> {
+  try {
+    if (contentLength !== null) {
+      await env.CACHE.put(key, toCache, { httpMetadata: { contentType } });
+      return;
+    }
+    const bytes = await readBounded(toCache, MAX_UNKNOWN_LENGTH_CACHE_BYTES);
+    if (bytes === null) {
+      // The size can only be named by buffering it, which is the thing the
+      // ceiling exists to refuse.
+      console.warn(
+        `[content] not caching ${key}: unknown-length origin body over the ` +
+          `${MAX_UNKNOWN_LENGTH_CACHE_BYTES} byte ceiling`
+      );
+      return;
+    }
+    await env.CACHE.put(key, bytes, { httpMetadata: { contentType } });
+  } catch (error) {
+    // The message, not the error: Workers Logs renders a thrown object as a
+    // stack, and the stack of a caught R2 rejection says nothing about why.
+    console.warn(`[content] failed to cache ${key}: ${messageOf(error)}`);
+  }
+}
+
+/**
+ * Stream an origin body to the client while a tee'd copy lands in R2. The
+ * client's half always streams — this is the path every untransformed miss
+ * takes, and the one the transform path falls back to when its source is too
+ * big to hold. Only the cache half is ever buffered, and only when the origin
+ * left its length unknown.
  */
 function streamAndCache(
   env: Env,
@@ -117,11 +182,7 @@ function streamAndCache(
   contentLength: number | null
 ): Response {
   const [toClient, toCache] = body.tee();
-  ctx.waitUntil(
-    env.CACHE.put(key, toCache, { httpMetadata: { contentType } }).catch(error => {
-      console.warn(`[content] failed to cache ${key}:`, error);
-    })
-  );
+  ctx.waitUntil(putCacheBranch(env, key, toCache, contentType, contentLength));
   const headers = contentHeaders(contentType, cacheControl);
   // Only ever forwarded, never computed: working it out would mean buffering
   // the very stream this path exists to avoid buffering.
@@ -252,7 +313,7 @@ async function loadOriginalBytes(
   ctx.waitUntil(
     env.CACHE.put(key, bytes, { httpMetadata: { contentType: options.contentType } }).catch(
       error => {
-        console.warn(`[content] failed to cache ${key}:`, error);
+        console.warn(`[content] failed to cache ${key}: ${messageOf(error)}`);
       }
     )
   );
@@ -304,7 +365,7 @@ async function serveVariant(
   ctx.waitUntil(
     env.CACHE.put(key, transformed, { httpMetadata: { contentType: mediaTypeFor(format) } }).catch(
       error => {
-        console.warn(`[content] failed to cache ${key}:`, error);
+        console.warn(`[content] failed to cache ${key}: ${messageOf(error)}`);
       }
     )
   );

--- a/apps/content/tests/helpers.ts
+++ b/apps/content/tests/helpers.ts
@@ -30,6 +30,19 @@ interface StoredObject {
   size?: number;
 }
 
+export interface FakeBucketOptions {
+  /**
+   * Whether the origin behind this test declared an honest `Content-Length`.
+   *
+   * Real R2 takes a `ReadableStream` only when the runtime already knows how
+   * many bytes are coming — which it does from the origin response's
+   * `Content-Length`, and only when the body was not encoded. There is no way
+   * to observe that from a stream object, so the test says it instead. Default
+   * false: GitHub gzips text, the runtime decodes it, and the length is gone.
+   */
+  originDeclaresLength?: boolean;
+}
+
 export interface FakeBucket {
   get(key: string): Promise<unknown>;
   head(key: string): Promise<unknown>;
@@ -38,7 +51,7 @@ export interface FakeBucket {
     value: unknown,
     options?: { httpMetadata?: { contentType?: string } }
   ): Promise<unknown>;
-  readonly puts: Array<{ key: string; contentType?: string; bytes: number }>;
+  readonly puts: Array<{ key: string; contentType?: string; bytes: number; streamed: boolean }>;
   readonly gets: string[];
   readonly heads: string[];
 }
@@ -69,9 +82,12 @@ async function drain(value: unknown): Promise<number> {
   return 0;
 }
 
-export function fakeBucket(initial: Record<string, StoredObject> = {}): FakeBucket {
+export function fakeBucket(
+  initial: Record<string, StoredObject> = {},
+  options: FakeBucketOptions = {}
+): FakeBucket {
   const store = new Map(Object.entries(initial));
-  const puts: Array<{ key: string; contentType?: string; bytes: number }> = [];
+  const puts: Array<{ key: string; contentType?: string; bytes: number; streamed: boolean }> = [];
   const gets: string[] = [];
   const heads: string[] = [];
 
@@ -102,10 +118,21 @@ export function fakeBucket(initial: Record<string, StoredObject> = {}): FakeBuck
       const object = store.get(key);
       return object ? metadata(key, object) : null;
     },
-    async put(key: string, value: unknown, options?: { httpMetadata?: { contentType?: string } }) {
+    async put(
+      key: string,
+      value: unknown,
+      putOptions?: { httpMetadata?: { contentType?: string } }
+    ) {
+      const streamed = value instanceof ReadableStream;
+      if (streamed && !options.originDeclaresLength) {
+        // The real rejection, verbatim: R2 refuses a stream whose length the
+        // runtime cannot see. A fake that drained it regardless is why every
+        // text blob silently failed to cache in production.
+        throw new Error('Provided readable stream must have a known length');
+      }
       const bytes = await drain(value);
-      puts.push({ key, contentType: options?.httpMetadata?.contentType, bytes });
-      store.set(key, { body: 'stored', contentType: options?.httpMetadata?.contentType });
+      puts.push({ key, contentType: putOptions?.httpMetadata?.contentType, bytes, streamed });
+      store.set(key, { body: 'stored', contentType: putOptions?.httpMetadata?.contentType });
       return {};
     },
   };

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAX_UNKNOWN_LENGTH_CACHE_BYTES } from '../src/blob.ts';
 import worker, { clearRotationLog } from '../src/index.ts';
 import { clearOriginCache } from '../src/token.ts';
 import { MAX_TRANSFORM_SOURCE_BYTES } from '../src/transform.ts';
@@ -20,6 +21,19 @@ import {
 } from './helpers.ts';
 
 const realFetch = globalThis.fetch;
+
+/** Size a body without holding a copy of it — the oversized cases are 32 MB. */
+async function countBytes(response: Response): Promise<number> {
+  const body = response.body;
+  if (!body) return 0;
+  const reader = body.getReader();
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return total;
+    total += value.byteLength;
+  }
+}
 
 /** Routes the two upstreams the Worker talks to: the token endpoint and GitHub. */
 function stubUpstreams(handlers: { blob?: () => Response; tree?: () => Response } = {}) {
@@ -307,11 +321,27 @@ describe('blob delivery', () => {
     stubUpstreams({
       blob: () => new Response('origin-bytes', { headers: { 'Content-Length': '12' } }),
     });
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const ctx = fakeContext();
     const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
 
-    const response = await worker.fetch(new Request(url), fakeEnv(), fakeContext());
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      ctx
+    );
 
     expect(response.headers.get('Content-Length')).toBe('12');
+    // A declared length is the one case R2 can take the stream itself.
+    await ctx.settled();
+    expect(bucket.puts).toEqual([
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'text/css; charset=utf-8',
+        bytes: 'origin-bytes'.length,
+        streamed: true,
+      },
+    ]);
   });
 
   it('drops the Content-Length of a compressed origin response', async () => {
@@ -430,6 +460,7 @@ describe('blob delivery', () => {
         key: `blobs/${BLOB_SHA}`,
         contentType: 'text/css; charset=utf-8',
         bytes: 'origin-bytes'.length,
+        streamed: false,
       },
     ]);
   });
@@ -608,6 +639,7 @@ describe('blob delivery', () => {
         key: `blobs/${BLOB_SHA}`,
         contentType: 'text/html; charset=utf-8',
         bytes: 'origin-bytes'.length,
+        streamed: false,
       },
     ]);
   });
@@ -633,7 +665,12 @@ describe('blob delivery', () => {
     expect(response.headers.get('Cache-Control')).toBe('no-store');
     await ctx.settled();
     expect(bucket.puts).toEqual([
-      { key: `blobs/${BLOB_SHA}`, contentType: 'image/png', bytes: 'origin-bytes'.length },
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'image/png',
+        bytes: 'origin-bytes'.length,
+        streamed: false,
+      },
     ]);
   });
 
@@ -655,8 +692,137 @@ describe('blob delivery', () => {
         key: `blobs/${BLOB_SHA}`,
         contentType: 'text/css; charset=utf-8',
         bytes: 'origin-bytes'.length,
+        streamed: false,
       },
     ]);
+  });
+
+  it('caches a gzipped text blob, whose decoded length the origin never declared', async () => {
+    // The production bug. GitHub gzips content.json, index.html and css; the
+    // runtime decodes them, so the declared length describes bytes we no longer
+    // hold and R2 refuses the resulting unknown-length stream. Every text read
+    // was served correctly and then re-pulled from GitHub, forever.
+    const bucket = fakeBucket();
+    const ctx = fakeContext();
+    stubUpstreams({
+      blob: () =>
+        new Response('{"page":"bytes"}', {
+          headers: { 'Content-Length': '19', 'Content-Encoding': 'gzip' },
+        }),
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'json' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"page":"bytes"}');
+    await ctx.settled();
+    expect(bucket.puts).toEqual([
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'application/json; charset=utf-8',
+        bytes: '{"page":"bytes"}'.length,
+        streamed: false,
+      },
+    ]);
+  });
+
+  it('hands R2 the stream itself when the origin measured the body', async () => {
+    // Images arrive identity-encoded with a real Content-Length, so the length
+    // survives to R2 and nothing is ever held in memory.
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const ctx = fakeContext();
+    stubUpstreams({
+      blob: () => new Response('png-bytes', { headers: { 'Content-Length': '9' } }),
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await ctx.settled();
+    expect(bucket.puts).toEqual([
+      {
+        key: `blobs/${BLOB_SHA}`,
+        contentType: 'image/png',
+        bytes: 'png-bytes'.length,
+        streamed: true,
+      },
+    ]);
+  });
+
+  it('serves an unknown-length body over the ceiling without caching it', async () => {
+    // Nothing on the real path comes near 32 MB of undeclared length. The
+    // ceiling is here so a body that does costs a re-fetch, not the isolate.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bucket = fakeBucket();
+    const ctx = fakeContext();
+    const chunk = new Uint8Array(4 * 1024 * 1024);
+    const chunks = MAX_UNKNOWN_LENGTH_CACHE_BYTES / chunk.byteLength;
+    stubUpstreams({
+      blob: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (let index = 0; index < chunks; index += 1) controller.enqueue(chunk);
+              controller.enqueue(new Uint8Array(1));
+              controller.close();
+            },
+          })
+        ),
+    });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(await countBytes(response)).toBe(MAX_UNKNOWN_LENGTH_CACHE_BYTES + 1);
+    await ctx.settled();
+    expect(bucket.puts).toEqual([]);
+    expect(warn.mock.calls[0]?.[0]).toBe(
+      `[content] not caching blobs/${BLOB_SHA}: unknown-length origin body over the ` +
+        `${MAX_UNKNOWN_LENGTH_CACHE_BYTES} byte ceiling`
+    );
+  });
+
+  it('logs what R2 actually said when a cache write fails', async () => {
+    // Workers Logs renders a thrown object as a bare stack, which is how a
+    // put that had been failing on every text blob for weeks read as noise.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bucket = fakeBucket();
+    const failing = {
+      ...bucket,
+      put: async () => {
+        throw new Error('the R2 service is having a bad day');
+      },
+    };
+    const ctx = fakeContext();
+    stubUpstreams();
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css' });
+
+    const response = await worker.fetch(
+      new Request(url),
+      fakeEnv({ CACHE: failing as unknown as R2Bucket }),
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await ctx.settled();
+    expect(warn.mock.calls[0]?.[0]).toBe(
+      `[content] failed to cache blobs/${BLOB_SHA}: the R2 service is having a bad day`
+    );
   });
 
   it('502s an origin failure and does not cache it', async () => {
@@ -776,7 +942,7 @@ describe('blob delivery', () => {
           headers: { 'Content-Length': String(MAX_TRANSFORM_SOURCE_BYTES + 1) },
         }),
     });
-    const bucket = fakeBucket();
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
     const images = { input: vi.fn() } as unknown as ImagesBinding;
     const ctx = fakeContext();
     const url = await signedBlobUrl({


### PR DESCRIPTION
## What
Every text blob (`content.json`, `index.html`, css) was served correctly but never cached: GitHub gzips text, the runtime decodes it, the length is unknown, and R2's streaming `put` rejects with `Provided readable stream must have a known length`. Images carry a `Content-Length` and were fine. Effect on staging: every text read re-pulled from GitHub (6–10 s) and the app's read budget sometimes tripped into its API fallback.

Fix: when the origin declares no usable length, buffer the cache branch (bounded at 32 MB, cancelled past the ceiling) and `put` the bytes; the client stream is untouched and identity-encoded bodies keep the streaming path. Cache-failure warnings now carry the error message, not just a stack.

## Test
Worker 148 passed (was 144), typecheck 0, lint clean. The test fake bucket now rejects unknown-length streams with R2's real message; reverting the fix fails 9 tests (4 new + 5 that had passed vacuously). On staging after deploy: read a public page twice → the second is an R2/edge hit and `content.json` appears in `classmoji-content-cache-stg` with `application/json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA