### PR TITLE
fix(pages): stop a column delete from bricking the page

### DIFF
--- a/apps/mcp/src/tools/pageContent.ts
+++ b/apps/mcp/src/tools/pageContent.ts
@@ -491,12 +491,22 @@ export const pageContentApplyTool: ToolDefinition<PageContentApplyArgs> = {
     // result/audit report the re-mints.
     const idRemints: Array<{ op_index: number; from: string; to: string }> = [];
 
+    // Ops that would leave the document unopenable (a columnList dropped below
+    // two columns, a stray block parked directly in one) are repaired rather
+    // than committed as-is. Reported back because the repair changes the
+    // layout the caller asked for: silently unwrapping a row would leave an
+    // agent believing its delete did exactly what it said.
+    const structureRepairs: Array<{ kind: string; id?: string }> = [];
+
     let newBlocks: unknown[];
     try {
       newBlocks = ClassmojiService.pageContent.applyBlockOps(
         priorBlocks,
         args.ops as Parameters<typeof ClassmojiService.pageContent.applyBlockOps>[1],
-        { onIdRemint: remint => idRemints.push(remint) }
+        {
+          onIdRemint: remint => idRemints.push(remint),
+          onStructureRepair: repair => structureRepairs.push(repair),
+        }
       );
     } catch (error) {
       if (error instanceof Error && error.name === 'BlockOpError') {
@@ -582,6 +592,7 @@ export const pageContentApplyTool: ToolDefinition<PageContentApplyArgs> = {
         commit_sha: saved.commit,
         committed_to: committedTo,
         ...(hasDestructiveOps ? { prior_block_count: priorCount } : {}),
+        ...(structureRepairs.length > 0 ? { structure_repairs: structureRepairs } : {}),
       } as Prisma.InputJsonValue,
     });
 
@@ -591,6 +602,15 @@ export const pageContentApplyTool: ToolDefinition<PageContentApplyArgs> = {
       block_count: countBlocks(newBlocks as BlockNode[]),
       committed_to: committedTo,
       applied,
+      ...(structureRepairs.length > 0
+        ? {
+            structure_repairs: structureRepairs,
+            note:
+              'The ops would have left a column layout BlockNote cannot open, so it was repaired ' +
+              '(a columnList needs at least two columns, and only columns as children). Re-read ' +
+              'the outline to see the resulting structure.',
+          }
+        : {}),
     });
   },
 };

--- a/apps/mcp/src/tools/pageContent.ts
+++ b/apps/mcp/src/tools/pageContent.ts
@@ -492,7 +492,8 @@ export const pageContentApplyTool: ToolDefinition<PageContentApplyArgs> = {
     const idRemints: Array<{ op_index: number; from: string; to: string }> = [];
 
     // Ops that would leave the document unopenable (a columnList dropped below
-    // two columns, a stray block parked directly in one) are repaired rather
+    // two columns, a stray block parked directly in one, a whole row inserted
+    // inside a column) are repaired rather
     // than committed as-is. Reported back because the repair changes the
     // layout the caller asked for: silently unwrapping a row would leave an
     // agent believing its delete did exactly what it said.
@@ -607,8 +608,9 @@ export const pageContentApplyTool: ToolDefinition<PageContentApplyArgs> = {
             structure_repairs: structureRepairs,
             note:
               'The ops would have left a column layout BlockNote cannot open, so it was repaired ' +
-              '(a columnList needs at least two columns, and only columns as children). Re-read ' +
-              'the outline to see the resulting structure.',
+              '(a columnList needs at least two columns and only columns as children, and a ' +
+              'column cannot contain another columnList — a nested one is lifted out to sit ' +
+              'after the row). Re-read the outline to see the resulting structure.',
           }
         : {}),
     });

--- a/packages/services/src/classmoji/__tests__/contentDelivery.canonicalizeSave.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.canonicalizeSave.test.ts
@@ -150,6 +150,9 @@ describe('savePageContent canonicalizes on the way in', () => {
   });
 
   it('reaches a reference nested inside a column layout', async () => {
+    // Two columns, because a row with fewer is not a document BlockNote can
+    // open and savePageContent's structural gate would unwrap it before the
+    // write — which would make this test about normalization, not refs.
     await savePageContent(page, [
       {
         id: 'cl',
@@ -159,6 +162,11 @@ describe('savePageContent canonicalizes on the way in', () => {
             id: 'c1',
             type: 'column',
             children: [{ id: 'b1', type: 'image', props: { url: signedPageUrl } }],
+          },
+          {
+            id: 'c2',
+            type: 'column',
+            children: [{ id: 'b2', type: 'paragraph', content: [] }],
           },
         ],
       },

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -1139,6 +1139,141 @@ describe('pageContent.normalizeBlockStructure', () => {
     expect(types(result as unknown[])).toEqual(['columnList']);
   });
 
+  // ── A column may hold only ordinary content ───────────────────────────────
+  //
+  // The third schema violation, and the one arity alone never catches: a
+  // `column` is `blockContainer+` and a `columnList` is a `bnBlock`, not a
+  // blockContainer. A row nested inside a column throws exactly the same
+  // "Error creating document from blocks passed as `initialContent`".
+
+  it('lifts a row nested inside a column out to sit after its row', () => {
+    // Both rows are individually valid — arity has nothing to complain about —
+    // and the document is still unopenable.
+    const inner = row('inner', [column('ic1', 'ip1'), column('ic2', 'ip2')]);
+    const repairs: Array<{ kind: string; id?: string }> = [];
+
+    const result = normalizeBlockStructure(
+      [
+        row('outer', [
+          { id: 'oc1', type: 'column', props: { width: 1 }, children: [inner] },
+          column('oc2', 'op2'),
+        ]),
+        { id: 'after', type: 'paragraph', content: [] },
+      ],
+      { onRepair: r => repairs.push(r) }
+    ) as Array<{
+      id: string;
+      type: string;
+      children?: Array<{ children: Array<{ id: string; type: string }> }>;
+    }>;
+
+    // The inner row is re-parented as the outer row's NEXT sibling — after the
+    // row it came out of, before whatever followed it.
+    expect(ids(result)).toEqual(['outer', 'inner', 'after']);
+    expect(types(result)).toEqual(['columnList', 'columnList', 'paragraph']);
+    // Lifted, not flattened: the inner row keeps both its columns.
+    expect((result[1].children ?? []).map(c => c.children.map(b => b.id))).toEqual([
+      ['ip1'],
+      ['ip2'],
+    ]);
+    // The lift emptied oc1, so the arity rule refills it — composed, not
+    // sequenced by luck: the empty check already ran on the way down.
+    expect((result[0].children ?? [])[0].children.map(b => b.type)).toEqual(['paragraph']);
+    expect(repairs).toEqual([
+      { kind: 'nested_column_list_lifted', id: 'inner' },
+      { kind: 'empty_column_filled', id: 'oc1' },
+    ]);
+  });
+
+  it('lifts a row parked directly in a row rather than wrapping it in a column', () => {
+    // Wrapping would satisfy `column column+` and still be unopenable, while
+    // reporting a repair that fixed nothing.
+    const repairs: Array<{ kind: string; id?: string }> = [];
+
+    const result = normalizeBlockStructure(
+      [
+        row('outer', [
+          column('oc1', 'op1'),
+          row('inner', [column('ic1', 'ip1'), column('ic2', 'ip2')]),
+        ]),
+      ],
+      { onRepair: r => repairs.push(r) }
+    ) as Array<{ id: string; type: string }>;
+
+    // Lifting leaves the outer row a single column, so it unwraps in turn —
+    // the two rules compose rather than fighting.
+    expect(ids(result)).toEqual(['op1', 'inner']);
+    expect(types(result)).toEqual(['paragraph', 'columnList']);
+    expect(repairs).toEqual([
+      { kind: 'nested_column_list_lifted', id: 'inner' },
+      { kind: 'column_list_unwrapped', id: 'outer' },
+    ]);
+  });
+
+  it('lifting is idempotent — a second pass repairs nothing', () => {
+    const once = normalizeBlockStructure([
+      row('outer', [
+        {
+          id: 'oc1',
+          type: 'column',
+          props: { width: 1 },
+          children: [row('inner', [column('ic1', 'ip1'), column('ic2', 'ip2')])],
+        },
+        column('oc2', 'op2'),
+      ]),
+    ]);
+
+    const repairs: Array<{ kind: string }> = [];
+    expect(normalizeBlockStructure(once, { onRepair: r => repairs.push(r) })).toEqual(once);
+    expect(repairs).toEqual([]);
+  });
+
+  it('leaves a valid document with deep, nesting-free columns byte-identical', () => {
+    // The promise the gate makes to every write path: calling it costs a walk,
+    // never a diff. A column may nest ordinary blocks as deep as it likes.
+    const doc = [
+      row('r', [
+        {
+          id: 'c1',
+          type: 'column',
+          props: { width: 1 },
+          children: [
+            {
+              id: 'list',
+              type: 'bulletListItem',
+              props: {},
+              content: [],
+              children: [
+                { id: 'sub', type: 'bulletListItem', props: {}, content: [], children: [] },
+              ],
+            },
+          ],
+        },
+        column('c2', 'p2'),
+      ]),
+      { id: 'tail', type: 'paragraph', content: [] },
+    ];
+
+    expect(JSON.stringify(normalizeBlockStructure(doc))).toBe(JSON.stringify(doc));
+  });
+
+  it('does not report a wrap the finished document holds no trace of', () => {
+    // A single stray in a row: it gets wrapped, then the one-column row unwraps
+    // and the wrap is gone. Reporting it would send a caller looking for a
+    // column that does not exist.
+    const repairs: Array<{ kind: string; id?: string }> = [];
+
+    const result = normalizeBlockStructure(
+      [row('r', [{ id: 'stray', type: 'paragraph', content: [] }])],
+      {
+        onRepair: r => repairs.push(r),
+      }
+    );
+
+    expect(ids(result)).toEqual(['stray']);
+    expect(repairs).toEqual([{ kind: 'column_list_unwrapped', id: 'r' }]);
+  });
+
   it('is idempotent', () => {
     const once = normalizeBlockStructure([row('r', [column('c1', 'p1')])]);
     expect(normalizeBlockStructure(once)).toEqual(once);
@@ -1216,6 +1351,48 @@ describe('pageContent.applyBlockOps — column invariants', () => {
 
     expect(result[0].children.map(c => c.type)).toEqual(['column', 'column', 'column', 'column']);
     expect(result[0].children[1].children[0].id).toBe('note');
+  });
+
+  it('an insert that lands a whole row inside a column lifts it back out', () => {
+    // The MCP shape of the bug: `after: 'profile-a'` names a block INSIDE a
+    // column, so the inserted row becomes that column's child. Arity is
+    // satisfied on both rows and the page is still unopenable.
+    const repairs: Array<{ kind: string; id?: string }> = [];
+
+    const result = applyBlockOps(
+      staffRow(),
+      [
+        {
+          op: 'insert',
+          blocks: [
+            {
+              id: 'inner',
+              type: 'columnList',
+              props: {},
+              children: ['x', 'y'].map(key => ({
+                id: `icol-${key}`,
+                type: 'column',
+                props: { width: 1 },
+                children: [{ id: `ip-${key}`, type: 'paragraph', content: [] }],
+              })),
+            },
+          ],
+          position: { after: 'profile-a' },
+        },
+      ],
+      { onStructureRepair: repair => repairs.push(repair) }
+    ) as Array<{ id: string; type: string; children: Array<{ children: Array<{ id: string }> }> }>;
+
+    // The staff row is untouched and the inserted row follows it.
+    expect(result.map(b => b.type)).toEqual(['columnList', 'columnList']);
+    expect(result.map(b => b.id)).toEqual(['row', 'inner']);
+    expect(result[0].children.map(c => c.children.map(b => b.id))).toEqual([
+      ['profile-a'],
+      ['profile-b'],
+      ['profile-c'],
+    ]);
+    // Reported, because the layout is not the one the caller asked for.
+    expect(repairs).toEqual([{ kind: 'nested_column_list_lifted', id: 'inner' }]);
   });
 
   it('replace_all carrying a one-column row is repaired too', () => {
@@ -1442,6 +1619,61 @@ describe('pageContent.acceptPreview', () => {
     // the REPAIR — the merge's own blob sha is already stale.
     expect(callArg(putMock)).toMatchObject({ expectedSha: 'merged-blob-sha' });
     expect(result).toEqual({ merged: true, sha: 'repaired-blob-sha' });
+  });
+
+  it('clean merge: records the repaired file once, not twice', async () => {
+    // The repair commit goes through savePageContent, which writes the map row
+    // (with the real byte size) and warms the file. Recording again here would
+    // overwrite that row with a sizeless one and pay a second warm for a sha
+    // the Worker is already pulling.
+    const keyedPage = {
+      ...page,
+      classroom: {
+        ...page.classroom,
+        id: 'class-1',
+        content_key_version: 3,
+        content_delivery_enabled: true,
+      },
+    };
+    recordContentAssetMock.mockResolvedValue(true);
+    mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });
+    deleteBranchMock.mockResolvedValue({ deleted: true });
+    getContentMock.mockResolvedValue({ content: mergedOneColumnRow, sha: 'merged-blob-sha' });
+    putMock.mockResolvedValue({ sha: 'repaired-blob-sha', commit: 'repair-commit' });
+    branchFullyMerged();
+
+    await acceptPreview(keyedPage);
+
+    expect(recordContentAssetMock).toHaveBeenCalledTimes(1);
+    expect(recordContentAssetMock).toHaveBeenCalledWith(
+      'class-1',
+      expect.objectContaining({
+        path: 'pages/syllabus/content.json',
+        sha: 'repaired-blob-sha',
+        size: Buffer.byteLength(callArg(putMock).content as string),
+      })
+    );
+    expect(warmContentTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clean merge: still records the merge itself when no repair was needed', async () => {
+    // The guard is on sha EQUALITY, not on "a repair was attempted" — a merge
+    // nobody had to fix still has to be written through, or accepting a preview
+    // serves the pre-accept version until the push webhook lands.
+    const keyedPage = { ...page, classroom: { ...page.classroom, id: 'class-1' } };
+    recordContentAssetMock.mockResolvedValue(true);
+    mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });
+    deleteBranchMock.mockResolvedValue({ deleted: true });
+    getContentMock.mockResolvedValue({ content: '{"blocks":[]}', sha: 'merged-blob-sha' });
+    branchFullyMerged();
+
+    await acceptPreview(keyedPage);
+
+    expect(putMock).not.toHaveBeenCalled();
+    expect(recordContentAssetMock).toHaveBeenCalledExactlyOnceWith(
+      'class-1',
+      expect.objectContaining({ path: 'pages/syllabus/content.json', sha: 'merged-blob-sha' })
+    );
   });
 
   it('clean merge: writes nothing when the merged document is already valid', async () => {

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -59,6 +59,7 @@ const {
   uploadPageAsset,
   ensureBlockIds,
   applyBlockOps,
+  normalizeBlockStructure,
   blankPageBlocks,
   blankPageContentJson,
   BlockOpError,
@@ -482,6 +483,59 @@ describe('pageContent.savePageContent write-through', () => {
 
     expect(result).toEqual({ sha: 'new-sha', commit: 'commit-1' });
     expect(recordContentAssetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('pageContent.savePageContent — structural gate', () => {
+  // The claim this makes true: a caller that forgets to normalize still cannot
+  // commit a document BlockNote refuses to open.
+  const oneColumnRow = [
+    {
+      id: 'row',
+      type: 'columnList',
+      props: {},
+      children: [
+        {
+          id: 'col',
+          type: 'column',
+          props: { width: 1 },
+          children: [{ id: 'kept', type: 'paragraph', content: [] }],
+        },
+      ],
+    },
+  ];
+
+  it('repairs a one-column row on the way into the commit', async () => {
+    await savePageContent(page, oneColumnRow, { coverImage: null });
+
+    const committed = writtenWrapper().blocks;
+    expect(committed.map((b: { id: string; type: string }) => b.type)).toEqual(['paragraph']);
+    expect(committed.map((b: { id: string }) => b.id)).toEqual(['kept']);
+  });
+
+  it('leaves a valid document byte-identical', async () => {
+    const valid = [
+      {
+        id: 'row',
+        type: 'columnList',
+        props: {},
+        children: ['a', 'b'].map(k => ({
+          id: `col-${k}`,
+          type: 'column',
+          props: { width: 1 },
+          children: [{ id: `p-${k}`, type: 'paragraph', content: [] }],
+        })),
+      },
+    ];
+
+    await savePageContent(page, valid, { coverImage: null });
+
+    expect(writtenWrapper().blocks).toEqual(valid);
+  });
+
+  it('passes a non-array through untouched (legacy/degenerate payloads)', async () => {
+    await savePageContent(page, null, { coverImage: null });
+    expect(writtenWrapper()).toEqual({ blocks: null });
   });
 });
 
@@ -960,6 +1014,239 @@ describe('pageContent.applyBlockOps', () => {
   });
 });
 
+// ─── normalizeBlockStructure ─────────────────────────────────────────────────
+
+// A `columnList` is `"column column+"` in BlockNote's ProseMirror schema and a
+// `column` is `"blockContainer+"`. A document that breaks either commits fine
+// and then throws "Error creating document from blocks passed as
+// `initialContent`" in every viewer AND the editor, so it can only be fixed by
+// a re-commit from outside — the reason these are repaired on write.
+
+describe('pageContent.normalizeBlockStructure', () => {
+  const column = (id: string, childId: string) => ({
+    id,
+    type: 'column',
+    props: { width: 1 },
+    children: [{ id: childId, type: 'paragraph', content: [] }],
+  });
+
+  const row = (id: string, columns: unknown[]) => ({
+    id,
+    type: 'columnList',
+    props: {},
+    children: columns,
+  });
+
+  const types = (blocks: unknown[]) => (blocks as Array<{ type: string }>).map(b => b.type);
+  const ids = (blocks: unknown[]) => (blocks as Array<{ id: string }>).map(b => b.id);
+
+  it('leaves a valid document structurally untouched', () => {
+    const doc = [row('r', [column('c1', 'p1'), column('c2', 'p2')])];
+    expect(normalizeBlockStructure(doc)).toEqual(doc);
+  });
+
+  it('is pure — the input is not mutated', () => {
+    const doc = [row('r', [column('c1', 'p1')])];
+    const snapshot = structuredClone(doc);
+    normalizeBlockStructure(doc);
+    expect(doc).toEqual(snapshot);
+  });
+
+  it('unwraps a columnList left with a single column, keeping the content', () => {
+    const result = normalizeBlockStructure([
+      { id: 'before', type: 'paragraph', content: [] },
+      row('r', [column('c1', 'p1')]),
+      { id: 'after', type: 'paragraph', content: [] },
+    ]);
+
+    expect(ids(result)).toEqual(['before', 'p1', 'after']);
+  });
+
+  it('drops a columnList with no columns at all', () => {
+    const result = normalizeBlockStructure([
+      row('r', []),
+      { id: 'keep', type: 'paragraph', content: [] },
+    ]);
+
+    expect(ids(result)).toEqual(['keep']);
+  });
+
+  it('wraps a non-column child of a columnList in its own column, in place', () => {
+    const result = normalizeBlockStructure([
+      row('r', [
+        column('c1', 'p1'),
+        { id: 'stray', type: 'paragraph', content: [] },
+        column('c2', 'p2'),
+      ]),
+    ]) as Array<{ children: Array<{ type: string; children: Array<{ id: string }> }> }>;
+
+    expect(types(result[0].children)).toEqual(['column', 'column', 'column']);
+    expect(result[0].children[1].children[0].id).toBe('stray');
+
+    const repairs: Array<{ kind: string; id?: string }> = [];
+    normalizeBlockStructure(
+      [
+        row('r', [
+          column('c1', 'p1'),
+          { id: 'stray', type: 'paragraph', content: [] },
+          column('c2', 'p2'),
+        ]),
+      ],
+      { onRepair: r => repairs.push(r) }
+    );
+    // The stray's id, not the row's — the caller is being pointed at a block.
+    expect(repairs).toEqual([{ kind: 'column_list_child_wrapped', id: 'stray' }]);
+  });
+
+  it('gives an emptied column a paragraph rather than killing the row', () => {
+    const result = normalizeBlockStructure([
+      row('r', [
+        column('c1', 'p1'),
+        { id: 'c2', type: 'column', props: { width: 1 }, children: [] },
+      ]),
+    ]) as Array<{ children: Array<{ children: Array<{ type: string; id?: string }> }> }>;
+
+    expect(types(result[0].children as unknown[])).toEqual(['column', 'column']);
+    expect(result[0].children[1].children).toMatchObject([
+      {
+        type: 'paragraph',
+        props: { textColor: 'default', backgroundColor: 'default', textAlignment: 'left' },
+        content: [],
+        children: [],
+      },
+    ]);
+    // Repairs invent blocks; they must not reach the repo without an id.
+    expect(result[0].children[1].children[0].id).toEqual(expect.any(String));
+  });
+
+  it('unwraps a column that is not inside a columnList', () => {
+    const result = normalizeBlockStructure([column('stray', 'p1')]);
+    expect(ids(result)).toEqual(['p1']);
+  });
+
+  it('repairs nested rows depth-first', () => {
+    const inner = row('inner', [column('ic1', 'ip1')]);
+    const result = normalizeBlockStructure([
+      row('outer', [
+        { id: 'oc1', type: 'column', props: { width: 1 }, children: [inner] },
+        column('oc2', 'op2'),
+      ]),
+    ]) as Array<{ children: Array<{ children: Array<{ id: string }> }> }>;
+
+    // The inner one-column row collapses into its content; the outer row,
+    // still two columns wide, survives.
+    expect(result[0].children[0].children.map(b => b.id)).toEqual(['ip1']);
+    expect(types(result as unknown[])).toEqual(['columnList']);
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeBlockStructure([row('r', [column('c1', 'p1')])]);
+    expect(normalizeBlockStructure(once)).toEqual(once);
+  });
+
+  it('reports each repair through onRepair', () => {
+    const repairs: Array<{ kind: string; id?: string }> = [];
+    normalizeBlockStructure([row('r', [column('c1', 'p1')])], {
+      onRepair: repair => repairs.push(repair),
+    });
+
+    expect(repairs).toEqual([{ kind: 'column_list_unwrapped', id: 'r' }]);
+  });
+});
+
+describe('pageContent.applyBlockOps — column invariants', () => {
+  // The live failure: an agent deleted two of three columns from a staff row,
+  // the commit succeeded, and every reader of the page threw on load.
+  const staffRow = () => [
+    {
+      id: 'row',
+      type: 'columnList',
+      props: {},
+      children: ['a', 'b', 'c'].map(key => ({
+        id: `col-${key}`,
+        type: 'column',
+        props: { width: 1 },
+        children: [{ id: `profile-${key}`, type: 'profile', props: { name: key }, children: [] }],
+      })),
+    },
+  ];
+
+  it('a delete that would leave one column unwraps the row instead', () => {
+    const result = applyBlockOps(staffRow(), [
+      { op: 'delete', id: 'col-b' },
+      { op: 'delete', id: 'col-c' },
+    ]) as Array<{ id: string; type: string }>;
+
+    expect(result.map(b => b.type)).toEqual(['profile']);
+    expect(result.map(b => b.id)).toEqual(['profile-a']);
+  });
+
+  it('a delete down to two columns leaves the row alone', () => {
+    const result = applyBlockOps(staffRow(), [{ op: 'delete', id: 'col-c' }]) as Array<{
+      type: string;
+      children: unknown[];
+    }>;
+
+    expect(result[0].type).toBe('columnList');
+    expect(result[0].children).toHaveLength(2);
+  });
+
+  it('reports the repair through onStructureRepair', () => {
+    const repairs: Array<{ kind: string; id?: string }> = [];
+    applyBlockOps(
+      staffRow(),
+      [
+        { op: 'delete', id: 'col-b' },
+        { op: 'delete', id: 'col-c' },
+      ],
+      { onStructureRepair: repair => repairs.push(repair) }
+    );
+
+    expect(repairs).toEqual([{ kind: 'column_list_unwrapped', id: 'row' }]);
+  });
+
+  it('an insert positioned beside a column is wrapped into a column of its own', () => {
+    const result = applyBlockOps(staffRow(), [
+      {
+        op: 'insert',
+        blocks: [{ id: 'note', type: 'paragraph', content: [] }],
+        position: { after: 'col-a' },
+      },
+    ]) as Array<{ children: Array<{ type: string; children: Array<{ id: string }> }> }>;
+
+    expect(result[0].children.map(c => c.type)).toEqual(['column', 'column', 'column', 'column']);
+    expect(result[0].children[1].children[0].id).toBe('note');
+  });
+
+  it('replace_all carrying a one-column row is repaired too', () => {
+    const result = applyBlockOps(
+      [{ id: 'x', type: 'paragraph', content: [] }],
+      [
+        {
+          op: 'replace_all',
+          blocks: [
+            {
+              id: 'row',
+              type: 'columnList',
+              props: {},
+              children: [
+                {
+                  id: 'only',
+                  type: 'column',
+                  props: { width: 1 },
+                  children: [{ id: 'p', type: 'paragraph', content: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+    ) as Array<{ id: string }>;
+
+    expect(result.map(b => b.id)).toEqual(['p']);
+  });
+});
+
 // ─── preview branches (plan §3b) ─────────────────────────────────────────────
 
 const PREVIEW_BRANCH = 'preview/pages/syllabus';
@@ -1113,6 +1400,76 @@ describe('pageContent.acceptPreview', () => {
       merge_base_sha: 'main-head',
       commits: [],
     });
+
+  // The incident class, reached through the path git merges CLEANLY: two sides
+  // each delete a different column of the same three-column row, neither side
+  // is invalid on its own, and the hunks don't overlap — so there is no 409 and
+  // the semantic fallback never runs. Without a post-merge check, main lands a
+  // one-column row and the page becomes unopenable in viewer AND editor.
+  const mergedOneColumnRow = JSON.stringify({
+    blocks: [
+      {
+        id: 'row',
+        type: 'columnList',
+        props: {},
+        children: [
+          {
+            id: 'col-a',
+            type: 'column',
+            props: { width: 1 },
+            children: [{ id: 'profile-a', type: 'profile', props: {}, children: [] }],
+          },
+        ],
+      },
+    ],
+  });
+
+  it('clean merge: repairs a column layout the merge broke, reporting the repair sha', async () => {
+    mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });
+    deleteBranchMock.mockResolvedValue({ deleted: true });
+    getContentMock.mockResolvedValue({ content: mergedOneColumnRow, sha: 'merged-blob-sha' });
+    putMock.mockResolvedValue({ sha: 'repaired-blob-sha', commit: 'repair-commit' });
+    branchFullyMerged();
+
+    const result = await acceptPreview(page);
+
+    // The row is gone; the profile it held survives at the top level.
+    const committed = writtenWrapper().blocks;
+    expect(committed.map((b: { type: string }) => b.type)).toEqual(['profile']);
+    expect(committed.map((b: { id: string }) => b.id)).toEqual(['profile-a']);
+
+    // CAS'd on the blob the merge produced, and the caller is handed the sha of
+    // the REPAIR — the merge's own blob sha is already stale.
+    expect(callArg(putMock)).toMatchObject({ expectedSha: 'merged-blob-sha' });
+    expect(result).toEqual({ merged: true, sha: 'repaired-blob-sha' });
+  });
+
+  it('clean merge: writes nothing when the merged document is already valid', async () => {
+    mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });
+    deleteBranchMock.mockResolvedValue({ deleted: true });
+    getContentMock.mockResolvedValue({ content: '{"blocks":[]}', sha: 'merged-blob-sha' });
+    branchFullyMerged();
+
+    const result = await acceptPreview(page);
+
+    expect(putMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ merged: true, sha: 'merged-blob-sha' });
+  });
+
+  it('clean merge: a failed repair commit leaves the merge standing', async () => {
+    mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });
+    deleteBranchMock.mockResolvedValue({ deleted: true });
+    getContentMock.mockResolvedValue({ content: mergedOneColumnRow, sha: 'merged-blob-sha' });
+    // A racing writer took the sha — that write went through savePageContent
+    // and was normalized itself, so the document ends up valid either way.
+    putMock.mockRejectedValue(Object.assign(new Error('conflict'), { status: 409 }));
+    branchFullyMerged();
+
+    const result = await acceptPreview(page);
+
+    expect(result).toEqual({ merged: true, sha: 'merged-blob-sha' });
+    expect(deleteBranchMock).toHaveBeenCalled();
+  });
 
   it('clean merge: merges main←preview, deletes the branch, returns the content BLOB sha', async () => {
     mergeBranchMock.mockResolvedValue({ merged: true, sha: 'merge-sha' });

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -918,15 +918,18 @@ function insertBlocksAt(
 // `columnList` / `column` (@blocknote/xl-multi-column) are the only blocks in
 // the page schema whose ProseMirror content expressions constrain their
 // CHILDREN: `columnList` is `"column column+"` (every child a column, minimum
-// two) and `column` is `"blockContainer+"` (at least one child). Everything
-// else accepts whatever children it is handed, which is why the op vocabulary
-// can otherwise stay schema-agnostic.
+// two) and `column` is `"blockContainer+"` (at least one child, and every child
+// an ordinary content block — a `columnList` is a `bnBlock`, NOT a
+// `blockContainer`, so a row nested directly in a column is as fatal as a row
+// with one column). Everything else accepts whatever children it is handed,
+// which is why the op vocabulary can otherwise stay schema-agnostic.
 //
 // That gap is not theoretical. A `delete` op naming a column splices it out
 // with no idea it was the second-to-last one; an `insert` positioned `after` a
-// column lands a paragraph as a columnList's direct child. Either document
-// serializes and commits perfectly happily — and then throws "Error creating
-// document from blocks passed as `initialContent`" for EVERY reader, because
+// paragraph that happens to live inside a column lands a whole row inside that
+// column. Either document serializes and commits perfectly happily — and then
+// throws "Error creating document from blocks passed as `initialContent`" for
+// EVERY reader, because
 // ProseMirror refuses to build a doc that violates the schema. The viewer and
 // the editor share that failure, so a page broken this way cannot be repaired
 // in the editor either; the only way back is a re-commit from outside. That
@@ -942,7 +945,8 @@ export interface BlockStructureRepair {
     | 'column_list_unwrapped'
     | 'column_list_child_wrapped'
     | 'empty_column_filled'
-    | 'stray_column_unwrapped';
+    | 'stray_column_unwrapped'
+    | 'nested_column_list_lifted';
   /** Id of the offending block, when it had one. */
   id?: string;
 }
@@ -962,17 +966,24 @@ function repairAt(block: BlockNode, kind: BlockStructureRepair['kind']): BlockSt
 /**
  * Restore the multi-column invariants, in place (callers pass clones).
  *
+ * - a `columnList` nested inside a `column` is LIFTED OUT, re-parented as the
+ *   next sibling of the row that contained it. Wrapping it in a column of its
+ *   own would satisfy the arity rule and still leave the document unopenable,
+ *   and unwrapping it would merge two authored layouts into one column; only
+ *   lifting keeps the rows distinct and the reading order intact
  * - a `column` with no children gets an empty paragraph, so emptying one slot
  *   of a row keeps the row rather than killing the document
  * - a non-column child of a `columnList` is wrapped in its own column, which
- *   keeps it exactly where it was authored
+ *   keeps it exactly where it was authored — unless it is itself a row, which
+ *   is lifted rather than wrapped
  * - a `columnList` left with fewer than two columns is unwrapped: its columns'
  *   children take its place, in order. This matches what the editor does when
  *   you delete the second-to-last column — the content returns to full width
  *   instead of growing a blank column nobody asked for
  * - a `column` outside any `columnList` is unwrapped the same way
  *
- * Content is never dropped: every unwrap splices the children up in place.
+ * Content is never dropped: every unwrap splices the children up in place, and
+ * every lift re-parents the row rather than flattening it.
  */
 function repairColumnStructure(
   blocks: BlockNode[],
@@ -1006,27 +1017,81 @@ function repairColumnStructure(
 
     const kids = Array.isArray(block.children) ? block.children : [];
 
-    // Strays become columns of their own so the row keeps its authored order.
-    const columns = kids.map(kid => {
-      if (kid?.type === COLUMN_TYPE) return kid;
-      // The stray's id, not the row's: the caller is being told to go look at
-      // something, and the row alone doesn't say which block moved.
-      onRepair?.(repairAt(kid ?? block, 'column_list_child_wrapped'));
-      return { type: COLUMN_TYPE, props: { width: 1 }, children: [kid ?? emptyParagraph()] };
-    });
+    // Rows pulled out of this one, re-parented as its siblings below. The
+    // children were already normalized on the way down, so anything still
+    // shaped like a row here is a row that belongs one level up.
+    const liftedRows: BlockNode[] = [];
+    // Wrap repairs are held rather than reported: see the unwrap branch.
+    const wrapRepairs: BlockStructureRepair[] = [];
+    const columns: BlockNode[] = [];
+
+    for (const kid of kids) {
+      // A row directly inside a row. Wrapping it in a column of its own would
+      // satisfy the arity rule and STILL be unopenable — `column` is
+      // `blockContainer+` and a `columnList` is not one — so the wrap would
+      // report a repair that fixed nothing. Lift it instead.
+      if (kid?.type === COLUMN_LIST_TYPE) {
+        liftedRows.push(kid);
+        onRepair?.(repairAt(kid, 'nested_column_list_lifted'));
+        continue;
+      }
+
+      if (kid?.type === COLUMN_TYPE) {
+        // Same violation one level down, and the likelier one: an `insert`
+        // positioned after a paragraph that lives in a column puts the whole
+        // row inside that column.
+        const grandkids = Array.isArray(kid.children) ? kid.children : [];
+        const kept = grandkids.filter(grandkid => {
+          if (grandkid?.type !== COLUMN_LIST_TYPE) return true;
+          liftedRows.push(grandkid);
+          onRepair?.(repairAt(grandkid, 'nested_column_list_lifted'));
+          return false;
+        });
+        if (kept.length !== grandkids.length) kid.children = kept;
+
+        // The arity rule already ran on the way down, so a column the lift
+        // just emptied has to be refilled HERE or it reaches the repo childless.
+        if (!Array.isArray(kid.children) || kid.children.length === 0) {
+          kid.children = [emptyParagraph()];
+          onRepair?.(repairAt(kid, 'empty_column_filled'));
+        }
+        columns.push(kid);
+        continue;
+      }
+
+      // An ordinary stray becomes a column of its own so the row keeps its
+      // authored order. The stray's id, not the row's: the caller is being told
+      // to go look at something, and the row alone doesn't say which block moved.
+      wrapRepairs.push(repairAt(kid ?? block, 'column_list_child_wrapped'));
+      columns.push({
+        type: COLUMN_TYPE,
+        props: { width: 1 },
+        children: [kid ?? emptyParagraph()],
+      });
+    }
 
     if (columns.length >= 2) {
       block.children = columns;
+      // The row survived, so the wrap is visible in the finished document.
+      for (const repair of wrapRepairs) onRepair?.(repair);
+      if (liftedRows.length > 0) {
+        blocks.splice(i + 1, 0, ...liftedRows);
+        i += liftedRows.length; // already normalized — don't walk them again
+      }
       continue;
     }
 
-    // One column (or none) left — unwrap, keeping the content in place.
+    // One column (or none) left — unwrap, keeping the content in place, and
+    // drop the wrap reports: the row they were made for is gone, so the
+    // finished document holds no trace of them and naming one would send a
+    // caller looking for a column that does not exist. The unwrap below is the
+    // repair that actually happened.
     const lifted = columns.flatMap(column =>
       Array.isArray(column.children) ? column.children : []
     );
-    blocks.splice(i, 1, ...lifted);
+    blocks.splice(i, 1, ...lifted, ...liftedRows);
     onRepair?.(repairAt(block, 'column_list_unwrapped'));
-    i += lifted.length - 1;
+    i += lifted.length + liftedRows.length - 1;
   }
 }
 
@@ -1414,6 +1479,11 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
     // ref immune to GitHub's eventually-consistent branch reads. 204 no-op
     // merges have no merge commit; fall back to a fresh main read.
     let newSha: string | null = null;
+    // Set only when the repair below actually committed. That commit went
+    // through savePageContent, which records the row (with the real byte size)
+    // and warms the file itself — so the write-through at the end of this block
+    // must not run again for it.
+    let repairedSha: string | null = null;
     try {
       const mergedFile = await ContentService.getContent({
         gitOrganization,
@@ -1431,7 +1501,8 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
       // This is the default route for a published page (applies land on the
       // preview branch), so it is the likeliest way the invariant gets broken,
       // not an exotic one. Repair on top of the merge commit.
-      newSha = (await repairMergedContent(page, mergedFile, newSha)) ?? newSha;
+      repairedSha = await repairMergedContent(page, mergedFile, newSha);
+      if (repairedSha) newSha = repairedSha;
     } catch (error: unknown) {
       // Advisory only — the merge itself stands.
       console.warn(
@@ -1446,7 +1517,7 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
     // which is the same value. Without this, accepting a preview would publish
     // content the read side keeps serving the pre-accept version of until the
     // webhook lands.
-    if (newSha) await recordPageFile(page, path, newSha);
+    if (newSha && newSha !== repairedSha) await recordPageFile(page, path, newSha);
 
     // Concurrent-stacking guard: a stacking apply may have committed to the
     // preview branch AFTER the merge snapshot GitHub used. If the branch now

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -440,7 +440,18 @@ export async function savePageContent(
   // absence both serialize as no key, matching what pre-merge saves produced —
   // a semantic accept must not sprinkle `"coverImage": null` into documents
   // that never had one. Reads treat a missing key and null identically.
-  const wrapper: { blocks: unknown; coverImage?: PageCoverImage } = { blocks };
+  // Last gate before the bytes hit the repo, so a caller that forgets to
+  // normalize still cannot commit an unopenable document. Idempotent, so the
+  // paths that already normalized pay only a structural walk.
+  //
+  // Two writers reach content.json WITHOUT coming through here, and neither is
+  // covered by this line: acceptPreview's clean git merge (handled explicitly,
+  // see repairMergedContent) and contentImport's byte-for-byte page copy, which
+  // never parses the blocks — a broken page in a source classroom still
+  // propagates to every classroom that imports it.
+  const wrapper: { blocks: unknown; coverImage?: PageCoverImage } = {
+    blocks: Array.isArray(blocks) ? normalizeBlockStructure(blocks) : blocks,
+  };
   if (coverImage != null) {
     wrapper.coverImage = coverImage;
   }
@@ -902,6 +913,150 @@ function insertBlocksAt(
   }
 }
 
+// ─── Structural normalization (multi-column invariants) ──────────────────────
+//
+// `columnList` / `column` (@blocknote/xl-multi-column) are the only blocks in
+// the page schema whose ProseMirror content expressions constrain their
+// CHILDREN: `columnList` is `"column column+"` (every child a column, minimum
+// two) and `column` is `"blockContainer+"` (at least one child). Everything
+// else accepts whatever children it is handed, which is why the op vocabulary
+// can otherwise stay schema-agnostic.
+//
+// That gap is not theoretical. A `delete` op naming a column splices it out
+// with no idea it was the second-to-last one; an `insert` positioned `after` a
+// column lands a paragraph as a columnList's direct child. Either document
+// serializes and commits perfectly happily — and then throws "Error creating
+// document from blocks passed as `initialContent`" for EVERY reader, because
+// ProseMirror refuses to build a doc that violates the schema. The viewer and
+// the editor share that failure, so a page broken this way cannot be repaired
+// in the editor either; the only way back is a re-commit from outside. That
+// asymmetry is why the invariant is enforced on the way IN rather than left to
+// render-time tolerance.
+
+const COLUMN_LIST_TYPE = 'columnList';
+const COLUMN_TYPE = 'column';
+
+/** A structural repair made on the way into a commit. */
+export interface BlockStructureRepair {
+  kind:
+    | 'column_list_unwrapped'
+    | 'column_list_child_wrapped'
+    | 'empty_column_filled'
+    | 'stray_column_unwrapped';
+  /** Id of the offending block, when it had one. */
+  id?: string;
+}
+
+function emptyParagraph(): BlockNode {
+  // Same shape blankPageBlocks persists: a repair writes to the repo, and a
+  // props-less paragraph would materialize with populated props on the next
+  // editor load, making the following save report a block nobody edited as
+  // changed. Ids are minted by normalizeBlockStructure once repairs settle.
+  return { type: 'paragraph', props: { ...STANDARD_BLOCK_PROPS }, content: [], children: [] };
+}
+
+function repairAt(block: BlockNode, kind: BlockStructureRepair['kind']): BlockStructureRepair {
+  return { kind, ...(typeof block.id === 'string' && block.id ? { id: block.id } : {}) };
+}
+
+/**
+ * Restore the multi-column invariants, in place (callers pass clones).
+ *
+ * - a `column` with no children gets an empty paragraph, so emptying one slot
+ *   of a row keeps the row rather than killing the document
+ * - a non-column child of a `columnList` is wrapped in its own column, which
+ *   keeps it exactly where it was authored
+ * - a `columnList` left with fewer than two columns is unwrapped: its columns'
+ *   children take its place, in order. This matches what the editor does when
+ *   you delete the second-to-last column — the content returns to full width
+ *   instead of growing a blank column nobody asked for
+ * - a `column` outside any `columnList` is unwrapped the same way
+ *
+ * Content is never dropped: every unwrap splices the children up in place.
+ */
+function repairColumnStructure(
+  blocks: BlockNode[],
+  insideColumnList: boolean,
+  onRepair?: (repair: BlockStructureRepair) => void
+): void {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (!block || typeof block !== 'object') continue;
+
+    // Depth first: a child columnList must already be valid (or gone) before
+    // this level decides what its own children are.
+    if (Array.isArray(block.children)) {
+      repairColumnStructure(block.children, block.type === COLUMN_LIST_TYPE, onRepair);
+    }
+
+    if (block.type === COLUMN_TYPE) {
+      if (!insideColumnList) {
+        const lifted = Array.isArray(block.children) ? block.children : [];
+        blocks.splice(i, 1, ...lifted);
+        onRepair?.(repairAt(block, 'stray_column_unwrapped'));
+        i += lifted.length - 1;
+      } else if (!Array.isArray(block.children) || block.children.length === 0) {
+        block.children = [emptyParagraph()];
+        onRepair?.(repairAt(block, 'empty_column_filled'));
+      }
+      continue;
+    }
+
+    if (block.type !== COLUMN_LIST_TYPE) continue;
+
+    const kids = Array.isArray(block.children) ? block.children : [];
+
+    // Strays become columns of their own so the row keeps its authored order.
+    const columns = kids.map(kid => {
+      if (kid?.type === COLUMN_TYPE) return kid;
+      // The stray's id, not the row's: the caller is being told to go look at
+      // something, and the row alone doesn't say which block moved.
+      onRepair?.(repairAt(kid ?? block, 'column_list_child_wrapped'));
+      return { type: COLUMN_TYPE, props: { width: 1 }, children: [kid ?? emptyParagraph()] };
+    });
+
+    if (columns.length >= 2) {
+      block.children = columns;
+      continue;
+    }
+
+    // One column (or none) left — unwrap, keeping the content in place.
+    const lifted = columns.flatMap(column =>
+      Array.isArray(column.children) ? column.children : []
+    );
+    blocks.splice(i, 1, ...lifted);
+    onRepair?.(repairAt(block, 'column_list_unwrapped'));
+    i += lifted.length - 1;
+  }
+}
+
+/**
+ * Return a document that BlockNote can actually open: same blocks, with the
+ * multi-column invariants restored (see `repairColumnStructure`). Pure and
+ * idempotent — a document that is already valid is returned structurally
+ * unchanged, so it is safe to call on every path that produces one.
+ */
+export function normalizeBlockStructure<T = unknown>(
+  blocks: T[],
+  { onRepair }: { onRepair?: (repair: BlockStructureRepair) => void } = {}
+): T[] {
+  const copy = structuredClone(blocks) as unknown as BlockNode[];
+
+  let repaired = false;
+  repairColumnStructure(copy, false, repair => {
+    repaired = true;
+    onRepair?.(repair);
+  });
+
+  // A repair invents blocks (the filler paragraph, the wrapping column) and
+  // they must not reach the repo id-less: only the MCP path runs ensureBlockIds
+  // afterwards, and apps/pages never id-fills on read, so BlockNote would mint
+  // a random id client-side and the next ops-shaped save would name a block the
+  // stored document doesn't have. Gated on an actual repair to keep the
+  // documented promise that a valid document comes back unchanged.
+  return (repaired ? ensureBlockIds(copy) : copy) as unknown as T[];
+}
+
 /**
  * Apply a sequence of block operations to a document. Pure — returns a new
  * blocks array, input untouched. Ops are applied sequentially, so later ops
@@ -927,7 +1082,13 @@ function insertBlocksAt(
 export function applyBlockOps(
   blocks: unknown[],
   ops: BlockOp[],
-  { onIdRemint }: { onIdRemint?: (remint: BlockIdRemint) => void } = {}
+  {
+    onIdRemint,
+    onStructureRepair,
+  }: {
+    onIdRemint?: (remint: BlockIdRemint) => void;
+    onStructureRepair?: (repair: BlockStructureRepair) => void;
+  } = {}
 ): unknown[] {
   let doc = structuredClone(blocks) as BlockNode[];
 
@@ -993,7 +1154,13 @@ export function applyBlockOps(
     }
   }
 
-  return doc;
+  // Ops are structural, not schema-aware: a delete that empties a columnList
+  // below two columns applies cleanly and yields a document no reader can
+  // open. Repair before the result escapes, so what callers report and what
+  // gets committed are the same document.
+  return normalizeBlockStructure(doc, {
+    ...(onStructureRepair ? { onRepair: onStructureRepair } : {}),
+  });
 }
 
 // ─── Preview branches (plan §3b) ─────────────────────────────────────────────
@@ -1183,6 +1350,50 @@ function extractBlocks(content: string | null | undefined): BlockNode[] {
  * top-level blocks (base = merge-base version, ours = main, theirs = preview)
  * so the caller can resolve semantically and re-apply.
  */
+/**
+ * Normalize a document GitHub's merge API just produced, committing a repair
+ * only when one was actually needed.
+ *
+ * @param mergedFile - the post-merge content.json read (content + blob sha).
+ * @returns the sha of the repair commit, or null when nothing needed fixing.
+ */
+async function repairMergedContent(
+  page: PageWithContentRepo,
+  mergedFile: { content?: string | null; sha?: string | null } | null,
+  mergedSha: string | null
+): Promise<string | null> {
+  const blocks = mergedFile?.content ? parseBlocksStrict(mergedFile.content) : null;
+  // Unparseable content.json is not this function's problem to solve — the
+  // merge stands and the existing conflict/reload flows already cover it.
+  if (!blocks) return null;
+
+  let repaired = false;
+  const normalized = normalizeBlockStructure(blocks, {
+    onRepair: () => {
+      repaired = true;
+    },
+  });
+  if (!repaired) return null;
+
+  try {
+    const saved = await savePageContent(page, normalized, {
+      coverImage: extractCover(mergedFile?.content),
+      // CAS on the blob the merge produced: if anything landed in between,
+      // that write went through savePageContent and was normalized itself, so
+      // losing this race leaves a valid document either way.
+      ...(mergedSha ? { expectedSha: mergedSha } : {}),
+      message: `Accept preview (repaired column layout): ${page.title}`,
+    });
+    return saved.sha;
+  } catch (error: unknown) {
+    console.warn(
+      `[pageContent.acceptPreview] Could not commit the post-merge column repair for ${page.content_path}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  }
+}
+
 export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPreviewResult> {
   const { gitOrganization, repo } = contentRepoFor(page);
   const branch = previewBranchName(page.content_path);
@@ -1211,6 +1422,16 @@ export async function acceptPreview(page: PageWithContentRepo): Promise<AcceptPr
         ...(result.sha ? { ref: result.sha } : { skipCache: true }),
       });
       newSha = mergedFile?.sha ?? null;
+
+      // A CLEAN git merge is not a valid document. Both sides can individually
+      // satisfy the multi-column invariants and still merge into something no
+      // reader can open: deleting two different columns from the same row is
+      // two non-overlapping hunks in a pretty-printed content.json, so git
+      // merges them without a conflict and never runs the semantic fallback.
+      // This is the default route for a published page (applies land on the
+      // preview branch), so it is the likeliest way the invariant gets broken,
+      // not an exotic one. Repair on top of the merge commit.
+      newSha = (await repairMergedContent(page, mergedFile, newSha)) ?? newSha;
     } catch (error: unknown) {
       // Advisory only — the merge itself stands.
       console.warn(
@@ -1959,8 +2180,14 @@ async function runSaveMerge(
           ? `Update page (merged): ${page.title}`
           : `Update page: ${page.title}`);
 
+    // Both sides can be individually valid and still merge into a document
+    // that isn't (each deletes a different column of the same three-column
+    // row). Normalize once, so the commit and the document handed back to the
+    // client are the same blocks — the client adopts what main now holds.
+    const merged = normalizeBlockStructure(merge.merged);
+
     try {
-      const saved = await savePageContent(page, merge.merged, {
+      const saved = await savePageContent(page, merged, {
         // Preserve main's CURRENT cover explicitly (the editor save carries no
         // cover; passing it avoids savePageContent's extra preserve re-read).
         coverImage: extractCover(ours.content),
@@ -1971,7 +2198,7 @@ async function runSaveMerge(
         merged: true,
         sha: saved.sha,
         commit: saved.commit,
-        document: merge.merged,
+        document: merged,
         auto_merged: merge.autoMerged,
         concurrent,
       };


### PR DESCRIPTION
## The invariant

`columnList` and `column` (`@blocknote/xl-multi-column`) are the only blocks in the page schema whose ProseMirror content expressions constrain their **children**: a `columnList` is `"column column+"` (every child a column, minimum two) and a `column` is `"blockContainer+"` (at least one child). Nothing enforced that on the way into a commit.

## Why it matters

A `page_content_apply` delete op took a three-column staff row down to one, spliced the columns out, and committed happily. The resulting `content.json` then threw

```
Error creating document from blocks passed as `initialContent`
```

for **every** reader. The viewer and the editor both build the document through `useCreateBlockNote`, so a page broken this way could not be opened *or* repaired in the UI — the only way back was an out-of-band re-commit. That is what happened to the CS52 course page.

The asymmetry (breakable by a normal write, unfixable in the product) is why the invariant is enforced on the way **in** rather than left to render-time tolerance.

## What this does

`normalizeBlockStructure` restores the invariants without dropping content:

- a row left below two columns unwraps, its content returning to full width — the same thing the editor does when you delete the second-to-last column
- a non-column child of a row is wrapped in a column of its own, where it was authored
- an emptied column gets a paragraph, so emptying one slot keeps the row
- a stray `column` outside any row unwraps

It is pure and idempotent, so a valid document comes back structurally unchanged and every path can call it.

### Write paths

`savePageContent` is the last gate before bytes hit the repo, so every write that funnels through it is covered:

| Path | Covered by |
| --- | --- |
| `savePageContent` (editor whole-document save, MCP apply commit, page route save) | the gate itself |
| `savePageContentFromOps` → `applyBlockOps` | `applyBlockOps` normalizes its result, then the gate |
| `savePageContentWithMerge` → `runSaveMerge` | normalizes `merge.merged` explicitly, so the commit and the document handed back to the client are the same blocks; then the gate |
| MCP `page_content_apply` | `applyBlockOps` with `onStructureRepair`, then the gate |
| `acceptPreview` — semantic fallback (`commitSemanticMergeToMain`) | goes through the gate |
| `acceptPreview` — **clean git merge** | does *not* go through the gate (GitHub writes the bytes); handled explicitly by the new `repairMergedContent` |
| page create (`blankPageContentJson`) | structurally valid by construction |

The clean-merge case is the likeliest one, not an exotic one: applies on a published page land on the preview branch by default, and two sides can each delete a different column of the same row — neither side invalid alone. In a pretty-printed `content.json` those are non-overlapping hunks, so git merges them without a conflict and the semantic fallback never runs. `acceptPreview` now normalizes what the merge produced and re-commits, CAS'd on the merge blob; a lost race is safe, because whatever won went through `savePageContent` and was normalized itself.

`contentImport`'s byte-for-byte page copy remains uncovered by design — it never parses the blocks — and is called out in a comment at the gate.

`page_content_apply` reports repairs as `structure_repairs` with a note. Silently unwrapping a row would leave an agent believing its delete did exactly what it asked.

## How it was rebased

Cherry-picked from `ce45bf81` (unmerged `fix/page-column-invariants`, Sept 2) onto current staging. `pageContent.service.ts` auto-merged despite the content-delivery reshaping (asset-map write-through, `fetchContentText`, warm-on-save, `recordPageFile`, `pageWarmContext`); the placements were then checked by hand:

- the gate sits **after** `canonicalizePageBlocks` and **inside** the wrapper that gets serialized, so `recordPageFile` and the cache warm see the repaired bytes and the size recorded is the size committed
- the repair `acceptPreview` commits goes through `savePageContent`, so it is written through to the asset map like any other save; `acceptPreview`'s own trailing `recordPageFile(newSha)` then re-records the same sha without a size, which is a no-op rather than an overwrite
- one conflict, in `pageContent.service.test.ts`: both sides appended a new `describe` after the same anchor (staging's `loadPageContent viaWorker` + `savePageContent write-through`, the commit's `savePageContent — structural gate`). Resolved by keeping both.
- one existing fixture in `contentDelivery.canonicalizeSave.test.ts` was a single-column row, which the gate now unwraps before the write. It gains a second column — that test is about reaching a nested asset ref, not about normalization.

## Verification

- `@classmoji/services` pageContent suites: 179 passed
- `@classmoji/services` full suite: 1659 passed, 13 failed — exactly the pre-existing failures on staging (12 `GitLabProvider` not-implemented, 1 `classroomMembership`)
- `@classmoji/mcp`: 559 passed
- `apps/pages` unit specs: 499 passed
- typecheck: `mcp` and `pages` clean; `services` clean apart from the same pre-existing `GitLabProvider` test errors
- eslint on the touched files: no new findings
- production builds: `npm run web:build` and `npm run pages:build` both green (forced, not cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA
