### PR TITLE
feat(content): name signing tiers by lifetime and choose them by visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -233,7 +233,7 @@ CONTENT_SIGNING_SECRET=""
 # instead of 403ing the moment the key changes.
 #
 # Set it to the old value at the same time you set the new CONTENT_SIGNING_SECRET,
-# leave it in place for 30 days (the longest signature lifetime, the public
+# leave it in place for 30 days (the longest signature lifetime, the `month`
 # tier's), then clear it. Shorter only if you are rotating because the old key
 # leaked — and then accept that every URL already in the wild starts 403ing.
 #

--- a/.github/workflows/e2e-content.yml
+++ b/.github/workflows/e2e-content.yml
@@ -23,7 +23,7 @@ on:
 # WHAT ACTUALLY RUNS AGAINST STAGING
 #
 # Eight of the nineteen scenarios, verified green against cs98-test on
-# 2026-09-04: the public-tier class-site render with its ladder, /healthz, the
+# 2026-09-04: the `month`-tier class-site render with its ladder, /healthz, the
 # 200 + HEAD parity, the four refusals (tampered sig, appended width, extended
 # expiry, foreign classroom) and the /missing/ 404. Every one is a read.
 #
@@ -40,9 +40,11 @@ on:
 #     set, the pack attaches that `classmoji.session_token` to the browser
 #     context — scoped to the three staging origins by URL, never by domain, so
 #     it cannot follow a redirect to production — and one more scenario runs:
-#     a member-facing page must not be served at the `public` tier. It cannot
-#     assert `enrolled` exactly, because a staff token would correctly produce
-#     `draft`; the local pack pins the exact values.
+#     a signed-in render must come back signed, origin-bound, and on a tier this
+#     deployment still recognises. It cannot assert a specific tier: the tier
+#     follows the CONTENT's visibility and the viewer's edit rights, and this
+#     scenario knows neither the token's role nor which page the index linked
+#     to. The local pack pins the exact values.
 #   - Uploads skip unless E2E_CD_CONTENT_REPO=1 says the target classroom's repo
 #     is genuinely writable. It is not set here on purpose: nothing scheduled
 #     should be committing fixture PNGs to a course repository.
@@ -97,7 +99,7 @@ jobs:
       #
       # `E2E_STAGING_SESSION_COOKIE` is a `classmoji.session_token` value for a
       # member of cs98-test on staging. With it, the signed-in scenarios (the
-      # editor's draft tier, a member's enrolled tier) run; without it they skip
+      # editor's `edit` tier, a member's read tier) run; without it they skip
       # with that exact instruction. It is NOT created here and no value is
       # invented: a maintainer mints a session and stores it, or leaves it unset
       # and accepts the smaller suite.

--- a/apps/content/README.md
+++ b/apps/content/README.md
@@ -22,7 +22,7 @@ GET /healthz
 OPTIONS *
 ```
 
-`p` is the tier (`public` | `enrolled` | `draft`), `v` the key version, `exp` a
+`p` is the tier (`month` | `week` | `edit`), `v` the key version, `exp` a
 unix-seconds expiry, `sig` the base64url HMAC. `w` (800 | 1600 | 2560) and `fmt`
 (webp | avif | auto) request an image variant and are part of the signed string,
 so they cannot be swapped.
@@ -45,6 +45,39 @@ percent-encoded after one decode is refused.
 is no separate version field. Anything else is a 404. An unsigned, tampered, or
 long-expired URL is a 403 with `Cache-Control: no-store` — a refusal is never
 cached.
+
+### Tiers
+
+Each tier is named for the window it buys, because that is the only thing it
+decides:
+
+| Tier | Window | Cache | Minted when |
+| --- | --- | --- | --- |
+| `edit` | exact `now + 4h`, 5m grace | `no-store` | the viewer can edit, or an explicit staff read of a preview branch |
+| `week` | end of the classroom's current 7d bucket, 6h grace | `public, max-age={exp-now}, immutable` | everything else — the ordinary members-only read |
+| `month` | end of the classroom's current 30d bucket, 6h grace | `public, max-age={exp-now}, immutable` | the content itself is public (`Page.is_public`, or a deck's) |
+
+**A tier is not access control — the signature is.** It picks a lifetime and a
+cacheability for a URL that has already been minted for someone who was allowed
+to have it. Nothing here reads a session, and the Worker cannot tell an enrolled
+student from an anonymous visitor.
+
+Which tier a render gets follows the CONTENT's visibility, not the surface
+showing it, so a public page is `month` whether it is rendered inside the pages
+app or on the class site, and inside one bucket the two are byte-identical.
+Bucket boundaries are staggered per classroom so the fleet does not cold-fill in
+unison.
+
+The corollary is the part worth saying out loud: flipping a page or deck from
+public to private does **not** revoke URLs already issued for it — the tier's
+lifetime is the mitigation, and **Reset content cache** (which bumps the
+classroom's key version) is what stops new URLs being minted under the old key.
+
+**Renamed 2026-09-05.** The tiers used to be called `public`, `enrolled` and
+`draft`, which read like permissions they never were. `p` is inside the
+canonical string, so a URL minted before that date verifies against nothing and
+403s with `bad-signature`. Nothing is in production, so this only ever bit
+staging.
 
 ### Text blobs
 
@@ -81,7 +114,7 @@ Two rules hold for all of them:
 mistake) is served untransformed from `blobs/{sha}`: the transform gate is
 `isRasterExtension`, and `svg`, `html` and `json` all fall outside it. Cache
 lifetimes are decided by the tier alone, so text gets exactly the `immutable`
-an image gets, and exactly the `no-store` on `draft`.
+an image gets, and exactly the `no-store` on `edit`.
 
 ## Behaviour worth knowing
 
@@ -106,9 +139,9 @@ an image gets, and exactly the `no-store` on `draft`.
   cache, and the place to strip metadata is upload. The Images *binding*
   exposes no `metadata` option to change that; it exists only on the `cf.image`
   fetch API.
-- **Draft content is `no-store`,** everything else `public, max-age=…, immutable`
+- **The `edit` tier is `no-store`,** everything else `public, max-age=…, immutable`
   for as long as its signature lives. A just-expired signature is still honoured
-  inside its tier's grace window (6h for public/enrolled, 5m for draft).
+  inside its tier's grace window (6h for `month` and `week`, 5m for `edit`).
 - **Every response** carries CORS (`*`, `GET, HEAD, OPTIONS`, exposing
   `Content-Type, Content-Length, ETag`), `X-Content-Type-Options: nosniff`, and
   `Content-Security-Policy: default-src 'none'; sandbox`. A `Set-Cookie` can
@@ -313,12 +346,14 @@ Three things beyond the flag, each of which fails in its own confusing way:
 - **Pages or decks with real `content_path`s.** The delivery layer resolves
   references; a classroom with no content has nothing to resolve, and every
   assertion about it is vacuously true.
-- **`SITE_BASE_DOMAIN`, if you want the `public` tier.** The class-site host
-  rewriter is a no-op without it, and `public` is only ever minted for the
-  class-site surface — so with it unset there is no way to see that tier at all.
-  Start the pages app with e.g. `SITE_BASE_DOMAIN=classmoji.io` and address the
-  site with a `Host:` header; there is no local DNS for it. The site also has to
-  be *enabled* and have a home page — a claimed-but-disabled site 404s.
+- **`SITE_BASE_DOMAIN`, if you want the class-site surface.** The class-site
+  host rewriter is a no-op without it, so with it unset there is no way to reach
+  the site at all. Start the pages app with e.g. `SITE_BASE_DOMAIN=classmoji.io`
+  and address the site with a `Host:` header; there is no local DNS for it. The
+  site also has to be *enabled* and have a home page — a claimed-but-disabled
+  site 404s. Seeing the `month` tier no longer needs any of it: the tier follows
+  the content's visibility, so a public page mints `month` inside the pages app
+  too.
 
 Then:
 
@@ -395,7 +430,7 @@ Logs** (`classmoji-content-staging` or `classmoji-content`), with
 
 A burst of `403 bad-signature` on one classroom usually means a stale page in
 someone's browser, not an attacker: signatures expire, and the grace window is
-6h (5m for draft). A burst of `404 missing` means content references drifted
+6h (5m for `edit`). A burst of `404 missing` means content references drifted
 from the repo — look at the resolver, not the Worker.
 
 A `\uFFFD` in a logged path is this Worker defusing the path, not a corrupt
@@ -442,9 +477,9 @@ in a browser, a `<link>` tag, or an edge cache.
    precisely because of the previous-key slot: the Worker is verifying with a
    key it already accepts either way.
 
-4. **Wait out the longest signature still in the wild** — 30 days, the public
-   tier's bucket, plus its 6h grace. `enrolled` is 7 days and `draft` is 4
-   hours, so the public tier is the one that sets the clock. Watch for the line
+4. **Wait out the longest signature still in the wild** — 30 days, the `month`
+   tier's bucket, plus its 6h grace. `week` is 7 days and `edit` is 4 hours, so
+   `month` is the one that sets the clock. Watch for the line
    that says the old key is still carrying traffic:
 
    ```

--- a/apps/content/src/index.ts
+++ b/apps/content/src/index.ts
@@ -43,7 +43,7 @@ const MAX_LOGGED_PATH = 512;
  * request.
  *
  * A rotation stays open for as long as the longest signature lives — 30 days
- * for the public tier — and a warn on every request for a month would bury the
+ * for the `month` tier — and a warn on every request for that long would bury the
  * 403 and 404 lines an operator actually searches for. The cost is that the
  * count is no longer traffic: it says which classrooms are still handing out
  * old URLs, not how often.

--- a/apps/content/tests/helpers.ts
+++ b/apps/content/tests/helpers.ts
@@ -209,7 +209,7 @@ export async function signedBlobUrl(options: {
 }): Promise<string> {
   const origin = options.origin ?? ORIGIN;
   const classroomId = options.classroomId ?? CLASSROOM;
-  const tier = options.tier ?? 'public';
+  const tier = options.tier ?? 'month';
   const keyVersion = options.keyVersion ?? 1;
   const master = options.master ?? MASTER;
 
@@ -254,7 +254,7 @@ export async function signedThemeUrl(options: {
 }): Promise<string> {
   const origin = options.origin ?? ORIGIN;
   const classroomId = options.classroomId ?? CLASSROOM;
-  const tier = options.tier ?? 'public';
+  const tier = options.tier ?? 'month';
   const keyVersion = options.keyVersion ?? 1;
   const master = options.master ?? MASTER;
 

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -146,7 +146,7 @@ describe('routing', () => {
   it('403s an unsigned or tampered URL, and never caches the refusal', async () => {
     const response = await worker.fetch(
       new Request(
-        `${ORIGIN}/c/${CLASSROOM}/blob/${BLOB_SHA}.png?p=public&v=1&exp=${futureExp()}&sig=nope`
+        `${ORIGIN}/c/${CLASSROOM}/blob/${BLOB_SHA}.png?p=month&v=1&exp=${futureExp()}&sig=nope`
       ),
       fakeEnv(),
       fakeContext()
@@ -160,7 +160,7 @@ describe('routing', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const path = `/c/${CLASSROOM}/blob/${BLOB_SHA}.png`;
     const response = await worker.fetch(
-      new Request(`${ORIGIN}${path}?p=public&v=1&exp=${futureExp()}&sig=nope`),
+      new Request(`${ORIGIN}${path}?p=month&v=1&exp=${futureExp()}&sig=nope`),
       fakeEnv(),
       fakeContext()
     );
@@ -170,7 +170,7 @@ describe('routing', () => {
     expect(message).toContain('bad-signature');
     expect(message).toContain(`classroom=${CLASSROOM}`);
     expect(message).toContain(`path=${path}`);
-    expect(message).toContain('p=public');
+    expect(message).toContain('p=month');
     expect(message).toContain('v=1');
     expect(message).not.toContain('sig=');
   });
@@ -490,7 +490,7 @@ describe('blob delivery', () => {
         contentType: 'text/html; charset=utf-8',
       },
     });
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'enrolled' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'week' });
 
     const response = await worker.fetch(
       new Request(url),
@@ -517,7 +517,7 @@ describe('blob delivery', () => {
     const bucket = fakeBucket({
       [`blobs/${BLOB_SHA}`]: { body: '<!doctype html><p>not json</p>' },
     });
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'json', tier: 'enrolled' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'json', tier: 'week' });
 
     const response = await worker.fetch(
       new Request(url),
@@ -542,7 +542,7 @@ describe('blob delivery', () => {
         contentType: 'text/plain; charset=utf-8',
       },
     });
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css', tier: 'enrolled' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'css', tier: 'week' });
 
     const response = await worker.fetch(
       new Request(url),
@@ -559,7 +559,7 @@ describe('blob delivery', () => {
     const bucket = fakeBucket({
       [`blobs/${BLOB_SHA}`]: { body: '<!doctype html>', contentType: 'application/octet-stream' },
     });
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'enrolled' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'week' });
 
     const response = await worker.fetch(
       new Request(url, { method: 'HEAD' }),
@@ -571,13 +571,13 @@ describe('blob delivery', () => {
     expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8');
   });
 
-  it('serves a draft html blob no-store, exactly like a draft image', async () => {
+  it('serves an `edit` html blob no-store, exactly like an `edit` image', async () => {
     // The per-tier cache lifetimes are decided by `cacheControlFor` on the
     // tier alone; text takes the same answer images take, unchanged.
     const bucket = fakeBucket({
       [`blobs/${BLOB_SHA}`]: { body: '<!doctype html>', contentType: 'text/html; charset=utf-8' },
     });
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'draft' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'edit' });
 
     const response = await worker.fetch(
       new Request(url),
@@ -602,7 +602,7 @@ describe('blob delivery', () => {
     const url = await signedBlobUrl({
       sha: BLOB_SHA,
       ext: 'json',
-      tier: 'enrolled',
+      tier: 'week',
       transform: { w: 800, fmt: 'auto' },
     });
 
@@ -624,7 +624,7 @@ describe('blob delivery', () => {
     const ctx = fakeContext();
     stubUpstreams();
 
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'enrolled' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'html', tier: 'week' });
     const response = await worker.fetch(
       new Request(url),
       fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
@@ -644,17 +644,17 @@ describe('blob delivery', () => {
     ]);
   });
 
-  it('marks draft content no-store, but still writes it to R2', async () => {
+  it('marks `edit` content no-store, but still writes it to R2', async () => {
     // Deliberate: `no-store` governs the SHARED caches in front of the Worker,
-    // which must never hold draft bytes. R2 sits behind the signature gate and
-    // is keyed by content hash, so a draft blob living there is not a
+    // which must never hold `edit` bytes. R2 sits behind the signature gate and
+    // is keyed by content hash, so an `edit` blob living there is not a
     // disclosure — and it is what makes publishing a flip rather than a cold
     // fetch. Empty bucket + stubbed origin so a put can actually happen and be
     // observed; seeding the object would have made this assertion vacuous.
     const bucket = fakeBucket();
     const ctx = fakeContext();
     stubUpstreams();
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png', tier: 'draft' });
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png', tier: 'edit' });
 
     const response = await worker.fetch(
       new Request(url),

--- a/apps/content/tests/signing.test.ts
+++ b/apps/content/tests/signing.test.ts
@@ -25,12 +25,12 @@ describe('canonical strings', () => {
         classroomId: CLASSROOM,
         sha: BLOB_SHA,
         ext: 'png',
-        tier: 'public',
+        tier: 'month',
         keyVersion: 1,
         exp: 1_700_000_000,
         transform: { w: 800, fmt: 'auto' },
       })
-    ).toBe(`cm1|blob|${HOST}|${CLASSROOM}|${BLOB_SHA}|png|public|1|1700000000|800|auto`);
+    ).toBe(`cm1|blob|${HOST}|${CLASSROOM}|${BLOB_SHA}|png|month|1|1700000000|800|auto`);
 
     expect(
       themeCanonicalString({
@@ -38,11 +38,11 @@ describe('canonical strings', () => {
         classroomId: CLASSROOM,
         theme: 'aurora',
         treeSha: TREE_SHA,
-        tier: 'enrolled',
+        tier: 'week',
         keyVersion: 2,
         exp: 1_700_000_000,
       })
-    ).toBe(`cm1|theme|${HOST}|${CLASSROOM}|aurora|${TREE_SHA}|enrolled|2|1700000000`);
+    ).toBe(`cm1|theme|${HOST}|${CLASSROOM}|aurora|${TREE_SHA}|week|2|1700000000`);
   });
 
   it('leaves the transform fields empty when there is no transform', () => {
@@ -52,11 +52,11 @@ describe('canonical strings', () => {
         classroomId: CLASSROOM,
         sha: BLOB_SHA,
         ext: 'css',
-        tier: 'draft',
+        tier: 'edit',
         keyVersion: 0,
         exp: 1_700_000_000,
       })
-    ).toBe(`cm1|blob|${HOST}|${CLASSROOM}|${BLOB_SHA}|css|draft|0|1700000000||`);
+    ).toBe(`cm1|blob|${HOST}|${CLASSROOM}|${BLOB_SHA}|css|edit|0|1700000000||`);
   });
 });
 
@@ -69,7 +69,7 @@ describe('verifyContentUrl — blob', () => {
       classroomId: CLASSROOM,
       sha: BLOB_SHA,
       ext: 'png',
-      tier: 'public',
+      tier: 'month',
       keyVersion: 1,
     });
   });
@@ -193,20 +193,20 @@ describe('verifyContentUrl — blob', () => {
     const url = await signedBlobUrl({
       sha: BLOB_SHA,
       ext: 'png',
-      tier: 'enrolled',
+      tier: 'week',
       exp: justExpired,
     });
     expect(await verifyContentUrl(MASTER, url)).toMatchObject({ ok: true, inGrace: true });
 
-    const past = justExpired + TIER_POLICY.enrolled.graceSeconds + 60;
+    const past = justExpired + TIER_POLICY.week.graceSeconds + 60;
     expect(await verifyContentUrl(MASTER, url, past)).toEqual({ ok: false, reason: 'expired' });
   });
 
-  it('gives draft a much shorter grace than enrolled', async () => {
+  it('gives edit a much shorter grace than week', async () => {
     const justExpired = nowSeconds() - 10;
-    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png', tier: 'draft', exp: justExpired });
-    const afterDraftGrace = justExpired + TIER_POLICY.draft.graceSeconds + 60;
-    expect(TIER_POLICY.draft.graceSeconds).toBeLessThan(TIER_POLICY.enrolled.graceSeconds);
+    const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'png', tier: 'edit', exp: justExpired });
+    const afterDraftGrace = justExpired + TIER_POLICY.edit.graceSeconds + 60;
+    expect(TIER_POLICY.edit.graceSeconds).toBeLessThan(TIER_POLICY.week.graceSeconds);
     expect(await verifyContentUrl(MASTER, url, afterDraftGrace)).toEqual({
       ok: false,
       reason: 'expired',
@@ -304,21 +304,21 @@ describe('verifyContentUrl — theme', () => {
 });
 
 describe('cacheControlFor', () => {
-  it('never stores draft content', () => {
-    expect(cacheControlFor('draft', futureExp(), nowSeconds())).toBe('no-store');
+  it('never stores `edit` content', () => {
+    expect(cacheControlFor('edit', futureExp(), nowSeconds())).toBe('no-store');
   });
 
   it('caches until the signature dies', () => {
     const now = 1_700_000_000;
-    expect(cacheControlFor('public', now + 600, now)).toBe('public, max-age=600, immutable');
-    expect(cacheControlFor('enrolled', now + 60, now)).toBe('public, max-age=60, immutable');
+    expect(cacheControlFor('month', now + 600, now)).toBe('public, max-age=600, immutable');
+    expect(cacheControlFor('week', now + 60, now)).toBe('public, max-age=60, immutable');
   });
 
   it('gives a past expiry a short positive TTL instead of pinning it immutable', () => {
     const now = 1_700_000_000;
     // Inside grace the URL is still served, but a zero max-age would send every
     // cache back to the origin at once — and it must not be pinned immutable.
-    expect(cacheControlFor('public', now - 600, now)).toBe('public, max-age=60');
-    expect(cacheControlFor('public', now, now)).toBe('public, max-age=60');
+    expect(cacheControlFor('month', now - 600, now)).toBe('public, max-age=60');
+    expect(cacheControlFor('month', now, now)).toBe('public, max-age=60');
   });
 });

--- a/apps/content/wrangler.jsonc
+++ b/apps/content/wrangler.jsonc
@@ -15,7 +15,7 @@
     "enabled": true
   },
   // Workers Caching sits in front of the Worker; the Cache-Control we emit
-  // (no-store for draft, immutable otherwise) is what decides what it keeps.
+  // (no-store for `edit`, immutable otherwise) is what decides what it keeps.
   "cache": {
     "enabled": true
   },

--- a/apps/pages/app/hooks/useAssetMap.ts
+++ b/apps/pages/app/hooks/useAssetMap.ts
@@ -84,7 +84,7 @@ const DELIVERY_URL =
 /**
  * Re-resolve once when a signed URL comes back 403.
  *
- * A draft URL lives four hours. A tab left open past that has a document full
+ * An `edit` URL lives four hours. A tab left open past that has a document full
  * of references whose signatures have expired, and every image on it breaks at
  * once — with no user action that would refresh them, because the document
  * itself did not change. One revalidation re-runs the loader, which mints a

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -187,10 +187,13 @@ export const loader = async ({
     page.classroom as unknown as Parameters<typeof assetResolveContext>[0],
     resolveTier
   );
-  // ONE pass for both. Two sequential resolves read the clock twice, and a
-  // draft-tier expiry bucket that turns over between them mints a different
-  // `src` for the same file — at which point every candidate list is thrown
-  // away for exactly the viewers who look at pages most. The cover is in the
+  // ONE pass for both. Two sequential resolves read the clock twice, and an
+  // expiry that moves between the two reads mints a different `src` for the
+  // same file — at which point every candidate list is thrown away, because the
+  // pairing is by string equality. On `edit` the expiry is an exact `now + 4h`,
+  // so it moves on EVERY tick; on `week` and `month` it only moves across a
+  // bucket boundary (or the roll-forward near one). Rare on a reader, constant
+  // for an editor, and wrong in both cases. The cover is in the
   // ref list for its display URL; it does not need candidates, because
   // `HeaderImage` renders it as a CSS background, where `srcset` means nothing.
   const { assets: resolvedAssets, srcSets: resolvedSrcSets } = await resolveDocumentAssets(

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.server.ts
@@ -165,15 +165,23 @@ export const loader = async ({
       : null);
 
   // Render-time URL resolution: the blocks keep their stored references and the
-  // client gets a parallel `ref → signed URL` map. Tier is per-VIEWER — an
-  // editor (or an explicit preview) gets short-lived draft URLs, everyone else
-  // the enrolled tier — which is exactly why the URL cannot live in the block.
+  // client gets a parallel `ref → signed URL` map. The lifetime is per-VIEWER
+  // and per-PAGE — an editor (or an explicit preview) gets short-lived `edit`
+  // URLs, a reader gets `month` on a public page and `week` otherwise — which
+  // is exactly why the URL cannot live in the block.
+  //
+  // `page.is_public` is passed because visibility, not surface, decides the
+  // lifetime: this same page rendered on the class site is the same file with
+  // the same readers, and used to be minted on a different bucket purely
+  // because it came through a different door.
+  //
   // `previewActive`, not `wantsPreview`: the raw query param is attacker-supplied
   // and is only honoured for staff. Passing it straight through would let an
-  // anonymous visitor mint draft-tier URLs by appending `?preview=1`.
+  // anonymous visitor mint `edit`-tier URLs by appending `?preview=1`.
   const resolveTier = ClassmojiService.contentDelivery.tierFor({
     canEdit,
     preview: previewActive,
+    isPublic: page.is_public,
   });
   const assetCtx = assetResolveContext(
     page.classroom as unknown as Parameters<typeof assetResolveContext>[0],
@@ -289,10 +297,10 @@ export const action = async ({
 
   // Save-side asset context. The tier is irrelevant to canonicalization (it
   // only ever turns a signed URL back into a path) but the context type carries
-  // one; 'draft' names the only tier a writer can be in.
+  // one; 'edit' names the only tier a writer can be in.
   const actionAssetCtx = assetResolveContext(
     page.classroom as unknown as Parameters<typeof assetResolveContext>[0],
-    'draft'
+    'edit'
   );
 
   // Check if user can edit

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -53,7 +53,7 @@ const PageRoute = () => {
   } = useLoaderData<typeof import('./route.server.ts').loader>();
   // Stored refs stay in the document; these are the URLs to display them with.
   const assets = useAssetMap(resolvedAssets, page.id);
-  // An expired draft signature on a stale tab re-resolves once instead of
+  // An expired `edit` signature on a stale tab re-resolves once instead of
   // leaving a page of broken images.
   const assetEpoch = useAssetRetry();
   // Responsive candidates, keyed by the stored reference and handed to the

--- a/apps/pages/app/routes/$classroomSlug/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug/route.tsx
@@ -99,28 +99,49 @@ export const loader = async ({
   }
 
   // Header thumbnails carry a stored reference, exactly like a block does, so
-  // they need the same render-time resolution — and the same PER-VIEWER tier as
-  // the page render itself: staff get short-lived draft URLs, an anonymous
-  // visitor the public bucket, everyone else enrolled. A failure here degrades
-  // to the stored references (the list still renders, thumbnails may not) rather
-  // than 500ing a classroom's whole page list over one image.
-  let resolvedPages = pages;
-  const assetCtx = assetResolveContext(
-    classroom as unknown as Parameters<typeof assetResolveContext>[0],
-    ClassmojiService.contentDelivery.tierFor({
-      canEdit: view === 'admin',
-      isPublicSite: view === 'public',
-    })
-  );
-  const headerRefs = headerImageRefs(pages);
-  if (assetCtx && headerRefs.length > 0) {
+  // they need the same render-time resolution — and the same lifetime rule as
+  // the page render itself. That rule is per-PAGE, not per-list: a list mixes
+  // public and members-only pages, and a thumbnail gets the lifetime its OWN
+  // page earns, not the one the visitor's door would have implied. So the
+  // refs are resolved in two passes, `week` then `month`, rather than one pass
+  // on a tier picked from `view`. Staff can edit any of them and take `edit`
+  // for the whole list in a single pass.
+  //
+  // A reference shared by a public and a members-only page is resolved twice
+  // and the `month` pass wins, which is the correct direction: the file is
+  // reachable by an anonymous reader either way.
+  //
+  // A failure here degrades to the stored references (the list still renders,
+  // thumbnails may not) rather than 500ing a classroom's whole page list over
+  // one image.
+  const canEditPages = view === 'admin';
+  const refGroups: Array<{ isPublic: boolean; refs: string[] }> = canEditPages
+    ? [{ isPublic: false, refs: headerImageRefs(pages) }]
+    : [
+        { isPublic: false, refs: headerImageRefs(pages.filter(page => !page.is_public)) },
+        { isPublic: true, refs: headerImageRefs(pages.filter(page => page.is_public)) },
+      ];
+
+  const resolvedRefs = new Map<string, string>();
+  for (const group of refGroups) {
+    if (group.refs.length === 0) continue;
+    const assetCtx = assetResolveContext(
+      classroom as unknown as Parameters<typeof assetResolveContext>[0],
+      ClassmojiService.contentDelivery.tierFor({
+        canEdit: canEditPages,
+        isPublic: group.isPublic,
+      })
+    );
+    if (!assetCtx) continue;
     try {
-      const resolved = await ClassmojiService.contentDelivery.resolveMany(assetCtx, headerRefs);
-      resolvedPages = withResolvedHeaderImages(pages, resolved);
+      const resolved = await ClassmojiService.contentDelivery.resolveMany(assetCtx, group.refs);
+      for (const [ref, url] of resolved) resolvedRefs.set(ref, url);
     } catch (error) {
       console.warn('[pages] Header image resolution failed, rendering stored refs:', error);
     }
   }
+  const resolvedPages =
+    resolvedRefs.size > 0 ? withResolvedHeaderImages(pages, resolvedRefs) : pages;
 
   return {
     view,

--- a/apps/pages/app/site/pageRender.server.ts
+++ b/apps/pages/app/site/pageRender.server.ts
@@ -114,16 +114,19 @@ export async function renderPageForViewer(
     throw error;
   }
 
-  // Render-time URL resolution. Public tier only for a page that is actually
-  // public: a members-only page reached by a signed-in member is `enrolled`, so
-  // its URLs expire on the shorter bucket and are not minted with the lifetime
-  // meant for anonymous readers. The rewrite runs on a CLONE —
-  // `loadSitePageContent` caches its blocks for five minutes, and writing
-  // signed URLs into that cache would hand the next reader this reader's
-  // (expiring, tier-specific) URLs.
+  // Render-time URL resolution. The lifetime comes from the PAGE's visibility,
+  // through the same `tierFor` the pages app calls — not from the fact that
+  // this is the class site. A public page is `month` here and `month` in the
+  // app, which is what makes the two URLs identical inside a bucket; a
+  // members-only page reached by a signed-in member is `week` on both, so its
+  // URLs expire on the shorter bucket rather than borrowing the lifetime meant
+  // for anonymous readers. Nothing on this surface can edit, so `canEdit` is
+  // pinned false. The rewrite runs on a CLONE — `loadSitePageContent` caches
+  // its blocks for five minutes, and writing signed URLs into that cache would
+  // hand the next reader this reader's (expiring, tier-specific) URLs.
   const assetCtx = assetResolveContext(
     context.site.classroom as unknown as Parameters<typeof assetResolveContext>[0],
-    page.is_public ? 'public' : 'enrolled'
+    ClassmojiService.contentDelivery.tierFor({ canEdit: false, isPublic: page.is_public })
   );
   const { blocks: resolvedBlocks, srcSets } = await resolveSiteAssets(assetCtx, content.blocks);
 

--- a/apps/pages/app/utils/assetRefs.server.ts
+++ b/apps/pages/app/utils/assetRefs.server.ts
@@ -5,7 +5,7 @@ import { ClassmojiService } from './db.server.ts';
  * Page-side asset resolution: the policy half of the two-pass rewrite.
  *
  * The tree walk itself lives in `@classmoji/utils` (pure, unit-tested); what is
- * here is everything that needs a classroom, a viewer tier, and the delivery
+ * here is everything that needs a classroom, a signature lifetime, and the delivery
  * service — building a resolve context, batching a document's references into
  * one resolve, and canonicalizing on the way back in.
  */
@@ -27,7 +27,7 @@ export type AssetResolveContext = {
     content_delivery_enabled: boolean;
     git_organization: { login: string };
   };
-  tier: 'public' | 'enrolled' | 'draft';
+  tier: 'edit' | 'week' | 'month';
 };
 
 /**
@@ -71,7 +71,7 @@ export function assetResolveContext(
  * read the clock twice: expiries are bucketed, so two passes that straddle a
  * bucket boundary mint different URLs for the same file, and every srcset would
  * be silently dropped for exactly the viewers on the shortest bucket — staff,
- * on the draft tier. `resolveDelivery` mints both under one `now`.
+ * on the `edit` tier. `resolveDelivery` mints both under one `now`.
  *
  * Empty (never throws, never rewrites the blocks) when the classroom is
  * unservable or the delivery layer is off, so the client falls through to the

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -706,7 +706,7 @@ test.describe('E2E CD — pages, what each audience sees', () => {
    *
    * A class site is anonymous and server-rendered, so it needs neither a
    * session nor a database — which is exactly the pair staging cannot give
-   * this pack. Against staging the site already carries public-tier images, so
+   * this pack. Against staging the site already carries `month`-tier images, so
    * the scenario reads what is there; locally it has to make one first,
    * because a freshly seeded classroom has no public site and no pictures.
    */
@@ -714,17 +714,31 @@ test.describe('E2E CD — pages, what each audience sees', () => {
    * The signed-in half of the staging story, and the only thing
    * `E2E_SESSION_COOKIE` is for.
    *
-   * With a member's token the pack can open a page the public site never shows
-   * and check the one property that distinguishes a member render from an
-   * anonymous one: the tier is NOT `public`. It cannot be more specific than
-   * that without knowing the token's role — a student's render is `enrolled`,
-   * a staff member's is `draft`, and both are correct — so the assertion is the
-   * boundary rather than the exact value. The exact values are pinned by the
-   * local scenarios, which know who they signed in as.
+   * This scenario knows two things it cannot look up: it does not know the
+   * token's ROLE (staff render `edit`, a member renders a read tier), and
+   * `discoverMemberContentUrl` takes the first content link on the index, so it
+   * does not know the page's VISIBILITY either (a public page correctly mints
+   * `month`, exactly like the class site). Every combination is legitimate, so
+   * there is no tier this render must avoid.
+   *
+   * It used to assert `not public`, which was true only while the tier was
+   * chosen by SURFACE. Under the visibility rule that assertion fails on a
+   * perfectly correct render of a public page — so what is left is the part
+   * that is true for every role and every visibility: the URLs are signed,
+   * bound to the delivery origin, and carry a tier this deployment still
+   * recognises. That last clause is not filler right after a rename: a surface
+   * left minting a retired tier name shows up here as an unknown `p`.
+   *
+   * The exact per-role, per-visibility values are pinned by the local
+   * scenarios, which know who they signed in as and what they are looking at,
+   * and by the `tierFor` unit tests.
    */
-  test('a signed-in member on staging gets a non-`month` tier', async ({ page, context }) => {
+  test('a signed-in member on staging gets a signed, origin-bound URL', async ({
+    page,
+    context,
+  }) => {
     requireDelivery();
-    test.skip(e2eTarget() !== 'staging', 'this is the staging form of the week-tier check');
+    test.skip(e2eTarget() !== 'staging', 'this is the staging form of the signed-render check');
     test.skip(authSkipReason() !== null, authSkipReason() ?? '');
 
     const applied = await applyStagingSession(context);
@@ -749,8 +763,8 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       expect(image.signed?.origin).toBe(env.deliveryOrigin);
       expect(
         image.signed?.tier,
-        `a member-facing render must not use the \`month\` tier: ${describeSignedUrl(image.src)}`
-      ).not.toBe('month');
+        `unknown tier — a surface is minting a retired name: ${describeSignedUrl(image.src)}`
+      ).toMatch(/^(edit|week|month)$/);
     }
   });
 
@@ -779,8 +793,8 @@ test.describe('E2E CD — pages, what each audience sees', () => {
 
     for (const image of images) {
       expect(image.signed?.origin).toBe(env.deliveryOrigin);
-      // Anonymous readers, so `public` and nothing else. A `draft` or
-      // a `week` URL on an anonymous page would be a lifetime mismatch.
+      // A public page on an anonymous surface, so `month` and nothing else.
+      // An `edit` or `week` URL here would be a lifetime mismatch.
       expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('month');
       expect(image.signed?.w, 'the fallback src carries no width').toBeNull();
       if (image.candidates.length > 0) {
@@ -899,8 +913,12 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       //
       // A student rather than the owner, because an owner can edit and would
       // (correctly) get `edit`. Byte-equality holds because both reads land in
-      // the same 30-day bucket for this classroom; only a read that straddled a
-      // bucket boundary could differ, and the bucket is 30 days wide.
+      // the same 30-day bucket for this classroom. Two windows could split
+      // them, and both are negligible here: a read that straddled a bucket
+      // boundary (the bucket is 30 days wide), and one where the two reads fall
+      // on either side of MIN_REMAINING_SECONDS — the last hour of a bucket,
+      // where minting rolls forward to the next one. Seconds apart, 30 days of
+      // bucket, so neither is a flake worth guarding against.
       await loginAs(page, 'student', `/${env.classroomSlug}/${publicPage.id}`);
       const inApp = await reloadUntilImages(
         page,
@@ -1207,7 +1225,7 @@ test.describe('E2E CD — the Worker, directly', () => {
 
     // Against a deployed target there is no database and no session, so the
     // signature comes off the public class site — anonymous, server-rendered,
-    // and already carrying current public-tier URLs. This is the whole reason
+    // and already carrying current `month`-tier URLs. This is the whole reason
     // the Worker's contract is checkable against staging at all.
     if (e2eTarget() === 'staging') {
       try {

--- a/apps/pages/tests/content-pipeline.spec.ts
+++ b/apps/pages/tests/content-pipeline.spec.ts
@@ -82,7 +82,7 @@ const env = targets();
  * No trace, no video, for this pack specifically.
  *
  * Both capture full request URLs, and every URL here is a signed credential
- * good for up to a month on the public tier. `retries: 0` happens to mean the
+ * good for up to a month on the `month` tier. `retries: 0` happens to mean the
  * config's `on-first-retry` never fires today, but that is a coincidence of a
  * setting in another file — one `--retries=1` on a command line and the pack
  * starts writing signatures into an artifact CI uploads. Turned off here so it
@@ -388,7 +388,7 @@ async function withFixtureImage(
 // ─────────────────────────────────────────────────────────────────────────────
 
 test.describe('E2E CD — pages, the editor', () => {
-  test('an uploaded raster image renders as a signed draft src with a three-rung srcset', async ({
+  test('an uploaded raster image renders as a signed `edit` src with a three-rung srcset', async ({
     page,
   }) => {
     requireDelivery();
@@ -429,8 +429,8 @@ test.describe('E2E CD — pages, the editor', () => {
       displaySigned,
       `displayUrl is not signed: ${describeSignedUrl(uploaded.displayUrl ?? '')}`
     ).not.toBeNull();
-    // Staff uploading into an editor is the draft tier by definition.
-    expect(displaySigned?.tier).toBe('draft');
+    // Staff uploading into an editor is the `edit` tier by definition.
+    expect(displaySigned?.tier).toBe('edit');
 
     // The asset map learned about the file as part of the upload — this is what
     // makes the very first render resolvable rather than a `/missing/`.
@@ -473,12 +473,12 @@ test.describe('E2E CD — pages, the editor', () => {
     // `previewWidth` rather than the generic viewer constant.
     expectResponsive(rendered, {
       classroomId: room.id,
-      tier: 'draft',
+      tier: 'edit',
       sizes: expectedSizesFor(FIXTURE_PREVIEW_WIDTH),
     });
 
     // Exactly one network request for this image. This is a safe count only
-    // because the draft tier is served `no-store` — on a cacheable tier a
+    // because the `edit` tier is served `no-store` — on a cacheable tier a
     // second navigation legitimately produces zero requests, and asserting
     // "exactly one" there would be asserting that the cache had missed.
     // candidate out of the set; a page that fetched two is a page that painted
@@ -629,7 +629,7 @@ test.describe('E2E CD — pages, the editor', () => {
             git_organization: { login: room.orgLogin },
             content_delivery_enabled: room.content_delivery_enabled,
           },
-          tier: 'draft',
+          tier: 'edit',
         },
         uploaded.path
       )
@@ -639,7 +639,7 @@ test.describe('E2E CD — pages, the editor', () => {
 });
 
 test.describe('E2E CD — pages, what each audience sees', () => {
-  test('a signed-in member gets the enrolled tier on a private page', async ({ page }) => {
+  test('a signed-in member gets the `week` tier on a private page', async ({ page }) => {
     requireDelivery();
     const room = requireClassroom();
     test.skip(authSkipReason() !== null, authSkipReason() ?? '');
@@ -664,10 +664,10 @@ test.describe('E2E CD — pages, what each audience sees', () => {
 
     // Staff puts the image there; a student looks at it. Two sessions in one
     // test because the tier is a property of the VIEWER, and the only way to
-    // observe `enrolled` is to be someone who cannot edit.
+    // observe `week` is to be someone who cannot edit.
     await loginAs(page, 'owner', `/${env.classroomSlug}`);
     markScenarioRan();
-    const fixture = await withFixtureImage(page, toTestPage(privatePage, room.id), 'enrolled');
+    const fixture = await withFixtureImage(page, toTestPage(privatePage, room.id), 'week');
 
     await loginAs(page, 'student', `/${env.classroomSlug}/${privatePage.id}`);
 
@@ -692,7 +692,7 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     ).toBeDefined();
 
     for (const image of signedImages) {
-      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('enrolled');
+      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('week');
     }
     expect(log.missing()).toEqual([]);
     expect(describeUrls(log.legacy()), 'a delivered page must not also fetch legacy refs').toEqual(
@@ -722,9 +722,9 @@ test.describe('E2E CD — pages, what each audience sees', () => {
    * boundary rather than the exact value. The exact values are pinned by the
    * local scenarios, which know who they signed in as.
    */
-  test('a signed-in member on staging gets a non-public tier', async ({ page, context }) => {
+  test('a signed-in member on staging gets a non-`month` tier', async ({ page, context }) => {
     requireDelivery();
-    test.skip(e2eTarget() !== 'staging', 'this is the staging form of the enrolled-tier check');
+    test.skip(e2eTarget() !== 'staging', 'this is the staging form of the week-tier check');
     test.skip(authSkipReason() !== null, authSkipReason() ?? '');
 
     const applied = await applyStagingSession(context);
@@ -749,12 +749,12 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       expect(image.signed?.origin).toBe(env.deliveryOrigin);
       expect(
         image.signed?.tier,
-        `a member-facing render must not use the public tier: ${describeSignedUrl(image.src)}`
-      ).not.toBe('public');
+        `a member-facing render must not use the \`month\` tier: ${describeSignedUrl(image.src)}`
+      ).not.toBe('month');
     }
   });
 
-  test('a public class site serves the public tier, with its ladder', async ({ request }) => {
+  test('a public class site serves the `month` tier, with its ladder', async ({ request }) => {
     requireDelivery();
     test.skip(e2eTarget() !== 'staging', 'the local form of this scenario is the next test');
 
@@ -780,8 +780,8 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     for (const image of images) {
       expect(image.signed?.origin).toBe(env.deliveryOrigin);
       // Anonymous readers, so `public` and nothing else. A `draft` or
-      // `enrolled` URL on an anonymous page would be a tier leak.
-      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('public');
+      // a `week` URL on an anonymous page would be a lifetime mismatch.
+      expect(image.signed?.tier, describeSignedUrl(image.src)).toBe('month');
       expect(image.signed?.w, 'the fallback src carries no width').toBeNull();
       if (image.candidates.length > 0) {
         expect(image.candidates.map(candidate => candidate.width)).toEqual([...EXPECTED_WIDTHS]);
@@ -798,7 +798,7 @@ test.describe('E2E CD — pages, what each audience sees', () => {
     expect(html).not.toMatch(/\/c\/[0-9a-f-]{36}\/missing\//i);
   });
 
-  test('a public class-site page is served at the public tier, with its ladder', async ({
+  test('one public page mints one URL, in the app and on the class site', async ({
     page,
     request,
   }) => {
@@ -825,7 +825,7 @@ test.describe('E2E CD — pages, what each audience sees', () => {
 
     await loginAs(page, 'owner', `/${env.classroomSlug}/${publicPage.id}`);
     markScenarioRan();
-    const fixture = await withFixtureImage(page, toTestPage(publicPage, room.id), 'public');
+    const fixture = await withFixtureImage(page, toTestPage(publicPage, room.id), 'month');
 
     // A classroom holds at most one site, so this may displace an existing row.
     // Whatever was there is put back in the `finally`.
@@ -862,7 +862,7 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       // Reached by Host header, not by hostname: there is no DNS for
       // `{subdomain}.{base}` locally. The site tree is script-less by design,
       // so the server's own markup is the whole story — which is precisely why
-      // this is the only place the `public` tier is observable.
+      // this is the only place the class-site render is observable.
       const response = await fetchUntilHtml(
         async url => {
           const result = await request.get(url, {
@@ -885,11 +885,43 @@ test.describe('E2E CD — pages, what each audience sees', () => {
       expect(ours, 'the fixture image should be on the public page').toBeDefined();
       if (!ours) return;
 
-      expect(ours.signed?.tier, describeSignedUrl(ours.src)).toBe('public');
+      expect(ours.signed?.tier, describeSignedUrl(ours.src)).toBe('month');
       // The class site sizes from the block's own `previewWidth` exactly as the
       // editor does — the hint follows the BLOCK, not the surface.
       expect(ours.sizes).toBe(expectedSizesFor(FIXTURE_PREVIEW_WIDTH));
       expect(ours.candidates.map(candidate => candidate.width)).toEqual([...EXPECTED_WIDTHS]);
+
+      // The point of tiering by VISIBILITY: this same public page, read in the
+      // pages app by a member who cannot edit, mints the SAME URL — same tier,
+      // same expiry bucket, same signature, byte for byte. It used to mint
+      // `enrolled` here and `public` on the site, which is two cache entries
+      // and two lifetimes for one public file.
+      //
+      // A student rather than the owner, because an owner can edit and would
+      // (correctly) get `edit`. Byte-equality holds because both reads land in
+      // the same 30-day bucket for this classroom; only a read that straddled a
+      // bucket boundary could differ, and the bucket is 30 days wide.
+      await loginAs(page, 'student', `/${env.classroomSlug}/${publicPage.id}`);
+      const inApp = await reloadUntilImages(
+        page,
+        `/${env.classroomSlug}/${publicPage.id}`,
+        images => images.some(image => image.signed?.sha === fixture.sha),
+        { attempts: 8, delayMs: 10_000 }
+      );
+      const appOurs = inApp.find(image => image.signed?.sha === fixture.sha);
+      expect(
+        appOurs,
+        `the student should see the fixture image in the app; saw ${
+          inApp.map(image => describeSignedUrl(image.src)).join(', ') || '<no images>'
+        }`
+      ).toBeDefined();
+      if (appOurs) {
+        expect(appOurs.signed?.tier, describeSignedUrl(appOurs.src)).toBe('month');
+        expect(
+          appOurs.src,
+          'the app viewer and the class site must mint the identical URL for one public image'
+        ).toBe(ours.src);
+      }
 
       // No legacy escape hatch left in the markup, and nothing unresolvable.
       expect(html).not.toContain('raw.githubusercontent.com');
@@ -967,7 +999,7 @@ test.describe('E2E CD — pages, when a file goes away', () => {
           git_organization: { login: room.orgLogin },
           content_delivery_enabled: room.content_delivery_enabled,
         },
-        tier: 'enrolled',
+        tier: 'week',
       },
       uploaded.path
     );

--- a/apps/pages/tests/unit/asset-resolve-context.spec.ts
+++ b/apps/pages/tests/unit/asset-resolve-context.spec.ts
@@ -23,7 +23,7 @@ const classroom = {
 
 test.describe('assetResolveContext', () => {
   test('carries the classroom flag through to the resolver', () => {
-    expect(assetResolveContext(classroom, 'enrolled')?.classroom.content_delivery_enabled).toBe(
+    expect(assetResolveContext(classroom, 'week')?.classroom.content_delivery_enabled).toBe(
       true
     );
   });
@@ -32,7 +32,7 @@ test.describe('assetResolveContext', () => {
     for (const value of [false, null, undefined]) {
       const ctx = assetResolveContext(
         { ...classroom, content_delivery_enabled: value as boolean | null },
-        'enrolled'
+        'week'
       );
       // Never `undefined` — a real `false`, because the resolver compares
       // strictly and "I did not ask" must not be able to mean yes.
@@ -44,13 +44,13 @@ test.describe('assetResolveContext', () => {
     // No content repo and no git org are normal states, not failures — every
     // caller degrades to the stored references, which is what the page did
     // before any of this existed.
-    expect(assetResolveContext({ ...classroom, content_repo: '' }, 'enrolled')).toBeNull();
-    expect(assetResolveContext({ ...classroom, git_organization: null }, 'enrolled')).toBeNull();
-    expect(assetResolveContext(null, 'enrolled')).toBeNull();
+    expect(assetResolveContext({ ...classroom, content_repo: '' }, 'week')).toBeNull();
+    expect(assetResolveContext({ ...classroom, git_organization: null }, 'week')).toBeNull();
+    expect(assetResolveContext(null, 'week')).toBeNull();
   });
 
   test('passes the tier through untouched', () => {
-    for (const tier of ['public', 'enrolled', 'draft'] as const) {
+    for (const tier of ['month', 'week', 'edit'] as const) {
       expect(assetResolveContext(classroom, tier)?.tier).toBe(tier);
     }
   });

--- a/apps/pages/tests/unit/header-images.spec.ts
+++ b/apps/pages/tests/unit/header-images.spec.ts
@@ -16,7 +16,7 @@ import { test, expect } from '@playwright/test';
 import { cssUrl, headerImageRefs, withResolvedHeaderImages } from '../../app/utils/headerImages.ts';
 
 const REF = 'pages/lab-1/assets/hero.png';
-const SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=enrolled&sig=x';
+const SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=week&sig=x';
 
 test.describe('headerImageRefs', () => {
   test('collects each reference once and skips rows without one', () => {
@@ -102,7 +102,7 @@ test.describe('cssUrl', () => {
   });
 
   test('leaves an ordinary signed URL alone', () => {
-    const signed = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=public&sig=x';
+    const signed = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=month&sig=x';
     expect(cssUrl(signed)).toBe(`url("${signed}")`);
   });
 });

--- a/apps/pages/tests/unit/image-sizes.spec.ts
+++ b/apps/pages/tests/unit/image-sizes.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../app/utils/imageSizes.ts';
 
 const REF = 'pages/lab-1/assets/hero.png';
-const SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=enrolled&sig=x';
+const SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=week&sig=x';
 const LADDER = `${SIGNED}&w=800&fmt=auto 800w, ${SIGNED}&w=1600&fmt=auto 1600w`;
 
 test.describe('imageSizesFor', () => {

--- a/apps/pages/tests/unit/site-render.spec.ts
+++ b/apps/pages/tests/unit/site-render.spec.ts
@@ -778,7 +778,7 @@ test.describe('article width', () => {
  * nowhere in the markup, and it is the only thing that says how wide the image
  * will actually be laid out.
  */
-const SITE_SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=public&sig=x';
+const SITE_SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.png?p=month&sig=x';
 const SITE_LADDER = `${SITE_SIGNED}&w=800&fmt=auto 800w, ${SITE_SIGNED}&w=1600&fmt=auto 1600w`;
 
 const renderImage = (props: Record<string, unknown>, srcSets?: Record<string, string>) =>

--- a/apps/slides/app/routes/$slideId/route.tsx
+++ b/apps/slides/app/routes/$slideId/route.tsx
@@ -172,9 +172,11 @@ export const loader = async ({
   // Staff asked for a preview but no branch exists → render main with a notice.
   const previewMissing = Boolean(canEdit && wantsPreview && !previewStatus?.exists);
 
-  // Per-VIEWER tier: staff and preview readers get short-lived draft URLs, a
-  // public deck's anonymous readers get the long public bucket, everyone else
-  // the enrolled one. This is the reason a signed URL cannot live in the deck.
+  // The deck VIEWER is the one EDITING surface, so it is the only one that can
+  // mint the short-lived `edit` bucket: staff, and a staff read of the preview
+  // BRANCH, get it. Every other reader here takes the DECK's own visibility —
+  // `month` for a public deck, `week` for the rest. This is the reason a signed
+  // URL cannot live in the deck.
   const deliveryCtx = deckDeliveryContext(
     slide,
     gitOrgLogin,

--- a/apps/slides/app/routes/$slideId_.follow/route.tsx
+++ b/apps/slides/app/routes/$slideId_.follow/route.tsx
@@ -6,7 +6,7 @@ import { SandpackRenderer } from '@classmoji/ui-components/sandpack';
 import RevealPresenter from '~/components/RevealPresenter';
 import {
   deckDeliveryContext,
-  followDeckAccess,
+  deckAccessFor,
   isThumbnailRequest,
   readDeckText,
   resolveDeckDelivery,
@@ -84,17 +84,19 @@ export const loader = async ({
   const contentResult = await readDeckText(slide, gitOrgLogin, repo, filePath, 'follow');
 
   if (contentResult) {
-    // Same read-side delivery pass the deck viewer runs. A follower is usually
-    // a student or a shareCode guest, so the tier lands on `enrolled`/`public`
-    // rather than the staff `draft` bucket — `tierFor` decides, not this route.
-    // `followDeckAccess` re-reads this route's THUMBNAIL flag off the URL and
-    // hands it to `deckAccessFor` as `thumbnail` — never as the viewer's
-    // preview-BRANCH flag. It marks the read-only iframe form (the speaker
-    // view's panes), so staff get the long-lived tier there instead of a 4h
-    // `draft` signature that expires part-way through a long lecture.
+    // Same read-side delivery pass the deck viewer runs, but `/follow` is a
+    // READ surface for everyone who opens it — staff included — so
+    // `deckAccessFor` pins `canEdit: false` and the lifetime comes from the
+    // DECK's visibility: `month` for a public deck, `week` for the rest.
+    // `canEdit` is still passed, and still ignored for the tier, because it is
+    // what `assertSlideAccess` answered and this route has no business
+    // rewriting it. The 4h `edit` bucket is unreachable here on purpose: a
+    // lecture that outruns four hours must not 403 a lazily-loaded background
+    // mid-talk, and the speaker view's `/follow?preview=true` panes are the
+    // highest-fanout case of exactly that.
     const { html } = await resolveDeckDelivery(
       contentResult.content,
-      deckDeliveryContext(slide, gitOrgLogin, repo, followDeckAccess(url, { canEdit }, slide))
+      deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('follow', { canEdit }, slide))
     );
     slideContent = html;
 

--- a/apps/slides/app/routes/$slideId_.present/route.tsx
+++ b/apps/slides/app/routes/$slideId_.present/route.tsx
@@ -71,7 +71,13 @@ export const loader = async ({
     // Same read-side delivery pass the deck viewer runs: the stored document
     // holds `/content/...` refs, and a presenter must see the signed ones or a
     // private content repo shows them nothing. `deckAccessFor` deliberately
-    // does NOT hand this surface the draft tier — see its comment.
+    // does NOT hand this surface the `edit` tier — see its comment.
+    //
+    // `canEdit` is passed because `assertSlideAccess` answered it and this
+    // route has no business rewriting it; `deckAccessFor` then IGNORES it for
+    // this surface and takes the deck's visibility instead. A presentation
+    // stays open for hours, and the 4h `edit` bucket would 403 a lazily loaded
+    // background mid-lecture.
     const { html } = await resolveDeckDelivery(
       contentResult.content,
       deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('present', { canEdit }, slide))

--- a/apps/slides/app/routes/$slideId_.speaker/route.tsx
+++ b/apps/slides/app/routes/$slideId_.speaker/route.tsx
@@ -75,6 +75,11 @@ export const loader = async ({
     // moment the content repo goes private. Assets only — this view keeps the
     // `.slides` fragment and throws the document's <head> away, so resolving a
     // theme base here would be a lookup for an answer nobody reads.
+    //
+    // `canEdit` is passed because `assertSlideAccess` answered it, and is then
+    // IGNORED by `deckAccessFor` for this surface: the speaker view is a read
+    // surface that stays open for a whole lecture, so it takes the deck's
+    // visibility rather than the 4h `edit` bucket.
     const html = await resolveDeckAssets(
       contentResult.content,
       deckDeliveryContext(slide, gitOrgLogin, repo, deckAccessFor('speaker', { canEdit }, slide))

--- a/apps/slides/app/utils/deckDelivery.server.ts
+++ b/apps/slides/app/utils/deckDelivery.server.ts
@@ -45,12 +45,13 @@ interface DeliverySlide {
   } | null;
 }
 
-/** What the viewer's tier decision is made of. Passed straight to `tierFor`. */
+/** What the tier decision is made of. Passed straight to `tierFor`. */
 export interface DeliveryAccess {
   canEdit: boolean;
   /** The staff-only preview BRANCH read — not a thumbnail render. */
   preview?: boolean;
-  isPublicSite?: boolean;
+  /** The DECK's own visibility, never the surface it is rendered on. */
+  isPublic?: boolean;
 }
 
 /** The deck surfaces that resolve content. Each has its own tier posture. */
@@ -64,52 +65,41 @@ export interface SlideAccessResultLike {
 }
 
 /**
- * `assertSlideAccess`'s answer + the deck's flags → the tier inputs, per surface.
+ * `assertSlideAccess`'s answer + the deck's visibility → the tier inputs.
  *
- * A function rather than four inline object literals because the surfaces do
- * NOT agree, and the places they disagree are the places this went wrong
- * before:
+ * The deck VIEWER is the only EDITING surface, so it is the only one that may
+ * reach `edit`. Every other surface pins `canEdit: false` and lands on the
+ * deck's own visibility: `month` for a public deck, `week` otherwise.
  *
- *   - `present` and `speaker` pin `canEdit: false` on purpose. Both stay open
- *     for hours, and `draft` is an exact `now + 4h` with five minutes of grace,
- *     so an instructor who opens the presenter in the morning and reaches slide
- *     40 after lunch would get a 403 on a lazily-loaded Reveal background.
- *     Content is sha-addressed and immutable, so the longer bucket shows the
- *     same bytes; `draft` exists for the editor's 403-and-revalidate flow, not
- *     for presenting.
- *   - only `viewer` honours `previewActive`. `follow` has a `?preview=true`
- *     query param of its own that means "thumbnail render", and letting that
- *     reach `tierFor` would mint draft URLs for a hall full of students. It
- *     arrives as `opts.thumbnail`, and is never allowed to become `preview`.
- *   - a THUMBNAIL `follow` is read-only, and gets the same treatment as
- *     `present`/`speaker` for the same reason. The speaker view embeds
- *     `/follow?preview=true` in its current and next panes, so staff opening
- *     `/speaker` were signing those iframes into the 4-hour `draft` bucket —
- *     and a lecture that runs longer than four hours 403s a lazily-loaded
- *     Reveal background mid-talk. Nobody edits through a thumbnail, so
- *     `canEdit` is pinned false and the tier lands on `enrolled` (or `public`
- *     for a public deck): the same immutable sha-addressed bytes, with an
- *     expiry that outlives the class.
+ * Pinning it rather than passing `access.canEdit` through is the whole point,
+ * and each surface earns it for its own reason:
+ *
+ *   - `present` and `speaker` stay open for hours, and `edit` is an exact
+ *     `now + 4h` with five minutes of grace — so an instructor who opened the
+ *     presenter in the morning and reached slide 40 after lunch would get a
+ *     403 on a lazily-loaded Reveal background. Content is sha-addressed and
+ *     immutable, so the longer bucket shows the same bytes.
+ *   - `follow` is a READ surface for everyone who opens it, staff included.
+ *     Nobody edits a deck through the audience view, and its highest-fanout
+ *     use is an iframe: the speaker view embeds `/follow?preview=true` in its
+ *     current and next panes. Staff used to get the 4h bucket on a plain
+ *     `/follow`, and a lecture that outran four hours 403'd mid-talk. No form
+ *     of `/follow` can be `edit` now — a stronger guarantee than the thumbnail
+ *     flag that used to carve out the iframe case, because this route's
+ *     `?preview=true` no longer reaches a tier decision at all and so can no
+ *     longer be confused with the deck viewer's `?preview=1`.
+ *   - only `viewer` honours `previewActive`, the staff read of the preview
+ *     BRANCH. That is a genuine pre-publication read of bytes that are about
+ *     to change, which is what the short TTL is for.
  */
 export function deckAccessFor(
   surface: DeckSurface,
   access: SlideAccessResultLike,
-  slide: { is_public?: boolean | null },
-  opts: { thumbnail?: boolean } = {}
+  slide: { is_public?: boolean | null }
 ): DeliveryAccess {
-  const isPublicSite = Boolean(slide.is_public);
-  if (surface === 'present' || surface === 'speaker') {
-    return { canEdit: false, isPublicSite };
-  }
-  // The read-only iframe form of `/follow`. Only `follow` has one here: the
-  // deck viewer's `?preview=true` landing-page thumbnail is a different
-  // surface with a different lifetime, and is deliberately left alone.
-  const isReadOnlyThumbnail = surface === 'follow' && Boolean(opts.thumbnail);
-  return {
-    canEdit: isReadOnlyThumbnail ? false : access.canEdit,
-    preview: surface === 'viewer' ? Boolean(access.previewActive) : false,
-    isPublicSite,
-  };
+  const isPublic = Boolean(slide.is_public);
+  if (surface !== 'viewer') return { canEdit: false, isPublic };
+  return { canEdit: access.canEdit, preview: Boolean(access.previewActive), isPublic };
 }
 
 /**
@@ -117,29 +107,15 @@ export function deckAccessFor(
  *
  * `?preview=true` on this route means "render me as a thumbnail" — the speaker
  * view's current/next panes and nothing else. It is a different parameter from
- * the deck viewer's `?preview=1`, which means "read the preview BRANCH", and
- * the two must never be confused: one is a read-only iframe, the other is a
- * staff read that legitimately earns draft URLs.
+ * the deck viewer's `?preview=1`, which means "read the preview BRANCH".
  *
- * Exported so the route reads the parameter in exactly one place, and so the
- * param → flag → tier chain can be pinned without a database behind it.
+ * It decides LAYOUT and nothing else. It used to feed the tier as well, to keep
+ * the speaker view's panes off the 4h bucket; `deckAccessFor` now pins every
+ * `/follow` read to `canEdit: false`, so the flag can no longer reach a
+ * signature at all.
  */
 export function isThumbnailRequest(url: URL): boolean {
   return url.searchParams.get('preview') === 'true';
-}
-
-/**
- * The `/follow` route's whole tier decision, from its request URL.
- *
- * The route's own wiring, hoisted out of the loader so it is testable: the
- * loader around it needs Prisma and a session, this does not.
- */
-export function followDeckAccess(
-  url: URL,
-  access: SlideAccessResultLike,
-  slide: { is_public?: boolean | null }
-): DeliveryAccess {
-  return deckAccessFor('follow', access, slide, { thumbnail: isThumbnailRequest(url) });
 }
 
 /**
@@ -148,9 +124,10 @@ export function followDeckAccess(
  *
  * The tier is decided HERE, by `ClassmojiService.contentDelivery.tierFor`, so
  * the four deck surfaces cannot drift into four different answers to "which
- * bucket is this viewer in". Staff and preview readers get short-lived draft
- * URLs, a public deck's anonymous readers the long public bucket, everyone else
- * the enrolled one. This is the reason a signed URL cannot live in the deck.
+ * bucket is this read in". An editing viewer and a preview-branch read get the
+ * short-lived `edit` bucket; everything else takes the DECK's visibility —
+ * `month` for a public deck, `week` for the rest. This is the reason a signed
+ * URL cannot live in the deck.
  */
 export function deckDeliveryContext(
   slide: DeliverySlide,
@@ -245,7 +222,7 @@ export async function readDeckText(
  *
  * Used to give a save the IDENTITY of the index.html it wrote, so the viewer can
  * tell its own commit from a stale read. Comparing rendered HTML instead cannot
- * work: the read side signs asset URLs, and the `draft` tier's expiry is an
+ * work: the read side signs asset URLs, and the `edit` tier's expiry is an
  * exact `now + 4h` rather than a bucket, so a staff read of an UNCHANGED deck
  * comes back with different bytes every second.
  */

--- a/apps/slides/app/utils/deckViewContent.ts
+++ b/apps/slides/app/utils/deckViewContent.ts
@@ -88,7 +88,7 @@ export interface SaveRefreshOutcome {
  * apart from a loader that came back with a STALE deck.
  *
  * The test is IDENTITY, not bytes. Comparing rendered HTML cannot work here:
- * the read side signs asset URLs per viewer, and the `draft` tier anyone with
+ * the read side signs asset URLs per viewer, and the `edit` tier anyone with
  * edit access gets is an exact `now + 4h` rather than a bucketed expiry, so two
  * reads of an unchanged deck differ every second. "The document changed" would
  * be true on every single read, and a stale one — a map row not yet updated, a

--- a/apps/slides/tests/content-pipeline.spec.ts
+++ b/apps/slides/tests/content-pipeline.spec.ts
@@ -156,13 +156,19 @@ async function keepAllImages(page: import('@playwright/test').Page): Promise<voi
 }
 
 /** The shared responsive contract, identical to the pages pack's. */
-function expectResponsive(image: RenderedImage, expected: { classroomId: string }): void {
+function expectResponsive(
+  image: RenderedImage,
+  expected: { classroomId: string; tier?: string }
+): void {
   const signed = image.signed;
   expect(signed, `src is not signed: ${describeSignedUrl(image.src)}`).not.toBeNull();
   if (!signed) return;
 
   expect(signed.origin).toBe(env.deliveryOrigin);
   expect(signed.classroomId.toLowerCase()).toBe(expected.classroomId.toLowerCase());
+  if (expected.tier !== undefined) {
+    expect(signed.tier, describeSignedUrl(image.src)).toBe(expected.tier);
+  }
   expect(signed.w, 'the fallback src carries no width').toBeNull();
   expect(signed.sig.length).toBeGreaterThan(0);
   expect(image.sizes).toBe(EXPECTED_SIZES);
@@ -294,7 +300,9 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
       image => image.alt === 'E2E CD fixture'
     );
     expect(viewerImages.length, 'the fixture image should be on the rendered deck').toBe(1);
-    expectResponsive(viewerImages[0], { classroomId: target.id });
+    // The deck VIEWER is the one editing surface, and this session owns the
+    // deck — so it, and only it, mints the 4h `edit` bucket.
+    expectResponsive(viewerImages[0], { classroomId: target.id, tier: 'edit' });
 
     expect(viewerLog.forSha(viewerImages[0].signed!.sha).length, 'one image, one fetch').toBe(1);
     expect(viewerLog.missing()).toEqual([]);
@@ -303,13 +311,32 @@ test.describe('E2E CD — slides, a deck with an uploaded image', () => {
     // `/present` is a different render path off the same deck, and it has
     // regressed independently before — a signed viewer with an unsigned
     // presentation is exactly the split this asserts against.
+    //
+    // It is also where the tier stops following the person and starts
+    // following the DECK. The same owner who just got `edit` in the viewer
+    // gets `week` here, because a presentation stays open for hours and the
+    // 4h bucket would 403 a lazily-loaded background mid-lecture. A new deck
+    // is not public, so `week` is the deck's own visibility answer.
     await presentSlide(page, deckId);
     await waitForReveal(page);
     const presentImages = (await readImages(page, '.reveal img')).filter(
       image => image.alt === 'E2E CD fixture'
     );
     expect(presentImages.length).toBe(1);
-    expectResponsive(presentImages[0], { classroomId: target.id });
+    expectResponsive(presentImages[0], { classroomId: target.id, tier: 'week' });
+
+    // And publishing the deck moves `/present` to the 30-day bucket, without
+    // anything about the VIEWER changing. This is the visibility rule end to
+    // end: one owner, one surface, two answers, decided by the deck.
+    const { setSlideVisibility } = await import('./helpers');
+    await setSlideVisibility(page, deckId, 'public');
+    await presentSlide(page, deckId);
+    await waitForReveal(page);
+    const publicPresentImages = (await readImages(page, '.reveal img')).filter(
+      image => image.alt === 'E2E CD fixture'
+    );
+    expect(publicPresentImages.length).toBe(1);
+    expectResponsive(publicPresentImages[0], { classroomId: target.id, tier: 'month' });
   });
 
   test('deck.json stores no signature, no srcset and no delivery origin', async ({ page }) => {

--- a/apps/slides/tests/unit/deck-delivery.spec.ts
+++ b/apps/slides/tests/unit/deck-delivery.spec.ts
@@ -13,15 +13,16 @@
  * The regression that produced this file: the rewrite lived inside the deck
  * VIEWER route, so `/present`, `/follow` and `/speaker` served raw
  * `/content/{org}/{repo}/...` URLs — dead the moment a content repo goes
- * private. `deckAccessFor` is the per-surface half of the fix, and the last
- * block here pins it against the shapes `assertSlideAccess` actually returns.
+ * private. `deckAccessFor` is the per-surface half of the fix, and the block
+ * below pins it against the shapes `assertSlideAccess` actually returns: the
+ * deck VIEWER is the only editing surface, and every other surface takes the
+ * DECK's visibility.
  */
 
 import { test, expect } from '@playwright/test';
 import {
   deckAccessFor,
   deckDeliveryContext,
-  followDeckAccess,
   gitBlobSha,
   isThumbnailRequest,
   isThemeRef,
@@ -109,7 +110,7 @@ function fakeResolvers(overrides: Partial<DeckDeliveryResolvers> = {}): DeckDeli
           urls.set(ref, ref);
           continue;
         }
-        const src = `${ORIGIN}/c/${CLASSROOM}/blob/sha-${ref.split('/').pop()}?p=draft`;
+        const src = `${ORIGIN}/c/${CLASSROOM}/blob/sha-${ref.split('/').pop()}?p=edit`;
         urls.set(ref, src);
         if (/\.(png|jpe?g|webp|avif)$/i.test(ref)) {
           srcSets.set(ref, {
@@ -129,16 +130,15 @@ function fakeResolvers(overrides: Partial<DeckDeliveryResolvers> = {}): DeckDeli
 
 test.describe('tier selection', () => {
   test('runs through tierFor rather than a per-route rule', () => {
-    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true })?.tier).toBe('draft');
-    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false })?.tier).toBe('enrolled');
-    expect(
-      deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false, isPublicSite: true })?.tier
-    ).toBe('public');
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: true })?.tier).toBe('edit');
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false })?.tier).toBe('week');
+    expect(deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false, isPublic: true })?.tier).toBe(
+      'month'
+    );
     // A staff preview outranks a public deck — editing, not browsing.
     expect(
-      deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false, preview: true, isPublicSite: true })
-        ?.tier
-    ).toBe('draft');
+      deckDeliveryContext(SLIDE, ORG, REPO, { canEdit: false, preview: true, isPublic: true })?.tier
+    ).toBe('edit');
   });
 
   test('no context at all when the classroom cannot be served', () => {
@@ -163,7 +163,7 @@ test.describe('asset rewriting', () => {
     const { html: out } = await resolveDeckDelivery(html, ctx(), {
       resolvers: fakeResolvers(),
     });
-    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=draft`);
+    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=edit`);
     expect(out).not.toContain(`/content/${ORG}/${REPO}/slides`);
   });
 
@@ -289,7 +289,7 @@ test.describe('shared theme links', () => {
     expect(themeBase).toBe(BASE);
     expect(out).toContain(`${BASE}lib/offline-v2.css`);
     expect(out).toContain(`${BASE}custom-theme.css`);
-    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=draft`);
+    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=edit`);
     // A theme file signed as a standalone blob would break the relative
     // `url()` references the folder signature exists for.
     expect(seen.some(ref => ref.includes('.slidesthemes/'))).toBe(false);
@@ -315,93 +315,58 @@ test.describe('shared theme links', () => {
 
     expect(themeCalls).toBe(0);
     expect(out).toContain(`/content/${ORG}/${REPO}/.slidesthemes/cs98/lib/offline-v2.css`);
-    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=draft`);
+    expect(out).toContain(`${ORIGIN}/c/${CLASSROOM}/blob/sha-hero.jpeg?p=edit`);
   });
 });
 
 test.describe('deckAccessFor — the tier inputs, per surface', () => {
-  test('the viewer follows the access result exactly', () => {
+  test('the viewer is the only editing surface, and follows the access result', () => {
     expect(deckAccessFor('viewer', OWNER, SLIDE)).toEqual({
       canEdit: true,
       preview: false,
-      isPublicSite: false,
+      isPublic: false,
     });
     expect(deckAccessFor('viewer', ASSISTANT_NO_EDIT, SLIDE)).toEqual({
       canEdit: false,
       preview: false,
-      isPublicSite: false,
+      isPublic: false,
     });
     expect(deckAccessFor('viewer', STUDENT, PUBLIC_SLIDE)).toEqual({
       canEdit: false,
       preview: false,
-      isPublicSite: true,
+      isPublic: true,
     });
   });
 
   test('only the viewer honours a preview-BRANCH read', () => {
     const staffPreview = { canEdit: true, previewActive: true };
     expect(deckAccessFor('viewer', staffPreview, SLIDE).preview).toBe(true);
-    // /follow has a `?preview=true` of its own that means "thumbnail". Even
-    // handed the viewer's flag, this surface must never mint draft URLs — a
-    // lecture hall of students would be signing into the 4h bucket.
-    expect(deckAccessFor('follow', staffPreview, SLIDE).preview).toBe(false);
-    expect(deckAccessFor('present', staffPreview, SLIDE).preview).toBeUndefined();
-    expect(deckAccessFor('speaker', staffPreview, SLIDE).preview).toBeUndefined();
-  });
-
-  test('present and speaker never claim edit access, whoever is looking', () => {
-    // Both surfaces stay open for hours; draft is an exact now+4h with five
-    // minutes of grace, so a lazily-loaded background on slide 40 would 403
-    // after lunch. Content is sha-addressed, so the longer bucket is the same
-    // bytes.
-    for (const surface of ['present', 'speaker'] as const) {
-      for (const access of [OWNER, ASSISTANT_NO_EDIT, STUDENT]) {
-        expect(deckAccessFor(surface, access, SLIDE)).toEqual({
-          canEdit: false,
-          isPublicSite: false,
-        });
-      }
-      expect(deckAccessFor(surface, OWNER, PUBLIC_SLIDE).isPublicSite).toBe(true);
+    // Everywhere else the flag is dropped on the floor. `/follow` has a
+    // `?preview=true` of its own that means "thumbnail", and a surface that
+    // let the two meet would sign a lecture hall into the 4h bucket.
+    for (const surface of ['present', 'speaker', 'follow'] as const) {
+      expect(deckAccessFor(surface, staffPreview, SLIDE).preview).toBeUndefined();
     }
   });
 
-  test('follow passes a follower through untouched', () => {
-    // A shareCode guest and an enrolled student are the same shape here.
-    expect(deckAccessFor('follow', STUDENT, SLIDE)).toEqual({
-      canEdit: false,
-      preview: false,
-      isPublicSite: false,
-    });
-    // Staff following along still edit, so they still get the draft bucket.
-    expect(deckAccessFor('follow', OWNER, SLIDE).canEdit).toBe(true);
-  });
-
-  test('the thumbnail form of follow is read-only, even for an owner', () => {
-    // `/speaker` embeds `/follow?preview=true` in its current and next panes.
-    // Signed as `draft`, those iframes expire four hours in — mid-lecture for
-    // a long class — and the lazily-loaded backgrounds start 403ing.
-    expect(deckAccessFor('follow', OWNER, SLIDE, { thumbnail: true })).toEqual({
-      canEdit: false,
-      preview: false,
-      isPublicSite: false,
-    });
-    // The thumbnail flag still never becomes the viewer's preview-BRANCH flag.
-    expect(
-      deckAccessFor('follow', { canEdit: true, previewActive: true }, SLIDE, { thumbnail: true })
-        .preview
-    ).toBe(false);
-    // Plain `/follow` is untouched: staff still edit there.
-    expect(deckAccessFor('follow', OWNER, SLIDE, { thumbnail: false }).canEdit).toBe(true);
-    expect(deckAccessFor('follow', OWNER, SLIDE).canEdit).toBe(true);
-    // A student was already read-only, and the flag changes nothing for them.
-    expect(deckAccessFor('follow', STUDENT, SLIDE, { thumbnail: true })).toEqual(
-      deckAccessFor('follow', STUDENT, SLIDE)
-    );
-    // Only `follow` has a thumbnail form — the other surfaces ignore the flag.
-    for (const surface of ['viewer', 'present', 'speaker'] as const) {
-      expect(deckAccessFor(surface, OWNER, SLIDE, { thumbnail: true })).toEqual(
-        deckAccessFor(surface, OWNER, SLIDE)
-      );
+  test('no surface but the viewer claims edit access, whoever is looking', () => {
+    // present/speaker stay open for hours and `edit` is an exact now+4h with
+    // five minutes of grace, so a lazily-loaded background on slide 40 would
+    // 403 after lunch. `/follow` is a READ surface for everyone including
+    // staff — nobody edits a deck through the audience view, and `/speaker`
+    // embeds it as an iframe. Content is sha-addressed, so the longer bucket
+    // is the same bytes.
+    for (const surface of ['present', 'speaker', 'follow'] as const) {
+      for (const access of [OWNER, ASSISTANT_NO_EDIT, STUDENT]) {
+        expect(deckAccessFor(surface, access, SLIDE)).toEqual({
+          canEdit: false,
+          isPublic: false,
+        });
+      }
+      expect(deckAccessFor(surface, OWNER, PUBLIC_SLIDE)).toEqual({
+        canEdit: false,
+        isPublic: true,
+      });
     }
   });
 
@@ -409,25 +374,47 @@ test.describe('deckAccessFor — the tier inputs, per surface', () => {
     const tierOf = (
       surface: Parameters<typeof deckAccessFor>[0],
       access: typeof OWNER,
-      slide = SLIDE,
-      opts: Parameters<typeof deckAccessFor>[3] = {}
-    ) => deckDeliveryContext(slide, ORG, REPO, deckAccessFor(surface, access, slide, opts))?.tier;
+      slide = SLIDE
+    ) => deckDeliveryContext(slide, ORG, REPO, deckAccessFor(surface, access, slide))?.tier;
 
-    expect(tierOf('viewer', OWNER)).toBe('draft');
-    expect(tierOf('present', OWNER)).toBe('enrolled');
-    expect(tierOf('speaker', OWNER)).toBe('enrolled');
-    expect(tierOf('present', OWNER, PUBLIC_SLIDE)).toBe('public');
-    expect(tierOf('follow', STUDENT)).toBe('enrolled');
-    expect(tierOf('follow', STUDENT, PUBLIC_SLIDE)).toBe('public');
-    expect(tierOf('follow', OWNER)).toBe('draft');
-    // The speaker view's panes: an owner, but not the 4h bucket.
-    expect(tierOf('follow', OWNER, SLIDE, { thumbnail: true })).toBe('enrolled');
-    expect(tierOf('follow', OWNER, PUBLIC_SLIDE, { thumbnail: true })).toBe('public');
-    expect(tierOf('follow', STUDENT, SLIDE, { thumbnail: true })).toBe('enrolled');
+    // The one editing surface.
+    expect(tierOf('viewer', OWNER)).toBe('edit');
+    expect(tierOf('viewer', OWNER, PUBLIC_SLIDE)).toBe('edit');
+    expect(tierOf('viewer', STUDENT)).toBe('week');
+    expect(tierOf('viewer', STUDENT, PUBLIC_SLIDE)).toBe('month');
+
+    // Every read surface reduces to the DECK's visibility and nothing else —
+    // same answer for an owner and for a student, which is the whole point.
+    for (const surface of ['present', 'speaker', 'follow'] as const) {
+      for (const access of [OWNER, ASSISTANT_NO_EDIT, STUDENT]) {
+        expect(tierOf(surface, access), `${surface} private`).toBe('week');
+        expect(tierOf(surface, access, PUBLIC_SLIDE), `${surface} public`).toBe('month');
+      }
+    }
+  });
+
+  test('no read surface can reach `edit`, even handed a staff preview', () => {
+    // The speaker view's current/next panes are `/follow?preview=true`
+    // iframes, and a lecture that outran four hours used to 403 a lazily
+    // loaded background mid-talk. This used to depend on `/follow` correctly
+    // spotting its thumbnail flag; now it is structural — the flag never
+    // reaches a tier decision, so there is nothing left to get wrong.
+    const staffPreview = { canEdit: true, previewActive: true };
+    for (const surface of ['present', 'speaker', 'follow'] as const) {
+      for (const slide of [SLIDE, PUBLIC_SLIDE]) {
+        const tier = deckDeliveryContext(
+          slide,
+          ORG,
+          REPO,
+          deckAccessFor(surface, staffPreview, slide)
+        )?.tier;
+        expect(tier, surface).not.toBe('edit');
+      }
+    }
   });
 });
 
-test.describe('the /follow route\'s own wiring', () => {
+test.describe("the /follow route's own preview parameter", () => {
   const followUrl = (query: string) => new URL(`https://slides.classmoji.io/deck-1/follow${query}`);
 
   test('only `preview=true` is the thumbnail form', () => {
@@ -440,28 +427,28 @@ test.describe('the /follow route\'s own wiring', () => {
     expect(isThumbnailRequest(followUrl('?shareCode=abc123'))).toBe(false);
   });
 
-  test('the URL alone decides the tier the speaker panes get', () => {
-    // The whole chain the route runs: query param → thumbnail flag → access
-    // shape → tier. This is what `/speaker` embeds, and it must not be draft.
-    const tierOf = (url: URL, access: typeof OWNER, slide = SLIDE) =>
-      deckDeliveryContext(slide, ORG, REPO, followDeckAccess(url, access, slide))?.tier;
-
-    expect(tierOf(followUrl('?preview=true'), OWNER)).toBe('enrolled');
-    expect(tierOf(followUrl('?preview=true'), OWNER, PUBLIC_SLIDE)).toBe('public');
-    // Plain /follow is untouched — staff editing along still get draft.
-    expect(tierOf(followUrl(''), OWNER)).toBe('draft');
-    // And a follower is a follower either way.
-    expect(tierOf(followUrl('?preview=true'), STUDENT)).toBe('enrolled');
-    expect(tierOf(followUrl(''), STUDENT)).toBe('enrolled');
-  });
-
-  test('a thumbnail never claims edit access', () => {
-    expect(followDeckAccess(followUrl('?preview=true'), OWNER, SLIDE)).toEqual({
-      canEdit: false,
-      preview: false,
-      isPublicSite: false,
-    });
-    expect(followDeckAccess(followUrl(''), OWNER, SLIDE).canEdit).toBe(true);
+  test('the flag decides layout and cannot reach a signature', () => {
+    // It used to feed the tier as well, to keep the speaker panes off the 4h
+    // bucket. `deckAccessFor` now pins every `/follow` read to `canEdit:
+    // false`, so both forms of the route mint the same tier and the parameter
+    // has no way to affect one.
+    for (const access of [OWNER, STUDENT]) {
+      const tier = deckDeliveryContext(
+        SLIDE,
+        ORG,
+        REPO,
+        deckAccessFor('follow', access, SLIDE)
+      )?.tier;
+      expect(tier).toBe('week');
+    }
+    expect(
+      deckDeliveryContext(
+        PUBLIC_SLIDE,
+        ORG,
+        REPO,
+        deckAccessFor('follow', OWNER, PUBLIC_SLIDE)
+      )?.tier
+    ).toBe('month');
   });
 });
 
@@ -520,7 +507,7 @@ test.describe('responsive images', () => {
     // And the untransformed original is still what `src` points at, which is
     // both the fallback for a browser that ignores srcset and the thing that
     // makes the src/srcset pair matchable by string equality.
-    expect(out).toMatch(/src="[^"]*\/blob\/sha-a\.png\?p=draft"/);
+    expect(out).toMatch(/src="[^"]*\/blob\/sha-a\.png\?p=edit"/);
   });
 
   test('never on a background attribute — Reveal paints those as CSS', async () => {

--- a/apps/slides/tests/unit/deck-view-content.spec.ts
+++ b/apps/slides/tests/unit/deck-view-content.spec.ts
@@ -117,7 +117,7 @@ test.describe('settleSaveRefresh — has the save’s loader refresh landed', ()
   test('a loader read that has not caught up never wins', () => {
     // The map row is not updated yet, or a Worker 502 fell back to another
     // instance's <60s API cache. The bytes WILL differ from the last read —
-    // `draft` expiries are an exact now+4h, so every signed URL in the document
+    // `edit` expiries are an exact now+4h, so every signed URL in the document
     // changes every second — which is exactly why identity is the test and
     // "the document changed" is not. Settling true here would put the PRE-save
     // deck on screen: worse than the bug this fixes.

--- a/packages/content-signing/README.md
+++ b/packages/content-signing/README.md
@@ -21,11 +21,25 @@ a revocation: URLs signed under the old version keep verifying until they expire
 
 ## Tiers
 
-| Tier       | Expiry                        | Grace on verify | Cache-Control                          |
-| ---------- | ----------------------------- | --------------- | -------------------------------------- |
-| `public`   | end of the current 30d bucket | 6h              | `public, max-age={exp-now}, immutable` |
-| `enrolled` | end of the current 7d bucket  | 6h              | `public, max-age={exp-now}, immutable` |
-| `draft`    | exact `now + 4h`              | 5m              | `no-store`                             |
+A tier is named for its window because that is all it decides. It is **not**
+access control — the signature is; a tier only sets how long an already-minted
+URL lives and whether a cache may keep it.
+
+| Tier    | Expiry                        | Grace on verify | Cache-Control                          |
+| ------- | ----------------------------- | --------------- | -------------------------------------- |
+| `month` | end of the current 30d bucket | 6h              | `public, max-age={exp-now}, immutable` |
+| `week`  | end of the current 7d bucket  | 6h              | `public, max-age={exp-now}, immutable` |
+| `edit`  | exact `now + 4h`              | 5m              | `no-store`                             |
+
+The caller picks the tier; this package only validates that `p` is one of the
+three. In the apps that choice follows the content's visibility — `edit` for a
+viewer who can edit, `month` for content that is public, `week` otherwise — so
+the same file rendered on two different surfaces mints the same URL.
+
+**Renamed 2026-09-05.** These were `public`, `enrolled` and `draft`, names that
+read like permissions they never were. `p` is a field of the canonical string,
+so every URL minted before that date now fails `bad-signature`. Nothing is in
+production; only staging ever held one.
 
 Bucket boundaries are staggered per classroom so the fleet does not cold-fill in
 unison:
@@ -42,7 +56,7 @@ every viewer back at once; grace keeps the outgoing bucket's URLs serving
 meanwhile.
 
 Grace covers a page rendered just before rollover and still sitting in a cache;
-for `draft` it covers clock skew only. An expired-beyond-grace signature fails
+for `edit` it covers clock skew only. An expired-beyond-grace signature fails
 with `expired`. Nothing validates that `exp` is not further in the future than the
 tier could have produced. Past `exp` but inside grace, `cacheControlFor` returns
 `public, max-age=60` rather than an immutable zero TTL.
@@ -110,7 +124,7 @@ Minting (Node app):
 ```ts
 import { signBlobUrl, signSrcSet, signThemeBase } from '@classmoji/content-signing';
 
-const ctx = { master: env.CONTENT_MASTER_SECRET, classroomId, keyVersion, tier: 'enrolled' };
+const ctx = { master: env.CONTENT_MASTER_SECRET, classroomId, keyVersion, tier: 'week' };
 
 const url = await signBlobUrl(origin, ctx, { sha, ext: 'png' });
 const { src, srcset } = await signSrcSet(origin, ctx, { sha, ext: 'png', sourceWidth: 1600 });

--- a/packages/content-signing/src/__tests__/bucket.test.ts
+++ b/packages/content-signing/src/__tests__/bucket.test.ts
@@ -23,14 +23,14 @@ describe('fnv1a32', () => {
 });
 
 describe('bucketExpiry', () => {
-  it('gives draft an exact now + 4h', () => {
-    expect(bucketExpiry('draft', CLASSROOM_A, NOW)).toBe(NOW + 4 * HOUR);
-    expect(bucketExpiry('draft', CLASSROOM_B, NOW)).toBe(NOW + 4 * HOUR);
-    expect(bucketExpiry('draft', CLASSROOM_A, NOW + 1)).toBe(NOW + 1 + 4 * HOUR);
+  it('gives edit an exact now + 4h', () => {
+    expect(bucketExpiry('edit', CLASSROOM_A, NOW)).toBe(NOW + 4 * HOUR);
+    expect(bucketExpiry('edit', CLASSROOM_B, NOW)).toBe(NOW + 4 * HOUR);
+    expect(bucketExpiry('edit', CLASSROOM_A, NOW + 1)).toBe(NOW + 1 + 4 * HOUR);
   });
 
   it('rounds bucketed tiers up to a boundary on the classroom stagger', () => {
-    for (const tier of ['public', 'enrolled'] as const) {
+    for (const tier of ['month', 'week'] as const) {
       const length = TIER_POLICY[tier].bucketSeconds as number;
       const exp = bucketExpiry(tier, CLASSROOM_A, NOW);
       expect(exp).toBeGreaterThan(NOW);
@@ -40,40 +40,38 @@ describe('bucketExpiry', () => {
     }
   });
 
-  it('uses 30-day buckets for public and 7-day for enrolled', () => {
-    expect(TIER_POLICY.public.bucketSeconds).toBe(30 * DAY);
-    expect(TIER_POLICY.enrolled.bucketSeconds).toBe(7 * DAY);
+  it('uses 30-day buckets for month and 7-day for week', () => {
+    expect(TIER_POLICY.month.bucketSeconds).toBe(30 * DAY);
+    expect(TIER_POLICY.week.bucketSeconds).toBe(7 * DAY);
   });
 
   it('is stable for every instant inside one bucket', () => {
-    const exp = bucketExpiry('enrolled', CLASSROOM_A, NOW);
-    expect(bucketExpiry('enrolled', CLASSROOM_A, NOW + 60)).toBe(exp);
+    const exp = bucketExpiry('week', CLASSROOM_A, NOW);
+    expect(bucketExpiry('week', CLASSROOM_A, NOW + 60)).toBe(exp);
     // Crossing the boundary moves to the next bucket, exactly one length on.
-    expect(bucketExpiry('enrolled', CLASSROOM_A, exp)).toBe(exp + 7 * DAY);
+    expect(bucketExpiry('week', CLASSROOM_A, exp)).toBe(exp + 7 * DAY);
   });
 
   it('never mints a URL with less than an hour left on it', () => {
-    const length = TIER_POLICY.enrolled.bucketSeconds as number;
-    const exp = bucketExpiry('enrolled', CLASSROOM_A, NOW);
+    const length = TIER_POLICY.week.bucketSeconds as number;
+    const exp = bucketExpiry('week', CLASSROOM_A, NOW);
 
     // Exactly at the floor the current bucket is still worth minting against.
-    expect(bucketExpiry('enrolled', CLASSROOM_A, exp - MIN_REMAINING_SECONDS)).toBe(exp);
+    expect(bucketExpiry('week', CLASSROOM_A, exp - MIN_REMAINING_SECONDS)).toBe(exp);
     // A second inside it, and a fresh URL would expire almost at once: roll on.
-    expect(bucketExpiry('enrolled', CLASSROOM_A, exp - MIN_REMAINING_SECONDS + 1)).toBe(
-      exp + length
-    );
-    expect(bucketExpiry('enrolled', CLASSROOM_A, exp - 1)).toBe(exp + length);
+    expect(bucketExpiry('week', CLASSROOM_A, exp - MIN_REMAINING_SECONDS + 1)).toBe(exp + length);
+    expect(bucketExpiry('week', CLASSROOM_A, exp - 1)).toBe(exp + length);
 
     for (const offsetIntoBucket of [0, 1, 3599, 3600, 100000]) {
       const at = exp - offsetIntoBucket;
-      expect(bucketExpiry('enrolled', CLASSROOM_A, at) - at).toBeGreaterThanOrEqual(
+      expect(bucketExpiry('week', CLASSROOM_A, at) - at).toBeGreaterThanOrEqual(
         MIN_REMAINING_SECONDS
       );
     }
   });
 
   it('staggers boundaries across classrooms so the fleet does not cold-fill at once', () => {
-    for (const tier of ['public', 'enrolled'] as const) {
+    for (const tier of ['month', 'week'] as const) {
       const a = bucketExpiry(tier, CLASSROOM_A, NOW);
       const b = bucketExpiry(tier, CLASSROOM_B, NOW);
       expect(a).not.toBe(b);
@@ -83,19 +81,19 @@ describe('bucketExpiry', () => {
   });
 
   it('handles a now that lands before the classroom offset', () => {
-    const length = TIER_POLICY.public.bucketSeconds as number;
+    const length = TIER_POLICY.month.bucketSeconds as number;
     const offset = bucketOffset(CLASSROOM_A, length);
     // One second before the first boundary: the floor rolls it to the next one.
-    expect(bucketExpiry('public', CLASSROOM_A, offset - 1)).toBe(offset + length);
-    expect(bucketExpiry('public', CLASSROOM_A, offset - MIN_REMAINING_SECONDS)).toBe(offset);
+    expect(bucketExpiry('month', CLASSROOM_A, offset - 1)).toBe(offset + length);
+    expect(bucketExpiry('month', CLASSROOM_A, offset - MIN_REMAINING_SECONDS)).toBe(offset);
   });
 
   it('rejects a bad tier, classroomId, or now', () => {
     // @ts-expect-error - exercising the runtime guard
     expect(() => bucketExpiry('secret', CLASSROOM_A, NOW)).toThrow(TypeError);
-    expect(() => bucketExpiry('public', 'not-a-uuid', NOW)).toThrow(TypeError);
+    expect(() => bucketExpiry('month', 'not-a-uuid', NOW)).toThrow(TypeError);
     for (const bad of [Number.NaN, Infinity, -1, 1.5, Number.MAX_SAFE_INTEGER + 2]) {
-      expect(() => bucketExpiry('public', CLASSROOM_A, bad)).toThrow(TypeError);
+      expect(() => bucketExpiry('month', CLASSROOM_A, bad)).toThrow(TypeError);
     }
   });
 });

--- a/packages/content-signing/src/__tests__/urls.test.ts
+++ b/packages/content-signing/src/__tests__/urls.test.ts
@@ -40,11 +40,11 @@ describe('canonical strings', () => {
         classroomId: CLASSROOM_A,
         sha: SHA,
         ext: 'png',
-        tier: 'public',
+        tier: 'month',
         keyVersion: 3,
         exp: 1767225600,
       })
-    ).toBe(`cm1|blob|${HOST}|${CLASSROOM_A}|${SHA}|png|public|3|1767225600||`);
+    ).toBe(`cm1|blob|${HOST}|${CLASSROOM_A}|${SHA}|png|month|3|1767225600||`);
 
     expect(
       blobCanonicalString({
@@ -52,12 +52,12 @@ describe('canonical strings', () => {
         classroomId: CLASSROOM_A,
         sha: SHA,
         ext: 'png',
-        tier: 'draft',
+        tier: 'edit',
         keyVersion: 0,
         exp: 1767225600,
         transform: { w: 1600, fmt: 'avif' },
       })
-    ).toBe(`cm1|blob|${HOST}|${CLASSROOM_A}|${SHA}|png|draft|0|1767225600|1600|avif`);
+    ).toBe(`cm1|blob|${HOST}|${CLASSROOM_A}|${SHA}|png|edit|0|1767225600|1600|avif`);
   });
 
   it('pins the theme shape', () => {
@@ -67,22 +67,22 @@ describe('canonical strings', () => {
         classroomId: CLASSROOM_A,
         theme: 'cosmo-dark',
         treeSha: TREE_SHA,
-        tier: 'enrolled',
+        tier: 'week',
         keyVersion: 2,
         exp: 1767225600,
       })
-    ).toBe(`cm1|theme|${HOST}|${CLASSROOM_A}|cosmo-dark|${TREE_SHA}|enrolled|2|1767225600`);
+    ).toBe(`cm1|theme|${HOST}|${CLASSROOM_A}|cosmo-dark|${TREE_SHA}|week|2|1767225600`);
   });
 });
 
 describe('signBlobUrl', () => {
   it('emits the documented shape', async () => {
-    const url = await signBlobUrl(ORIGIN, ctx('public'), { sha: SHA, ext: 'png' });
-    const exp = bucketExpiry('public', CLASSROOM_A, NOW);
+    const url = await signBlobUrl(ORIGIN, ctx('month'), { sha: SHA, ext: 'png' });
+    const exp = bucketExpiry('month', CLASSROOM_A, NOW);
     expect(url.startsWith(`${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?`)).toBe(true);
 
     const params = new URL(url).searchParams;
-    expect(params.get('p')).toBe('public');
+    expect(params.get('p')).toBe('month');
     expect(params.get('v')).toBe('0');
     expect(params.get('exp')).toBe(String(exp));
     expect(params.get('sig')).toMatch(/^[A-Za-z0-9_-]{43}$/);
@@ -91,7 +91,7 @@ describe('signBlobUrl', () => {
   });
 
   it('carries transform params', async () => {
-    const url = await signBlobUrl(ORIGIN, ctx('enrolled'), {
+    const url = await signBlobUrl(ORIGIN, ctx('week'), {
       sha: SHA,
       ext: 'jpg',
       transform: { w: 2560, fmt: 'webp' },
@@ -102,8 +102,8 @@ describe('signBlobUrl', () => {
   });
 
   it('is byte-identical for every mint inside one bucket', async () => {
-    const first = await signBlobUrl(ORIGIN, ctx('public'), { sha: SHA, ext: 'png' });
-    const later = await signBlobUrl(ORIGIN, ctx('public', { now: NOW + 3600 }), {
+    const first = await signBlobUrl(ORIGIN, ctx('month'), { sha: SHA, ext: 'png' });
+    const later = await signBlobUrl(ORIGIN, ctx('month', { now: NOW + 3600 }), {
       sha: SHA,
       ext: 'png',
     });
@@ -111,26 +111,26 @@ describe('signBlobUrl', () => {
   });
 
   it('trims a trailing slash off the origin', async () => {
-    const url = await signBlobUrl(`${ORIGIN}/`, ctx('public'), { sha: SHA, ext: 'png' });
+    const url = await signBlobUrl(`${ORIGIN}/`, ctx('month'), { sha: SHA, ext: 'png' });
     expect(url.startsWith(`${ORIGIN}/c/`)).toBe(true);
   });
 
   it('rejects malformed refs', async () => {
-    await expect(signBlobUrl(ORIGIN, ctx('public'), { sha: 'nope', ext: 'png' })).rejects.toThrow(
+    await expect(signBlobUrl(ORIGIN, ctx('month'), { sha: 'nope', ext: 'png' })).rejects.toThrow(
       TypeError
     );
-    await expect(signBlobUrl(ORIGIN, ctx('public'), { sha: SHA, ext: 'PNG' })).rejects.toThrow(
+    await expect(signBlobUrl(ORIGIN, ctx('month'), { sha: SHA, ext: 'PNG' })).rejects.toThrow(
       TypeError
     );
     await expect(
       // @ts-expect-error - exercising the runtime guard
-      signBlobUrl(ORIGIN, ctx('public'), { sha: SHA, ext: 'png', transform: { w: 1024 } })
+      signBlobUrl(ORIGIN, ctx('month'), { sha: SHA, ext: 'png', transform: { w: 1024 } })
     ).rejects.toThrow(TypeError);
   });
 
   it('rejects an origin with no host', async () => {
     await expect(
-      signBlobUrl('cdn.classmoji.test', ctx('public'), { sha: SHA, ext: 'png' })
+      signBlobUrl('cdn.classmoji.test', ctx('month'), { sha: SHA, ext: 'png' })
     ).rejects.toThrow(TypeError);
   });
 
@@ -141,7 +141,7 @@ describe('signBlobUrl', () => {
     // FIELD of the canonical string, so a signature for one extension can
     // never serve another.
     for (const ext of ['html', 'json', 'css', 'js', 'md', 'txt', 'svg', 'woff', 'woff2', 'ttf']) {
-      const url = await signBlobUrl(ORIGIN, ctx('enrolled'), { sha: SHA, ext });
+      const url = await signBlobUrl(ORIGIN, ctx('week'), { sha: SHA, ext });
       expect(url.startsWith(`${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.${ext}?`)).toBe(true);
       const parsed = parseContentUrl(url);
       expect(parsed).toMatchObject({ kind: 'blob', sha: SHA, ext });
@@ -151,8 +151,8 @@ describe('signBlobUrl', () => {
   it('gives one blob a different signature per extension', async () => {
     // The guarantee behind "never sniff" on the Worker: re-labelling a signed
     // .json as .html is not a URL edit, it is a forgery.
-    const asJson = await signBlobUrl(ORIGIN, ctx('enrolled'), { sha: SHA, ext: 'json' });
-    const asHtml = await signBlobUrl(ORIGIN, ctx('enrolled'), { sha: SHA, ext: 'html' });
+    const asJson = await signBlobUrl(ORIGIN, ctx('week'), { sha: SHA, ext: 'json' });
+    const asHtml = await signBlobUrl(ORIGIN, ctx('week'), { sha: SHA, ext: 'html' });
     expect(new URL(asJson).searchParams.get('sig')).not.toBe(
       new URL(asHtml).searchParams.get('sig')
     );
@@ -161,12 +161,12 @@ describe('signBlobUrl', () => {
   it('rejects a nonsense now or keyVersion at mint', async () => {
     for (const now of [Number.NaN, -1, 1.5, Infinity]) {
       await expect(
-        signBlobUrl(ORIGIN, ctx('public', { now }), { sha: SHA, ext: 'png' })
+        signBlobUrl(ORIGIN, ctx('month', { now }), { sha: SHA, ext: 'png' })
       ).rejects.toThrow(TypeError);
     }
     for (const keyVersion of [-1, 1.5, Number.NaN, Number.MAX_SAFE_INTEGER + 2]) {
       await expect(
-        signBlobUrl(ORIGIN, ctx('public', { keyVersion }), { sha: SHA, ext: 'png' })
+        signBlobUrl(ORIGIN, ctx('month', { keyVersion }), { sha: SHA, ext: 'png' })
       ).rejects.toThrow(TypeError);
     }
   });
@@ -174,11 +174,11 @@ describe('signBlobUrl', () => {
 
 describe('signThemeBase', () => {
   it('puts the policy in the path and ends with a slash', async () => {
-    const base = await signThemeBase(ORIGIN, ctx('enrolled'), {
+    const base = await signThemeBase(ORIGIN, ctx('week'), {
       theme: 'cosmo-dark',
       treeSha: TREE_SHA,
     });
-    const exp = bucketExpiry('enrolled', CLASSROOM_A, NOW);
+    const exp = bucketExpiry('week', CLASSROOM_A, NOW);
     expect(base.endsWith('/')).toBe(true);
 
     const prefix = `${ORIGIN}/c/${CLASSROOM_A}/theme/cosmo-dark/${TREE_SHA}/`;
@@ -186,14 +186,14 @@ describe('signThemeBase', () => {
 
     const policy = base.slice(prefix.length, -1).split('.');
     expect(policy.length).toBe(4);
-    expect(policy[0]).toBe('enrolled');
+    expect(policy[0]).toBe('week');
     expect(policy[1]).toBe('0');
     expect(policy[2]).toBe(String(exp));
     expect(policy[3]).toMatch(/^[A-Za-z0-9_-]{43}$/);
   });
 
   it('authorizes any relative path under the folder', async () => {
-    const base = await signThemeBase(ORIGIN, ctx('public'), {
+    const base = await signThemeBase(ORIGIN, ctx('month'), {
       theme: 'cosmo-dark',
       treeSha: TREE_SHA,
     });
@@ -204,14 +204,14 @@ describe('signThemeBase', () => {
 
   it('rejects malformed refs, including a leading dot in the theme', async () => {
     await expect(
-      signThemeBase(ORIGIN, ctx('public'), { theme: 'Cosmo Dark', treeSha: TREE_SHA })
+      signThemeBase(ORIGIN, ctx('month'), { theme: 'Cosmo Dark', treeSha: TREE_SHA })
     ).rejects.toThrow(TypeError);
     await expect(
-      signThemeBase(ORIGIN, ctx('public'), { theme: 'cosmo', treeSha: 'nope' })
+      signThemeBase(ORIGIN, ctx('month'), { theme: 'cosmo', treeSha: 'nope' })
     ).rejects.toThrow(TypeError);
     for (const theme of ['.git', '..', '.', '.hidden']) {
       await expect(
-        signThemeBase(ORIGIN, ctx('public'), { theme, treeSha: TREE_SHA })
+        signThemeBase(ORIGIN, ctx('month'), { theme, treeSha: TREE_SHA })
       ).rejects.toThrow(TypeError);
     }
   });
@@ -219,7 +219,7 @@ describe('signThemeBase', () => {
 
 describe('signSrcSet', () => {
   it('emits all three widths when the source width is unknown', async () => {
-    const { src, srcset } = await signSrcSet(ORIGIN, ctx('public'), { sha: SHA, ext: 'png' });
+    const { src, srcset } = await signSrcSet(ORIGIN, ctx('month'), { sha: SHA, ext: 'png' });
     const entries = entriesOf(srcset);
     expect(entries.map(entry => entry.descriptor)).toEqual([800, 1600, 2560]);
     expect(widthOf(src)).toBe(2560);
@@ -227,7 +227,7 @@ describe('signSrcSet', () => {
 
   it('never emits a width larger than sourceWidth', async () => {
     for (const sourceWidth of [800, 900, 1599, 1600, 1700, 2560, 4000]) {
-      const { src, srcset } = await signSrcSet(ORIGIN, ctx('public'), {
+      const { src, srcset } = await signSrcSet(ORIGIN, ctx('month'), {
         sha: SHA,
         ext: 'png',
         sourceWidth,
@@ -246,7 +246,7 @@ describe('signSrcSet', () => {
   });
 
   it('fills the gap with the original when the source sits between rungs', async () => {
-    const { srcset } = await signSrcSet(ORIGIN, ctx('public'), {
+    const { srcset } = await signSrcSet(ORIGIN, ctx('month'), {
       sha: SHA,
       ext: 'png',
       sourceWidth: 1599,
@@ -260,7 +260,7 @@ describe('signSrcSet', () => {
 
   it('does not add an original above the top rung, where the cap is deliberate', async () => {
     for (const sourceWidth of [2560, 4000]) {
-      const { srcset } = await signSrcSet(ORIGIN, ctx('public'), {
+      const { srcset } = await signSrcSet(ORIGIN, ctx('month'), {
         sha: SHA,
         ext: 'png',
         sourceWidth,
@@ -271,7 +271,7 @@ describe('signSrcSet', () => {
 
   it('lands exactly on the ladder without a duplicate original', async () => {
     for (const sourceWidth of TRANSFORM_WIDTHS) {
-      const { srcset } = await signSrcSet(ORIGIN, ctx('public'), {
+      const { srcset } = await signSrcSet(ORIGIN, ctx('month'), {
         sha: SHA,
         ext: 'png',
         sourceWidth,
@@ -285,7 +285,7 @@ describe('signSrcSet', () => {
   });
 
   it('serves an untransformed original when the source is narrower than 800', async () => {
-    const { src, srcset } = await signSrcSet(ORIGIN, ctx('public'), {
+    const { src, srcset } = await signSrcSet(ORIGIN, ctx('month'), {
       sha: SHA,
       ext: 'png',
       sourceWidth: 500,
@@ -295,7 +295,7 @@ describe('signSrcSet', () => {
   });
 
   it('threads the format through every rendition', async () => {
-    const { srcset } = await signSrcSet(ORIGIN, ctx('public'), {
+    const { srcset } = await signSrcSet(ORIGIN, ctx('month'), {
       sha: SHA,
       ext: 'png',
       fmt: 'avif',
@@ -308,7 +308,7 @@ describe('signSrcSet', () => {
 
   it('rejects a nonsense sourceWidth', async () => {
     await expect(
-      signSrcSet(ORIGIN, ctx('public'), { sha: SHA, ext: 'png', sourceWidth: 0 })
+      signSrcSet(ORIGIN, ctx('month'), { sha: SHA, ext: 'png', sourceWidth: 0 })
     ).rejects.toThrow(TypeError);
   });
 });

--- a/packages/content-signing/src/__tests__/verify.test.ts
+++ b/packages/content-signing/src/__tests__/verify.test.ts
@@ -29,7 +29,7 @@ import {
   withoutParam,
 } from './fixtures.ts';
 
-const TIERS: Tier[] = ['public', 'enrolled', 'draft'];
+const TIERS: Tier[] = ['month', 'week', 'edit'];
 
 const blob = (tier: Tier, transform?: { w?: 800 | 1600 | 2560; fmt?: 'webp' | 'avif' | 'auto' }) =>
   signBlobUrl(ORIGIN, ctx(tier), { sha: SHA, ext: 'png', transform });
@@ -91,21 +91,21 @@ describe('round trip', () => {
   });
 
   it('dispatches on shape through verifyContentUrl', async () => {
-    const blobResult = await verifyContentUrl(MASTER, await blob('public'), NOW);
+    const blobResult = await verifyContentUrl(MASTER, await blob('month'), NOW);
     expect(blobResult.ok && blobResult.kind).toBe('blob');
 
-    const themeResult = await verifyContentUrl(MASTER, `${await themeBase('public')}a.css`, NOW);
+    const themeResult = await verifyContentUrl(MASTER, `${await themeBase('month')}a.css`, NOW);
     expect(themeResult.ok && themeResult.kind).toBe('theme');
   });
 
   it('accepts a URL object as well as a string', async () => {
-    const url = await blob('enrolled');
+    const url = await blob('week');
     expect((await verifyBlobUrl(MASTER, new URL(url), NOW)).ok).toBe(true);
   });
 
   it('survives a keyVersion bump only under the matching version', async () => {
-    const v0 = await blob('public');
-    const v1 = await signBlobUrl(ORIGIN, ctx('public', { keyVersion: 1 }), {
+    const v0 = await blob('month');
+    const v1 = await signBlobUrl(ORIGIN, ctx('month', { keyVersion: 1 }), {
       sha: SHA,
       ext: 'png',
     });
@@ -116,7 +116,7 @@ describe('round trip', () => {
 });
 
 describe('grace', () => {
-  it.each(['public', 'enrolled'] as const)(
+  it.each(['month', 'week'] as const)(
     'accepts a previous-bucket %s signature inside 6h, not after',
     async tier => {
       const url = await blob(tier);
@@ -138,23 +138,23 @@ describe('grace', () => {
     }
   );
 
-  it('gives draft only a 5 minute skew allowance', async () => {
-    const url = await blob('draft');
+  it('gives edit only a 5 minute skew allowance', async () => {
+    const url = await blob('edit');
     const exp = NOW + 4 * 3600;
-    expect(TIER_POLICY.draft.graceSeconds).toBe(300);
+    expect(TIER_POLICY.edit.graceSeconds).toBe(300);
 
     const inGrace = await verifyBlobUrl(MASTER, url, exp + 300);
     expect(inGrace.ok).toBe(true);
     if (inGrace.ok) expect(inGrace.inGrace).toBe(true);
 
     expect(await verifyBlobUrl(MASTER, url, exp + 301)).toEqual({ ok: false, reason: 'expired' });
-    // A 6h grace would have covered this; draft must not.
+    // A 6h grace would have covered this; edit must not.
     expect(await verifyBlobUrl(MASTER, url, exp + 3600)).toEqual({ ok: false, reason: 'expired' });
   });
 
   it('applies the same grace to theme URLs', async () => {
-    const base = await themeBase('enrolled');
-    const exp = bucketExpiry('enrolled', CLASSROOM_A, NOW);
+    const base = await themeBase('week');
+    const exp = bucketExpiry('week', CLASSROOM_A, NOW);
     const inGrace = await verifyThemeUrl(MASTER, `${base}theme.css`, exp + 60);
     expect(inGrace.ok).toBe(true);
     if (inGrace.ok) expect(inGrace.inGrace).toBe(true);
@@ -168,52 +168,52 @@ describe('grace', () => {
 
 describe('tamper vectors', () => {
   it('rejects a stripped signature as malformed', async () => {
-    const url = withoutParam(await blob('public'), 'sig');
+    const url = withoutParam(await blob('month'), 'sig');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'malformed' });
   });
 
   it('rejects a flipped tier', async () => {
-    const url = withParam(await blob('enrolled'), 'p', 'public');
+    const url = withParam(await blob('week'), 'p', 'month');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects an altered width', async () => {
-    const url = withParam(await blob('public', { w: 800 }), 'w', '2560');
+    const url = withParam(await blob('month', { w: 800 }), 'w', '2560');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects an added width on an untransformed URL', async () => {
-    const url = withParam(await blob('public'), 'w', '800');
+    const url = withParam(await blob('month'), 'w', '800');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects an altered format', async () => {
-    const url = withParam(await blob('public', { fmt: 'webp' }), 'fmt', 'avif');
+    const url = withParam(await blob('month', { fmt: 'webp' }), 'fmt', 'avif');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects an altered sha', async () => {
-    const url = (await blob('public')).replace(SHA, OTHER_SHA);
+    const url = (await blob('month')).replace(SHA, OTHER_SHA);
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects an altered ext', async () => {
-    const url = (await blob('public')).replace(`${SHA}.png`, `${SHA}.gif`);
+    const url = (await blob('month')).replace(`${SHA}.png`, `${SHA}.gif`);
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects a swapped classroomId', async () => {
-    const url = (await blob('public')).replace(CLASSROOM_A, CLASSROOM_B);
+    const url = (await blob('month')).replace(CLASSROOM_A, CLASSROOM_B);
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects a bumped keyVersion', async () => {
-    const url = withParam(await blob('public'), 'v', '1');
+    const url = withParam(await blob('month'), 'v', '1');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects a stretched expiry', async () => {
-    const url = await blob('draft');
+    const url = await blob('edit');
     const stretched = withParam(url, 'exp', String(NOW + 400 * 86400));
     expect(await verifyBlobUrl(MASTER, stretched, NOW)).toEqual({
       ok: false,
@@ -222,7 +222,7 @@ describe('tamper vectors', () => {
   });
 
   it('rejects a theme relPath that escapes the folder', async () => {
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     // Escaping eats the policy segment, so there is nothing left to verify against.
     for (const relPath of ['../secret.css', 'css/../../secret.css', '../../../../etc/passwd']) {
       expect(await verifyThemeUrl(MASTER, `${base}${relPath}`, NOW)).toEqual({
@@ -233,7 +233,7 @@ describe('tamper vectors', () => {
   });
 
   it('never lets a traversal survive into relPath', async () => {
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     // %2e%2e is a dot segment to the URL parser: this collapses back inside the
     // folder rather than escaping it, and what the Worker sees is the normalized path.
     const result = await verifyThemeUrl(MASTER, `${base}css/%2e%2e/theme.css`, NOW);
@@ -244,8 +244,8 @@ describe('tamper vectors', () => {
   });
 
   it('rejects a tampered theme policy segment', async () => {
-    const base = await themeBase('enrolled');
-    const tampered = base.replace('/enrolled.', '/public.');
+    const base = await themeBase('week');
+    const tampered = base.replace('/week.', '/month.');
     expect(await verifyThemeUrl(MASTER, `${tampered}theme.css`, NOW)).toEqual({
       ok: false,
       reason: 'bad-signature',
@@ -253,13 +253,13 @@ describe('tamper vectors', () => {
   });
 
   it('rejects an unknown canonical version', async () => {
-    const url = (await blob('public')).replace('/c/', '/c2/');
+    const url = (await blob('month')).replace('/c/', '/c2/');
     expect(await verifyBlobUrl(MASTER, url, NOW)).toEqual({
       ok: false,
       reason: 'unsupported-version',
     });
 
-    const base = (await themeBase('public')).replace('/c/', '/c9/');
+    const base = (await themeBase('month')).replace('/c/', '/c9/');
     expect(await verifyThemeUrl(MASTER, `${base}theme.css`, NOW)).toEqual({
       ok: false,
       reason: 'unsupported-version',
@@ -271,13 +271,13 @@ describe('tamper vectors', () => {
       'not-a-url',
       `${ORIGIN}/`,
       `${ORIGIN}/c/${CLASSROOM_A}`,
-      `${ORIGIN}/c/not-a-uuid/blob/${SHA}.png?p=public&v=0&exp=1&sig=AAAA`,
-      `${ORIGIN}/c/${CLASSROOM_A}/other/${SHA}.png?p=public&v=0&exp=1&sig=AAAA`,
+      `${ORIGIN}/c/not-a-uuid/blob/${SHA}.png?p=month&v=0&exp=1&sig=AAAA`,
+      `${ORIGIN}/c/${CLASSROOM_A}/other/${SHA}.png?p=month&v=0&exp=1&sig=AAAA`,
       `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=teacher&v=0&exp=1&sig=AAAA`,
-      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=public&v=x&exp=1&sig=AAAA`,
-      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=public&v=0&exp=1&sig=AA*A`,
-      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=public&v=0&exp=1&sig=AAAA&w=999`,
-      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}?p=public&v=0&exp=1&sig=AAAA`,
+      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=month&v=x&exp=1&sig=AAAA`,
+      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=month&v=0&exp=1&sig=AA*A`,
+      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}.png?p=month&v=0&exp=1&sig=AAAA&w=999`,
+      `${ORIGIN}/c/${CLASSROOM_A}/blob/${SHA}?p=month&v=0&exp=1&sig=AAAA`,
     ];
     for (const url of cases) {
       expect(await verifyContentUrl(MASTER, url, NOW)).toEqual({ ok: false, reason: 'malformed' });
@@ -285,11 +285,11 @@ describe('tamper vectors', () => {
   });
 
   it('will not verify a blob URL as a theme URL, or vice versa', async () => {
-    expect(await verifyThemeUrl(MASTER, await blob('public'), NOW)).toEqual({
+    expect(await verifyThemeUrl(MASTER, await blob('month'), NOW)).toEqual({
       ok: false,
       reason: 'malformed',
     });
-    expect(await verifyBlobUrl(MASTER, `${await themeBase('public')}a.css`, NOW)).toEqual({
+    expect(await verifyBlobUrl(MASTER, `${await themeBase('month')}a.css`, NOW)).toEqual({
       ok: false,
       reason: 'malformed',
     });
@@ -298,11 +298,11 @@ describe('tamper vectors', () => {
 
 describe('master secret', () => {
   it('rejects everything signed under a different master', async () => {
-    expect(await verifyBlobUrl(OTHER_MASTER, await blob('public'), NOW)).toEqual({
+    expect(await verifyBlobUrl(OTHER_MASTER, await blob('month'), NOW)).toEqual({
       ok: false,
       reason: 'bad-signature',
     });
-    expect(await verifyThemeUrl(OTHER_MASTER, `${await themeBase('public')}a.css`, NOW)).toEqual({
+    expect(await verifyThemeUrl(OTHER_MASTER, `${await themeBase('month')}a.css`, NOW)).toEqual({
       ok: false,
       reason: 'bad-signature',
     });
@@ -311,14 +311,14 @@ describe('master secret', () => {
 
 describe('parseContentUrl', () => {
   it('returns raw fields without touching key material', async () => {
-    const url = await blob('draft', { w: 800 });
+    const url = await blob('edit', { w: 800 });
     const parsed = parseContentUrl(url);
     expect(parsed).toMatchObject({
       kind: 'blob',
       classroomId: CLASSROOM_A,
       sha: SHA,
       ext: 'png',
-      tier: 'draft',
+      tier: 'edit',
       keyVersion: 0,
       exp: NOW + 4 * 3600,
       transform: { w: 800 },
@@ -334,40 +334,38 @@ describe('parseContentUrl', () => {
 });
 
 describe('cacheControlFor', () => {
-  it('never stores draft', () => {
-    expect(cacheControlFor('draft', NOW + 4 * 3600, NOW)).toBe('no-store');
+  it('never stores edit', () => {
+    expect(cacheControlFor('edit', NOW + 4 * 3600, NOW)).toBe('no-store');
   });
 
   it('caches the rest for exactly the remaining life of the signature', () => {
-    expect(cacheControlFor('public', NOW + 100, NOW)).toBe('public, max-age=100, immutable');
-    expect(cacheControlFor('enrolled', NOW + 604800, NOW)).toBe(
-      'public, max-age=604800, immutable'
-    );
+    expect(cacheControlFor('month', NOW + 100, NOW)).toBe('public, max-age=100, immutable');
+    expect(cacheControlFor('week', NOW + 604800, NOW)).toBe('public, max-age=604800, immutable');
   });
 
   it('gives a short positive TTL inside grace, never immutable', () => {
-    expect(cacheControlFor('public', NOW - 10, NOW)).toBe('public, max-age=60');
-    expect(cacheControlFor('enrolled', NOW, NOW)).toBe('public, max-age=60');
-    expect(cacheControlFor('draft', NOW - 10, NOW)).toBe('no-store');
+    expect(cacheControlFor('month', NOW - 10, NOW)).toBe('public, max-age=60');
+    expect(cacheControlFor('week', NOW, NOW)).toBe('public, max-age=60');
+    expect(cacheControlFor('edit', NOW - 10, NOW)).toBe('no-store');
   });
 });
 
 describe('host binding', () => {
   it('rejects a URL replayed against another host', async () => {
-    const url = await blob('public');
+    const url = await blob('month');
     expect(await verifyBlobUrl(MASTER, url.replace(ORIGIN, OTHER_ORIGIN), NOW)).toEqual({
       ok: false,
       reason: 'bad-signature',
     });
 
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     expect(
       await verifyThemeUrl(MASTER, `${base.replace(ORIGIN, OTHER_ORIGIN)}theme.css`, NOW)
     ).toEqual({ ok: false, reason: 'bad-signature' });
   });
 
   it('rejects the same host on a different port', async () => {
-    const url = await blob('public');
+    const url = await blob('month');
     expect(await verifyBlobUrl(MASTER, url.replace(HOST, `${HOST}:8443`), NOW)).toEqual({
       ok: false,
       reason: 'bad-signature',
@@ -375,13 +373,13 @@ describe('host binding', () => {
   });
 
   it('does not distinguish http from https on the same host', async () => {
-    const url = await blob('public');
+    const url = await blob('month');
     const overHttp = await verifyBlobUrl(MASTER, url.replace('https://', 'http://'), NOW);
     expect(overHttp.ok).toBe(true);
   });
 
   it('is case-insensitive about the host', async () => {
-    const url = await blob('public');
+    const url = await blob('month');
     const shouted = await verifyBlobUrl(MASTER, url.replace(HOST, HOST.toUpperCase()), NOW);
     expect(shouted.ok).toBe(true);
   });
@@ -389,13 +387,13 @@ describe('host binding', () => {
 
 describe('query parameters', () => {
   it('rejects a repeated key', async () => {
-    const withWidth = await blob('public', { w: 800 });
+    const withWidth = await blob('month', { w: 800 });
     expect(await verifyBlobUrl(MASTER, `${withWidth}&w=2560`, NOW)).toEqual({
       ok: false,
       reason: 'malformed',
     });
 
-    const url = await blob('public');
+    const url = await blob('month');
     expect(await verifyBlobUrl(MASTER, `${url}&sig=AAAA`, NOW)).toEqual({
       ok: false,
       reason: 'malformed',
@@ -403,7 +401,7 @@ describe('query parameters', () => {
   });
 
   it('rejects an unsigned extra key', async () => {
-    const url = await blob('public');
+    const url = await blob('month');
     for (const extra of ['attacker=1', 'utm_source=x', 'W=800']) {
       expect(await verifyBlobUrl(MASTER, `${url}&${extra}`, NOW)).toEqual({
         ok: false,
@@ -413,7 +411,7 @@ describe('query parameters', () => {
   });
 
   it('accepts exactly the allowlist', async () => {
-    const url = await blob('public', { w: 1600, fmt: 'webp' });
+    const url = await blob('month', { w: 1600, fmt: 'webp' });
     expect([...new URL(url).searchParams.keys()].sort()).toEqual([
       'exp',
       'fmt',
@@ -426,9 +424,9 @@ describe('query parameters', () => {
   });
 
   it('rejects any query at all on a theme URL', async () => {
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     expect((await verifyThemeUrl(MASTER, `${base}theme.css`, NOW)).ok).toBe(true);
-    for (const query of ['?x=1', '?p=draft', '?sig=AAAA']) {
+    for (const query of ['?x=1', '?p=edit', '?sig=AAAA']) {
       expect(await verifyThemeUrl(MASTER, `${base}theme.css${query}`, NOW)).toEqual({
         ok: false,
         reason: 'malformed',
@@ -439,7 +437,7 @@ describe('query parameters', () => {
 
 describe('relPath decoding', () => {
   it('rejects a double-encoded traversal', async () => {
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     for (const relPath of [
       '%252e%252e%252fsecret.css',
       'css/%252e%252e%252f%252e%252e%252fsecret.css',
@@ -453,7 +451,7 @@ describe('relPath decoding', () => {
   });
 
   it('rejects an encoded separator, backslash, or NUL', async () => {
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     for (const relPath of ['a%5c..%5cb.css', 'a%2fb.css', 'theme%00.css']) {
       expect(await verifyThemeUrl(MASTER, `${base}${relPath}`, NOW)).toEqual({
         ok: false,
@@ -463,7 +461,7 @@ describe('relPath decoding', () => {
   });
 
   it('collapses a singly-encoded dot segment inside the folder instead of escaping', async () => {
-    const base = await themeBase('public');
+    const base = await themeBase('month');
     const result = await verifyThemeUrl(MASTER, `${base}css/%2e%2e/theme.css`, NOW);
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -507,7 +505,7 @@ describe('key rotation', () => {
   const both = [ROTATED, MASTER] as const;
 
   const mintedUnder = (master: string) =>
-    signBlobUrl(ORIGIN, ctx('public', { master }), { sha: SHA, ext: 'png' });
+    signBlobUrl(ORIGIN, ctx('month', { master }), { sha: SHA, ext: 'png' });
 
   it('verifies a current-key URL and says which key did it', async () => {
     const url = await mintedUnder(ROTATED);
@@ -563,7 +561,7 @@ describe('key rotation', () => {
         reason: 'bad-signature',
       });
 
-      const signedWithBlank = await signBlobUrl(ORIGIN, ctx('public', { master: blank }), {
+      const signedWithBlank = await signBlobUrl(ORIGIN, ctx('month', { master: blank }), {
         sha: SHA,
         ext: 'png',
       });
@@ -589,7 +587,7 @@ describe('key rotation', () => {
   });
 
   it('applies the same fallback to theme URLs', async () => {
-    const base = await signThemeBase(ORIGIN, ctx('public', { master: MASTER }), {
+    const base = await signThemeBase(ORIGIN, ctx('month', { master: MASTER }), {
       theme: 'cosmo-dark',
       treeSha: TREE_SHA,
     });

--- a/packages/content-signing/src/bucket.ts
+++ b/packages/content-signing/src/bucket.ts
@@ -21,9 +21,9 @@ export interface TierPolicy {
 }
 
 export const TIER_POLICY: Readonly<Record<Tier, TierPolicy>> = {
-  public: { bucketSeconds: 30 * DAY, ttlSeconds: null, graceSeconds: 6 * HOUR },
-  enrolled: { bucketSeconds: 7 * DAY, ttlSeconds: null, graceSeconds: 6 * HOUR },
-  draft: { bucketSeconds: null, ttlSeconds: 4 * HOUR, graceSeconds: 5 * 60 },
+  edit: { bucketSeconds: null, ttlSeconds: 4 * HOUR, graceSeconds: 5 * 60 },
+  week: { bucketSeconds: 7 * DAY, ttlSeconds: null, graceSeconds: 6 * HOUR },
+  month: { bucketSeconds: 30 * DAY, ttlSeconds: null, graceSeconds: 6 * HOUR },
 };
 
 /**
@@ -50,7 +50,7 @@ export function bucketOffset(classroomId: string, bucketSeconds: number): number
  * Bucketed tiers round up to the end of the classroom's current bucket, so
  * every URL minted inside one bucket is byte-identical and cacheable - unless
  * that end is less than MIN_REMAINING_SECONDS away, in which case they roll to
- * the following bucket. Draft is an exact `now + 4h`. The result is always
+ * the following bucket. `edit` is an exact `now + 4h`. The result is always
  * strictly greater than `now`.
  */
 export function bucketExpiry(tier: Tier, classroomId: string, now: number): number {

--- a/packages/content-signing/src/canonical.ts
+++ b/packages/content-signing/src/canonical.ts
@@ -16,7 +16,8 @@ export const SCHEME_SEGMENTS: Readonly<Record<string, string>> = { c: CANONICAL_
 /** A segment that looks like a content scheme, known or not. */
 export const SCHEME_SEGMENT_PATTERN = /^c[0-9]*$/;
 
-export const TIERS: readonly Tier[] = ['public', 'enrolled', 'draft'];
+/** Every tier, shortest lifetime first. See `Tier` in types.ts. */
+export const TIERS: readonly Tier[] = ['edit', 'week', 'month'];
 export const TRANSFORM_WIDTHS: readonly TransformWidth[] = [800, 1600, 2560];
 export const TRANSFORM_FORMATS: readonly TransformFormat[] = ['webp', 'avif', 'auto'];
 

--- a/packages/content-signing/src/types.ts
+++ b/packages/content-signing/src/types.ts
@@ -1,5 +1,19 @@
-/** Access tier a signed URL was minted for. */
-export type Tier = 'public' | 'enrolled' | 'draft';
+/**
+ * How long a signed URL lives, named for its window.
+ *
+ * NOT access control — the signature is. A tier only decides the lifetime and
+ * the cacheability of a URL that has already been minted for a viewer who was
+ * allowed to have it:
+ *
+ *   - `edit`  — an exact 4h TTL, 5 minutes of grace, `no-store`. The editor's
+ *               403-and-revalidate flow, and the only tier a writer is in.
+ *   - `week`  — a 7-day bucket, 6h of grace, `immutable`.
+ *   - `month` — a 30-day bucket, 6h of grace, `immutable`.
+ *
+ * Bucketed tiers are staggered per classroom, so every URL minted for one file
+ * inside one bucket is byte-identical and therefore cacheable.
+ */
+export type Tier = 'edit' | 'week' | 'month';
 
 /** Widths the image pipeline is allowed to render. */
 export type TransformWidth = 800 | 1600 | 2560;

--- a/packages/content-signing/src/verify.ts
+++ b/packages/content-signing/src/verify.ts
@@ -422,7 +422,7 @@ export async function verifyContentUrl(
 }
 
 /**
- * Draft URLs are never stored anywhere. Everything else is immutable for the
+ * `edit` URLs are never stored anywhere. Everything else is immutable for the
  * life of its signature: the content is sha-addressed and the expiry is baked
  * into the URL, so a cache entry can live exactly that long.
  *
@@ -431,7 +431,7 @@ export async function verifyContentUrl(
  * max-age would send every cache back to the origin at once.
  */
 export function cacheControlFor(tier: Tier, exp: number, now: number): string {
-  if (tier === 'draft') return 'no-store';
+  if (tier === 'edit') return 'no-store';
   const maxAge = Math.floor(exp) - Math.floor(now);
   if (maxAge <= 0) return 'public, max-age=60';
   return `public, max-age=${maxAge}, immutable`;

--- a/packages/services/src/classmoji/__tests__/contentDelivery.canonicalizeSave.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.canonicalizeSave.test.ts
@@ -89,7 +89,7 @@ const classroom = {
 const page = { title: 'Lab 1', content_path: 'pages/lab-1', classroom };
 const slide = { id: 'slide-1', title: 'Lecture 1', content_path: 'slides/lecture-1', classroom };
 
-const ctx = { classroom, tier: 'draft' as const };
+const ctx = { classroom, tier: 'edit' as const };
 
 /** A URL a foreign CDN owns — the pass must not touch it, ever. */
 const FOREIGN = 'https://images.example.com/hero.png';

--- a/packages/services/src/classmoji/__tests__/contentDelivery.resolve.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.resolve.test.ts
@@ -65,7 +65,7 @@ const ctx = {
     content_delivery_enabled: true,
     git_organization: { login: 'dartmouth-cs52' },
   },
-  tier: 'enrolled' as const,
+  tier: 'week' as const,
 };
 
 /** The same classroom with its own switch off — the shipping default. */
@@ -121,18 +121,52 @@ describe('isContentDeliveryConfigured', () => {
 });
 
 describe('tierFor', () => {
-  it('gives an editor draft — even on the public site they are editing, not browsing', () => {
-    expect(tierFor({ canEdit: true })).toBe('draft');
-    expect(tierFor({ canEdit: true, isPublicSite: true })).toBe('draft');
+  it('gives an editor `edit` — public or not, they are editing, not browsing', () => {
+    expect(tierFor({ canEdit: true })).toBe('edit');
+    expect(tierFor({ canEdit: true, isPublic: true })).toBe('edit');
   });
 
-  it('gives an explicit preview draft regardless of edit rights', () => {
-    expect(tierFor({ canEdit: false, preview: true })).toBe('draft');
+  it('gives an explicit preview `edit` regardless of edit rights', () => {
+    expect(tierFor({ canEdit: false, preview: true })).toBe('edit');
+    expect(tierFor({ canEdit: false, preview: true, isPublic: true })).toBe('edit');
   });
 
-  it('gives the anonymous class site public and everyone else enrolled', () => {
-    expect(tierFor({ canEdit: false, isPublicSite: true })).toBe('public');
-    expect(tierFor({ canEdit: false })).toBe('enrolled');
+  it('reads the CONTENT for everyone else: public is `month`, the rest `week`', () => {
+    expect(tierFor({ canEdit: false, isPublic: true })).toBe('month');
+    expect(tierFor({ canEdit: false, isPublic: false })).toBe('week');
+    // Absent is not public. A caller that has not looked up a visibility must
+    // land on the shorter lifetime, never the 30-day one.
+    expect(tierFor({ canEdit: false })).toBe('week');
+  });
+
+  it('pins the whole matrix, so no caller has to re-derive it', () => {
+    const matrix: Array<[Parameters<typeof tierFor>[0], string]> = [
+      [{ canEdit: true, isPublic: true }, 'edit'],
+      [{ canEdit: true, isPublic: false }, 'edit'],
+      [{ canEdit: false, preview: true, isPublic: true }, 'edit'],
+      [{ canEdit: false, preview: true, isPublic: false }, 'edit'],
+      [{ canEdit: false, isPublic: true }, 'month'],
+      [{ canEdit: false, isPublic: false }, 'week'],
+    ];
+    for (const [input, tier] of matrix) {
+      expect(tierFor(input), JSON.stringify(input)).toBe(tier);
+    }
+  });
+
+  it('never looks at the surface: one public file, one lifetime', () => {
+    // The regression this rule replaces. The pages app viewer and the class
+    // site render the SAME public page, and the surface-keyed rule minted
+    // `enrolled` for one and `public` for the other — two lifetimes and two
+    // cache entries for one file. Both now reduce to the same inputs, which is
+    // what makes the two URLs byte-identical inside a bucket.
+    const appViewer = tierFor({ canEdit: false, preview: false, isPublic: true });
+    const classSite = tierFor({ canEdit: false, isPublic: true });
+    expect(appViewer).toBe('month');
+    expect(classSite).toBe(appViewer);
+
+    // And the same for a members-only page: `week` through either door.
+    expect(tierFor({ canEdit: false, preview: false, isPublic: false })).toBe('week');
+    expect(tierFor({ canEdit: false, isPublic: false })).toBe('week');
   });
 });
 
@@ -148,7 +182,7 @@ describe('resolveAssetUrl — case 1: a repo-relative reference', () => {
       classroomId: CLASSROOM_ID,
       sha: BLOB_SHA,
       ext: 'png',
-      tier: 'enrolled',
+      tier: 'week',
       keyVersion: 7,
     });
 

--- a/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
@@ -121,7 +121,7 @@ describe('fetchContentText through the Worker', () => {
     expect(getContent).not.toHaveBeenCalled();
   });
 
-  it('always mints the enrolled tier, whoever is reading', async () => {
+  it('always mints the `week` tier, whoever is reading', async () => {
     // This is a server-to-server fetch: the bytes go to a loader that has
     // already authorized its viewer, and the URL is never handed to a browser.
     // The tier here picks an expiry bucket and a Cache-Control, nothing else.

--- a/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.text.test.ts
@@ -128,7 +128,7 @@ describe('fetchContentText through the Worker', () => {
     const calls = stubFetch({});
     await fetchContentText(ctx, DECK_PATH);
 
-    expect(new URL(calls[0]).searchParams.get('p')).toBe('enrolled');
+    expect(new URL(calls[0]).searchParams.get('p')).toBe('week');
   });
 
   it('follows the sha, so a save is visible the moment its row lands', async () => {

--- a/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
@@ -217,7 +217,7 @@ describe('rewriteContentUrls: our own signed URLs', () => {
   const SHA = 'c'.repeat(40);
 
   it('turns a signed blob URL back into a repo path via the source map', () => {
-    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft&v=0&exp=1&sig=x`;
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=edit&v=0&exp=1&sig=x`;
     const shaPaths = new Map([[SHA, 'pages/lab-1/assets/d.png']]);
 
     // Resolved to the SOURCE path, then carried onto the target's folder by
@@ -229,7 +229,7 @@ describe('rewriteContentUrls: our own signed URLs', () => {
     // A blob URL names CONTENT, not location. Inventing a path would put a
     // confidently wrong reference into content nobody will think to check;
     // leaving it keeps the breakage where it already was, and visible.
-    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft&v=0`;
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=edit&v=0`;
     const onWarn = vi.fn();
 
     expect(rewriteContentUrls(url, { ...suffixed, onWarn })).toBe(url);
@@ -259,7 +259,7 @@ describe('rewriteContentUrls: our own signed URLs', () => {
   it('collects the blob shas a document references, for the map lookup', () => {
     const other = 'd'.repeat(40);
     const text = [
-      `/c/${CLASS_ID}/blob/${SHA}.png?p=draft`,
+      `/c/${CLASS_ID}/blob/${SHA}.png?p=edit`,
       `/c/${CLASS_ID}/blob/${other}.svg?p=live`,
       `/c/${CLASS_ID}/blob/${SHA}.png?p=live`,
       `/c/${CLASS_ID}/theme/midnight/${'a'.repeat(40)}/draft.0.1.s/`,
@@ -291,7 +291,7 @@ describe('rewriteContentUrls: a fixture carrying every shape', () => {
       proxy: '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/pages/lab-1/assets/proxy.svg',
       bare: 'pages/lab-1/assets/bare.png',
       crossItem: 'pages/lab-9/assets/other.png',
-      signed: `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft&v=0&exp=1&sig=z`,
+      signed: `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=edit&v=0&exp=1&sig=z`,
       missing: `https://cdn.classmoji.test/c/${CLASS_ID}/missing/${encodeURIComponent(
         'pages/lab-1/assets/gone.png'
       )}`,
@@ -398,7 +398,7 @@ describe('resolveShaPaths', () => {
     lookupContentAssetsBySha.mockResolvedValue(new Map([[SHA, 'pages/lab-1/a.png']]));
 
     const found = await resolveShaPaths(CLASS_ID, [
-      `<img src="/c/${CLASS_ID}/blob/${SHA}.png?p=draft">`,
+      `<img src="/c/${CLASS_ID}/blob/${SHA}.png?p=edit">`,
       `<img src="/c/${CLASS_ID}/blob/${OTHER}.svg?p=live">`,
       // The same sha again, and a shape that carries none.
       `<img src="/c/${CLASS_ID}/blob/${SHA}.png?p=live">`,
@@ -431,7 +431,7 @@ describe('resolveShaPaths', () => {
 
   it('feeds the rewriter, which leaves an unresolved sha verbatim and warns', async () => {
     lookupContentAssetsBySha.mockResolvedValue(new Map());
-    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=draft`;
+    const url = `https://cdn.classmoji.test/c/${CLASS_ID}/blob/${SHA}.png?p=edit`;
     const onWarn = vi.fn();
 
     const shaPaths = await resolveShaPaths(CLASS_ID, [url]);

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -494,7 +494,7 @@ describe('pageContent.uploadPageAsset', () => {
     expect(result.path).toBe('pages/syllabus/assets/a.png');
     // Display is a separate field precisely so it cannot be stored by accident.
     expect(result.displayUrl).toContain('https://cdn.classmoji.test/c/');
-    expect(result.displayUrl).toContain('p=draft');
+    expect(result.displayUrl).toContain('p=edit');
     expect(result.displayUrl).not.toBe(result.url);
   });
 

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -87,7 +87,7 @@ export async function bumpContentKeyVersion(
  *   - the SHA changes when the file changes, so a stored URL stops following
  *     its file and a re-upload never shows;
  *   - the tier is per-VIEWER, so one stored URL cannot be right for a student
- *     and for the instructor previewing a draft.
+ *     and for the instructor editing the same page.
  *
  * Everything here is therefore pure derivation, and the save paths run
  * `canonicalizeAssetRef` to make sure the derivation never leaks back into
@@ -112,7 +112,7 @@ export async function bumpContentKeyVersion(
  * a second after a save shows the deck that was just saved.
  */
 
-/** Access tier a render mints URLs for. See @classmoji/content-signing. */
+/** Signature lifetime a render mints URLs for. See @classmoji/content-signing. */
 export type ResolveTier = Tier;
 
 /** The classroom fields a resolve needs. Narrow on purpose — no secrets. */
@@ -205,28 +205,44 @@ function deliveryEnv(): { origin: string; master: string } | null {
 }
 
 /**
- * Which tier this render is for.
+ * Which LIFETIME this render mints URLs for.
  *
- * `draft` for anyone who can edit and for an explicit preview — they are the
- * only viewers allowed to see content that has not been published, and the
- * short expiry is the price. `public` only for the class-site surface, whose
- * readers are anonymous by definition. Everything else is `enrolled`.
+ * Not a permission, however the names used to read: what a viewer is allowed
+ * to fetch is decided by the signature, and by the authorization the caller
+ * did before it got here. A tier only picks how long the URL lives and whether
+ * it may be cached.
  *
- * Order matters: an instructor previewing their own class site is editing, not
- * browsing, so the draft check comes first.
+ *   - `edit` for anyone who can edit and for an explicit staff preview. Both
+ *     are looking at bytes that may be about to change, and both depend on the
+ *     403-and-revalidate flow, which is what the exact 4h TTL and `no-store`
+ *     are for.
+ *   - `month` for content that is PUBLIC. Its readers are anonymous by
+ *     definition, so there is nothing a shorter lifetime would buy.
+ *   - `week` for everything else.
+ *
+ * Order matters: an instructor previewing their own public page is editing,
+ * not browsing, so the edit check comes first.
+ *
+ * `isPublic` is the CONTENT's own visibility — `Page.is_public`, a deck's
+ * `is_public` — and never "is this the class-site surface". Keying off the
+ * SURFACE is what this replaces, and what it got wrong: the same public page
+ * was minted `p=enrolled` inside the pages app and `p=public` on the class
+ * site, so one public file had two lifetimes and two cache entries depending
+ * on which door a reader came through. Visibility is a property of the file;
+ * the surface is not.
  */
 export function tierFor({
   canEdit,
   preview,
-  isPublicSite,
+  isPublic,
 }: {
   canEdit: boolean;
   preview?: boolean;
-  isPublicSite?: boolean;
+  isPublic?: boolean;
 }): ResolveTier {
-  if (canEdit || preview) return 'draft';
-  if (isPublicSite) return 'public';
-  return 'enrolled';
+  if (canEdit || preview) return 'edit';
+  if (isPublic) return 'month';
+  return 'week';
 }
 
 /**
@@ -839,15 +855,15 @@ function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T>
  * becomes a property of the address — which is why the save paths write the
  * returned sha into the map (`recordContentAsset`) the moment a commit lands.
  *
- * ## The tiers
+ * ## The tier
  *
- * Always `enrolled`, whoever is reading. This is a server-to-server fetch: the
+ * Always `week`, whoever is reading. This is a server-to-server fetch: the
  * bytes are handed to a loader that has already done its own authorization, and
  * they are never given to a browser as a URL. The tier here therefore decides
  * nothing about access — it only picks an expiry bucket and a `Cache-Control`,
- * and `enrolled`'s week is the right middle: long enough that one signature
- * serves a lecture hall's worth of `/follow` reads out of the edge, short
- * enough not to mint the 30-day public bucket for content nobody published.
+ * and a week is the right middle: long enough that one signature serves a
+ * lecture hall's worth of `/follow` reads out of the edge, short enough not to
+ * mint the 30-day bucket for content nobody published.
  *
  * ## When the map cannot answer
  *
@@ -932,12 +948,12 @@ async function readTextThroughWorker(
   try {
     const url = await signBlobUrl(
       env.origin,
-      // Server-to-server: `enrolled` names the cache bucket, not the reader.
+      // Server-to-server: `week` names the cache bucket, not the reader.
       {
         master: env.master,
         classroomId: ctx.classroom.id,
         keyVersion: ctx.classroom.content_key_version,
-        tier: 'enrolled',
+        tier: 'week',
       },
       { sha: asset.sha, ext }
     );

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -287,7 +287,7 @@ function pageResolveContext(page: PageWithContentRepo): ResolveContext | null {
       content_delivery_enabled: classroom.content_delivery_enabled === true,
       git_organization: { login },
     },
-    tier: 'draft',
+    tier: 'edit',
   };
 }
 
@@ -584,7 +584,7 @@ async function signUploadedAsset(
         classroomId: classroom.id,
         keyVersion:
           typeof classroom.content_key_version === 'number' ? classroom.content_key_version : 0,
-        tier: 'draft',
+        tier: 'edit',
       },
       { sha, ext: name.slice(dot + 1).toLowerCase() }
     );

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -263,7 +263,7 @@ async function loadPageContentViaWorker(
  * lets the route keep its own pass without either of them having to know about
  * the other.
  *
- * The tier is `draft` and it does not matter: canonicalization only ever
+ * The tier is `edit` and it does not matter: canonicalization only ever
  * REMOVES a signature, and it never mints one, so nothing in the context
  * except the classroom id is read.
  */
@@ -542,10 +542,11 @@ export async function uploadPageAsset(
 }
 
 /**
- * Sign a just-uploaded blob at the draft tier, or null if that is not possible.
+ * Sign a just-uploaded blob at the `edit` tier, or null if that is not possible.
  *
- * Draft because only a writer ever sees this URL, and a writer is by definition
- * looking at unpublished content. Every failure path returns null: an upload
+ * `edit` because only a writer ever sees this URL, and a writer is by definition
+ * looking at content that may be about to change. Every failure path returns
+ * null: an upload
  * that succeeded must not be reported as failed because a URL could not be
  * minted for it.
  *

--- a/packages/services/src/slides/__tests__/deckAssets.test.ts
+++ b/packages/services/src/slides/__tests__/deckAssets.test.ts
@@ -116,13 +116,13 @@ describe('rewriteDeckAssetUrls', () => {
     // an attribute the `&` must become `&amp;`, and must decode back to the
     // exact URL the resolver minted — an over- or under-escaped one is a
     // broken signature, not a cosmetic difference.
-    const MULTI = `https://cdn.test/c/3f2504e0-4f89-41d3-9a0c-0305e82c3301/blob/abc.png?p=enrolled&v=0&exp=1&sig=abc`;
+    const MULTI = `https://cdn.test/c/3f2504e0-4f89-41d3-9a0c-0305e82c3301/blob/abc.png?p=week&v=0&exp=1&sig=abc`;
     const html = `<section data-background-image="${REF}"><img src="${REF}"></section>`;
 
     const out = await rewriteDeckAssetUrls(html, resolver({ [REF]: MULTI }));
 
-    expect(out).toContain('?p=enrolled&amp;v=0&amp;exp=1&amp;sig=abc');
-    expect(out).not.toContain('?p=enrolled&v=0');
+    expect(out).toContain('?p=week&amp;v=0&amp;exp=1&amp;sig=abc');
+    expect(out).not.toContain('?p=week&v=0');
 
     // Re-parsing is what the browser and the deck parser both do; the URL that
     // comes back out must be the one that went in.

--- a/packages/services/src/slides/slideContent.service.ts
+++ b/packages/services/src/slides/slideContent.service.ts
@@ -225,7 +225,7 @@ function deckResolveContext(slide: SlideContentTarget): ResolveContext | null {
       content_delivery_enabled: classroom.content_delivery_enabled === true,
       git_organization: { login },
     },
-    tier: 'draft',
+    tier: 'edit',
   };
 }
 

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -448,7 +448,7 @@ export async function workerHealth(origin: string): Promise<WorkerHealth | null>
 // Signed URL shape
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type Tier = 'public' | 'enrolled' | 'draft';
+export type Tier = 'month' | 'week' | 'edit';
 
 /** The three rungs `signSrcSet` emits. Mirrors TRANSFORM_WIDTHS. */
 export const EXPECTED_WIDTHS = [800, 1600, 2560] as const;
@@ -521,7 +521,7 @@ export function parseSignedUrl(raw: string): SignedUrl | null {
   const exp = url.searchParams.get('exp');
   const sig = url.searchParams.get('sig');
   if (!tier || !keyVersion || !exp || !sig) return null;
-  if (tier !== 'public' && tier !== 'enrolled' && tier !== 'draft') return null;
+  if (tier !== 'month' && tier !== 'week' && tier !== 'edit') return null;
 
   const w = url.searchParams.get('w');
   return {

--- a/tests/content-delivery/contentDelivery.helpers.ts
+++ b/tests/content-delivery/contentDelivery.helpers.ts
@@ -388,6 +388,12 @@ export function hasStagingSession(): boolean {
  * hard-coding an id would rot the first time someone tidied the classroom. The
  * index is the same list a member browses, so whatever it links to is by
  * definition something they may open.
+ *
+ * It says nothing about the page's VISIBILITY, though — it takes the first
+ * link, public or members-only. A caller cannot infer a tier from what comes
+ * back: the tier follows the content's visibility, so a public page here mints
+ * `month` exactly as the class site does. Assert the shape of the URL, not
+ * which tier it landed on.
  */
 export async function discoverMemberContentUrl(
   page: Page,


### PR DESCRIPTION
## What
Tiers are lifetimes, not permissions, and the names said otherwise: a public page rendered in the app minted `p=enrolled`. Two changes, one commit plus review follow-ups:

- **Rename** `draft/enrolled/public` → `edit/week/month`. Policy values unchanged: `edit` = exact 4 h, no-store; `week` = 7-day bucket, staggered per classroom, immutable; `month` = 30-day bucket, immutable. The tier is inside the signed string, so URLs minted under the old names stop verifying once the Worker deploys (nothing is in prod; staging 403s images for the minutes between the app and Worker deploys).
- **Tier by visibility, not surface.** `tierFor`: editor context → `edit`; content public (`Page.is_public` / `Slide.is_public`) → `month`; else → `week`. A public page now mints the same URL in the app viewer and on the class site. No read surface (present, speaker, any form of follow) can reach `edit`; the page list resolves per page. Accepted consequence: flipping public → private leaves issued URLs valid for the rest of a 30-day bucket; Reset content cache stops new mints under the old key.
- Docs: tier tables in both READMEs with "a tier is not access control — the signature is", the non-revocation note; every stale comment and test title updated; the staging e2e no longer asserts the retired surface invariant.

## Test
signing 92 (both targets), Worker 148, services 1560 / 13 known, pages 489, slides unit 108 (−2: thumbnail-specific cases folded into a structural guarantee), mcp 559; typechecks clean except the 16 known GitLabProvider. On staging: the public `CD test page 0448 UTC` image URL is `p=month` on both `pages.staging` and the class site, byte-identical; a private page for a member is `week`; the editor is `edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA