### PR TITLE
fix(thumbnails): read the data URI Cloudflare sends, and stop burning renders

### DIFF
--- a/apps/slides/app/routes/$slideId_.thumbnail-source/route.tsx
+++ b/apps/slides/app/routes/$slideId_.thumbnail-source/route.tsx
@@ -106,10 +106,13 @@ export const RENDER_HEADERS: Record<string, string> = {
 /**
  * The ONE refusal this route has.
  *
- * An unknown slide id and a bad token answer byte-for-byte identically, so the
- * response tells a caller nothing about which decks exist. That is only true if
+ * An unknown slide id, a bad token and a deck with no content in the repo all
+ * answer byte-for-byte identically, so the response tells a caller nothing about
+ * which decks exist or which of them have been generated. That is only true if
  * there is a single place that builds it — two `new Response('Forbidden')`
- * literals drift, and the drift is the oracle.
+ * literals drift, and the drift is the oracle. Two THROW SITES is fine and one
+ * BUILDER is the invariant: the missing-content case is caught further down,
+ * once the token has already been verified, and comes back here for its bytes.
  */
 export function renderRefusal(): Response {
   return new Response('Forbidden', { status: 403, headers: RENDER_HEADERS });
@@ -298,7 +301,31 @@ export const loader = async ({
   // per-process with no cross-instance invalidation — a cached deck here would
   // freeze the PREVIOUS save's picture under the CURRENT save's sha, and the
   // task's skip-if-unchanged check would then never render it again.
-  const loaded = await loadDeck(slide, { skipCache: true });
+  //
+  // A deck with NO CONTENT in the repo takes the same refusal as a bad token.
+  // `loadDeck` throws for that, and an uncaught throw here is a 500 carrying a
+  // stack — served to an unauthenticated caller, and one the screenshot service
+  // does not read as a failure either: it goes on waiting for a readiness
+  // attribute that page will never raise, and spends the whole `waitForSelector`
+  // budget arriving at a render we already know cannot happen. The task now
+  // skips these before it calls Browser Run at all; this is the other half of
+  // the same fix, for the deck that loses its content between the two.
+  let loaded: Awaited<ReturnType<typeof loadDeck>>;
+  try {
+    loaded = await loadDeck(slide, { skipCache: true });
+  } catch (error: unknown) {
+    if (!(error instanceof Error) || !error.message.startsWith('Slide content not found')) {
+      throw error;
+    }
+    // SERVER-SIDE ONLY, exactly as the token refusal above. The caller gets the
+    // same bare `Forbidden` from the same builder, so the response still says
+    // nothing about which decks exist or which of them have content.
+    console.warn(
+      `[thumbnail-source] Refused a render for ${slideId}: no content at ${slide.content_path}`
+    );
+    throw renderRefusal();
+  }
+
   const deck = firstSlideOnly(loaded.deck);
 
   // Pinned to the deck's own visibility, exactly as `deckAccessFor` pins every

--- a/apps/slides/tests/unit/thumbnail-source.spec.ts
+++ b/apps/slides/tests/unit/thumbnail-source.spec.ts
@@ -12,9 +12,10 @@
  *   - the RESPONSE HEADERS are identical on the render and on the refusal. A
  *     403 that got cached, or a render that got indexed, is its own small
  *     problem and there is no reason for the two to differ.
- *   - the REFUSAL is one function, so an unknown slide id and a bad token are
- *     byte-identical. Two `new Response('Forbidden')` literals drift, and the
- *     drift is an oracle for which decks exist.
+ *   - the REFUSAL is one function, so an unknown slide id, a bad token and a
+ *     deck with no content in the repo are byte-identical. Two
+ *     `new Response('Forbidden')` literals drift, and the drift is an oracle
+ *     for which decks exist and which have been generated.
  *   - the route is a RESOURCE route: no `default` export, no `ErrorBoundary`.
  *     Either one would put React chrome inside the screenshot.
  *   - the render TOKEN never reaches an access log, and never reaches a
@@ -122,14 +123,44 @@ test.describe('the response headers', () => {
   });
 });
 
-test.describe('an unknown slide and a bad token are the same answer', () => {
-  test('both go through the one refusal', () => {
-    // One condition, one throw. Splitting these — a 404 for an unknown id, a
-    // 403 for a bad token — would tell an unauthenticated caller exactly which
-    // slide ids exist.
+test.describe('an unknown slide, a bad token and a deck with no content are one answer', () => {
+  test('all of them go through the one refusal', () => {
+    // One condition for the two token cases, one throw. Splitting them — a 404
+    // for an unknown id, a 403 for a bad token — would tell an unauthenticated
+    // caller exactly which slide ids exist.
     expect(ROUTE_SOURCE).toContain('if (!slide || !verification.ok)');
-    expect(ROUTE_SOURCE.match(/throw renderRefusal\(\)/g)).toHaveLength(1);
+
+    // TWO throw sites now: the missing-content case is caught further down,
+    // once the token has already been verified. What must stay at ONE is the
+    // BUILDER — a second `status: 403` literal is how the answers start to
+    // differ, and the difference is an oracle for which decks have content.
+    expect(ROUTE_SOURCE.match(/throw renderRefusal\(\)/g)).toHaveLength(2);
     expect(ROUTE_SOURCE.match(/status: 403/g)).toHaveLength(1);
+  });
+
+  test('a deck whose content is missing is refused, not 500ed', () => {
+    // `loadDeck` throws `Slide content not found: …` for a deck that was never
+    // generated, or whose repo this installation cannot read — the ordinary
+    // state of a staging classroom copied from production. Uncaught, that is a
+    // 500 with a stack in the body, served to a caller holding nothing but a
+    // render token; and Browser Rendering does not read it as a failure either,
+    // so it goes on waiting for a readiness attribute that page will never
+    // raise and burns the entire `waitForSelector` budget first.
+    expect(ROUTE_SOURCE).toContain("error.message.startsWith('Slide content not found')");
+    expect(ROUTE_SOURCE).toContain('loaded = await loadDeck(slide, { skipCache: true })');
+
+    // Anything else out of `loadDeck` — a malformed deck, GitHub being down —
+    // still propagates. Swallowing those would turn a real fault into a silent
+    // refusal that reads like a permissions problem.
+    expect(ROUTE_SOURCE).toContain('throw error;');
+  });
+
+  test('the missing-content refusal carries no more detail than the others', () => {
+    // The path and the reason go to the SERVER log; the caller gets the same
+    // bare `Forbidden`, from the same builder.
+    expect(ROUTE_SOURCE).toContain('no content at ${slide.content_path}');
+    expect(ROUTE_SOURCE.match(/console\.warn\(/g)).toHaveLength(2);
+    expect(ROUTE_SOURCE).not.toContain("new Response('Slide content not found'");
   });
 
   test('the refusal is byte-identical every time it is built', async () => {

--- a/packages/tasks/src/helpers/__tests__/browserRun.test.ts
+++ b/packages/tasks/src/helpers/__tests__/browserRun.test.ts
@@ -104,12 +104,52 @@ describe('the request', () => {
     expect(JSON.parse(init.body)).toEqual({
       url: 'https://slides.classmoji.test/deck/thumbnail-source',
       viewport: { width: 1280, height: 720, deviceScaleFactor: 1 },
-      gotoOptions: { waitUntil: 'networkidle0', timeout: 30000 },
-      waitForSelector: { selector: '[data-thumbnail-ready]', timeout: 15000 },
+      gotoOptions: { waitUntil: 'load', timeout: 60000 },
+      waitForSelector: { selector: '[data-thumbnail-ready]', timeout: 30000 },
       screenshotOptions: { type: 'webp', quality: 80, encoding: 'base64' },
       rejectResourceTypes: ['media', 'websocket'],
       cookies: [RENDER_COOKIE],
     });
+  });
+
+  it('budgets for a cold origin and lets the readiness selector be the gate', async () => {
+    // The first staging render timed out with the route answering in 461ms: the
+    // whole 30s went on a Fly machine that had scaled to zero. 60000 is the
+    // spec's `gotoOptions.timeout` MAXIMUM, and `waitForSelector.timeout` may go
+    // to 120000, so both of these are inside what the endpoint accepts.
+    //
+    // `load` rather than `networkidle0` because `[data-thumbnail-ready]` is the
+    // real readiness gate — the page raises it only after its own images and
+    // fonts settle — and `networkidle0` is a weaker gate in front of it that a
+    // lazily loaded image can keep from ever arriving.
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(response(IMAGE_BASE64, { headers: { 'content-type': 'text/plain' } }));
+
+    await screenshotToBase64(request(fetchImpl as unknown as typeof fetch));
+
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.gotoOptions.waitUntil).toBe('load');
+    expect(body.gotoOptions.timeout).toBe(60000);
+    expect(body.gotoOptions.timeout).toBeLessThanOrEqual(60000);
+    expect(body.waitForSelector.timeout).toBe(30000);
+    expect(body.waitForSelector.timeout).toBeLessThanOrEqual(120000);
+  });
+
+  it('lets the caller override both budgets', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(response(IMAGE_BASE64, { headers: { 'content-type': 'text/plain' } }));
+
+    await screenshotToBase64({
+      ...request(fetchImpl as unknown as typeof fetch),
+      navigationTimeoutMs: 45000,
+      readyTimeoutMs: 20000,
+    });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.gotoOptions.timeout).toBe(45000);
+    expect(body.waitForSelector.timeout).toBe(20000);
   });
 
   it('carries the token as a HOST-SCOPED cookie, never as an extra header', async () => {
@@ -213,6 +253,154 @@ describe('reading the response', () => {
       .mockResolvedValue(
         response('<html>gateway error</html>', { headers: { 'content-type': 'text/html' } })
       );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).rejects.toThrow(
+      /not an image/
+    );
+  });
+});
+
+/**
+ * What Cloudflare actually sends: `result` is a `data:` URI, not bare base64.
+ *
+ * This is not a hypothetical tolerance. The first staging renders answered 200
+ * with `"data:image/webp;base64,UklGR…"`, and the two branches failed
+ * differently and both badly — JSON handed the prefix straight to
+ * `Buffer.from(…, 'base64')`, which does not throw on characters it cannot
+ * decode, it skips them, so a short buffer went to the size window and would
+ * have been committed; text refused it as "not an image", which pointed the
+ * investigation at the render route rather than at this file.
+ */
+describe('a data: URI is the shape production sends', () => {
+  const dataUri = (base64: string, mediaType = 'image/webp') =>
+    `data:${mediaType};base64,${base64}`;
+
+  it('strips the prefix off a JSON string result', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(JSON.stringify({ success: true, result: dataUri(IMAGE_BASE64) }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).resolves.toBe(
+      IMAGE_BASE64
+    );
+  });
+
+  it('strips it off the nested `result.screenshot` envelope too', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(JSON.stringify({ success: true, result: { screenshot: dataUri(IMAGE_BASE64) } }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).resolves.toBe(
+      IMAGE_BASE64
+    );
+  });
+
+  it('strips it off a text/plain body, which used to be refused outright', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        response(`${dataUri(IMAGE_BASE64)}\n`, { headers: { 'content-type': 'text/plain' } })
+      );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).resolves.toBe(
+      IMAGE_BASE64
+    );
+  });
+
+  it('reads the prefix case-insensitively, as RFC 2397 allows', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(
+        JSON.stringify({ success: true, result: `DATA:IMAGE/WEBP;BASE64,${IMAGE_BASE64}` }),
+        {
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+    );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).resolves.toBe(
+      IMAGE_BASE64
+    );
+  });
+
+  it('still takes bare base64 — the prefix is optional, not required', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(response(IMAGE_BASE64, { headers: { 'content-type': 'text/plain' } }));
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).resolves.toBe(
+      IMAGE_BASE64
+    );
+  });
+
+  it('refuses a media type we did not ask for', async () => {
+    // `screenshotOptions.type` said webp. A PNG committed at `thumbnail.webp`
+    // is a file whose bytes and whose extension disagree, served to every
+    // classroom that opens the index.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(JSON.stringify({ success: true, result: dataUri(IMAGE_BASE64, 'image/png') }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const error = (await screenshotToBase64(request(fetchImpl as unknown as typeof fetch)).catch(
+      (e: unknown) => e
+    )) as BrowserRunError;
+
+    expect(error).toBeInstanceOf(BrowserRunError);
+    expect(error.message).toMatch(/image\/png/);
+    expect(error.message).toMatch(/image\/webp/);
+    // The endpoint will answer the same way next time.
+    expect(error.retryable).toBe(false);
+  });
+
+  it('measures the size window on the DECODED bytes, not the prefixed string', async () => {
+    // The prefix is 23 characters. Left on, `Buffer.from` drops what it cannot
+    // decode and the count comes out short — which is how an image just over
+    // the floor gets reported as under it, and a corrupt one gets committed.
+    const justOverTheFloor = Buffer.alloc(MIN_IMAGE_BYTES + 16, 7).toString('base64');
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(JSON.stringify({ success: true, result: dataUri(justOverTheFloor) }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).resolves.toBe(
+      justOverTheFloor
+    );
+  });
+
+  it('applies the floor to a data URI as well', async () => {
+    const tooSmall = Buffer.alloc(MIN_IMAGE_BYTES - 1, 7).toString('base64');
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(JSON.stringify({ success: true, result: dataUri(tooSmall) }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).rejects.toThrow(
+      /floor/
+    );
+  });
+
+  it('refuses a data URI whose payload is not base64 at all', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(
+        JSON.stringify({ success: true, result: 'data:image/webp;base64,<html>nope</html>' }),
+        {
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+    );
+    await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).rejects.toThrow(
+      /not an image/
+    );
+  });
+
+  it('refuses a JSON result that is prose rather than an image', async () => {
+    // The JSON branch used to skip validation entirely and hand whatever it
+    // found to the size window.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      response(JSON.stringify({ success: true, result: 'the page could not be rendered' }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    );
     await expect(screenshotToBase64(request(fetchImpl as unknown as typeof fetch))).rejects.toThrow(
       /not an image/
     );

--- a/packages/tasks/src/helpers/browserRun.ts
+++ b/packages/tasks/src/helpers/browserRun.ts
@@ -23,6 +23,17 @@
  * the cost of tolerating the other two is four lines, whereas the cost of
  * getting it wrong is a silently corrupt image committed into a content repo.
  *
+ * And in every one of them the base64 may arrive as a `data:` URI rather than
+ * bare, which is what production actually sends: the first staging renders came
+ * back `{"result": "data:image/webp;base64,UklGR…"}`. That is not a variant to
+ * guess at per branch — `imageFromPayload` is the SINGLE place a payload becomes
+ * an image, so all three shapes strip the prefix, validate what is left, and
+ * take the size window on the same bytes. It has to be stripped rather than
+ * tolerated: `Buffer.from(…, 'base64')` does not fail on a data URI, it silently
+ * skips the characters it cannot read and returns a short buffer — so an
+ * unstripped prefix reads as a plausible image of the wrong length, not as an
+ * error.
+ *
  * ── Failures ───────────────────────────────────────────────────────────────
  * `retryable` is the whole contract this hands its caller. 429 (rate limited,
  * with `Retry-After` in seconds) and 5xx are worth another attempt; 400 and 422
@@ -101,9 +112,16 @@ export interface ScreenshotRequest {
   readySelector: string;
   /** WebP quality, 1-100. */
   quality: number;
-  /** Whole-navigation budget in ms (Browser Run caps `gotoOptions.timeout` at 60000). */
+  /**
+   * Whole-navigation budget in ms. Defaults to 60000, which is also the spec's
+   * `gotoOptions.timeout` MAXIMUM — anything larger is rejected, and the thing
+   * this budget has to absorb is a cold Fly machine, not a slow page.
+   */
   navigationTimeoutMs?: number;
-  /** How long to wait for `readySelector` after navigation, in ms. */
+  /**
+   * How long to wait for `readySelector` after navigation, in ms. Defaults to
+   * 30000; the spec allows up to 120000.
+   */
   readyTimeoutMs?: number;
   /**
    * Cookies the headless browser is seeded with — how the render token travels.
@@ -183,7 +201,27 @@ async function describeFailure(response: Response): Promise<string> {
   return `HTTP ${response.status}`;
 }
 
+/**
+ * Standard base64, plus the line breaks a wrapped encoder inserts — and NOTHING
+ * else, spaces included. Tested BEFORE whitespace is stripped, on purpose: strip
+ * first and `the page could not be rendered` collapses into a run of letters
+ * that matches this pattern perfectly.
+ */
 const BASE64_PATTERN = /^[A-Za-z0-9+/\r\n]+={0,2}$/;
+
+/** The media type we ask for, and the only one a `data:` URI may claim. */
+const SCREENSHOT_MEDIA_TYPE = 'image/webp';
+
+/**
+ * `data:image/webp;base64,` and its siblings, per RFC 2397.
+ *
+ * Case-insensitive and tolerant of spacing because the prefix is written by the
+ * far side and nothing obliges it to be canonical; the SUBTYPE is captured
+ * rather than matched, so a payload that announces itself as something we did
+ * not ask for is refused with the type it claimed instead of being quietly
+ * accepted or quietly mangled.
+ */
+const IMAGE_DATA_URI_PREFIX = /^data:\s*(image\/[A-Za-z0-9.+-]+)\s*;\s*base64\s*,/i;
 
 /**
  * Screenshot one page, returning the image as base64 (what a git blob wants).
@@ -228,16 +266,26 @@ export async function screenshotToBase64(request: ScreenshotRequest): Promise<st
         url: request.url,
         viewport: { width: request.width, height: request.height, deviceScaleFactor: 1 },
         gotoOptions: {
-          waitUntil: 'networkidle0',
-          timeout: request.navigationTimeoutMs ?? 30000,
+          // `load`, NOT `networkidle0`. The readiness gate here is
+          // `[data-thumbnail-ready]`, which the page raises only after its
+          // images and fonts have settled — so `networkidle0` is a second,
+          // weaker gate in front of the real one, and one that a lazily loaded
+          // image or a cold token mint can keep from ever arriving. `load`
+          // hands off to `waitForSelector`, which is the check that means
+          // something.
+          waitUntil: 'load',
+          // The spec maximum. The budget is not for the page — the route
+          // answers in ~460ms once it is reached — it is for a Fly machine
+          // that has scaled to zero and has to boot before it can answer.
+          timeout: request.navigationTimeoutMs ?? 60000,
         },
         waitForSelector: {
           selector: request.readySelector,
-          timeout: request.readyTimeoutMs ?? 15000,
+          timeout: request.readyTimeoutMs ?? 30000,
         },
         screenshotOptions: { type: 'webp', quality: request.quality, encoding: 'base64' },
         // Nothing on a slide is a video or a socket, and both are ways for
-        // `networkidle0` to never arrive.
+        // `load` to sit waiting on a connection that never closes.
         rejectResourceTypes: ['media', 'websocket'],
         ...(request.cookies?.length ? { cookies: request.cookies } : {}),
       }),
@@ -272,23 +320,62 @@ export async function screenshotToBase64(request: ScreenshotRequest): Promise<st
     if (!image) {
       throw new BrowserRunError('Browser Run returned no image', { status: 200, retryable: false });
     }
-    return withinSizeWindow(image);
+    return imageFromPayload(image);
   }
 
   if (contentType.startsWith('image/')) {
     // `encoding: 'base64'` was asked for, so this is the endpoint disagreeing
     // with us rather than an error — take the bytes and encode them ourselves.
-    return withinSizeWindow(Buffer.from(await response.arrayBuffer()).toString('base64'));
+    return imageFromPayload(Buffer.from(await response.arrayBuffer()).toString('base64'));
   }
 
-  const text = (await response.text()).trim();
-  if (!text || !BASE64_PATTERN.test(text)) {
+  return imageFromPayload(await response.text());
+}
+
+/**
+ * A response payload becomes an image here, or it does not become one at all.
+ *
+ * One function for all three response shapes, because the failure this guards
+ * against is SILENT. The JSON branch used to hand `result` straight to the size
+ * window; when Cloudflare started answering `data:image/webp;base64,…` that made
+ * `Buffer.from` skip the 23 characters of prefix it could not decode and return
+ * a buffer several bytes short — still inside the size window, still committed,
+ * and corrupt. The text branch failed more honestly (`BASE64_PATTERN` has no
+ * `:` in it) but reported the data URI as "not an image", which sent the
+ * investigation at the render route rather than at the client.
+ *
+ * Order matters: strip, check the media type, validate, and only then measure.
+ * The size window has to see the DECODED bytes — which is what it measures,
+ * `Buffer.from(base64, 'base64').length` — and those bytes are only the image's
+ * once the prefix is gone.
+ */
+function imageFromPayload(payload: string): string {
+  const trimmed = payload.trim();
+  const prefix = IMAGE_DATA_URI_PREFIX.exec(trimmed);
+
+  if (prefix) {
+    const mediaType = prefix[1].toLowerCase();
+    // We asked for WebP. A payload announcing anything else is the endpoint
+    // having ignored `screenshotOptions.type`, and committing a PNG under a
+    // `.webp` name would serve every classroom a file whose bytes and whose
+    // extension disagree.
+    if (mediaType !== SCREENSHOT_MEDIA_TYPE) {
+      throw new BrowserRunError(
+        `Browser Run returned ${mediaType}, not the ${SCREENSHOT_MEDIA_TYPE} that was asked for`,
+        { status: 200, retryable: false }
+      );
+    }
+  }
+
+  const encoded = (prefix ? trimmed.slice(prefix[0].length) : trimmed).trim();
+  if (!encoded || !BASE64_PATTERN.test(encoded)) {
     throw new BrowserRunError('Browser Run returned a body that is not an image', {
       status: 200,
       retryable: false,
     });
   }
-  return withinSizeWindow(text.replace(/\s+/g, ''));
+
+  return withinSizeWindow(encoded.replace(/\s+/g, ''));
 }
 
 /**
@@ -302,6 +389,12 @@ export async function screenshotToBase64(request: ScreenshotRequest): Promise<st
  * thumbnail it already had and nothing is written.
  *
  * Not retryable: the same page will produce the same bytes on the next attempt.
+ *
+ * The window is in DECODED bytes, not base64 characters — a base64 count would
+ * be ~4/3 of the truth and both thresholds would sit in the wrong place. Reached
+ * only through `imageFromPayload`, so `base64` is validated and prefix-free by
+ * the time it arrives; handed a `data:` URI directly, `Buffer.from` would drop
+ * the prefix's characters and undercount.
  */
 function withinSizeWindow(base64: string): string {
   const bytes = Buffer.from(base64, 'base64').length;

--- a/packages/tasks/src/workflows/__tests__/deckThumbnail.test.ts
+++ b/packages/tasks/src/workflows/__tests__/deckThumbnail.test.ts
@@ -558,6 +558,78 @@ describe('skips rather than fails when it cannot run at all', () => {
   });
 });
 
+/**
+ * A 404 on the deck's document and a metadata read that BLEW UP are opposite
+ * situations, and "no sha" used to be the answer to both.
+ *
+ * Rendering the first one costs a browser, a token and the entire
+ * `waitForSelector` budget to arrive at a refusal that was knowable from the
+ * metadata read — and staging is full of them, because its classrooms are
+ * copies whose content repos the staging installation cannot read.
+ */
+describe('a deck with no document is skipped, not rendered', () => {
+  beforeEach(() => {
+    // Force the metadata read: with a row in the asset map there is already a
+    // sha and no question to ask.
+    lookupContentAsset.mockResolvedValue(null);
+  });
+
+  it('returns no-content without minting a token or booting a browser', async () => {
+    getMeta.mockResolvedValue(null);
+
+    await expect(run()).resolves.toEqual({ status: 'skipped', reason: 'no-content' });
+
+    expect(signDeckRenderToken).not.toHaveBeenCalled();
+    expect(screenshotToBase64).not.toHaveBeenCalled();
+    expect(uploadBatch).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('says so at INFO — for a staging classroom this is the permanent state', async () => {
+    // A warning per deck per save would train everyone to ignore the channel.
+    getMeta.mockResolvedValue(null);
+    await run();
+
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.stringContaining('nothing to screenshot'),
+      expect.objectContaining({ slideId: SLIDE_ID, path: 'slides/week-01-intro/index.html' })
+    );
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
+  it('is not overridden by force — force cannot conjure a document', async () => {
+    // `force` means "the sha is answering the wrong question", which is true of
+    // a theme edit and irrelevant to a file that is not there.
+    getMeta.mockResolvedValue(null);
+
+    await expect(run({ force: true })).resolves.toEqual({
+      status: 'skipped',
+      reason: 'no-content',
+    });
+    expect(screenshotToBase64).not.toHaveBeenCalled();
+  });
+
+  it('still RENDERS when the read merely failed — that is the other case', async () => {
+    // `getMeta` answers null for a 404 and rethrows everything else, which is
+    // the whole reason the two can be told apart. A transient GitHub fault must
+    // not read as a missing deck.
+    getMeta.mockRejectedValue(new Error('GitHub is having a moment'));
+
+    await expect(run()).resolves.toMatchObject({ status: 'rendered' });
+    expect(screenshotToBase64).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders on a metadata row carrying no sha, rather than calling it absent', async () => {
+    // Not a 404 and not an answer either. Rendering is the safe reading: the
+    // worst case is one WebP nobody needed, against a deck that never gets a
+    // picture at all.
+    getMeta.mockResolvedValue({ size: 1234 });
+
+    await expect(run()).resolves.toMatchObject({ status: 'rendered' });
+    expect(screenshotToBase64).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('loop guard', () => {
   const source = readFileSync(
     fileURLToPath(new URL('../deckThumbnail.ts', import.meta.url)),

--- a/packages/tasks/src/workflows/deckThumbnail.ts
+++ b/packages/tasks/src/workflows/deckThumbnail.ts
@@ -43,6 +43,11 @@ import {
  * object in the repo's history whether or not the picture changed.
  *
  * ── FAILURE ────────────────────────────────────────────────────────────────
+ * Before any of that: a deck whose document is not in the repo is SKIPPED, not
+ * rendered and not failed. Step 2a catches it from the same metadata read the
+ * skip check already makes, so no token is minted and no browser is booted for
+ * a page that could only refuse.
+ *
  * A render that fails keeps the thumbnail already in the repo. Nothing is ever
  * deleted and no placeholder is ever committed — the index draws its own
  * placeholder for a deck that has none, which is strictly better than a repo
@@ -56,16 +61,31 @@ import {
  * be re-asked for by every page load forever.
  */
 
-/** How long the whole navigation may take. Browser Run caps this at 60s. */
-const NAVIGATION_TIMEOUT_MS = 30000;
+/**
+ * How long the whole navigation may take — the spec's maximum, deliberately.
+ *
+ * The render route itself answers in ~460ms. What this budget is actually for
+ * is the slides app's Fly machine having scaled to zero: the first staging run
+ * spent its entire 30s on a cold start and never reached a page at all. A cold
+ * boot is the ordinary case for the first render after a quiet period, not an
+ * anomaly, and failing it costs a browser and a retry to learn nothing.
+ */
+const NAVIGATION_TIMEOUT_MS = 60000;
 
-/** How long to wait for the render page to declare itself painted. */
-const READY_TIMEOUT_MS = 15000;
+/**
+ * How long to wait for the render page to declare itself painted.
+ *
+ * This is the gate that means something — `[data-thumbnail-ready]` goes up only
+ * on a page the route actually served, and the page's own hard cap on settling
+ * is 8s. Thirty seconds leaves room for a deck whose images come from a cold
+ * content Worker without ever being the thing that decides a render.
+ */
+const READY_TIMEOUT_MS = 30000;
 
 /**
  * The longest we will sit on a 429's `Retry-After` before rethrowing.
  *
- * `maxDuration` is 120s and a render costs ~6s of it, so honouring an
+ * `maxDuration` is 180s and a render costs ~6s of it, so honouring an
  * arbitrarily long back-off would spend the whole run waiting and then be killed
  * for it. Past this the retry policy's own scheduling is the better instrument:
  * it costs nothing to wait between attempts.
@@ -92,22 +112,46 @@ export type DeckThumbnailResult =
   | { status: 'failed'; reason: string };
 
 /**
- * The blob sha of the deck's rendered document.
+ * What is known about the deck's rendered document.
+ *
+ * Three answers, not two, and the third is the point. "No sha" used to mean
+ * both "the file is not there" and "we could not find out", and the task
+ * rendered on either — so a classroom whose repo this installation cannot read
+ * booted a browser, navigated to a route that could only 500, and then sat out
+ * the whole `waitForSelector` budget before failing. Those are different
+ * situations with opposite right answers: absent means there is nothing to
+ * photograph and the run should end; unknown means render and simply do not
+ * touch the recorded sha afterwards.
+ */
+type IndexDocumentLookup =
+  /** The sha to compare against, and to record once a render lands. */
+  | { kind: 'known'; sha: string }
+  /** GitHub answered 404: no such file, on a repo we can read or cannot. */
+  | { kind: 'absent' }
+  /** The read failed. Render anyway; the stored sha stays as it was. */
+  | { kind: 'unknown' };
+
+/**
+ * Resolve that, from the asset map first and GitHub second.
  *
  * The asset map answers first and usually: the save path writes the row through
  * at commit time, so the sha is already there by the time this runs. A classroom
  * the delivery layer does not serve has no map at all, and one GitHub metadata
  * read is well worth it — without a sha there is no skip check, and without the
  * skip check every save of every deck commits a fresh WebP.
+ *
+ * `getMeta` is what makes `absent` distinguishable at all: it answers `null` for
+ * a 404 and RETHROWS everything else, so a null here is GitHub saying the file
+ * is not there rather than a request that went wrong.
  */
 async function currentIndexSha(
   classroomId: string,
   gitOrganization: unknown,
   repo: string,
   path: string
-): Promise<string | null> {
+): Promise<IndexDocumentLookup> {
   const row = await ClassmojiService.contentAssets.lookupContentAsset(classroomId, path);
-  if (row?.sha) return row.sha;
+  if (row?.sha) return { kind: 'known', sha: row.sha };
 
   try {
     const meta = await ContentService.getMeta({
@@ -116,14 +160,16 @@ async function currentIndexSha(
       path,
       skipCache: true,
     });
-    return meta?.sha ?? null;
+    if (meta?.sha) return { kind: 'known', sha: meta.sha };
+    // A metadata row with no sha is not a 404 and is not an answer either.
+    return meta === null ? { kind: 'absent' } : { kind: 'unknown' };
   } catch (error: unknown) {
     logger.warn('Could not read index.html sha; rendering without the skip check', {
       classroomId,
       path,
       error: error instanceof Error ? error.message : String(error),
     });
-    return null;
+    return { kind: 'unknown' };
   }
 }
 
@@ -138,8 +184,15 @@ export const deckThumbnailRender = task({
    * deck and lets this queue meter them, rather than pacing itself.
    */
   queue: { concurrencyLimit: 4 },
-  /** A render is ~6s. Two minutes is the point at which something is wrong. */
-  maxDuration: 120,
+  /**
+   * A render is ~6s; this is the ceiling for the case where nothing goes right.
+   *
+   * It has to exceed the worst legal render end to end — 60s of navigation, then
+   * 30s waiting on the readiness selector, then the commit — or the run is
+   * killed at the exact moment the budget it was given would have paid off. Two
+   * minutes did not clear that; three does, with room for the commit.
+   */
+  maxDuration: 180,
   retry: { maxAttempts: 3, minTimeoutInMs: 5000 },
   run: async (payload: DeckThumbnailPayload): Promise<DeckThumbnailResult> => {
     const { slideId, force = false } = payload;
@@ -182,7 +235,34 @@ export const deckThumbnailRender = task({
     //      unless the caller knows something the sha cannot express. A theme
     //      edit changes how every deck in a classroom LOOKS without touching a
     //      byte of any of them.
-    const indexSha = await currentIndexSha(slide.classroom_id, gitOrganization, repo, indexPath);
+    const lookup = await currentIndexSha(slide.classroom_id, gitOrganization, repo, indexPath);
+
+    // 2a. Nothing to photograph. The document this task exists to render is not
+    //     in the repo — the deck was never generated, or this installation
+    //     cannot read the repo at all, which is the ordinary state of a staging
+    //     classroom copied from production.
+    //
+    //     BEFORE the token is minted, and before Browser Run is called: a render
+    //     of a deck with no content cannot succeed, and the way it fails is
+    //     expensive. The route answers a refusal, the readiness selector never
+    //     appears, and the browser sits out the entire `waitForSelector` budget
+    //     to reach a conclusion available here for one metadata read.
+    //
+    //     `force` does not override this. Force means "the sha is answering the
+    //     wrong question"; it cannot conjure a document that is not there.
+    //
+    //     INFO, not warn: for a staging classroom this is the correct and
+    //     permanent state of affairs, and a warning per deck per save would
+    //     train everyone to ignore the channel.
+    if (lookup.kind === 'absent') {
+      logger.info('Deck has no rendered document in the content repo; nothing to screenshot', {
+        slideId,
+        path: indexPath,
+      });
+      return { status: 'skipped', reason: 'no-content' };
+    }
+
+    const indexSha = lookup.kind === 'known' ? lookup.sha : null;
     if (!force && indexSha && indexSha === slide.thumbnail_rendered_sha && slide.thumbnail_path) {
       logger.info('Deck unchanged since its thumbnail was rendered', { slideId, sha: indexSha });
       return { status: 'unchanged', sha: indexSha };


### PR DESCRIPTION
Three findings from the first staging renders of `deck-thumbnail-render`.

## 1. Cloudflare returns a data URI, not bare base64

A direct `POST /accounts/{id}/browser-rendering/screenshot` with
`screenshotOptions: { type: 'webp', quality: 80, encoding: 'base64' }` answers
200 with `result` = `"data:image/webp;base64,UklGR…"`.

Both branches got this wrong, and one of them got it wrong quietly. The JSON
branch passed `result` straight to the size window — and `Buffer.from(…,
'base64')` does not throw on a data URI, it silently skips the 23 characters it
cannot decode and returns a short buffer, which is still inside the window and
would have been committed into a classroom's content repo. The text branch
refused it as "not an image", because `BASE64_PATTERN` has no `:` in it, which
sent the investigation at the render route rather than at the client.

All three response shapes (JSON string, JSON `{result:{screenshot}}`, and
`text/plain`) now go through a single `imageFromPayload`: strip a
case-insensitive `data:image/…;base64,` prefix, refuse a media type that is not
the `image/webp` we asked for, validate the remainder as base64 *before*
whitespace is stripped (strip first and `the page could not be rendered`
collapses into a run of letters that matches base64 perfectly), then apply the
size window. The window was already measuring decoded bytes
(`Buffer.from(base64, 'base64').length`) — confirmed, and documented as
load-bearing.

Bare base64 is still accepted; the prefix is optional, not required.

## 2. Missing deck content should skip, not burn a render

A deck whose `index.html` is not in the repo — a staging classroom whose repo
the staging installation cannot read, for instance — threw `Error: Slide
content not found` out of the route as a 500 with a stack, which Browser
Rendering does not read as a failure: it went on waiting for a readiness
attribute that page would never raise and spent the whole `waitForSelector`
budget first.

Fixed at both ends:

- **Task.** `currentIndexSha` used to answer `null` for both "the file is not
  there" and "the read blew up", and the task rendered on either. It now returns
  a three-way `known` / `absent` / `unknown` — `getMeta` answers `null` for a
  404 and rethrows everything else, which is what makes the two
  distinguishable. `absent` returns `{ status: 'skipped', reason: 'no-content' }`
  before the render token is minted and before Browser Rendering is called, and
  logs at info (for a staging classroom this is the permanent state; a warning
  per deck per save would train everyone to ignore the channel). `force` does
  not override it — force means the sha is answering the wrong question, and it
  cannot conjure a document that is not there. A *transient* failure still
  renders, exactly as before.
- **Route.** The not-found from `loadDeck` is caught and answered with the
  existing `renderRefusal()` — same builder, same headers, same bare
  `Forbidden`, no stack and no body detail — with one server-side info line.
  Anything else out of `loadDeck` still propagates. There are two throw sites
  now but still one builder and one `status: 403` literal, which is the
  invariant the tests pin.

## 3. Navigation budget

The first staging run timed out because the staging Fly machine cold-started;
the route itself answered in 461 ms once reached.

- `gotoOptions.timeout` 30000 → **60000**
- `waitForSelector.timeout` 15000 → **30000**
- `gotoOptions.waitUntil` `networkidle0` → **`load`** — `[data-thumbnail-ready]`
  is the real readiness gate (the page raises it only after its own images and
  fonts settle), and `networkidle0` is a weaker gate in front of it that a
  lazily loaded image or a cold token mint can keep from ever arriving
- task `maxDuration` 120 → **180**, so the run outlives the budget it was given
  (60s navigation + 30s selector + the commit)

Verified against the Cloudflare OpenAPI spec for
`POST /accounts/{account_id}/browser-rendering/screenshot`:
`gotoOptions.timeout` has `maximum: 60000` (default 30000), so 60000 is exactly
the ceiling; `gotoOptions.waitUntil` enumerates `load` alongside
`domcontentloaded`, `networkidle0` and `networkidle2`; `waitForSelector.timeout`
has `maximum: 120000`, so 30000 has room to spare. Contract and doc comments
naming the old numbers were updated with them.

## Verification

- `packages/tasks` tests: 173 passed (11 files), including 10 new data-URI cases
  and 5 new no-content cases
- `npm run test -w apps/slides -- tests/unit`: 156 passed
- typecheck: `packages/tasks` and `apps/slides` both clean
- eslint on all six touched files: clean
- `npm run slides:build`: clean (client + SSR bundles)

No `package-lock.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA
