### PR TITLE
fix(import): rewrite asset refs a chained import left two repos back

### DIFF
--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -210,7 +210,7 @@ export const action = async ({ request }: { request: Request }) => {
       const newContentPath = `slides/${newSlug}`;
 
       // Copy content folder in GitHub
-      await ContentService.copyFolder({
+      const copy = await ContentService.copyFolder({
         gitOrganization,
         repo,
         sourcePath: slide.content_path,
@@ -218,16 +218,51 @@ export const action = async ({ request }: { request: Request }) => {
         message: `Duplicate slides: ${slide.title}`,
       });
 
-      // Rewrite content paths in the copied index.html
-      // Images and other assets reference the old content_path in their URLs
-      // e.g., /content/{org}/{repo}/{old_content_path}/images/...
+      // The two texts that carry references: the generated index.html and, for
+      // deck-first slides, deck.json. 404-tolerant — a legacy deck has no
+      // deck.json, and getContent returns null.
       const indexPath = `${newContentPath}/index.html`;
-      const indexFile = await ContentService.getContent({
-        gitOrganization,
-        repo,
-        path: indexPath,
-        skipCache: true,
-      });
+      const deckPath = `${newContentPath}/deck.json`;
+      const [indexFile, deckFile] = await Promise.all([
+        ContentService.getContent({ gitOrganization, repo, path: indexPath, skipCache: true }),
+        ContentService.getContent({ gitOrganization, repo, path: deckPath, skipCache: true }),
+      ]);
+
+      // Repoint the copy's references at the copy, through the SAME rewriter
+      // the classroom import uses. Not a blind `replaceAll` of the old folder
+      // name: that reaches inside a URL belonging to another repo — or another
+      // org — and rewrites the matching segment there, turning a reference that
+      // at least resolved into one that names a folder existing nowhere.
+      //
+      // The repo is the same on both sides, so ordinarily only the item folder
+      // moves. The exception is a CHAINED reference: a deck that arrived here
+      // by import still names the repo it came from, and `copyFolder` has just
+      // put those files in the new folder — so those are repointed at this
+      // repo, and only where the file is actually in the copy.
+      //
+      // `shaPaths` comes along for the ride so the rewriter can turn any signed
+      // URL in the source deck back into the repo path it names — the stored
+      // form, which the deck loader signs again at render — instead of leaving
+      // it to expire in the copy and warning about every one.
+      const copiedPaths = new Set(copy.paths);
+      let uncopiedRefs = 0;
+      const shaPaths = await ClassmojiService.contentImport.resolveShaPaths(slide.classroom_id, [
+        indexFile?.content ?? '',
+        deckFile?.content ?? '',
+      ]);
+      const rewriteCtx = {
+        sourceLogin: gitOrganization.login,
+        sourceRepo: repo,
+        sourcePath: slide.content_path,
+        targetLogin: gitOrganization.login,
+        targetRepo: repo,
+        targetPath: newContentPath,
+        shaPaths,
+        targetHasPath: (candidate: string) => copiedPaths.has(candidate),
+        onUncopiedRef: () => {
+          uncopiedRefs++;
+        },
+      };
 
       // Both rewrites below record what they wrote. index.html and deck.json
       // are READ through the asset map now (fetchContentText), and the copy's
@@ -242,45 +277,32 @@ export const action = async ({ request }: { request: Request }) => {
       // webhook arrives rather than showing the wrong deck.
       const written: Array<{ path: string; sha: string }> = [];
 
-      if (indexFile?.content && slide.content_path !== newContentPath) {
-        const updatedContent = indexFile.content.replaceAll(slide.content_path, newContentPath);
+      for (const [path, file] of [
+        [indexPath, indexFile],
+        [deckPath, deckFile],
+      ] as const) {
+        if (!file?.content || slide.content_path === newContentPath) continue;
+        const updated = ClassmojiService.contentImport.rewriteContentUrls(file.content, rewriteCtx);
+        if (updated === file.content) continue;
 
-        if (updatedContent !== indexFile.content) {
-          const result = await ContentService.put({
-            gitOrganization,
-            repo,
-            path: indexPath,
-            content: updatedContent,
-            message: `Rewrite content paths for duplicated slides: ${slide.title}`,
-          });
-          written.push({ path: indexPath, sha: result.sha });
-        }
+        const result = await ContentService.put({
+          gitOrganization,
+          repo,
+          path,
+          content: updated,
+          message: `Rewrite content paths for duplicated slides: ${slide.title}`,
+        });
+        written.push({ path, sha: result.sha });
       }
 
-      // Apply the same content-path rewrite to the copied deck.json (the
-      // source of truth for deck-first slides). 404-tolerant: legacy decks
-      // have no deck.json yet — getContent returns null and we skip.
-      const deckPath = `${newContentPath}/deck.json`;
-      const deckFile = await ContentService.getContent({
-        gitOrganization,
-        repo,
-        path: deckPath,
-        skipCache: true,
-      });
-
-      if (deckFile?.content && slide.content_path !== newContentPath) {
-        const updatedDeck = deckFile.content.replaceAll(slide.content_path, newContentPath);
-
-        if (updatedDeck !== deckFile.content) {
-          const result = await ContentService.put({
-            gitOrganization,
-            repo,
-            path: deckPath,
-            content: updatedDeck,
-            message: `Rewrite content paths for duplicated slides: ${slide.title}`,
-          });
-          written.push({ path: deckPath, sha: result.sha });
-        }
+      // One line for the duplicate, not one per reference. These are links that
+      // were already pointing at another repo and whose files did not come
+      // along; repointing them would have invented a path.
+      if (uncopiedRefs > 0) {
+        console.warn(
+          `[slides.duplicate] left ${uncopiedRefs} reference(s) into another ${gitOrganization.login} ` +
+            `repository untouched in "${slide.title}" — those files are not in this copy`
+        );
       }
 
       // Never throws: the copy is already committed, and the next sync writes

--- a/apps/slides/app/routes/_index/route.tsx
+++ b/apps/slides/app/routes/_index/route.tsx
@@ -245,7 +245,21 @@ export const action = async ({ request }: { request: Request }) => {
       // form, which the deck loader signs again at render — instead of leaving
       // it to expire in the copy and warning about every one.
       const copiedPaths = new Set(copy.paths);
+      // The copy is ADDITIVE — the rest of the repo is still there — so the
+      // classroom's asset index answers for everything `copyFolder` did not
+      // just write. Without it a chained reference to another deck that IS in
+      // this repo would be read as broken and counted as a residual.
+      let existingPaths: ReadonlySet<string>;
+      try {
+        existingPaths = await ClassmojiService.contentAssets.listContentAssetPaths(
+          slide.classroom_id
+        );
+      } catch {
+        existingPaths = new Set<string>();
+      }
+
       let uncopiedRefs = 0;
+      let unresolvedSignedRefs = 0;
       const shaPaths = await ClassmojiService.contentImport.resolveShaPaths(slide.classroom_id, [
         indexFile?.content ?? '',
         deckFile?.content ?? '',
@@ -258,9 +272,18 @@ export const action = async ({ request }: { request: Request }) => {
         targetRepo: repo,
         targetPath: newContentPath,
         shaPaths,
-        targetHasPath: (candidate: string) => copiedPaths.has(candidate),
+        targetHasPath: (candidate: string) =>
+          copiedPaths.has(candidate) || existingPaths.has(candidate),
         onUncopiedRef: () => {
           uncopiedRefs++;
+        },
+        // Counted, not logged one by one — and deliberately not through the
+        // rewriter's own wording, which is written for an IMPORT. A duplicate
+        // stays in the same classroom, so a signed URL it could not turn back
+        // into a repo path still resolves; it is simply frozen at today's key
+        // version instead of following the file.
+        onWarn: () => {
+          unresolvedSignedRefs++;
         },
       };
 
@@ -302,6 +325,13 @@ export const action = async ({ request }: { request: Request }) => {
         console.warn(
           `[slides.duplicate] left ${uncopiedRefs} reference(s) into another ${gitOrganization.login} ` +
             `repository untouched in "${slide.title}" — those files are not in this copy`
+        );
+      }
+      if (unresolvedSignedRefs > 0) {
+        console.warn(
+          `[slides.duplicate] kept ${unresolvedSignedRefs} signed URL(s) verbatim in ` +
+            `"${slide.title}" — the classroom's asset map has no path for them, so the copy ` +
+            `holds a frozen URL rather than a reference that follows the file`
         );
       }
 

--- a/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentAssets.service.test.ts
@@ -85,6 +85,7 @@ const {
   lookupContentAsset,
   lookupContentTree,
   lookupContentAssetBySha,
+  listContentAssetPaths,
 } = await import('../contentAssets.service.ts');
 
 /** The default branch head every full sync in this file reads the tree at. */
@@ -1111,5 +1112,39 @@ describe('contentAssets.service', () => {
 
       await expect(syncContentAssets('nope')).rejects.toThrow(/No such classroom/i);
     });
+  });
+});
+
+/**
+ * The path index the import and the deck duplicate ask "did this file come
+ * along?" of, for everything the copy itself did not just write.
+ */
+describe('listContentAssetPaths', () => {
+  beforeEach(() => {
+    contentAssetFindMany.mockReset();
+  });
+
+  it('returns the classroom’s file paths as a set, excluding trees', async () => {
+    contentAssetFindMany.mockResolvedValue([
+      { path: 'pages/lab-1/content.json' },
+      { path: 'slides/intro/index.html' },
+    ]);
+
+    const paths = await listContentAssetPaths('class-1');
+
+    expect(paths).toBeInstanceOf(Set);
+    expect([...paths].sort()).toEqual(['pages/lab-1/content.json', 'slides/intro/index.html']);
+    // A directory is not a file a reference can resolve to: signing a tree sha
+    // as a blob mints a URL the Worker cannot serve.
+    const [args] = contentAssetFindMany.mock.calls[0] as [
+      { where: { classroom_id: string; type: string }; select: Record<string, boolean> },
+    ];
+    expect(args.where).toEqual({ classroom_id: 'class-1', type: 'blob' });
+    expect(args.select).toEqual({ path: true });
+  });
+
+  it('returns an empty set for a classroom with no rows', async () => {
+    contentAssetFindMany.mockResolvedValue([]);
+    await expect(listContentAssetPaths('class-empty')).resolves.toEqual(new Set());
   });
 });

--- a/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
@@ -206,6 +206,212 @@ describe('rewriteContentUrls', () => {
 });
 
 /**
+ * Chained imports: the source repo was ITSELF created by an earlier import, so
+ * its content still names the repo it came from — two hops back. The files came
+ * along at every hop and sit in the target under the same relative path; only
+ * the reference is stale, and the target's delivery layer cannot sign another
+ * classroom's repo, so every one of those images is a 403.
+ *
+ * Prod, 2026-09-07: `dartmouth-cs98-26f` ← `content-27w` ← `content-…-26w`,
+ * where every deck's index.html still pointed at the 26W repo.
+ */
+describe('rewriteContentUrls: a chained import’s references to an earlier repo', () => {
+  /** A THIRD repo in the source org — where the content originally came from. */
+  const ORIGIN_REPO = 'content-dartmouth-cs52-cs52-24w';
+  const deck = { ...ctx, sourcePath: 'slides/lecture-1', targetPath: 'slides/lecture-1' };
+  /** The files the copy actually carries, target-shaped. */
+  const copied = (paths: string[]) => (path: string) => paths.includes(path);
+
+  it('repoints a /content/ proxy ref into the earlier repo when the file came along', () => {
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/images/x.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+      })
+    ).toBe('/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1/images/x.png');
+  });
+
+  it('repoints the raw shape the same way, ref segment carried across', () => {
+    const text = `https://raw.githubusercontent.com/dartmouth-cs52/${ORIGIN_REPO}/main/slides/lecture-1/images/x.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+      })
+    ).toBe(
+      'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/main/slides/lecture-1/images/x.png'
+    );
+  });
+
+  it('repoints the {login}.github.io Pages-CDN shape the same way', () => {
+    const text = `https://dartmouth-cs52.github.io/${ORIGIN_REPO}/slides/lecture-1/images/x.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+      })
+    ).toBe(
+      'https://brown-cs32.github.io/content-brown-cs32-cs32-26f/slides/lecture-1/images/x.png'
+    );
+  });
+
+  it('carries a chained ref onto a RENAMED item folder, like every other shape', () => {
+    // The item-specific rewrite runs first: the deck picked up a dedupe suffix
+    // in the target, and the copied file is under the suffixed folder.
+    const renamed = { ...deck, targetPath: 'slides/lecture-1-2' };
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/images/x.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...renamed,
+        targetHasPath: copied(['slides/lecture-1-2/images/x.png']),
+      })
+    ).toBe('/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1-2/images/x.png');
+  });
+
+  it('repoints a chained ref to ANOTHER item repo-generally when that path exists', () => {
+    // Not under this deck's folder, so it keeps its own — the same repo-general
+    // fallback the immediate-source shapes use.
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-9/images/y.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-9/images/y.png']),
+      })
+    ).toBe('/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-9/images/y.png');
+  });
+
+  it('leaves a chained ref alone — and counts it — when the file is NOT in the copy', () => {
+    // THE rule: never invent a copy. The link is already broken; repointing it
+    // would replace a broken link with a confidently wrong one.
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/images/gone.png`;
+    const onUncopiedRef = vi.fn();
+
+    expect(rewriteContentUrls(text, { ...deck, targetHasPath: copied([]), onUncopiedRef })).toBe(
+      text
+    );
+    expect(onUncopiedRef).toHaveBeenCalledTimes(1);
+    expect(onUncopiedRef).toHaveBeenCalledWith(expect.stringContaining(ORIGIN_REPO));
+  });
+
+  it('never widens past the source org — another org’s repo is untouched, file or not', () => {
+    const text = '/content/someone-else/their-content/slides/lecture-1/images/x.png';
+    const onUncopiedRef = vi.fn();
+
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        // Even though a file by that path IS in the copy.
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+        onUncopiedRef,
+      })
+    ).toBe(text);
+    expect(onUncopiedRef).not.toHaveBeenCalled();
+  });
+
+  it('leaves a COMMIT-pinned chained raw URL alone: the target has no history', () => {
+    const text = `https://raw.githubusercontent.com/dartmouth-cs52/${ORIGIN_REPO}/${'a'.repeat(
+      40
+    )}/slides/lecture-1/images/x.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+      })
+    ).toBe(text);
+  });
+
+  it('does nothing at all without a targetHasPath predicate', () => {
+    // Opt-in: a caller that cannot say what the copy carries gets exactly the
+    // behaviour that predates the chained rewrite.
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/images/x.png`;
+    expect(rewriteContentUrls(text, deck)).toBe(text);
+  });
+
+  it('leaves a reference that already names the TARGET repo alone', () => {
+    // Same org on both sides: this is the earlier passes' own output, and
+    // reconsidering it would make the result depend on whether two classrooms
+    // happen to share an org.
+    const sameOrg = {
+      ...deck,
+      targetLogin: 'dartmouth-cs52',
+      targetRepo: 'content-dartmouth-cs52-cs52-26f',
+      targetPath: 'slides/lecture-1-2',
+    };
+    const text = '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-26f/slides/lecture-1/x.png';
+    const onUncopiedRef = vi.fn();
+
+    expect(rewriteContentUrls(text, { ...sameOrg, targetHasPath: copied([]), onUncopiedRef })).toBe(
+      text
+    );
+    expect(onUncopiedRef).not.toHaveBeenCalled();
+  });
+
+  it('rewrites a chained ref on a whole-repo clone, where nothing moves', () => {
+    // cloneContentRepo passes an empty sourcePath: only the repo-general half
+    // of the rule can fire, and the cloned tree is the existence answer.
+    const clone = { ...ctx, sourcePath: '', targetPath: '' };
+    const text = `https://raw.githubusercontent.com/dartmouth-cs52/${ORIGIN_REPO}/main/slides/lecture-1/images/x.png`;
+    expect(
+      rewriteContentUrls(text, {
+        ...clone,
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+      })
+    ).toBe(
+      'https://raw.githubusercontent.com/brown-cs32/content-brown-cs32-cs32-26f/main/slides/lecture-1/images/x.png'
+    );
+  });
+
+  it('keeps a query string on a rewritten chained ref', () => {
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/images/x.png?v=2`;
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/images/x.png']),
+      })
+    ).toBe('/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1/images/x.png?v=2');
+  });
+
+  it('reports every uncopied chained ref, so the count is the real one', () => {
+    const onUncopiedRef = vi.fn();
+    const text = [
+      `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/a.png`,
+      `https://dartmouth-cs52.github.io/${ORIGIN_REPO}/slides/lecture-1/b.png`,
+      `https://raw.githubusercontent.com/dartmouth-cs52/${ORIGIN_REPO}/main/slides/lecture-1/c.png`,
+    ].join(' ');
+
+    expect(rewriteContentUrls(text, { ...deck, targetHasPath: copied([]), onUncopiedRef })).toBe(
+      text
+    );
+    expect(onUncopiedRef).toHaveBeenCalledTimes(3);
+  });
+
+  it('still repoints the IMMEDIATE source alongside a chained ref, in one pass', () => {
+    const fixture = JSON.stringify({
+      immediate:
+        '/content/dartmouth-cs52/content-dartmouth-cs52-cs52-25s/slides/lecture-1/images/now.png',
+      chained: `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/images/then.png`,
+      bare: 'slides/lecture-1/images/bare.png',
+    });
+
+    expect(
+      JSON.parse(
+        rewriteContentUrls(fixture, {
+          ...deck,
+          targetPath: 'slides/lecture-1-2',
+          targetHasPath: copied(['slides/lecture-1-2/images/then.png']),
+        })
+      )
+    ).toEqual({
+      immediate:
+        '/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1-2/images/now.png',
+      chained: '/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1-2/images/then.png',
+      bare: 'slides/lecture-1-2/images/bare.png',
+    });
+  });
+});
+
+/**
  * A signed URL is bound to the SOURCE classroom's id and key version, and the
  * imported copy renders under a different classroom. Copying one verbatim does
  * not produce a stale link — it produces a permanently unauthorized one, and

--- a/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentImport.rewrite.test.ts
@@ -646,3 +646,136 @@ describe('resolveShaPaths', () => {
     expect(onWarn).toHaveBeenCalledWith(expect.stringContaining(SHA));
   });
 });
+
+/**
+ * The deck DUPLICATE: one repo on both sides, only the item folder moves.
+ *
+ * The boundary class is what decides whether a path is rewritten, and a
+ * duplicate can afford two characters an import cannot. The blind
+ * `replaceAll(content_path, newPath)` this replaced caught these; a
+ * boundary-anchored rewrite that excluded `,` and `;` would silently leave
+ * every entry after the first pointing at the ORIGINAL deck.
+ */
+describe('rewriteContentUrls: same-repo copy (deck duplicate) boundaries', () => {
+  const dup = {
+    sourceLogin: 'dartmouth-cs52',
+    sourceRepo: 'content-dartmouth-cs52-cs52-25s',
+    sourcePath: 'slides/intro',
+    targetLogin: 'dartmouth-cs52',
+    targetRepo: 'content-dartmouth-cs52-cs52-25s',
+    targetPath: 'slides/intro-copy-1',
+  };
+
+  it('rewrites every entry of a comma-separated video list', () => {
+    const text = '<section data-background-video="slides/intro/a.mp4,slides/intro/b.webm">';
+    expect(rewriteContentUrls(text, dup)).toBe(
+      '<section data-background-video="slides/intro-copy-1/a.mp4,slides/intro-copy-1/b.webm">'
+    );
+  });
+
+  it('rewrites every candidate of a srcset', () => {
+    const text = '<img srcset="slides/intro/a.png 1x,slides/intro/b.png 2x">';
+    expect(rewriteContentUrls(text, dup)).toBe(
+      '<img srcset="slides/intro-copy-1/a.png 1x,slides/intro-copy-1/b.png 2x">'
+    );
+  });
+
+  it('rewrites a path behind an HTML-escaped quote, which ends in a semicolon', () => {
+    const text = '<div style="background:url(&quot;slides/intro/a.png&quot;)">';
+    expect(rewriteContentUrls(text, dup)).toBe(
+      '<div style="background:url(&quot;slides/intro-copy-1/a.png&quot;)">'
+    );
+  });
+
+  it('still refuses `=`, so a foreign query string is safe even here', () => {
+    const text = 'https://images.example.com/resize?src=slides/intro/a.png&w=800';
+    expect(rewriteContentUrls(text, dup)).toBe(text);
+  });
+
+  it('keeps `,` OUT of the boundary for a cross-repo import', () => {
+    // The relaxation is only sound when there is no other repo in play. On an
+    // import, a comma before a path can belong to somebody else's query string.
+    const text = 'https://images.example.com/pick?list=1,pages/lab-1/a.png';
+    expect(rewriteContentUrls(text, { ...ctx, targetPath: 'pages/lab-1-2' })).toBe(text);
+  });
+});
+
+/**
+ * Anchoring and parsing of the chained pass — the ways a loose pattern turns a
+ * reference it should not have matched into a broken one.
+ */
+describe('rewriteContentUrls: chained pass anchoring and parsing', () => {
+  const ORIGIN_REPO = 'content-dartmouth-cs52-cs52-24w';
+  const deck = { ...ctx, sourcePath: 'slides/lecture-1', targetPath: 'slides/lecture-1' };
+  const copied = (paths: string[]) => (path: string) => paths.includes(path);
+
+  it('does not reach inside a foreign URL that merely contains /content/{login}/', () => {
+    // `/content/` on somebody else's host is their path, not our proxy.
+    const text = `https://example.com/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/x.png`;
+    const onUncopiedRef = vi.fn();
+
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/x.png']),
+        onUncopiedRef,
+      })
+    ).toBe(text);
+    expect(onUncopiedRef).not.toHaveBeenCalled();
+  });
+
+  it('still rewrites the proxy shape at a real value boundary', () => {
+    const text = `<img src="/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/x.png">`;
+    expect(
+      rewriteContentUrls(text, { ...deck, targetHasPath: copied(['slides/lecture-1/x.png']) })
+    ).toBe('<img src="/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1/x.png">');
+  });
+
+  it('does not read a content ROOT as a repo when the ref dropped its repo segment', () => {
+    // `/content/{login}/slides/…` is malformed — it has no repo. Parsed
+    // positionally it would eat `slides/` and leave `intro/x.png`, a path no
+    // import ever meant.
+    const text = '/content/dartmouth-cs52/slides/intro/x.png';
+    const onUncopiedRef = vi.fn();
+
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['intro/x.png', 'slides/intro/x.png']),
+        onUncopiedRef,
+      })
+    ).toBe(text);
+    expect(onUncopiedRef).not.toHaveBeenCalled();
+  });
+
+  it('treats a bare `…/{repo}/` with no path as a base, not a broken reference', () => {
+    const text = `/content/dartmouth-cs52/${ORIGIN_REPO}/`;
+    const onUncopiedRef = vi.fn();
+
+    expect(rewriteContentUrls(text, { ...deck, targetHasPath: copied([]), onUncopiedRef })).toBe(
+      text
+    );
+    expect(onUncopiedRef).not.toHaveBeenCalled();
+  });
+
+  it('handles a comma-separated list of chained refs as separate references', () => {
+    // A tail class that swallowed the comma would match the whole list as one
+    // reference: nothing rewritten, and one bogus residual counted.
+    const text =
+      `"/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/a.mp4,` +
+      `/content/dartmouth-cs52/${ORIGIN_REPO}/slides/lecture-1/b.webm"`;
+    const onUncopiedRef = vi.fn();
+
+    expect(
+      rewriteContentUrls(text, {
+        ...deck,
+        targetHasPath: copied(['slides/lecture-1/a.mp4', 'slides/lecture-1/b.webm']),
+        onUncopiedRef,
+      })
+    ).toBe(
+      '"/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1/a.mp4,' +
+        '/content/brown-cs32/content-brown-cs32-cs32-26f/slides/lecture-1/b.webm"'
+    );
+    expect(onUncopiedRef).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -970,6 +970,26 @@ export async function lookupContentAssets(
 }
 
 /**
+ * Every FILE path a classroom's content repo holds, in one query.
+ *
+ * The import's chained-reference rewrite asks "did this file come along?", and
+ * for a target that already had content the answer lives here rather than in
+ * the batch being written. Whole-index rather than a filtered `path IN (…)`
+ * because the caller does not know the candidate paths until it has walked the
+ * content it is about to rewrite — and one index scan of short strings is
+ * cheaper than the two-pass walk that would avoid it.
+ *
+ * Trees are excluded: a directory is not a file a reference can resolve to.
+ */
+export async function listContentAssetPaths(classroomId: string): Promise<Set<string>> {
+  const rows = await getPrisma().contentAsset.findMany({
+    where: { classroom_id: classroomId, type: 'blob' },
+    select: { path: true },
+  });
+  return new Set(rows.map((row: { path: string }) => row.path));
+}
+
+/**
  * A directory's tree object, for the folders that are served whole — themes.
  *
  * Explicitly filtered to `type: 'tree'` rather than just looked up by path: a

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -22,7 +22,11 @@
 import getPrisma from '@classmoji/database';
 import { ContentService } from '../content/ContentService.ts';
 import { contentProxyBase, isCommitRef, pagesContentBase, splitRawRef } from './contentRefs.ts';
-import { lookupContentAssetsBySha, recordContentAssets } from './contentAssets.service.ts';
+import {
+  listContentAssetPaths,
+  lookupContentAssetsBySha,
+  recordContentAssets,
+} from './contentAssets.service.ts';
 import { getGitProvider } from '../git/index.ts';
 import * as contentManifestService from './contentManifest.service.ts';
 import { createWithUniquePageSlug, ensureContentRepo, isPageSlugConflict } from './page.service.ts';
@@ -156,6 +160,22 @@ export interface UrlRewriteContext {
   shaPaths?: ReadonlyMap<string, string>;
   /** Where an unresolvable signed URL is reported. Defaults to console.warn. */
   onWarn?: (detail: string) => void;
+  /**
+   * Will the TARGET repo hold this path once the copy lands? Answers for the
+   * files this copy is writing PLUS whatever the target already had.
+   *
+   * This is the whole gate on the chained-import rewrite below: a reference
+   * into another repo of the SOURCE org is repointed only when the file it
+   * names actually came along. Absent (the default) means no chained rewriting
+   * happens at all, which is exactly the behaviour that predates it.
+   */
+  targetHasPath?: (path: string) => boolean;
+  /**
+   * Called once per chained reference left untouched because its file is not
+   * in the copy. Callers count these and report the total ONCE per import — a
+   * course can carry hundreds, and one warning each would bury everything else.
+   */
+  onUncopiedRef?: (ref: string) => void;
 }
 
 const RAW_HOST = 'https://raw.githubusercontent.com';
@@ -179,6 +199,8 @@ const THEMES_FOLDER = '.slidesthemes';
  *      new content is in.
  *   5. One of OUR signed URLs — `/c/{classroomId}/blob/…`, `/theme/…`,
  *      `/missing/…`.
+ *   6. Any of shapes 1-3 naming a DIFFERENT repo of the SAME org — what a repo
+ *      that was ITSELF created by an earlier import still holds. See below.
  *
  * The first four are the same thing with different prefixes: swap the source
  * repo's prefix for the target's. The fifth cannot be copied at all. A signed
@@ -196,6 +218,28 @@ const THEMES_FOLDER = '.slidesthemes';
  * whenever that item was imported un-renamed; a renamed cross-referenced item
  * is a documented residual.
  *
+ * CHAINED IMPORTS (shape 6). An import's source can itself be an import's
+ * target, and a copy carries its references along verbatim. Content that went
+ * A → B → C arrives at C still naming repo A, two hops back — which the passes
+ * above do not touch, because A is not the immediate source. The FILES came
+ * along at every hop and sit in C under the same relative path; only the
+ * reference is stale. That is not a cosmetic residual: C's delivery layer
+ * cannot sign another classroom's repo, and the legacy proxy answers 403 to
+ * anyone who is not a member of A's classroom, so every one of those images is
+ * simply gone. (Prod, 2026-09-07: `dartmouth-cs98-26f`, imported from
+ * `content-27w`, itself imported from `content-dartmouth-cs98-26w`, whose decks
+ * all still pointed at the 26W repo.)
+ *
+ * So a reference into ANY repo of the SOURCE org is a candidate, rewritten
+ * exactly like an immediate-source one — item-specific folder first, then
+ * repo-general — but ONLY when the file it names actually came along:
+ * `targetHasPath` must say the path is in this copy or already in the target
+ * repo. THE FILE MUST EXIST. A reference whose file did not come along is left
+ * exactly as it was — repointing it would replace a broken link with a
+ * confidently wrong one — and is reported through `onUncopiedRef` so the
+ * import can say how many it left. The org is never widened: a repo under a
+ * DIFFERENT login belongs to someone else and is untouched, file or no file.
+ *
  * RESIDUALS this does not fix, and cannot from here:
  *
  *   - A recovered `/theme/` reference becomes `.slidesthemes/{name}`, which is
@@ -207,6 +251,8 @@ const THEMES_FOLDER = '.slidesthemes';
  *     theme copy here would not be.
  *   - A cross-item bare path (`pages/lab-9/…`) keeps its folder, for the same
  *     reason and with the same caveat as the URL shapes above.
+ *   - A chained reference whose file is NOT in the copy: counted, reported, and
+ *     left alone, because nothing here can conjure the bytes.
  */
 export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string {
   const rawSourcePrefix = `${RAW_HOST}/${ctx.sourceLogin}/${ctx.sourceRepo}/`;
@@ -239,7 +285,120 @@ export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string
     prefixed
   );
 
-  return rewriteBarePaths(rewritten, ctx);
+  // AFTER the immediate-source passes, so anything they own is already gone —
+  // and so a target-repo URL they just produced is never reconsidered here.
+  const chained = rewriteChainedRepoUrls(rewritten, ctx);
+
+  return rewriteBarePaths(chained, ctx);
+}
+
+/** A repo name inside a URL: one path segment, no URL or markup delimiter. */
+const REPO_SEGMENT = `[^/\\s"'()<>]+`;
+
+/** Everything after the repo, up to the first delimiter. */
+const URL_TAIL = `[^\\s"'()<>]*`;
+
+/**
+ * Shape 6: the same three URL shapes, naming another repo of the SOURCE org.
+ *
+ * Every rewrite is gated on `targetHasPath` — see the shape-6 paragraph above
+ * for why a reference whose file did not come along has to be left alone. With
+ * no predicate this pass does nothing at all, which is how every caller that
+ * has not opted in keeps its old behaviour.
+ *
+ * The SOURCE repo is skipped because the passes above already owned it, and the
+ * TARGET repo is skipped because a reference already pointing at the target is
+ * either their output or correct as it stands — reinterpreting it would make
+ * this pass' behaviour depend on whether the two classrooms happen to share an
+ * org, which is exactly the kind of asymmetry that hides bugs.
+ */
+function rewriteChainedRepoUrls(text: string, ctx: UrlRewriteContext): string {
+  if (!ctx.targetHasPath) return text;
+
+  const rawPattern = new RegExp(
+    `${escapeRegExp(`${RAW_HOST}/${ctx.sourceLogin}/`)}(${REPO_SEGMENT})/(${URL_TAIL})`,
+    'g'
+  );
+  const withRaw = text.replace(rawPattern, (match, repo: string, rest: string) => {
+    if (!isChainedRepo(repo, ctx)) return match;
+    // Same ref handling as the immediate-source raw pass: the ref is consumed
+    // positionally (it may be `refs/heads/main`), and a commit-pinned URL names
+    // history the target repo does not have, so it is never repointed.
+    const split = splitRawRef(rest);
+    if (!split || isCommitRef(split.ref)) return match;
+    const [path, tail] = splitPathTail(split.path);
+    const mapped = mapCopiedPath(path, ctx);
+    if (mapped === null) return reportUncopied(match, ctx);
+    return `${RAW_HOST}/${ctx.targetLogin}/${ctx.targetRepo}/${split.ref}/${mapped}${tail}`;
+  });
+
+  const withPagesCdn = rewriteChainedPlain(
+    withRaw,
+    `https://${ctx.sourceLogin}.github.io`,
+    pagesContentBase(ctx.targetLogin, ctx.targetRepo),
+    ctx
+  );
+
+  return rewriteChainedPlain(
+    withPagesCdn,
+    `/content/${ctx.sourceLogin}`,
+    contentProxyBase(ctx.targetLogin, ctx.targetRepo),
+    ctx
+  );
+}
+
+/**
+ * The two ref-less shapes (Pages CDN, content proxy), which are a base, a repo
+ * segment and a path — so one implementation covers both.
+ */
+function rewriteChainedPlain(
+  text: string,
+  sourceOrgBase: string,
+  targetBase: string,
+  ctx: UrlRewriteContext
+): string {
+  const pattern = new RegExp(`${escapeRegExp(sourceOrgBase)}/(${REPO_SEGMENT})/(${URL_TAIL})`, 'g');
+  return text.replace(pattern, (match, repo: string, rest: string) => {
+    if (!isChainedRepo(repo, ctx)) return match;
+    const [path, tail] = splitPathTail(rest);
+    const mapped = mapCopiedPath(path, ctx);
+    if (mapped === null) return reportUncopied(match, ctx);
+    return `${targetBase}/${mapped}${tail}`;
+  });
+}
+
+/** Another repo of the source org — neither the immediate source nor the target. */
+function isChainedRepo(repo: string, ctx: UrlRewriteContext): boolean {
+  if (repo === ctx.sourceRepo) return false;
+  return !(ctx.sourceLogin === ctx.targetLogin && repo === ctx.targetRepo);
+}
+
+/**
+ * A path in some other repo of the org → where it lands in the TARGET, or null
+ * when the copy does not carry it.
+ *
+ * Item-specific first, repo-general second — the same order every other shape
+ * uses. Existence is checked on the DECODED path (the map holds repo paths, not
+ * percent-encoded URL segments) while the rewritten reference keeps the URL's
+ * own encoding: the prefixes being swapped are slugs, which never carry an
+ * escape.
+ */
+function mapCopiedPath(rawPath: string, ctx: UrlRewriteContext): string | null {
+  const has = ctx.targetHasPath;
+  if (!has || !rawPath) return null;
+
+  const itemPrefix = ctx.sourcePath ? `${ctx.sourcePath}/` : '';
+  if (itemPrefix && rawPath.startsWith(itemPrefix)) {
+    const candidate = `${ctx.targetPath}/${rawPath.slice(itemPrefix.length)}`;
+    if (has(decodePathOnce(candidate))) return candidate;
+  }
+  return has(decodePathOnce(rawPath)) ? rawPath : null;
+}
+
+/** Leave a chained reference exactly as it was, and say that it was left. */
+function reportUncopied(match: string, ctx: UrlRewriteContext): string {
+  ctx.onUncopiedRef?.(match);
+  return match;
 }
 
 /**
@@ -386,8 +545,13 @@ function blobShaOf(tail: string): string | null {
 }
 
 function stripQuery(value: string): string {
+  return splitPathTail(value)[0];
+}
+
+/** `path?query#hash` → the path and the tail, so a rewrite can re-attach it. */
+function splitPathTail(value: string): [string, string] {
   const cut = value.search(/[?#]/);
-  return cut === -1 ? value : value.slice(0, cut);
+  return cut === -1 ? [value, ''] : [value.slice(0, cut), value.slice(cut)];
 }
 
 function decodePathOnce(value: string): string {
@@ -622,6 +786,33 @@ export async function resolveShaPaths(
   }
 }
 
+/**
+ * "Will the target repo hold this path?", for one import pass.
+ *
+ * The union of what this pass is about to write (staged paths are already
+ * TARGET-shaped — `collectFolderFiles` remaps them on read) and what the target
+ * classroom already had. Both halves matter: the first covers the ordinary
+ * chained import, the second a second import into a classroom that has content
+ * already, including the slides pass seeing the pages this run just committed.
+ *
+ * Best effort on the index — a chained reference is repointed only on a
+ * positive answer, so a failed lookup costs residuals, never a wrong rewrite,
+ * and an import must not fail over a reference it could not tidy up.
+ */
+async function buildTargetPathIndex<Source>(
+  targetClassroomId: string,
+  staged: StagedItem<Source>[]
+): Promise<(path: string) => boolean> {
+  const incoming = new Set(staged.flatMap(item => item.files.map(({ file }) => file.path)));
+  let existing: ReadonlySet<string>;
+  try {
+    existing = await listContentAssetPaths(targetClassroomId);
+  } catch {
+    existing = new Set<string>();
+  }
+  return (path: string) => incoming.has(path) || existing.has(path);
+}
+
 /** Every decoded text a staged item carries, for the sha sweep. */
 function stagedTexts<Source>(items: StagedItem<Source>[]): string[] {
   return items.flatMap(item =>
@@ -704,6 +895,15 @@ export const importClassroomContent = async (
   const commitMessage = `Import content from ${source.slug}`;
   let createdAny = false;
 
+  // Chained references left alone because their file is not in the copy.
+  // Counted across BOTH passes and reported once at the end: a course can carry
+  // hundreds of them, and one warning each would push everything else out of
+  // the capped warning list.
+  let uncopiedRefs = 0;
+  const onUncopiedRef = (): void => {
+    uncopiedRefs++;
+  };
+
   // ── Pages ──
   if (wantPages) {
     try {
@@ -715,6 +915,7 @@ export const importClassroomContent = async (
         warn,
         idMap: summary.page_id_map,
         onProgress: opts.onProgress,
+        onUncopiedRef,
       });
       summary.pages = created;
       if (created > 0) createdAny = true;
@@ -740,12 +941,24 @@ export const importClassroomContent = async (
         warn,
         idMap: summary.slide_id_map,
         onProgress: opts.onProgress,
+        onUncopiedRef,
       });
       summary.slides = created;
       if (created > 0) createdAny = true;
     } catch (error: unknown) {
       warn('slides', `slide import failed: ${errText(error)}`);
     }
+  }
+
+  // One line for the whole import, so the residuals are visible without being
+  // deafening. They are broken links either way; what this says is that the
+  // import saw them and declined to guess.
+  if (uncopiedRefs > 0) {
+    const detail =
+      `left ${uncopiedRefs} reference(s) into another ${source.login} repository untouched — ` +
+      `those files are not in this copy, so repointing them would have invented a path`;
+    console.warn(`[contentImport] ${detail}`);
+    warn('content', detail);
   }
 
   // ── Manifest refresh (once, non-fatal — mirrors create/delete flows) ──
@@ -774,6 +987,7 @@ async function importPages({
   warn,
   idMap,
   onProgress,
+  onUncopiedRef,
 }: {
   source: RepoContext;
   target: RepoContext;
@@ -782,6 +996,7 @@ async function importPages({
   warn: WarnFn;
   idMap: Record<string, string>;
   onProgress?: ContentProgressFn;
+  onUncopiedRef?: (ref: string) => void;
 }): Promise<number> {
   const sourcePages = await getPrisma().page.findMany({
     where: { classroom_id: source.classroomId },
@@ -862,6 +1077,9 @@ async function importPages({
     ...stagedTexts(staged),
     ...staged.map(item => item.source.header_image_url ?? ''),
   ]);
+  // Gates the chained-import rewrite: a reference into another repo of the
+  // source org is repointed only if that file is actually here.
+  const targetHasPath = await buildTargetPathIndex(target.classroomId, staged);
 
   const written = staged.map(item => ({
     item,
@@ -873,6 +1091,8 @@ async function importPages({
       targetRepo: target.repo,
       targetPath: item.targetContentPath,
       shaPaths,
+      targetHasPath,
+      onUncopiedRef,
     }),
   }));
 
@@ -929,6 +1149,8 @@ async function importPages({
                   targetRepo: target.repo,
                   targetPath: item.targetContentPath,
                   shaPaths,
+                  targetHasPath,
+                  onUncopiedRef,
                 })
               : item.source.header_image_url,
             header_image_position: item.source.header_image_position,
@@ -967,6 +1189,7 @@ async function importSlides({
   warn,
   idMap,
   onProgress,
+  onUncopiedRef,
 }: {
   source: RepoContext;
   target: RepoContext;
@@ -975,6 +1198,7 @@ async function importSlides({
   warn: WarnFn;
   idMap: Record<string, string>;
   onProgress?: ContentProgressFn;
+  onUncopiedRef?: (ref: string) => void;
 }): Promise<number> {
   const sourceSlides = await getPrisma().slide.findMany({
     where: { classroom_id: source.classroomId },
@@ -1046,6 +1270,8 @@ async function importSlides({
   // Repoint source-repo asset references at the copied files (deck.json +
   // index.html are rewritten in lockstep, keeping the pair consistent).
   const shaPaths = await resolveShaPaths(source.classroomId, stagedTexts(staged));
+  // Same gate as the page pass — see buildTargetPathIndex.
+  const targetHasPath = await buildTargetPathIndex(target.classroomId, staged);
 
   const files = staged.flatMap(item =>
     rewriteDecodedFiles(item.files, {
@@ -1056,6 +1282,8 @@ async function importSlides({
       targetRepo: target.repo,
       targetPath: item.targetContentPath,
       shaPaths,
+      targetHasPath,
+      onUncopiedRef,
     })
   );
 

--- a/packages/services/src/classmoji/contentImport.service.ts
+++ b/packages/services/src/classmoji/contentImport.service.ts
@@ -253,6 +253,15 @@ const THEMES_FOLDER = '.slidesthemes';
  *     reason and with the same caveat as the URL shapes above.
  *   - A chained reference whose file is NOT in the copy: counted, reported, and
  *     left alone, because nothing here can conjure the bytes.
+ *   - The chained gate is PATH EXISTENCE, not content identity. It asks whether
+ *     the target holds a file at that path, never whether it is the SAME file.
+ *     For content that arrived by import — the case this exists for — the two
+ *     coincide, because the copy is what put the path there. For a HAND-authored
+ *     cross-repo reference that happens to collide with a path the copy carries,
+ *     they do not: it is repointed at a different file with the same name. The
+ *     alternative is comparing shas across two repos on the rewrite path, and
+ *     landing a same-named asset where a 403 used to be is the better end of
+ *     that trade.
  */
 export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string {
   const rawSourcePrefix = `${RAW_HOST}/${ctx.sourceLogin}/${ctx.sourceRepo}/`;
@@ -293,10 +302,18 @@ export function rewriteContentUrls(text: string, ctx: UrlRewriteContext): string
 }
 
 /** A repo name inside a URL: one path segment, no URL or markup delimiter. */
-const REPO_SEGMENT = `[^/\\s"'()<>]+`;
+const REPO_SEGMENT = `[^/,\\s"'()<>]+`;
 
-/** Everything after the repo, up to the first delimiter. */
-const URL_TAIL = `[^\\s"'()<>]*`;
+/**
+ * Everything after the repo, up to the first delimiter.
+ *
+ * A COMMA ends it. `srcset` and `data-background-video` hold comma-separated
+ * lists of these references, and a class that swallowed the comma would match
+ * the whole list as one reference — a path no existence check can recognise, so
+ * every entry after the first would be left behind AND counted as a residual.
+ * Repo paths do not carry commas; lists of them do.
+ */
+const URL_TAIL = `[^,\\s"'()<>]*`;
 
 /**
  * Shape 6: the same three URL shapes, naming another repo of the SOURCE org.
@@ -327,11 +344,13 @@ function rewriteChainedRepoUrls(text: string, ctx: UrlRewriteContext): string {
     const split = splitRawRef(rest);
     if (!split || isCommitRef(split.ref)) return match;
     const [path, tail] = splitPathTail(split.path);
+    if (!path) return match;
     const mapped = mapCopiedPath(path, ctx);
     if (mapped === null) return reportUncopied(match, ctx);
     return `${RAW_HOST}/${ctx.targetLogin}/${ctx.targetRepo}/${split.ref}/${mapped}${tail}`;
   });
 
+  // The CDN shape carries its own host, so it is unambiguous wherever it sits.
   const withPagesCdn = rewriteChainedPlain(
     withRaw,
     `https://${ctx.sourceLogin}.github.io`,
@@ -339,11 +358,24 @@ function rewriteChainedRepoUrls(text: string, ctx: UrlRewriteContext): string {
     ctx
   );
 
+  // The proxy shape is a root-relative path and has to be ANCHORED on a value
+  // boundary, like `rewriteBarePaths`. Unanchored it matches the tail of any
+  // URL that happens to contain the same segments — a foreign
+  // `https://example.com/content/{login}/anything/…` is somebody else's path,
+  // not our proxy, and rewriting it would point it at our repo.
+  //
+  // `,` and `;` ARE boundaries here, unconditionally, where `rewriteBarePaths`
+  // allows them only within one repo. The two are anchoring different things:
+  // a bare path is a folder name anyone's query string may contain, while
+  // `/content/{sourceLogin}/{repo}/` names our proxy and this org. What the
+  // comma buys is the same either way — `srcset` and comma-separated video
+  // lists put one immediately before a reference.
   return rewriteChainedPlain(
     withPagesCdn,
     `/content/${ctx.sourceLogin}`,
     contentProxyBase(ctx.targetLogin, ctx.targetRepo),
-    ctx
+    ctx,
+    `(^|["'(,;\\s>])`
   );
 }
 
@@ -355,21 +387,37 @@ function rewriteChainedPlain(
   text: string,
   sourceOrgBase: string,
   targetBase: string,
-  ctx: UrlRewriteContext
+  ctx: UrlRewriteContext,
+  lead = '()'
 ): string {
-  const pattern = new RegExp(`${escapeRegExp(sourceOrgBase)}/(${REPO_SEGMENT})/(${URL_TAIL})`, 'g');
-  return text.replace(pattern, (match, repo: string, rest: string) => {
+  const pattern = new RegExp(
+    `${lead}${escapeRegExp(sourceOrgBase)}/(${REPO_SEGMENT})/(${URL_TAIL})`,
+    'g'
+  );
+  return text.replace(pattern, (match, before: string, repo: string, rest: string) => {
     if (!isChainedRepo(repo, ctx)) return match;
     const [path, tail] = splitPathTail(rest);
+    // `…/{repo}/` with nothing after it names no file. It is a base, not a
+    // reference — leave it, and do NOT count it as a residual.
+    if (!path) return match;
     const mapped = mapCopiedPath(path, ctx);
     if (mapped === null) return reportUncopied(match, ctx);
-    return `${targetBase}/${mapped}${tail}`;
+    return `${before}${targetBase}/${mapped}${tail}`;
   });
 }
 
+/**
+ * The folder names a content repo keeps at its root. None of them is a repo.
+ *
+ * A malformed reference that dropped its repo segment — `/content/{login}/
+ * slides/intro/x.png` — otherwise parses as repo `slides` with the folder
+ * eaten, and the leftover `intro/x.png` is a path no import ever meant.
+ */
+const CONTENT_ROOTS = new Set(['pages', 'slides', THEMES_FOLDER]);
+
 /** Another repo of the source org — neither the immediate source nor the target. */
 function isChainedRepo(repo: string, ctx: UrlRewriteContext): boolean {
-  if (repo === ctx.sourceRepo) return false;
+  if (repo === ctx.sourceRepo || CONTENT_ROOTS.has(repo)) return false;
   return !(ctx.sourceLogin === ctx.targetLogin && repo === ctx.targetRepo);
 }
 
@@ -452,14 +500,26 @@ function rewriteRawUrls(
  * Skipped when the item's folder does not move: a whole-repo clone copies every
  * path unchanged and passes an empty `sourcePath`, where a prefix rewrite is
  * meaningless.
+ *
+ * `,` and `;` are boundaries ONLY when the copy stays inside ONE repo — the
+ * deck duplicate. What excluding them guards against is a FOREIGN url's query
+ * string (`https://images.example.com/resize?src=pages/lab-1/a.png`), and that
+ * hazard needs the reference to belong to some other repo; where source and
+ * target ARE the same repo, every path that matches is this repo's. What they
+ * buy there is not hypothetical: `srcset="…/a.png 1x,…/b.png 2x"`,
+ * `data-background-video="a.mp4,b.webm"` and `url(&quot;…&quot;)` each put a
+ * comma or a semicolon immediately before a path, and without them every entry
+ * after the first keeps pointing at the ORIGINAL deck's folder.
  */
 function rewriteBarePaths(text: string, ctx: UrlRewriteContext): string {
   if (!ctx.sourcePath || ctx.sourcePath === ctx.targetPath) return text;
 
-  // `=` and `,` are deliberately NOT boundaries: a foreign URL's query string
-  // (`?src=pages/lab-1/a.png`) would otherwise be rewritten inside a link this
-  // import has no business touching.
-  const pattern = new RegExp(`(^|["'(\\s>])${escapeRegExp(ctx.sourcePath)}/`, 'g');
+  const sameRepo = ctx.sourceLogin === ctx.targetLogin && ctx.sourceRepo === ctx.targetRepo;
+  // `=` is deliberately NOT a boundary in either mode: a foreign URL's query
+  // string (`?src=pages/lab-1/a.png`) must never be rewritten inside a link
+  // this copy has no business touching.
+  const boundary = sameRepo ? `["'(,;\\s>]` : `["'(\\s>]`;
+  const pattern = new RegExp(`(^|${boundary})${escapeRegExp(ctx.sourcePath)}/`, 'g');
   return text.replace(pattern, (_match, lead: string) => `${lead}${ctx.targetPath}/`);
 }
 

--- a/packages/services/src/content/ContentService.ts
+++ b/packages/services/src/content/ContentService.ts
@@ -1475,7 +1475,12 @@ export class ContentService {
    * @param {string} options.sourcePath - Source folder path
    * @param {string} options.destPath - Destination folder path
    * @param {string} [options.message] - Commit message
-   * @returns {Promise<{ copied: number }>}
+   * @returns {Promise<{ copied: number, paths: string[] }>}
+   *
+   * `paths` are the DESTINATION paths written, recursively. The caller needs
+   * them to decide what the copy actually carries: a duplicated deck's HTML can
+   * reference a file by way of another repo, and repointing such a reference at
+   * this copy is only correct when the file is in it.
    */
   static async copyFolder({
     gitOrganization,
@@ -1489,12 +1494,13 @@ export class ContentService {
     sourcePath: string;
     destPath: string;
     message?: string;
-  }): Promise<{ copied: number }> {
+  }): Promise<{ copied: number; paths: string[] }> {
     const octokit = await getOctokit(gitOrganization);
 
     // Get all files in source folder
     const sourceFiles = await this.listFolder({ gitOrganization, repo, path: sourcePath });
     let copied = 0;
+    const paths: string[] = [];
 
     for (const item of sourceFiles) {
       if (item.type === 'file') {
@@ -1519,6 +1525,7 @@ export class ContentService {
         });
 
         copied++;
+        paths.push(newPath);
       } else if (item.type === 'dir') {
         // Recursively copy subdirectories
         const relativePath = item.path.slice(sourcePath.length).replace(/^\//, '');
@@ -1530,10 +1537,11 @@ export class ContentService {
           message,
         });
         copied += result.copied;
+        paths.push(...result.paths);
       }
     }
 
-    return { copied };
+    return { copied, paths };
   }
 
   /**

--- a/packages/services/src/content/__tests__/ContentService.test.ts
+++ b/packages/services/src/content/__tests__/ContentService.test.ts
@@ -921,3 +921,54 @@ describe('getBlobContent', () => {
     ).rejects.toThrow('Server error');
   });
 });
+
+/**
+ * copyFolder reports the DESTINATION paths it wrote, recursively.
+ *
+ * The count alone was never enough: the deck duplicate has to decide whether a
+ * reference into another repo names a file the copy actually carries, and that
+ * question is asked per path. A recursion that counted subdirectories but
+ * dropped their paths would answer "not copied" for every nested asset and
+ * leave the whole images folder pointing at the original deck.
+ */
+describe('copyFolder', () => {
+  it('returns every destination path it wrote, nested folders included', async () => {
+    const repo = 'copyfolder-paths';
+    requestMock.mockImplementation(async (route: string, params: RequestParams) => {
+      if (route === 'GET /repos/{owner}/{repo}/contents/{path}') {
+        switch (params.path) {
+          case 'slides/intro':
+            return {
+              data: [
+                { name: 'index.html', path: 'slides/intro/index.html', type: 'file', sha: 'a' },
+                { name: 'images', path: 'slides/intro/images', type: 'dir', sha: 'b' },
+              ],
+            };
+          case 'slides/intro/images':
+            return {
+              data: [{ name: 'x.png', path: 'slides/intro/images/x.png', type: 'file', sha: 'c' }],
+            };
+          default:
+            return { data: { content: 'Ym9keQ==', sha: 'blob' } };
+        }
+      }
+      if (route === 'PUT /repos/{owner}/{repo}/contents/{path}') {
+        return { data: { content: { sha: 'written' }, commit: { sha: 'commit' } } };
+      }
+      throw new Error(`unexpected route ${route}`);
+    });
+
+    const result = await ContentService.copyFolder({
+      gitOrganization,
+      repo,
+      sourcePath: 'slides/intro',
+      destPath: 'slides/intro-copy',
+    });
+
+    expect(result.copied).toBe(2);
+    expect([...result.paths].sort()).toEqual([
+      'slides/intro-copy/images/x.png',
+      'slides/intro-copy/index.html',
+    ]);
+  });
+});

--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -88,6 +88,16 @@ export type CloneContentRepoResult =
       rewritten: number;
       /** Files in the pushed tree (excluding .git). */
       files: number;
+      /**
+       * Every repo path the push put in the target, POSIX-separated.
+       *
+       * Handed back because the URL rewrite does not end with the tree: the
+       * page ROWS carry a `header_image_url` that needs the same chained-import
+       * treatment, and that rewrite runs after this returns. It is the same set
+       * this helper gated its own rewrites on, so both halves of an import
+       * answer "did that file come along?" identically.
+       */
+      copied: ReadonlySet<string>;
       skipped?: never;
     }
   | {
@@ -95,6 +105,7 @@ export type CloneContentRepoResult =
       pushed: false;
       rewritten: number;
       files: number;
+      copied?: never;
       skipped: CloneSkipReason;
     };
 
@@ -187,7 +198,7 @@ function rewriteAssetUrls({
   root: string;
   source: ContentRepoCoordinates;
   target: ContentRepoCoordinates;
-}): { rewritten: number; files: number } {
+}): { rewritten: number; files: number; copied: ReadonlySet<string> } {
   const { rewriteContentUrls, isTextContentPath } = ClassmojiService.contentImport;
   const files = listFilesRecursive(root);
   // Repo-relative and POSIX-separated, which is how a reference spells a path.
@@ -242,7 +253,7 @@ function rewriteAssetUrls({
     });
   }
 
-  return { rewritten, files: files.length };
+  return { rewritten, files: files.length, copied };
 }
 
 /**
@@ -320,7 +331,7 @@ export const cloneContentRepo = async (
     }
     fs.rmSync(path.join(localPath, MANIFEST_PATH), { force: true });
 
-    const { rewritten, files } = rewriteAssetUrls({ root: localPath, source, target });
+    const { rewritten, files, copied } = rewriteAssetUrls({ root: localPath, source, target });
     if (files === 0) {
       logger.warn('content import: nothing left to push after pruning', {
         repo: `${source.orgLogin}/${source.repo}`,
@@ -360,7 +371,7 @@ export const cloneContentRepo = async (
       rewritten,
     });
 
-    return { pushed: true, rewritten, files };
+    return { pushed: true, rewritten, files, copied };
   } finally {
     if (fs.existsSync(localPath)) {
       fs.rmSync(localPath, { recursive: true, force: true });

--- a/packages/tasks/src/helpers/cloneContentRepo.ts
+++ b/packages/tasks/src/helpers/cloneContentRepo.ts
@@ -171,6 +171,13 @@ function listFilesRecursive(dir: string): string[] {
  * the org/repo segments of a URL actually change. The per-item path arguments
  * are therefore passed as the same value; the helper's item-specific pass
  * becomes a no-op and its repo-general pass does all the work.
+ *
+ * `targetHasPath` reads the pruned working tree, and on this path that IS the
+ * answer: what is pushed is the whole tree, force-pushed over the target's
+ * `main`, so a file is in the target exactly when it is on disk here. It gates
+ * the chained-import rewrite — a source repo that was itself imported still
+ * names the repo it came from, and those references are repointed only where
+ * the bytes actually came along. Everything else is counted and left alone.
  */
 function rewriteAssetUrls({
   root,
@@ -183,6 +190,13 @@ function rewriteAssetUrls({
 }): { rewritten: number; files: number } {
   const { rewriteContentUrls, isTextContentPath } = ClassmojiService.contentImport;
   const files = listFilesRecursive(root);
+  // Repo-relative and POSIX-separated, which is how a reference spells a path.
+  const copied = new Set(files.map(file => path.relative(root, file).split(path.sep).join('/')));
+  const targetHasPath = (candidate: string): boolean => copied.has(candidate);
+  let uncopiedRefs = 0;
+  const onUncopiedRef = (): void => {
+    uncopiedRefs++;
+  };
   let rewritten = 0;
 
   for (const file of files) {
@@ -210,10 +224,22 @@ function rewriteAssetUrls({
       targetLogin: target.orgLogin,
       targetRepo: target.repo,
       targetPath: '',
+      targetHasPath,
+      onUncopiedRef,
     });
     if (updated === original) continue;
     fs.writeFileSync(file, updated, 'utf8');
     rewritten++;
+  }
+
+  // One line for the whole copy: these are already-broken links the import
+  // declined to guess at, and a course can carry hundreds of them.
+  if (uncopiedRefs > 0) {
+    logger.warn('content import: left chained references to another repo in the org untouched', {
+      refs: uncopiedRefs,
+      org: source.orgLogin,
+      sourceRepo: source.repo,
+    });
   }
 
   return { rewritten, files: files.length };

--- a/packages/tasks/src/workflows/__tests__/classroomImport.pageRows.test.ts
+++ b/packages/tasks/src/workflows/__tests__/classroomImport.pageRows.test.ts
@@ -201,3 +201,78 @@ describe('importPageRows', () => {
     expect(writer.warnings).toEqual([]);
   });
 });
+
+/**
+ * `header_image_url` is the one reference that does NOT live in the pushed
+ * tree, so the clone's own rewrite pass never sees it. Without the copied-path
+ * set and the residual counter reaching this column, a header image that a
+ * chained import left pointing two repos back stayed pointing there — the tree
+ * repaired, the row not.
+ */
+describe('importPageRows: header_image_url rewriting', () => {
+  const withHeader = { ...sourcePage('src-1', 'Lab 1'), header_image_url: 'pages/lab-1/hero.png' };
+
+  beforeEach(() => {
+    mocks.pageFindMany.mockResolvedValue([withHeader]);
+  });
+
+  it('hands the rewriter the clone’s copied set and a residual counter', async () => {
+    const writer = makeWriter();
+    const copied = new Set(['pages/lab-1/hero.png']);
+
+    await importPageRows({
+      prisma: prisma as unknown as Args['prisma'],
+      job: job as unknown as Args['job'],
+      writer: writer as unknown as Args['writer'],
+      source: REPO,
+      target: REPO,
+      copied,
+    });
+
+    const [ref, ctx] = mocks.rewriteContentUrls.mock.calls[0] as [
+      string,
+      { targetHasPath?: (p: string) => boolean; onUncopiedRef?: (r: string) => void },
+    ];
+    expect(ref).toBe('pages/lab-1/hero.png');
+    // The SAME answer the clone gated its file rewrites on, not a fresh guess.
+    expect(ctx.targetHasPath?.('pages/lab-1/hero.png')).toBe(true);
+    expect(ctx.targetHasPath?.('pages/lab-9/gone.png')).toBe(false);
+    expect(typeof ctx.onUncopiedRef).toBe('function');
+  });
+
+  it('reports uncopied header references ONCE, not once per page', async () => {
+    mocks.pageFindMany.mockResolvedValue([
+      withHeader,
+      { ...sourcePage('src-2', 'Lab 2'), header_image_url: 'pages/lab-2/hero.png' },
+    ]);
+    // Stand in for the real rewriter leaving a chained reference alone.
+    mocks.rewriteContentUrls.mockImplementation((...a: unknown[]) => {
+      (a[1] as { onUncopiedRef?: (r: string) => void }).onUncopiedRef?.('ref');
+      return a[0];
+    });
+    const writer = makeWriter();
+
+    await importPageRows({
+      prisma: prisma as unknown as Args['prisma'],
+      job: job as unknown as Args['job'],
+      writer: writer as unknown as Args['writer'],
+      source: REPO,
+      target: REPO,
+      copied: new Set<string>(),
+    });
+
+    const residual = writer.warnings.filter(w => w.includes('header image reference'));
+    expect(residual).toHaveLength(1);
+    expect(residual[0]).toContain('left 2 header image reference(s)');
+  });
+
+  it('omits the predicate entirely when no copied set is given', async () => {
+    // No set means the caller cannot say what the copy carries, and the
+    // rewriter must then do no chained rewriting at all rather than guess.
+    const writer = makeWriter();
+    await run(writer);
+
+    const [, ctx] = mocks.rewriteContentUrls.mock.calls[0] as [string, { targetHasPath?: unknown }];
+    expect(ctx.targetHasPath).toBeUndefined();
+  });
+});

--- a/packages/tasks/src/workflows/classroomImport.ts
+++ b/packages/tasks/src/workflows/classroomImport.ts
@@ -496,7 +496,14 @@ export const importContentTask = task({
 
     const counts = { pages: 0, slides: 0 };
     if (wantPages) {
-      counts.pages = await importPageRows({ prisma, job, writer, source, target });
+      counts.pages = await importPageRows({
+        prisma,
+        job,
+        writer,
+        source,
+        target,
+        copied: clone.copied,
+      });
     }
     if (wantSlides) {
       counts.slides = await importSlideRows({ prisma, job, writer });
@@ -565,12 +572,21 @@ export async function importPageRows({
   writer,
   source,
   target,
+  copied,
 }: {
   prisma: PrismaClient;
   job: LoadedImportJob;
   writer: ProgressWriter;
   source: { orgLogin: string; repo: string };
   target: { orgLogin: string; repo: string };
+  /**
+   * Every repo path the clone pushed — what `header_image_url` is checked
+   * against for the chained-import rewrite. The tree and the rows have to
+   * answer "did that file come along?" the same way, so this is the SAME set
+   * the clone gated its own file rewrites on. Absent simply means no chained
+   * rewriting on this column.
+   */
+  copied?: ReadonlySet<string>;
 }): Promise<number> {
   const { rewriteContentUrls } = ClassmojiService.contentImport;
   const { createWithUniquePageSlug, isPageSlugConflict } = ClassmojiService.page;
@@ -585,6 +601,12 @@ export async function importPageRows({
   let done = already.size;
   let created = 0;
   const warnings: string[] = [];
+  // Chained header-image references left alone because the file is not in the
+  // copy. Reported once for the whole pass, never once per page.
+  let uncopiedRefs = 0;
+  const onUncopiedRef = (): void => {
+    uncopiedRefs++;
+  };
   for (const page of sourcePages) {
     // Resume: this page's row already exists from an earlier attempt. It still
     // counts as done — it IS imported — and it is not warned about.
@@ -616,6 +638,13 @@ export async function importPageRows({
                   targetLogin: target.orgLogin,
                   targetRepo: target.repo,
                   targetPath: '',
+                  // A header image is a reference like any other, and a page
+                  // whose classroom arrived by import can hold one naming the
+                  // repo two hops back. Without these it is the one reference
+                  // the copy leaves behind — the tree got rewritten, the row
+                  // did not.
+                  ...(copied ? { targetHasPath: (p: string) => copied.has(p) } : {}),
+                  onUncopiedRef,
                 })
               : page.header_image_url,
             header_image_position: page.header_image_position,
@@ -640,6 +669,17 @@ export async function importPageRows({
       done++;
       writer.patch({ phase: 'pages', status: 'running', done, total });
     }
+  }
+
+  if (uncopiedRefs > 0) {
+    logger.warn('content import: uncopied header image references', {
+      refs: uncopiedRefs,
+      org: source.orgLogin,
+    });
+    warnings.push(
+      `pages: left ${uncopiedRefs} header image reference(s) into another ${source.orgLogin} ` +
+        `repository untouched — those files are not in this copy`
+    );
   }
 
   writer.addWarnings(warnings);


### PR DESCRIPTION
## The bug

A content repo can itself be an import's target, and a copy carries its references along verbatim. `rewriteContentUrls` only ever recognised the **immediate** source repo, so content that went A → B → C arrived at C still naming repo A, two hops back.

Found in prod 2026-09-07: classroom `dartmouth-cs98-26f` was imported from `content-27w`, which had itself been imported from `content-dartmouth-cs98-26w`. Every deck's `index.html` still read `/content/dartmouth-cs98/content-dartmouth-cs98-26w/slides/<deck>/images/x.png`.

The image *files* had been copied into the target at each hop — same deck folder, same relative path. Only the references were stale. That is not a cosmetic residual: the delivery Worker cannot sign another classroom's repo, and the legacy proxy answers 403 to anyone who is not a member of the 26W classroom, so every one of those images was simply gone for students.

## The rule

A reference into **any** repo of the SOURCE org (all three URL shapes — `/content/{login}/{repo}/…`, `raw.githubusercontent.com/{login}/{repo}/{ref}/…`, `{login}.github.io/{repo}/…`) is now a candidate, rewritten exactly like an immediate-source reference: item-specific folder first, then repo-general, preserving the documented ordering (signed URLs → item-specific → repo-general → bare paths).

Gated on one thing: **the file must exist**. A new `targetHasPath` predicate answers "will the target hold this path once the copy lands?" — the files this copy is writing, plus what the target already had. A reference whose file did **not** come along is left exactly as it was (repointing it would swap a broken link for a confidently wrong one), counted, and reported once per import at warn with the total. The org is never widened: another login's repo is untouched, file or no file. A commit-pinned raw URL is still left alone, as before.

Callers that supply no predicate get exactly the behaviour that predates this.

Wired into all three copy paths:

- `cloneContentRepo` (`packages/tasks`) — the path prod actually runs. The pruned working tree *is* the target's content (it is force-pushed whole), so the tree on disk is the existence answer, with no extra queries.
- `importClassroomContent` (`packages/services`) — the file-by-file importer. Union of the staged batch and the target classroom's asset index (`listContentAssetPaths`, one query per pass, best-effort).
- The deck **duplicate** action (`apps/slides`) — see below.

## Deck duplicate / copyFolder

Affected, and worse than the import was. It rewrote with `content.replaceAll(slide.content_path, newContentPath)`, which reaches inside a URL belonging to another repo — or another org — and rewrites the matching path segment there, turning a reference that at least resolved into one naming a folder that exists nowhere. It also never repointed a chained reference at the copy, even though `copyFolder` had just put those files in the new folder.

It now goes through the same shared rewriter, with `targetHasPath` reading the destination paths `copyFolder` reports (its return is extended from `{ copied }` to `{ copied, paths }`; one caller). Bare-path rewriting is anchored on a value boundary instead of blanket, so foreign URLs are safe. `resolveShaPaths` comes along so a signed URL in the source deck becomes the repo path it names — the stored form the deck loader signs again at render.

## Test steps

`npm run test -w @classmoji/services -- contentImport` — 52 → 66 tests, all passing. New coverage:

- chained `/content/` ref with the file present → rewritten onto the target repo
- same for the `raw.githubusercontent.com` and `{login}.github.io` shapes
- chained ref whose file is **absent** → untouched, one `onUncopiedRef` (and a 3-ref case asserting the count is the real one)
- a different **org's** repo → untouched even when a file by that path is in the copy, and not counted
- item folder rename (dedupe suffix) still correct for chained refs
- chained ref to another item → repo-general rewrite when that path exists
- commit-pinned chained raw URL → untouched
- no `targetHasPath` → no chained rewriting at all
- a ref already naming the TARGET repo → untouched
- whole-repo clone (empty `sourcePath`) → repo-general half fires
- query string preserved; immediate-source + chained + bare in one pass

Full suites: `@classmoji/services` 1609 passed / 13 failed (the known 12 GitLabProvider + 1 classroomMembership, unchanged from baseline), `@classmoji/tasks` 97 passed. Typecheck clean on services (only the same pre-existing GitLabProvider test errors), tasks, content and slides. ESLint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA
