### PR TITLE
fix(pages): paint the signed image URL on first render, never the bare path

### DIFF
--- a/apps/pages/app/components/editor/PageEditor.tsx
+++ b/apps/pages/app/components/editor/PageEditor.tsx
@@ -28,6 +28,11 @@ import {
 } from './blocks/index.tsx';
 import { ReplaceUrlItem, RemoveProfileImageItem } from './ReplaceUrlItem.tsx';
 import { AssetSrcSetContext, NO_SRC_SETS, type AssetSrcSets } from '~/hooks/useAssetSrcSets.ts';
+import {
+  AssetDisplayUrlContext,
+  IDENTITY_DISPLAY_URL,
+  type DisplayUrlLookup,
+} from '~/hooks/useAssetDisplayUrl.ts';
 
 // Custom drag handle menu — extends default with block-specific actions
 const CustomDragHandleMenu = () => (
@@ -65,6 +70,12 @@ interface PageEditorProps {
    * `resolveFileUrl` returns one string and has no room for a second value.
    */
   srcSets?: AssetSrcSets;
+  /**
+   * The same map as `resolveFileUrl`, read synchronously. Custom blocks call it
+   * during render so the signed URL is in `src` on the FIRST commit — an
+   * effect-time swap paints the bare stored path, and the browser fetches it.
+   */
+  displayUrl?: DisplayUrlLookup;
   /** Called after an upload with the ref that was stored and the URL to show it with. */
   onAssetUploaded?: (ref: string, displayUrl: string | null) => void;
   onChange?: (document: unknown) => void;
@@ -88,6 +99,7 @@ const PageEditor = forwardRef(function PageEditor(
     editable = true,
     resolveFileUrl,
     srcSets,
+    displayUrl,
     onAssetUploaded,
   }: PageEditorProps,
   ref: React.Ref<{ getContent: () => unknown }>
@@ -311,24 +323,26 @@ const PageEditor = forwardRef(function PageEditor(
           into this tree (its own file blocks read their dictionary the same
           way), so a provider here is what the image and profile blocks see. */}
       <AssetSrcSetContext.Provider value={srcSets ?? NO_SRC_SETS}>
-        <BlockNoteView
-          editor={editor}
-          editable={editable}
-          theme={darkMode ? 'dark' : 'light'}
-          slashMenu={false}
-          formattingToolbar={false}
-          sideMenu={false}
-          onChange={() => onChange?.(editor.document)}
-        >
-          <SideMenuController
-            sideMenu={props => <SideMenu {...props} dragHandleMenu={CustomDragHandleMenu} />}
-          />
-          <FormattingToolbarController formattingToolbar={() => <FormattingToolbar />} />
-          <SuggestionMenuController
-            triggerCharacter="/"
-            getItems={async query => filterSuggestionItems(getAllSlashMenuItems(editor), query)}
-          />
-        </BlockNoteView>
+        <AssetDisplayUrlContext.Provider value={displayUrl ?? IDENTITY_DISPLAY_URL}>
+          <BlockNoteView
+            editor={editor}
+            editable={editable}
+            theme={darkMode ? 'dark' : 'light'}
+            slashMenu={false}
+            formattingToolbar={false}
+            sideMenu={false}
+            onChange={() => onChange?.(editor.document)}
+          >
+            <SideMenuController
+              sideMenu={props => <SideMenu {...props} dragHandleMenu={CustomDragHandleMenu} />}
+            />
+            <FormattingToolbarController formattingToolbar={() => <FormattingToolbar />} />
+            <SuggestionMenuController
+              triggerCharacter="/"
+              getItems={async query => filterSuggestionItems(getAllSlashMenuItems(editor), query)}
+            />
+          </BlockNoteView>
+        </AssetDisplayUrlContext.Provider>
       </AssetSrcSetContext.Provider>
     </div>
   );

--- a/apps/pages/app/components/editor/blocks/useResolvedFileUrl.ts
+++ b/apps/pages/app/components/editor/blocks/useResolvedFileUrl.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { useAssetDisplayUrl } from '~/hooks/useAssetDisplayUrl.ts';
+
 /**
  * Turn a stored asset reference into the URL a custom block should render.
  *
@@ -9,34 +11,68 @@ import { useEffect, useState } from 'react';
  * asks the browser to fetch `pages/lab-1/assets/tim.jpg` relative to the pages
  * origin — a 404. This hook is that missing call.
  *
- * ## Why it starts on the reference and then swaps
+ * ## Why it does not start on the reference
  *
- * `resolveFileUrl` is async (it is allowed to be — the editor's contract says
- * so), so there is no resolved value on the first paint. Rendering the raw
- * reference for that one frame is the right default: when the delivery layer
- * is switched off the reference IS the URL (uploads store an absolute one), and
- * when it is on the swap lands in the same tick.
+ * It used to, and that was a bug with a network request attached. The signed
+ * URL was only applied in an effect, so the FIRST commit put the bare stored
+ * path in `src` — and the browser starts fetching the moment an `<img>` lands,
+ * without waiting to see whether React is about to swap the attribute. Every
+ * image the rendition ladder does not cover (a GIF, an SVG, anything with no
+ * `srcset` to give the browser a candidate to prefer over `src`) fired one
+ * guaranteed 404 at the pages origin before loading correctly. Raster images
+ * were not immune, only quiet: their `srcset` is computed synchronously, so the
+ * browser picked a candidate and never asked for `src`.
  *
- * The effect re-runs when `url` changes, which is what makes a just-uploaded
- * avatar appear: the upload handler seeds the display map before it writes the
- * new reference into the block, so the very next resolve is a hit.
+ * So resolution is now synchronous wherever it can be. The loader ships the
+ * whole `ref → signed URL` map with the document and `useAssetMap` seeds it
+ * during render, which means the answer already exists on the first render —
+ * `resolveFileUrl` is async because BlockNote's contract says it may be, not
+ * because the data is late. `useAssetDisplayUrl` reads that same map through
+ * context, and the async path stays as the fallback for the refs the map does
+ * not have: an upload resolved by a handler, a surface with no provider above
+ * it, a future resolver that really does go to the network.
+ *
+ * A miss returns the reference unchanged, which is the right answer for an
+ * external image, a `data:` URI, and for a deployment where the delivery layer
+ * is switched off — there, the reference IS the URL.
  */
 export function useResolvedFileUrl(
   url: string,
   resolveFileUrl: ((url: string) => Promise<string>) | undefined
 ): string {
-  const [resolved, setResolved] = useState(url);
+  const displayUrl = useAssetDisplayUrl();
+  // Synchronous, on this tick, before anything is committed to the DOM.
+  const immediate = displayUrl(url);
+
+  const [state, setState] = useState({ ref: url, value: immediate });
+
+  // Adjusted DURING render rather than in an effect — React's own pattern for
+  // derived state that has to follow a prop. An effect here would commit the
+  // previous reference's value for one frame, and that frame is precisely what
+  // sent the browser after the bare path. A just-uploaded avatar takes this
+  // path too: the upload handler seeds the display map before it writes the new
+  // reference into the block, so the render that sees the new `url` already has
+  // its signed URL.
+  let resolved = state.value;
+  if (state.ref !== url) {
+    resolved = immediate;
+    setState({ ref: url, value: immediate });
+  }
 
   useEffect(() => {
-    // The reference is always the correct fallback, and re-seeding it here is
-    // what keeps a stale resolution from one url showing under the next.
-    setResolved(url);
     if (!url || !resolveFileUrl) return;
 
     let live = true;
     resolveFileUrl(url)
       .then(next => {
-        if (live && typeof next === 'string' && next) setResolved(next);
+        if (!live || typeof next !== 'string' || !next) return;
+        // Guarded on the reference, so a resolution that lands after the block
+        // has moved on cannot show one url's asset under the next. When the
+        // synchronous lookup already found this exact URL — the common case —
+        // the identical state bails out and the DOM is never touched.
+        setState(prev =>
+          prev.ref === url && prev.value !== next ? { ref: url, value: next } : prev
+        );
       })
       .catch(() => {
         // A resolver that throws leaves the reference in place — the same

--- a/apps/pages/app/components/viewer/BlockNoteViewer.tsx
+++ b/apps/pages/app/components/viewer/BlockNoteViewer.tsx
@@ -4,6 +4,11 @@ import { MantineProvider } from '@mantine/core';
 import { useState, useEffect } from 'react';
 import { schema, type PageBlockInsertions } from '~/components/editor/blocks/index.tsx';
 import { AssetSrcSetContext, NO_SRC_SETS, type AssetSrcSets } from '~/hooks/useAssetSrcSets.ts';
+import {
+  AssetDisplayUrlContext,
+  IDENTITY_DISPLAY_URL,
+  type DisplayUrlLookup,
+} from '~/hooks/useAssetDisplayUrl.ts';
 
 import '@blocknote/mantine/style.css';
 import '@blocknote/core/fonts/inter.css';
@@ -24,6 +29,12 @@ interface BlockNoteViewerProps {
   resolveFileUrl?: (url: string) => Promise<string>;
   /** Responsive candidates, keyed by the stored reference. Same as the editor's. */
   srcSets?: AssetSrcSets;
+  /**
+   * The same map as `resolveFileUrl`, read synchronously. Custom blocks call it
+   * during render so the signed URL is in `src` on the FIRST commit — an
+   * effect-time swap paints the bare stored path, and the browser fetches it.
+   */
+  displayUrl?: DisplayUrlLookup;
 }
 
 const BlockNoteViewer = ({
@@ -31,6 +42,7 @@ const BlockNoteViewer = ({
   darkMode,
   resolveFileUrl,
   srcSets,
+  displayUrl,
 }: BlockNoteViewerProps) => {
   const [isMounted, setIsMounted] = useState(false);
   const initialContent =
@@ -67,7 +79,9 @@ const BlockNoteViewer = ({
     >
       <div className="page-editor">
         <AssetSrcSetContext.Provider value={srcSets ?? NO_SRC_SETS}>
-          <BlockNoteView editor={editor} editable={false} theme={darkMode ? 'dark' : 'light'} />
+          <AssetDisplayUrlContext.Provider value={displayUrl ?? IDENTITY_DISPLAY_URL}>
+            <BlockNoteView editor={editor} editable={false} theme={darkMode ? 'dark' : 'light'} />
+          </AssetDisplayUrlContext.Provider>
         </AssetSrcSetContext.Provider>
       </div>
     </MantineProvider>

--- a/apps/pages/app/hooks/useAssetDisplayUrl.ts
+++ b/apps/pages/app/hooks/useAssetDisplayUrl.ts
@@ -1,0 +1,43 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * The SYNCHRONOUS half of render-time URL resolution.
+ *
+ * The document stores references (`pages/lab-1/assets/loop.gif`) and the loader
+ * ships a parallel `ref → signed URL` map, so by the time any block renders the
+ * answer already exists — in memory, on this tick. `resolveFileUrl` is the
+ * async door onto that same map, and async is BlockNote's contract, not a fact
+ * about the data.
+ *
+ * That distinction is the bug this context exists to close. A block that only
+ * had the async door painted the bare reference on its first commit and swapped
+ * the signed URL in afterwards; the browser does not wait for the second commit
+ * to start fetching, so every image without a `srcset` to distract it — a GIF,
+ * an SVG, anything the rendition ladder does not cover — issued a doomed
+ * request to `https://pages.../pages/<slug>/assets/<file>` before loading
+ * correctly. Raster images hid it only because `responsiveImageAttrs` gave the
+ * browser a candidate list to pick from instead of `src`.
+ *
+ * A React context, and deliberately the same delivery mechanism
+ * `useAssetSrcSets` uses: BlockNote portals every block render into the
+ * `BlockNoteView` tree, so a provider above the view is what reaches them. Both
+ * values are keyed by the stored reference, which a block has synchronously on
+ * its first render.
+ */
+
+/** Stored reference in, display URL out. A miss returns the reference unchanged. */
+export type DisplayUrlLookup = (ref: string) => string;
+
+/**
+ * No provider — and, equally, a deployment with the delivery layer switched
+ * off. In both the reference IS the URL, which is what every surface degraded
+ * to before any of this existed.
+ */
+export const IDENTITY_DISPLAY_URL: DisplayUrlLookup = ref => ref;
+
+export const AssetDisplayUrlContext = createContext<DisplayUrlLookup>(IDENTITY_DISPLAY_URL);
+
+/** The lookup for the document being rendered. Safe to call during render. */
+export function useAssetDisplayUrl(): DisplayUrlLookup {
+  return useContext(AssetDisplayUrlContext);
+}

--- a/apps/pages/app/hooks/useAssetMap.ts
+++ b/apps/pages/app/hooks/useAssetMap.ts
@@ -17,6 +17,37 @@ import { useRevalidator } from 'react-router';
  * external image, a `data:` URI, and for a deployment where the delivery layer
  * is switched off entirely.
  */
+/**
+ * Fold the loader's `ref → signed URL` payload into a display map, in place.
+ *
+ * A MERGE, not a replacement: a revalidation ships a fresh payload for the same
+ * document, and the entries `remember` added for assets uploaded since the last
+ * load have no row on the server yet. Dropping them would un-resolve every
+ * image the author just added. Discarding the map wholesale is the NAVIGATION
+ * case, and that decision belongs to the caller, against the reset key.
+ */
+export function seedAssetMap(
+  map: Map<string, string>,
+  resolvedAssets: Record<string, string> | null | undefined
+): Map<string, string> {
+  if (!resolvedAssets) return map;
+  for (const [ref, url] of Object.entries(resolvedAssets)) map.set(ref, url);
+  return map;
+}
+
+/**
+ * The lookup itself, lifted out of the hook so the first-paint guarantee is
+ * testable without an editor: a seeded reference resolves to its signed URL,
+ * and everything else — an external image, a `data:` URI, a reference the map
+ * has never heard of, an empty string — comes back untouched.
+ */
+export function lookupDisplayUrl<T extends string | null | undefined>(
+  map: ReadonlyMap<string, string>,
+  ref: T
+): T {
+  return ref ? ((map.get(ref) ?? ref) as T) : ref;
+}
+
 export function useAssetMap(
   resolvedAssets: Record<string, string> | null | undefined,
   /**
@@ -43,16 +74,22 @@ export function useAssetMap(
       // which belong to the document being navigated away from.
       mapRef.current = new Map();
     }
-    if (!resolvedAssets) return;
-    for (const [ref, url] of Object.entries(resolvedAssets)) mapRef.current.set(ref, url);
+    seedAssetMap(mapRef.current, resolvedAssets);
   }, [resolvedAssets, resetKey]);
 
   /** BlockNote's `resolveFileUrl`: display URL in, stored ref untouched. */
   const resolveFileUrl = useCallback(async (url: string) => mapRef.current.get(url) ?? url, []);
 
-  /** Synchronous lookup for markup this app renders itself (the cover image). */
+  /**
+   * The synchronous lookup, for every surface that can ask during render.
+   *
+   * That is the cover image this app renders itself AND, through
+   * `AssetDisplayUrlContext`, every custom block — which is what keeps a bare
+   * stored path off the first DOM commit. A stable identity because it reads
+   * through the ref rather than closing over a map.
+   */
   const displayUrl = useCallback(
-    (ref: string | null | undefined) => (ref ? (mapRef.current.get(ref) ?? ref) : ref),
+    <T extends string | null | undefined>(ref: T): T => lookupDisplayUrl(mapRef.current, ref),
     []
   );
 

--- a/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
+++ b/apps/pages/app/routes/$classroomSlug.$pageId/route.tsx
@@ -700,6 +700,7 @@ const PageRoute = () => {
                 onReady={handleEditorReady}
                 resolveFileUrl={assets.resolveFileUrl}
                 srcSets={srcSets}
+                displayUrl={assets.displayUrl}
                 onAssetUploaded={assets.remember}
                 // P5: block editing while the save-merge chooser is open so no
                 // edits are silently discarded when the resolved merge remounts
@@ -726,6 +727,7 @@ const PageRoute = () => {
                 darkMode={darkMode}
                 resolveFileUrl={assets.resolveFileUrl}
                 srcSets={srcSets}
+                displayUrl={assets.displayUrl}
               />
             </Suspense>
           )}

--- a/apps/pages/tests/unit/asset-first-paint.spec.ts
+++ b/apps/pages/tests/unit/asset-first-paint.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the first-paint guarantee on image (and video, embed, avatar)
+ * blocks.
+ *
+ * The regression: a block's `src` was only corrected in an effect, so the FIRST
+ * commit carried the bare stored reference — `pages/lab-1/assets/loop.gif` —
+ * and the browser started fetching it against the pages origin before React
+ * swapped in the signed URL. Observed in DevTools on staging as a 404 that
+ * precedes every image the rendition ladder does not cover: a GIF, an SVG,
+ * anything non-raster. Raster images never showed it, and never fixed it
+ * either: their `srcset` is computed synchronously, so the browser had a
+ * candidate to prefer over `src` and simply never asked for it.
+ *
+ * The fix is that the answer was never actually async. The loader ships the
+ * whole `ref → signed URL` map with the document; `useAssetMap` seeds it during
+ * render; `useAssetDisplayUrl` hands it to blocks through context. So these
+ * tests pin two things:
+ *
+ *  - the lookup itself — a seeded ref resolves, everything else passes through;
+ *  - that a block rendered with a seeded map emits the signed URL in its very
+ *    first HTML, with a `resolveFileUrl` that NEVER settles. If the async path
+ *    were still load-bearing, that render would emit the bare path.
+ */
+
+import { createElement, type ReactElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { test, expect } from '@playwright/test';
+
+import { lookupDisplayUrl, seedAssetMap } from '../../app/hooks/useAssetMap.ts';
+import {
+  AssetDisplayUrlContext,
+  IDENTITY_DISPLAY_URL,
+  type DisplayUrlLookup,
+} from '../../app/hooks/useAssetDisplayUrl.ts';
+import { useResolvedFileUrl } from '../../app/components/editor/blocks/useResolvedFileUrl.ts';
+
+const GIF = 'pages/lab-1/assets/loop.gif';
+const SIGNED = 'https://content.classmoji.io/c/abc/blob/aaa.gif?p=week&sig=x';
+const EXTERNAL = 'https://example.edu/mascot.svg';
+
+test.describe('seedAssetMap', () => {
+  test('folds the loader payload into the map', () => {
+    const map = seedAssetMap(new Map(), { [GIF]: SIGNED });
+    expect(map.get(GIF)).toBe(SIGNED);
+  });
+
+  test('merges rather than replaces, so an upload survives a revalidation', () => {
+    // `remember` put this there: the asset exists in the repo but the server's
+    // map has no row for it yet, so the next loader payload will not mention it.
+    const map = seedAssetMap(new Map(), { [GIF]: SIGNED });
+    map.set('pages/lab-1/assets/fresh.png', 'https://content.classmoji.io/c/abc/blob/new.png');
+
+    seedAssetMap(map, { [GIF]: `${SIGNED}&t=2` });
+
+    expect(map.get(GIF), 'the reloaded signature wins').toBe(`${SIGNED}&t=2`);
+    expect(map.get('pages/lab-1/assets/fresh.png'), 'the upload is still resolvable').toBe(
+      'https://content.classmoji.io/c/abc/blob/new.png'
+    );
+  });
+
+  test('an absent payload is a no-op, not a wipe', () => {
+    const map = seedAssetMap(new Map(), { [GIF]: SIGNED });
+    expect(seedAssetMap(map, null).get(GIF)).toBe(SIGNED);
+    expect(seedAssetMap(map, undefined).get(GIF)).toBe(SIGNED);
+  });
+});
+
+test.describe('lookupDisplayUrl', () => {
+  const map = new Map([[GIF, SIGNED]]);
+
+  test('a seeded reference resolves to its signed URL', () => {
+    expect(lookupDisplayUrl(map, GIF)).toBe(SIGNED);
+  });
+
+  test('anything else comes back untouched', () => {
+    // An external image, a data URI and a ref this document has never heard of
+    // are all the same case, and the reference IS the URL for all three — which
+    // is also what a deployment with the delivery layer off gets for every ref.
+    expect(lookupDisplayUrl(map, EXTERNAL)).toBe(EXTERNAL);
+    expect(lookupDisplayUrl(map, 'data:image/gif;base64,R0lGOD')).toBe(
+      'data:image/gif;base64,R0lGOD'
+    );
+    expect(lookupDisplayUrl(map, 'pages/lab-2/assets/loop.gif')).toBe(
+      'pages/lab-2/assets/loop.gif'
+    );
+    expect(lookupDisplayUrl(new Map(), GIF)).toBe(GIF);
+  });
+
+  test('empty, null and undefined pass through without a lookup', () => {
+    expect(lookupDisplayUrl(map, '')).toBe('');
+    expect(lookupDisplayUrl(map, null)).toBeNull();
+    expect(lookupDisplayUrl(map, undefined)).toBeUndefined();
+  });
+});
+
+/** A block, reduced to the one thing under test: what lands in `src`. */
+function ImageUnderTest({
+  url,
+  resolveFileUrl,
+}: {
+  url: string;
+  resolveFileUrl?: (url: string) => Promise<string>;
+}) {
+  return createElement('img', { src: useResolvedFileUrl(url, resolveFileUrl) });
+}
+
+/** A resolver that NEVER settles: only the synchronous path can answer. */
+const neverResolves = () => new Promise<string>(() => {});
+
+function firstPaint(element: ReactElement): string {
+  const match = renderToStaticMarkup(element).match(/src="([^"]*)"/);
+  // `&` in a signed URL's query comes back as `&amp;` — an HTML fact about the
+  // serializer, not about the value React put in the attribute.
+  return match ? match[1].replace(/&amp;/g, '&') : '';
+}
+
+function withMap(map: Record<string, string>, element: ReactElement): ReactElement {
+  const displayUrl: DisplayUrlLookup = ref => lookupDisplayUrl(seedAssetMap(new Map(), map), ref);
+  return createElement(AssetDisplayUrlContext.Provider, { value: displayUrl }, element);
+}
+
+test.describe('first paint', () => {
+  test('a seeded ref is signed in the very first commit', () => {
+    // The whole bug, in one assertion: no effect has run, no promise has
+    // settled, and the markup already carries the signed URL. The bare path is
+    // never in the DOM, so the browser never requests it.
+    const html = firstPaint(
+      withMap(
+        { [GIF]: SIGNED },
+        createElement(ImageUnderTest, { url: GIF, resolveFileUrl: neverResolves })
+      )
+    );
+
+    expect(html).toBe(SIGNED);
+    expect(html).not.toContain(GIF);
+  });
+
+  test('a ref the map does not have falls back to the reference', () => {
+    // Not a regression — the reference is the correct URL when the delivery
+    // layer is off, and the async resolver is still there for the rest.
+    expect(
+      firstPaint(
+        withMap(
+          { [GIF]: SIGNED },
+          createElement(ImageUnderTest, { url: EXTERNAL, resolveFileUrl: neverResolves })
+        )
+      )
+    ).toBe(EXTERNAL);
+  });
+
+  test('with no provider above it, a block renders the reference', () => {
+    // The default context is the identity, so a surface that never mounts a
+    // provider degrades exactly as it did before any of this existed.
+    expect(IDENTITY_DISPLAY_URL(GIF)).toBe(GIF);
+    expect(
+      firstPaint(createElement(ImageUnderTest, { url: GIF, resolveFileUrl: neverResolves }))
+    ).toBe(GIF);
+  });
+
+  test('no resolver at all is still the reference, not an empty src', () => {
+    expect(firstPaint(createElement(ImageUnderTest, { url: GIF }))).toBe(GIF);
+  });
+});


### PR DESCRIPTION
## What
In the pages editor and in-app viewer, image blocks without a srcset (GIF, SVG, files) issued a first request to the bare stored path against the pages origin (404) before the signed URL arrived; raster blocks masked it only because their synchronously computed srcset won. Now a sibling context exposes the asset map's synchronous lookup, and `useResolvedFileUrl` initializes (and re-derives on ref change) during render, so the first DOM commit already carries the signed URL. Image, Profile, Video and Embed blocks share the hook. The async `resolveFileUrl` stays as the fallback for refs not yet in the map (fresh uploads) and no longer touches the DOM when the value is unchanged. The class site was already server-rendered with signed URLs and is unaffected.

## Test
pages unit 499 passed (was 489), typecheck 0. Mutation-tested: with a never-settling `resolveFileUrl`, static markup contains the signed URL and not the bare path; reverting the init makes that fail. On staging: load a page with a GIF in the viewer → no request to `pages.staging…/assets/…gif`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA