### PR TITLE
perf(content): cache down-scoped installation tokens per repo

### DIFF
--- a/apps/webapp/app/routes/api.content.token/route.ts
+++ b/apps/webapp/app/routes/api.content.token/route.ts
@@ -150,6 +150,14 @@ export const action = async ({ request }: Route.ActionArgs) => {
     // one already limited, so the blast radius of a leaked token — or of a
     // leaked CONTENT_WORKER_SHARED_SECRET — is read-only on one content repo
     // for one hour, rather than write access across the org.
+    //
+    // NOT one GitHub API call per request. Two caches sit in front of this
+    // mint and they compose: the Worker keeps the token for its lifetime in
+    // each isolate, so it only asks here on a cold isolate, and the provider
+    // caches the down-scoped token per (installation, repo, permissions) while
+    // collapsing concurrent cold asks into a single mint. The effective rate is
+    // roughly one mint per content repo per hour, rather than the one-per-pull
+    // it would be if every call reached GitHub.
     const { token, expiresAt } = await provider.getInstallationToken({
       repositories: [repo],
       permissions: { contents: 'read' },

--- a/packages/services/src/git/GitHubProvider.ts
+++ b/packages/services/src/git/GitHubProvider.ts
@@ -41,6 +41,50 @@ export class GitHubProvider extends GitProvider {
   static #installationCache: Map<string, { octokit: Octokit; expiresAt: number }> = new Map();
   static #CACHE_TTL_MS: number = 50 * 60 * 1000; // 50 minutes (before 1-hour expiry)
 
+  /**
+   * Minted SCOPED tokens, keyed by what they are scoped to.
+   *
+   * `#installationCache` above caches the Octokit client, which is a different
+   * thing: it holds the installation's full authority and refreshes its own
+   * credential internally. A scoped token is a value we hand to another process
+   * and then forget, so nothing was reusing it — every caller re-minted, one
+   * `POST /app/installations/{id}/access_tokens` per call.
+   *
+   * That is the whole cost being removed here. The content Worker asks for a
+   * token on any origin pull whose isolate has no cached one, which on staging
+   * was five mints in two minutes of light clicking. The token it gets back is
+   * read-only on a single repo and lives an hour, so serving the same one to
+   * the next asker grants nobody anything they were not already being handed.
+   *
+   * Keyed by (installation, repos, permissions) because those three are exactly
+   * what the minted token's authority depends on — a different repo or a wider
+   * permission set is a different token and must not share this entry.
+   */
+  static #scopedTokenCache: Map<string, { token: string; expiresAt: string; expiresAtMs: number }> =
+    new Map();
+
+  /**
+   * Mints currently in flight, same keys as `#scopedTokenCache`.
+   *
+   * A cold cache with N concurrent requests for one repo would otherwise fire N
+   * mints — the exact burst this is meant to remove, since the Worker's misses
+   * arrive together when a page's assets are pulled in parallel. Sharing the
+   * in-flight promise collapses them into one call. Cleared when it settles, so
+   * a failed mint is retried rather than remembered.
+   */
+  static #scopedTokenInFlight: Map<string, Promise<{ token: string; expiresAt: string }>> =
+    new Map();
+
+  // Stop serving a token this long before GitHub stops honouring it, so one
+  // handed out at the edge of the window still has life left when it is used.
+  static #TOKEN_SKEW_MS: number = 5 * 60 * 1000;
+
+  // Keys are per (installation, repo, permissions), so the natural ceiling is
+  // the number of content repos being served. Capped anyway: this map lives for
+  // the process's lifetime, and an unbounded map that only ever grows is a leak
+  // regardless of how slowly it fills.
+  static #TOKEN_CACHE_MAX: number = 256;
+
   installationId: string;
   orgLogin: string | null;
   _octokit: Octokit | null;
@@ -131,12 +175,135 @@ export class GitHubProvider extends GitProvider {
    * repo the installation cannot access, or a permission it was not granted,
    * is a 422 rather than a quietly-broader token.
    *
+   * ── SCOPED tokens are cached, unscoped ones are not ───────────────────────
+   * A scoped token is safe to reuse: it is pinned to the repos and permissions
+   * that were asked for, so the second caller asking for the same scope can
+   * only receive authority it was going to be granted anyway. It is also worth
+   * reusing — this used to be one GitHub API call per request, and the content
+   * Worker calls on every origin pull with a cold isolate.
+   *
+   * An UNSCOPED mint is left exactly as it was. Those tokens carry the
+   * installation's full authority, they are used by our own background work
+   * rather than handed outward, and nobody has complained about their rate — so
+   * caching them would be a change in the blast radius of a shared value bought
+   * for no measured gain. The behaviour of a `getInstallationToken()` with no
+   * argument is byte-for-byte what it has always been.
+   *
    * @param {Object} [scope] - Optional narrowing for the minted token
    * @param {string[]} [scope.repositories] - Repo short names to limit the token to
    * @param {Object} [scope.permissions] - Permission subset, e.g. { contents: 'read' }
    * @returns {Promise<{token: string, expiresAt: string}>} Token and its ISO-8601 expiry
    */
   async getInstallationToken(scope?: {
+    repositories?: string[];
+    permissions?: Record<string, string>;
+  }): Promise<{ token: string; expiresAt: string }> {
+    const repositories = scope?.repositories?.length ? scope.repositories : null;
+    const permissions =
+      scope?.permissions && Object.keys(scope.permissions).length ? scope.permissions : null;
+
+    // Same emptiness test the mint itself applies, so `{ repositories: [] }` is
+    // an unscoped call here for the same reason it is one on the wire.
+    if (!repositories && !permissions) {
+      return this.#mintInstallationToken(scope);
+    }
+
+    const key = GitHubProvider.#scopedTokenCacheKey(this.installationId, repositories, permissions);
+
+    const cached = GitHubProvider.#scopedTokenCache.get(key);
+    if (cached && Date.now() < cached.expiresAtMs - GitHubProvider.#TOKEN_SKEW_MS) {
+      return { token: cached.token, expiresAt: cached.expiresAt };
+    }
+
+    const inFlight = GitHubProvider.#scopedTokenInFlight.get(key);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const pending = this.#mintInstallationToken(scope)
+      .then(minted => {
+        GitHubProvider.#rememberScopedToken(key, minted);
+        return minted;
+      })
+      // Evicted whether it resolved or rejected. A rejection left in the map
+      // would make one transient GitHub failure the permanent answer for that
+      // repo, which is worse than the re-mint this exists to avoid.
+      .finally(() => {
+        GitHubProvider.#scopedTokenInFlight.delete(key);
+      });
+
+    GitHubProvider.#scopedTokenInFlight.set(key, pending);
+    return pending;
+  }
+
+  /**
+   * The identity of a scoped token: what it can reach, and as whom.
+   *
+   * Both lists are sorted so that callers who ask for the same authority in a
+   * different order share an entry rather than minting twice. ` ` joins the
+   * parts because it cannot occur in a repo name or a permission, so no pair of
+   * different scopes can collide on one key.
+   */
+  static #scopedTokenCacheKey(
+    installationId: string,
+    repositories: string[] | null,
+    permissions: Record<string, string> | null
+  ): string {
+    const repoPart = repositories ? [...repositories].sort().join(',') : '';
+    const permPart = permissions
+      ? Object.entries(permissions)
+          .map(([name, level]) => `${name}=${level}`)
+          .sort()
+          .join(',')
+      : '';
+    return `${installationId} ${repoPart} ${permPart}`;
+  }
+
+  /**
+   * Record a freshly minted token, and keep the map from growing without limit.
+   *
+   * Expired entries are swept on every insert rather than on a timer: this is a
+   * cache on a hot path, so the one moment it is guaranteed to be running is
+   * when something is being added to it, and a background sweep would be a
+   * second mechanism to keep a process alive for no benefit.
+   */
+  static #rememberScopedToken(key: string, minted: { token: string; expiresAt: string }): void {
+    const expiresAtMs = Date.parse(minted.expiresAt);
+    // Without a readable expiry there is no way to know when this token stops
+    // working, and a cache entry that outlives its token serves 401s. Hand it
+    // to the caller unremembered; the next call mints again.
+    if (!Number.isFinite(expiresAtMs)) {
+      return;
+    }
+
+    const cache = GitHubProvider.#scopedTokenCache;
+    const now = Date.now();
+    for (const [existingKey, entry] of cache) {
+      if (now >= entry.expiresAtMs - GitHubProvider.#TOKEN_SKEW_MS) {
+        cache.delete(existingKey);
+      }
+    }
+
+    // Delete-then-set so the refreshed entry moves to the back of the Map's
+    // insertion order, which is what makes the eviction below oldest-first.
+    cache.delete(key);
+    cache.set(key, { token: minted.token, expiresAt: minted.expiresAt, expiresAtMs });
+
+    while (cache.size > GitHubProvider.#TOKEN_CACHE_MAX) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
+  }
+
+  /**
+   * The actual mint — one `POST /app/installations/{id}/access_tokens`.
+   *
+   * Split out of `getInstallationToken` so the caching above wraps a call that
+   * unconditionally hits GitHub. Everything below this line is the request as it
+   * was before the cache existed.
+   */
+  async #mintInstallationToken(scope?: {
     repositories?: string[];
     permissions?: Record<string, string>;
   }): Promise<{ token: string; expiresAt: string }> {

--- a/packages/services/src/git/__tests__/GitHubProvider.getInstallationToken.test.ts
+++ b/packages/services/src/git/__tests__/GitHubProvider.getInstallationToken.test.ts
@@ -93,3 +93,226 @@ describe('GitHubProvider.getInstallationToken', () => {
     );
   });
 });
+
+/**
+ * The cache in front of the mint.
+ *
+ * It is static and process-lifetime, exactly as it is in production, so these
+ * tests give every case its own installation id rather than reaching in to
+ * reset it. That keeps the entries disjoint without adding a test-only escape
+ * hatch to a class whose whole job is handing out credentials.
+ */
+describe('GitHubProvider.getInstallationToken caching', () => {
+  const READ_ONE_REPO = {
+    repositories: ['content-cs101'],
+    permissions: { contents: 'read' },
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function anHourOut(): string {
+    return new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  }
+
+  /** A fetch that answers each call with the next payload in the list. */
+  function stubFetchSequence(payloads: Record<string, unknown>[]) {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      const payload = payloads[Math.min(call++, payloads.length - 1)];
+      return { ok: true, status: 201, json: async () => payload };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  it('serves a second request for the same scope from cache, without calling GitHub again', async () => {
+    const fetchMock = stubFetchSequence([
+      { token: 'ghs_first', expires_at: anHourOut() },
+      { token: 'ghs_second', expires_at: anHourOut() },
+    ]);
+
+    const provider = new GitHubProvider('cache-hit', 'org');
+    const first = await provider.getInstallationToken(READ_ONE_REPO);
+    const second = await provider.getInstallationToken(READ_ONE_REPO);
+
+    expect(second).toEqual(first);
+    expect(second.token).toBe('ghs_first');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the entry across provider instances, since the cache is per installation not per object', async () => {
+    const fetchMock = stubFetchSequence([{ token: 'ghs_shared', expires_at: anHourOut() }]);
+
+    await new GitHubProvider('cache-shared', 'org').getInstallationToken(READ_ONE_REPO);
+    const second = await new GitHubProvider('cache-shared', 'org').getInstallationToken(
+      READ_ONE_REPO
+    );
+
+    expect(second.token).toBe('ghs_shared');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-mints once the cached token is inside the expiry skew', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = stubFetchSequence([
+      { token: 'ghs_first', expires_at: anHourOut() },
+      { token: 'ghs_fresh', expires_at: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString() },
+    ]);
+
+    const provider = new GitHubProvider('cache-expiry', 'org');
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_first');
+
+    // Still comfortably inside the window: the same token is still the answer.
+    vi.advanceTimersByTime(50 * 60 * 1000);
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_first');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Now within five minutes of expiry. A token handed out here could die
+    // mid-use, so it is replaced rather than served.
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_fresh');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a separate entry per repo, so one repo never answers for another', async () => {
+    const fetchMock = stubFetchSequence([
+      { token: 'ghs_cs101', expires_at: anHourOut() },
+      { token: 'ghs_cs200', expires_at: anHourOut() },
+    ]);
+
+    const provider = new GitHubProvider('cache-per-repo', 'org');
+    const cs101 = await provider.getInstallationToken({
+      repositories: ['content-cs101'],
+      permissions: { contents: 'read' },
+    });
+    const cs200 = await provider.getInstallationToken({
+      repositories: ['content-cs200'],
+      permissions: { contents: 'read' },
+    });
+
+    expect(cs101.token).toBe('ghs_cs101');
+    expect(cs200.token).toBe('ghs_cs200');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a separate entry per permission set, so a narrow ask never returns a wider token', async () => {
+    const fetchMock = stubFetchSequence([
+      { token: 'ghs_read', expires_at: anHourOut() },
+      { token: 'ghs_write', expires_at: anHourOut() },
+    ]);
+
+    const provider = new GitHubProvider('cache-per-perm', 'org');
+    const read = await provider.getInstallationToken({
+      repositories: ['content-cs101'],
+      permissions: { contents: 'read' },
+    });
+    const write = await provider.getInstallationToken({
+      repositories: ['content-cs101'],
+      permissions: { contents: 'write' },
+    });
+
+    expect(read.token).toBe('ghs_read');
+    expect(write.token).toBe('ghs_write');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('collapses concurrent cold requests into ONE mint', async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({ token: 'ghs_only', expires_at: anHourOut() }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new GitHubProvider('cache-concurrent', 'org');
+    const inFlight = Promise.all([
+      provider.getInstallationToken(READ_ONE_REPO),
+      provider.getInstallationToken(READ_ONE_REPO),
+      provider.getInstallationToken(READ_ONE_REPO),
+    ]);
+
+    release();
+    const results = await inFlight;
+
+    expect(results.map(r => r.token)).toEqual(['ghs_only', 'ghs_only', 'ghs_only']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not remember a failed mint - the next call tries again', async () => {
+    const failing = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: 'Not Found' }),
+    }));
+    vi.stubGlobal('fetch', failing);
+
+    const provider = new GitHubProvider('cache-rejection', 'org');
+    await expect(provider.getInstallationToken(READ_ONE_REPO)).rejects.toThrow(
+      /Failed to retrieve GitHub installation token \(404\)/
+    );
+
+    const succeeding = stubFetchSequence([{ token: 'ghs_after_retry', expires_at: anHourOut() }]);
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_after_retry');
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects every waiter on a failed mint, and leaves nothing behind', async () => {
+    const failing = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: 'boom' }),
+    }));
+    vi.stubGlobal('fetch', failing);
+
+    const provider = new GitHubProvider('cache-concurrent-failure', 'org');
+    const results = await Promise.allSettled([
+      provider.getInstallationToken(READ_ONE_REPO),
+      provider.getInstallationToken(READ_ONE_REPO),
+    ]);
+
+    expect(results.map(r => r.status)).toEqual(['rejected', 'rejected']);
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    const succeeding = stubFetchSequence([{ token: 'ghs_recovered', expires_at: anHourOut() }]);
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_recovered');
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT cache unscoped mints, which still carry the full installation authority', async () => {
+    const fetchMock = stubFetchSequence([
+      { token: 'ghs_unscoped_a', expires_at: anHourOut() },
+      { token: 'ghs_unscoped_b', expires_at: anHourOut() },
+    ]);
+
+    const provider = new GitHubProvider('cache-unscoped', 'org');
+    expect((await provider.getInstallationToken()).token).toBe('ghs_unscoped_a');
+    // An empty scope is an unscoped request on the wire, so it is one here too.
+    expect((await provider.getInstallationToken({ repositories: [] })).token).toBe(
+      'ghs_unscoped_b'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a token whose expiry it cannot read', async () => {
+    const fetchMock = stubFetchSequence([
+      { token: 'ghs_bad_expiry', expires_at: 'not-a-date' },
+      { token: 'ghs_bad_expiry_2', expires_at: 'not-a-date' },
+    ]);
+
+    const provider = new GitHubProvider('cache-bad-expiry', 'org');
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_bad_expiry');
+    expect((await provider.getInstallationToken(READ_ONE_REPO)).token).toBe('ghs_bad_expiry_2');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## What
The content Worker mints a down-scoped GitHub installation token (one repo, `contents:read`) through `POST /api/content/token` on every cold isolate. `getInstallationToken` with a scope minted a fresh token every call (the existing provider cache only covers the unscoped Octokit), so staging showed five mints in two minutes during light testing. This caches scoped tokens per (installation, repos, permissions) until five minutes before expiry, single-flight under concurrency, bounded at 256 entries, with rejections retried. Unscoped mints are unchanged. Combined with the Worker's per-isolate cache the effective rate is about one mint per content repo per hour.

## Test
services GitHubProvider 24 passed (10 new: hit, cross-instance sharing, expiry re-mint, per-repo and per-permission entries, concurrent → one mint, rejection retry, unscoped not cached, unparseable expiry not cached); webapp token route 18 passed; typechecks at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA