### PR TITLE
docs: document class websites and custom domains

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -54,6 +54,16 @@ export default defineConfig({
             },
             { label: 'Build pages', slug: 'docs/instructors/pages' },
             { label: 'Build modules', slug: 'docs/instructors/modules' },
+            {
+              label: 'Class website',
+              slug: 'docs/instructors/class-sites',
+              badge: { text: 'New', variant: 'tip' },
+            },
+            {
+              label: 'Custom domain',
+              slug: 'docs/instructors/custom-domains',
+              badge: { text: 'New', variant: 'tip' },
+            },
             { label: 'Grade assignments', slug: 'docs/instructors/grading' },
             { label: 'Configure tokens', slug: 'docs/instructors/tokens' },
             {

--- a/apps/site/src/content/docs/docs/instructors/class-sites.mdx
+++ b/apps/site/src/content/docs/docs/instructors/class-sites.mdx
@@ -1,0 +1,67 @@
+---
+title: Publish a class website
+description: Put your pages, schedule and forms on a public address like cs52.classmoji.io
+---
+
+### What is a class website?
+
+A class website is a public address for your classroom. Claim a subdomain and the site is live at `cs52.classmoji.io`, serving the pages you choose, the course schedule, and any published forms.
+
+Publishing something to your students and putting it on the public web are two separate switches. Turning the site on publishes nothing by itself: every page keeps the status you already gave it, and you decide item by item what an anonymous visitor can see.
+
+### Claim a subdomain
+
+Go to **Settings → Website**. The **Course Website** section holds the subdomain field, pre-filled with your classroom slug when that slug is a legal subdomain.
+
+A subdomain is a single DNS label:
+
+- lowercase letters, numbers and hyphens
+- starts and ends with a letter or a number
+- up to 63 characters
+- unique across Classmoji, and names the platform needs (`app`, `api`, `docs` and similar) are reserved
+
+Availability is checked as you type, so a name that is taken or reserved is rejected before you save.
+
+### Choose a home page
+
+The **Home page** section picks the page served at the root of your site. You have to choose one before the site can be turned on, because a site with no home page has nothing to answer with.
+
+Any page can be the home page. Choosing a members-only page is allowed and sometimes deliberate (a syllabus behind sign-in), so it produces a hint rather than an error.
+
+### Turn the site on
+
+Flip **Website enabled**. The switch stays disabled until a home page is chosen.
+
+Switching it back off takes the site offline but keeps your subdomain claimed, so you can put a course site away between semesters and bring it back at the same address.
+
+### What visitors see
+
+Each page carries the same status it has everywhere else in Classmoji.
+
+| Status | Who can access |
+|--------|---------------|
+| **Draft** | Nobody. The page is hidden from all students. |
+| **Private** | Enrolled students only (requires login) |
+| **Public** | Anyone with the link, no login required |
+
+A visitor who opens a private page gets a sign-in page that names the course, rather than being thrown straight at a Github login screen. Students sign in there and read the page on the site.
+
+### Publish the schedule
+
+The **Public schedule** section publishes your course calendar at `/schedule` on the site. Modules marked **Public** appear there, with their items listed as pages, slides and assignments.
+
+Set the **Time zone** in the same section. Dates then read in the course's zone rather than in whatever zone the visitor's browser happens to be in.
+
+### Paths the platform owns
+
+A few first path segments belong to Classmoji and cannot be served by one of your pages: `app`, `classmoji`, `sign-in`, `schedule`, `forms` and `robots.txt`. Give a page any other slug and it is reachable at `cs52.classmoji.io/{slug}`.
+
+### Remove the site
+
+**Remove site** takes the site offline and frees the subdomain for another class. Use it when a course is finished and the address should go back into circulation; use the **Website enabled** switch instead when you want to keep the name.
+
+### What's next
+
+- [Use your own domain](/docs/instructors/custom-domains)
+- [Build pages](/docs/instructors/pages)
+- [Build modules](/docs/instructors/modules)

--- a/apps/site/src/content/docs/docs/instructors/custom-domains.mdx
+++ b/apps/site/src/content/docs/docs/instructors/custom-domains.mdx
@@ -1,0 +1,66 @@
+---
+title: Use your own domain
+description: Serve your class website on a domain you own, like cs52.me
+---
+
+:::note
+Connecting your own domain is a **Pro** feature. A class website on a `classmoji.io` subdomain is not.
+:::
+
+### Before you start
+
+You need three things: a class website already live on a subdomain, a domain (or a subdomain of one) that you control, and access to that domain's DNS records. A departmental domain and a course domain you bought yourself both work.
+
+### Add the domain
+
+Go to **Settings → Website** and find the **Custom domain** section. Enter the domain you want the site served on, such as `cs52.me` or `cs52.department.edu`, and save it.
+
+Classmoji then shows the DNS records to add. Nothing changes for your visitors until those records exist.
+
+### Point the domain at Classmoji
+
+There are two groups of records, and they answer two different questions.
+
+**Routing — add ONE of these, not both**
+
+| Option | When to use it |
+|--------|---------------|
+| **A (and AAAA) records** | Point the name straight at our addresses. Works anywhere, including at a root domain like `cs52.me` where a CNAME often cannot go. |
+| **CNAME record** | One record, and it follows us if our addresses ever change. Many DNS hosts refuse a CNAME at a root domain: there, use their ALIAS, ANAME or CNAME flattening record with the same value (Cloudflare flattens automatically). |
+
+Adding both is not extra insurance. A CNAME alongside an A record for the same name is an invalid zone, so pick the row that fits your DNS host and add only that one.
+
+**Proof of ownership — any one of these**
+
+| Record | Name |
+|--------|------|
+| **CNAME** | `_acme-challenge.{your domain}` |
+| **TXT** | `_fly-ownership.{your domain}` |
+
+If your routing choice included an AAAA record, it does double duty: it routes IPv6 traffic and proves ownership, so you can skip this group entirely. The page tells you when that applies.
+
+### Watch the certificate
+
+Classmoji requests the TLS certificate for you as soon as the records resolve. The status chip next to the domain reports where it is:
+
+| Chip | Meaning |
+|------|---------|
+| **No certificate yet** | The request has not started |
+| **Pending DNS** | We are still waiting on your records |
+| **Issuing** | Records found, certificate being issued |
+| **Active** | The certificate is live and the domain is served over HTTPS |
+
+DNS changes take anywhere from a few minutes to a few hours to propagate, depending on your host and the record's previous TTL. Nothing here needs babysitting: leave the tab, come back later.
+
+The domain is marked verified once the site has actually served a request on that hostname, which is a stronger signal than a record merely existing.
+
+### Disconnect a domain
+
+Use the disconnect button in the same section. The site stays reachable at its `classmoji.io` subdomain, so disconnecting takes the custom address down without taking the course site down.
+
+Disconnecting stays available even if a Pro subscription lapses. A domain you pointed at us is one you must always be able to point somewhere else.
+
+### What's next
+
+- [Publish a class website](/docs/instructors/class-sites)
+- [Build pages](/docs/instructors/pages)


### PR DESCRIPTION
The two newest instructor-facing features had no docs page, so nothing in the product or in outbound email could link to them.

## Pages

**`instructors/class-sites.mdx`** — Publish a class website. Claiming a subdomain (label rules and reserved names as enforced in `packages/utils/src/subdomains.ts`), why a home page gates the enable switch, what each page status means to a visitor, the sign-in interstitial a private page shows, the public schedule and its time zone, the platform-owned path segments, and remove-vs-disable.

**`instructors/custom-domains.mdx`** — Use your own domain. The Pro note, the A/AAAA-or-CNAME routing choice with the root-domain caveat and why adding both is an invalid zone, the two ownership proofs and when an AAAA makes them unnecessary, the certificate states (No certificate yet → Pending DNS → Issuing → Active), and why disconnecting stays available after a lapsed subscription.

Content is drawn from `admin.$class.settings.website/` (`siteSettings.ts`, `customDomain.ts`) and the site server in `apps/pages/app/site/`, so the docs describe what the code does rather than what the feature was meant to do.

## Sidebar

Both added under **For Instructors** after "Build modules", with the `New` badge the other recent pages use.

## Test steps

1. `npm run site:dev`, then open `/docs/instructors/class-sites` and `/docs/instructors/custom-domains` (the site dev server listens on port 4000).
2. Confirm both appear in the For Instructors sidebar and that the cross-links between the two pages resolve.
3. `npm run site:build` completes; both routes are emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152e3TdpwbtvjYktXUPSufk