### PR TITLE
perf: prebuild staging images and stabilize dependency installs

### DIFF
--- a/.github/workflows/build-fly-staging.yml
+++ b/.github/workflows/build-fly-staging.yml
@@ -1,0 +1,59 @@
+name: Build staging Fly image
+
+on:
+  workflow_call:
+    inputs:
+      service:
+        required: true
+        type: string
+    secrets:
+      FLY_API_TOKEN:
+        required: true
+      PERSONAL_ACCESS_TOKEN:
+        required: true
+    outputs:
+      image:
+        description: Image pushed for this staging service and workflow attempt
+        value: ${{ jobs.build.outputs.image }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Heal package-lock.json against submodule workspaces
+        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Build and push staging image
+        id: build
+        env:
+          SERVICE: ${{ inputs.service }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          case "$SERVICE" in
+            webapp|ai-agent|hook-station|mcp|pages|slides|admin) ;;
+            *) echo "Unsupported staging service: $SERVICE" >&2; exit 1 ;;
+          esac
+          APP="classmoji-${SERVICE}-staging"
+          if [ "$SERVICE" = mcp ] && ! flyctl status --app "$APP" >/dev/null 2>&1; then
+            echo "::notice::Skipping mcp build because its staging app is not provisioned."
+            exit 0
+          fi
+          DOCKERFILE="apps/${SERVICE}/Dockerfile"
+          if [ "$SERVICE" = ai-agent ]; then
+            DOCKERFILE=scripts/docker/ai-agent.staging.Dockerfile
+          fi
+          LABEL="staging-${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          flyctl deploy --config "apps/${SERVICE}/fly.toml" --dockerfile "$DOCKERFILE" \
+            --app "$APP" --remote-only --depot=true --depot-scope=app \
+            --build-only --push --image-label "$LABEL"
+          echo "image=registry.fly.io/${APP}:${LABEL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-fly-staging.yml
+++ b/.github/workflows/deploy-fly-staging.yml
@@ -36,6 +36,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'apps/webapp/**'
               - 'packages/**'
             ai-agent:
@@ -44,6 +45,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'scripts/docker/ai-agent.staging.Dockerfile'
               - 'apps/ai-agent'
               - 'apps/ai-agent/**'
@@ -54,6 +56,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'apps/hook-station/**'
               - 'packages/**'
             mcp:
@@ -62,6 +65,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'apps/mcp/**'
               - 'packages/**'
             site:
@@ -72,6 +76,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'apps/slides/**'
               - 'packages/**'
             pages:
@@ -80,6 +85,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'apps/pages/**'
               - 'packages/**'
             admin:
@@ -88,6 +94,7 @@ jobs:
               - '.npmrc'
               - '.dockerignore'
               - '.github/workflows/deploy-fly-staging.yml'
+              - '.github/workflows/build-fly-staging.yml'
               - 'apps/admin/**'
               - 'packages/**'
             tasks:
@@ -96,40 +103,102 @@ jobs:
               - 'packages/services/**'
               - 'packages/utils/**'
 
-  deploy-webapp:
+  # Build images before the migration barrier; only rollouts wait for webapp.
+  # At most six monorepo builds: admin takes ai-agent's slot when it finishes.
+  build-webapp:
     needs: changes
+    if: needs.changes.outputs.webapp == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: webapp
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  build-ai-agent:
+    needs: changes
+    if: needs.changes.outputs.ai-agent == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: ai-agent
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  build-hook-station:
+    needs: changes
+    if: needs.changes.outputs.hook-station == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: hook-station
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  build-mcp:
+    needs: changes
+    if: needs.changes.outputs.mcp == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: mcp
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  build-pages:
+    needs: changes
+    if: needs.changes.outputs.pages == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: pages
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  build-slides:
+    needs: changes
+    if: needs.changes.outputs.slides == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: slides
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  build-admin:
+    needs: [changes, build-ai-agent]
+    if: always() && !cancelled() && needs.changes.outputs.admin == 'true'
+    uses: ./.github/workflows/build-fly-staging.yml
+    with:
+      service: admin
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  deploy-webapp:
+    needs: [changes, build-webapp]
     if: needs.changes.outputs.webapp == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy webapp
         run: |
           CONFIG=$(scripts/fly-autostop-config.sh apps/webapp/fly.toml stop)
-          flyctl deploy --config "$CONFIG" --dockerfile apps/webapp/Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-webapp-staging
+          flyctl deploy --config "$CONFIG" --image "$IMAGE" --app classmoji-webapp-staging
         env:
+          IMAGE: ${{ needs.build-webapp.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-  # Keep at most two monorepo builds active after webapp completes.
-  # Lane 1: ai-agent -> mcp -> slides. Lane 2: hook-station -> pages -> admin.
-  # Existing always() guards let a lane continue after a failed/skipped sibling;
-  # every service still requires a successful/skipped webapp migration barrier.
+  # Each rollout requires its image and the successful webapp migration barrier.
   deploy-ai-agent:
-    needs: [changes, deploy-webapp]
+    needs: [changes, deploy-webapp, build-ai-agent]
     # Always wait on deploy-webapp so that any pending Prisma migration
     # (run by the webapp's release_command) has applied before non-webapp
     # services come up with new code that targets the new schema.
     # `always()` lets this run even when deploy-webapp was skipped.
-    if: always() && needs.changes.outputs.ai-agent == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    if: always() && !cancelled() && needs.build-ai-agent.result == 'success' && needs.build-ai-agent.outputs.image != '' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -137,34 +206,22 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy ai-agent
         run: |
           CONFIG=$(scripts/fly-autostop-config.sh apps/ai-agent/fly.toml suspend)
-          flyctl deploy --config "$CONFIG" --dockerfile scripts/docker/ai-agent.staging.Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-ai-agent-staging
+          flyctl deploy --config "$CONFIG" --image "$IMAGE" --app classmoji-ai-agent-staging
         env:
+          IMAGE: ${{ needs.build-ai-agent.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-hook-station:
-    needs: [changes, deploy-webapp]
-    if: always() && needs.changes.outputs.hook-station == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    needs: [changes, deploy-webapp, build-hook-station]
+    if: always() && !cancelled() && needs.build-hook-station.result == 'success' && needs.build-hook-station.outputs.image != '' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy hook-station
         run: |
@@ -173,35 +230,29 @@ jobs:
           # no retry, so every push/issue event that arrived while it slept was
           # lost. Deploy the production config as-is (auto_stop off, one machine
           # always running; shared-cpu-1x, pennies).
-          flyctl deploy --config apps/hook-station/fly.toml --dockerfile apps/hook-station/Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-hook-station-staging
+          flyctl deploy --config apps/hook-station/fly.toml --image "$IMAGE" --app classmoji-hook-station-staging
         env:
+          IMAGE: ${{ needs.build-hook-station.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-mcp:
-    needs: [changes, deploy-webapp, deploy-ai-agent]
-    if: always() && needs.changes.outputs.mcp == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    needs: [changes, deploy-webapp, build-mcp]
+    if: always() && !cancelled() && needs.build-mcp.result == 'success' && needs.build-mcp.outputs.image != '' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy mcp
         run: |
           if flyctl status --app classmoji-mcp-staging >/dev/null 2>&1; then
             CONFIG=$(scripts/fly-autostop-config.sh apps/mcp/fly.toml stop)
-            flyctl deploy --config "$CONFIG" --dockerfile apps/mcp/Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-mcp-staging
+            flyctl deploy --config "$CONFIG" --image "$IMAGE" --app classmoji-mcp-staging
           else
             echo "::notice::Skipping mcp deploy because Fly app classmoji-mcp-staging is not provisioned."
           fi
         env:
+          IMAGE: ${{ needs.build-mcp.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-site:
@@ -233,77 +284,56 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-slides:
-    needs: [changes, deploy-webapp, deploy-ai-agent, deploy-mcp]
-    if: always() && needs.changes.outputs.slides == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    needs: [changes, deploy-webapp, build-slides]
+    if: always() && !cancelled() && needs.build-slides.result == 'success' && needs.build-slides.outputs.image != '' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy slides
         run: |
           CONFIG=$(scripts/fly-autostop-config.sh apps/slides/fly.toml stop)
-          flyctl deploy --config "$CONFIG" --dockerfile apps/slides/Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-slides-staging
+          flyctl deploy --config "$CONFIG" --image "$IMAGE" --app classmoji-slides-staging
         env:
+          IMAGE: ${{ needs.build-slides.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-pages:
-    needs: [changes, deploy-webapp, deploy-hook-station]
-    if: always() && needs.changes.outputs.pages == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    needs: [changes, deploy-webapp, build-pages]
+    if: always() && !cancelled() && needs.build-pages.result == 'success' && needs.build-pages.outputs.image != '' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy pages
         run: |
           CONFIG=$(scripts/fly-autostop-config.sh apps/pages/fly.toml stop)
-          flyctl deploy --config "$CONFIG" --dockerfile apps/pages/Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-pages-staging
+          flyctl deploy --config "$CONFIG" --image "$IMAGE" --app classmoji-pages-staging
         env:
+          IMAGE: ${{ needs.build-pages.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-admin:
-    needs: [changes, deploy-webapp, deploy-hook-station, deploy-pages]
-    if: always() && needs.changes.outputs.admin == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    needs: [changes, deploy-webapp, build-admin]
+    if: always() && !cancelled() && needs.build-admin.result == 'success' && needs.build-admin.outputs.image != '' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Heal package-lock.json against submodule workspaces
-        run: npm install --package-lock-only --no-audit --no-fund --legacy-peer-deps
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Deploy admin
         run: |
           CONFIG=$(scripts/fly-autostop-config.sh apps/admin/fly.toml stop)
-          flyctl deploy --config "$CONFIG" --dockerfile apps/admin/Dockerfile --remote-only --depot=true --depot-scope=app --app classmoji-admin-staging
+          flyctl deploy --config "$CONFIG" --image "$IMAGE" --app classmoji-admin-staging
         env:
+          IMAGE: ${{ needs.build-admin.outputs.image }}
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
   deploy-trigger:
     needs: [changes, deploy-webapp]
-    if: always() && needs.changes.outputs.tasks == 'true' && (needs.deploy-webapp.result == 'success' || needs.deploy-webapp.result == 'skipped')
+    if: always() && !cancelled() && needs.changes.outputs.tasks == 'true' && (needs.deploy-webapp.result == 'success' || (needs.changes.outputs.webapp != 'true' && needs.deploy-webapp.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Fix lightningcss / tailwind oxide for Alpine
 RUN --mount=type=cache,target=/root/.npm \

--- a/apps/hook-station/Dockerfile
+++ b/apps/hook-station/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Generate Prisma client at build time
 COPY packages/database/schema.prisma packages/database/

--- a/apps/mcp/Dockerfile
+++ b/apps/mcp/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Generate Prisma client at build time
 COPY packages/database/schema.prisma packages/database/

--- a/apps/pages/Dockerfile
+++ b/apps/pages/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Fix lightningcss / tailwind oxide for Alpine
 RUN --mount=type=cache,target=/root/.npm \

--- a/apps/slides/Dockerfile
+++ b/apps/slides/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Fix lightningcss / tailwind oxide for Alpine
 RUN --mount=type=cache,target=/root/.npm \

--- a/apps/webapp/Dockerfile
+++ b/apps/webapp/Dockerfile
@@ -29,8 +29,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Fix lightningcss / tailwind oxide for Alpine
 RUN --mount=type=cache,target=/root/.npm \

--- a/scripts/docker/ai-agent.staging.Dockerfile
+++ b/scripts/docker/ai-agent.staging.Dockerfile
@@ -30,8 +30,11 @@ COPY packages/tasks/package.json packages/tasks/
 COPY packages/ui-components/package.json packages/ui-components/
 COPY packages/utils/package.json packages/utils/
 
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --legacy-peer-deps --no-audit --no-fund
+# Keep the Docker install layer cached, but use a fresh npm download cache on
+# a cache miss. Unpacking the populated cache exhausted the 4 GB build host.
+RUN NODE_OPTIONS=--max-old-space-size=1024 npm ci --legacy-peer-deps --no-audit --no-fund \
+    --maxsockets=5 --cache=/tmp/npm-ci-cache \
+    && rm -rf /tmp/npm-ci-cache
 
 # Generate Prisma client at build time
 COPY packages/database/schema.prisma packages/database/


### PR DESCRIPTION
Staging currently waits for webapp to build and deploy before starting other images. Build up to six images ahead of that barrier, then deploy each completed image after webapp succeeds. This preserves migration ordering while removing most of the build queue.

Fresh-install testing also exposed a separate failure: `npm ci` was killed with exit code 137 on the roughly 4 GB Depot builder, including with only one build running. Available memory fell to about 40 MB while processing cached packages. Fresh npm download caches with five connections and a 1 GB npm heap completed the same 2,569-package install. The Docker dependency layer remains cached for source-only changes; dependency lifecycle scripts remain enabled.

Changes:
- Add a reusable staging-only image build workflow with an explicit service allowlist, app-scoped Depot caches, and image tags unique to the commit/run/attempt.
- Start up to six builds immediately; admin takes AI-agent's slot. Rollouts consume the pushed images and require successful webapp migration/rollout. A skipped webapp job only passes the barrier when webapp was not selected; a failed webapp build cannot bypass it.
- Keep AI-agent's private submodule checkout for its deployment config. Preserve optional MCP provisioning behavior and staging run serialization.
- Update the seven Dockerfiles used by staging to bound fresh-install memory without changing their runtime stages, dependency versions, or lockfile.

Measured on staging on 2026-09-05 using temporary CLI benchmarks:

| Approach | Dependency-cache reuse | Fresh dependency install |
|---|---:|---:|
| Webapp first, then three concurrent services | 6m37s | — |
| Webapp first, then six concurrent services | 5m23s | 8m02s |
| Build ahead, up to six simultaneous builds | 2m47s | 5m06s |

The final patch's build-ahead cache-reuse run completed in **2m43s**. Fresh build-ahead was **36.5% faster** than webapp-first with six services. All seven application health checks returned 200 after every successful trial, including private Flycast health for AI-agent.

Measurement scope: wall time for all seven Fly builds and rollouts, including Fly's internal rollout checks. These are CLI measurements, not full GitHub Actions timings: runner setup/queue time, the release command, and subsequent external health probes are excluded. Benchmarks used `--skip-release-command` because application/schema revisions were unchanged; the committed workflow retains the release command and migration barrier. Cache-reuse trials changed build context and reran frontend builds; they did not introduce a user-facing feature. Fresh trials invalidated the install layer without changing dependency versions. All seven final fresh build-ahead npm layers were verified uncached, then cached in the final reuse run.

The initial schedule comparison used staging `76045f7`. After PR #300 merged, testing paused for its deployment to finish, then resumed from `9dd7912` with that content-worker change included. The final fresh comparisons and cache-reuse run used the same final patch. Before the npm fix, both fresh approaches failed during dependency installation; failed images were never rolled out.

Validation: actionlint passed; temporary checks covered 448 deployment prerequisite states, 128 build-selection combinations, all seven build/rollout commands, rejected service inputs, failed builds, missing MCP, and unchanged runtime stages/lockfile. No benchmark files or persistent tests are included in the PR. No production app, database, or secrets were accessed or changed; production/dev workflow files and Fly configurations are unchanged.
