### PR TITLE
fix(slides): keep the services barrel out of the client bundle

### DIFF
--- a/apps/slides/app/routes/$slideId_.thumbnail-source/route.tsx
+++ b/apps/slides/app/routes/$slideId_.thumbnail-source/route.tsx
@@ -59,6 +59,24 @@ import {
   type DeckJson,
   type DeckSlide,
 } from '@classmoji/services/slides';
+/**
+ * Geometry and the readiness attribute come from the shared contract, not from a
+ * constant here: the render task waits for exactly this attribute and renders at
+ * exactly this size, and it cannot import this route.
+ *
+ * From `@classmoji/services/deck-thumbnail-contract` — the pure module — and NOT
+ * off `ClassmojiService.deckThumbnail` on the barrel. This route exports helpers
+ * besides `loader` (`renderTokenFromCookies` and friends, for the unit tests),
+ * so React Router's server-export stripping cannot empty the module: whatever
+ * those helpers reference survives into the CLIENT bundle. Reading the two
+ * constants off the barrel therefore dragged `@classmoji/services`' `index.ts` —
+ * and through it `GitHubProvider` and `node:crypto` — into the browser build,
+ * which failed it outright.
+ */
+import {
+  RENDER_TOKEN_COOKIE,
+  THUMBNAIL_READY_ATTRIBUTE,
+} from '@classmoji/services/deck-thumbnail-contract';
 import {
   deckDeliveryContext,
   publicDeckThemeUrls,
@@ -66,14 +84,6 @@ import {
   resolveDeckAssetsPublic,
   resolveDeliveryThemeUrls,
 } from '~/utils/deckDelivery.server';
-
-/**
- * Geometry and the readiness attribute come from the shared contract in
- * `@classmoji/services`, not from a constant here: the render task waits for
- * exactly this attribute and renders at exactly this size, and it cannot import
- * this route.
- */
-const { RENDER_TOKEN_COOKIE, THUMBNAIL_READY_ATTRIBUTE } = ClassmojiService.deckThumbnail;
 
 /**
  * Never cached, never indexed, never framed. The SAME headers on the refusal

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -11,6 +11,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./deck-thumbnail-contract": "./src/classmoji/deckThumbnail.contract.ts",
     "./flags": "./src/classmoji/repoAnalytics.flags.ts",
     "./form-contract": "./src/classmoji/formContract.ts",
     "./import-progress": "./src/classmoji/importProgress.ts",


### PR DESCRIPTION
`npm run slides:build` has been failing on `staging` since #306:

```
../../packages/services/src/git/GitHubProvider.ts (3:9): "createHmac" is not
exported by "__vite-browser-external", imported by
"../../packages/services/src/git/GitHubProvider.ts".
```

## The leaking chain

```
apps/slides/app/routes/$slideId_.thumbnail-source/route.tsx
  → const { RENDER_TOKEN_COOKIE, THUMBNAIL_READY_ATTRIBUTE } = ClassmojiService.deckThumbnail
  → @classmoji/services (src/index.ts, the barrel)
  → src/classmoji/index.ts → classroom.service.ts / githubClassroomApi.service.ts
  → src/git/index.ts → src/git/GitHubProvider.ts
  → node:crypto (`createHmac`, `timingSafeEqual`)
```

React Router strips `loader`/`action` from the client build and then tree-shakes
what is left. This route exports helpers besides `loader` —
`renderTokenFromCookies`, `refusalDetail`, `firstSlideOnly`, `RENDER_HEADERS`,
`renderRefusal`, all there for `tests/unit/thumbnail-source.spec.ts` — so the
module can never be emptied. `renderTokenFromCookies` compares against
`RENDER_TOKEN_COOKIE`, which held the module-level destructure alive, which held
the barrel alive, which put `GitHubProvider` in the browser graph.

The route's other services imports (`getPrisma`, `ClassmojiService.deckRenderToken`,
`generateDeckHtml`, `loadDeck`) are used only inside `loader` and were already
tree-shaken; `~/utils/deckDelivery.server` is a `.server` module and is dropped.
The constants were the one thing reaching the barrel from module scope.

## The fix

Import the two constants from the pure contract module instead:

- `packages/services/package.json` — new `./deck-thumbnail-contract` export
  subpath, alongside the existing `./form-contract` and `./import-progress`.
- the route — imports `RENDER_TOKEN_COOKIE` / `THUMBNAIL_READY_ATTRIBUTE` from
  `@classmoji/services/deck-thumbnail-contract`.

`deckThumbnail.contract.ts` has no imports at all, which is exactly why it was
split from `deckThumbnail.service.ts` (see that file's header note). #306 reached
it through the barrel and gave the split away; this restores it, and the comment
at the import now says why so it does not regress.

No `package-lock.json` change.

## Verification

- `npm run slides:build` — passes; client bundle greps clean for
  `GitHubProvider` / `getUserOctokit` / `createAppAuth`
- `npm run test -w apps/slides -- tests/unit` — 154 passed
- `apps/slides` `tsc --noEmit` — clean
- eslint + prettier on the touched route — clean
- `npm run web:build` — passes (a shared package was touched)
- `npm run test -w packages/services` — 13 failures, identical to the
  `staging` baseline with this change stashed (GitLabProvider and
  classroomMembership; pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA