### PR TITLE
fix: repo search, self-formed team links, invites that never resolved, and heading parity

### DIFF
--- a/apps/pages/app/site/render.server.ts
+++ b/apps/pages/app/site/render.server.ts
@@ -337,9 +337,18 @@ export function addHeadingAnchors(html: string): {
  * `bn-root` / `bn-container` / `bn-mantine` on the outside and
  * `ProseMirror bn-editor bn-default-styles` on the inside is the official
  * recipe for rendering serialized BlockNote HTML with the editor's stylesheet,
- * and it is the reason this feature ships ZERO custom block CSS: every block's
- * appearance comes from `@blocknote/mantine/style.css` plus the app's existing
- * overrides, which is also what makes the site look identical to the editor.
+ * and it is the reason this feature ships almost no custom block CSS: every
+ * block's appearance comes from `@blocknote/mantine/style.css` plus the app's
+ * existing overrides.
+ *
+ * That recipe carries every override keyed on a BlockNote class — but NOT the
+ * ones scoped to `.page-editor`, a class only the editor and the in-app viewer
+ * put on their wrapper. Headings are what proved it: their sizes lived under
+ * `.page-editor`, so a site page fell through to BlockNote's 3em/2em/1.3em and
+ * published a 48px H1 where the editor showed 30px (#288). The scale now lives
+ * unscoped in `blocknote-overrides.css`, as `--level`. Before assuming this
+ * wrapper makes the site identical to the editor, check whether the rule you
+ * care about is `.page-editor`-scoped; if it is, it does not ship here.
  *
  * The colour scheme is fixed to `light` server-side. BlockNote's theme is an
  * attribute, not a media query, and the document's dark-mode script toggles a

--- a/apps/pages/app/site/styles.ts
+++ b/apps/pages/app/site/styles.ts
@@ -79,6 +79,21 @@ export const SITE_STYLES = `
   .page-header-image { height: 18rem; }
 }
 
+/* --- headings: deliberately absent ------------------------------------ */
+
+/* Headings are NOT restated here, and adding them would be a regression.
+
+   They used to be the same bug the cover band above fixes: sizes scoped to
+   .page-editor, which a site page does not have, so the site published a 48px
+   H1 against the editor's 30px (#288). The fix went the other way -- the scale
+   now lives UNSCOPED in app/styles/blocknote-overrides.css as BlockNote's own
+   --level custom property, which ships to every surface via root.tsx, so the
+   editor, the in-app viewer and this page read one definition.
+
+   If a heading looks wrong on a site page, fix it there, not here. A rule in
+   this file would fork the scale again and only the site would move.
+   site-render.spec.ts asserts this section stays empty of heading sizes. */
+
 /* --- page link -------------------------------------------------------- */
 
 /* The editor draws a pageLink as a bordered row around a SPAN, so its

--- a/apps/pages/app/styles/blocknote-overrides.css
+++ b/apps/pages/app/styles/blocknote-overrides.css
@@ -57,8 +57,79 @@
   color: #ff6b6b !important;
 }
 
-/* Heading sizes - Notion style (H1: 30px, H2: 24px, H3: 20px) */
-/* More specific selectors to override inline styles */
+/* Heading scale — ONE definition, every surface.
+   Notion style: H1 30px, H2 24px, H3 20px, H4-H6 16px.
+
+   These sizes used to exist only under `.page-editor` (below), the class the
+   editor and the in-app viewer wrap content in. A server-rendered class-site
+   page has no `.page-editor` — it serves BlockNote's markup under
+   `.site-article` — so the overrides never matched and the site fell through to
+   BlockNote's own em ladder off a 16px base: 3em/2em/1.3em, or 48/32/20.8px.
+   An author who opened a section with a 30px H1 published a 48px one, and
+   nothing in the editor said so. See issue #288.
+
+   Setting `--level` rather than `font-size` feeds BlockNote's OWN hook. It is
+   read by exactly one declaration in the whole @blocknote CSS surface —
+   `.bn-block-outer:not([data-prev-type]) > .bn-block >
+   .bn-block-content[data-content-type=heading] { font-size: var(--level) }` —
+   so there are no side channels, and because `.bn-default-styles h1..h6` is
+   `font-size: inherit`, one declaration sizes both the block box and the
+   heading tag. Sizing the tag instead would leave a phantom 48px on the
+   wrapper for the next `em`-based rule to trip over.
+
+   No `!important` anywhere: we supply the input rather than compete with the
+   output. Every rule here is (0,3,0) against BlockNote's (0,1,0)/(0,2,0), so it
+   wins on specificity and never on stylesheet order — which matters, because
+   this file ships TWICE (root.tsx imports it, tailwind.css @imports it again).
+
+   An H1 carries NO `data-level` attribute: BlockNote omits a prop equal to its
+   default and heading's default level is 1 (which is why its own CSS has a bare
+   `[data-content-type=heading]` rule with no `[data-level="1"]` twin).
+   `:not([data-level])` is the H1 rule — do not "simplify" it away. */
+.bn-block-content[data-content-type="heading"]:not([data-level]),
+.bn-block-content[data-content-type="heading"][data-level="1"] {
+  --level: 30px;
+}
+
+.bn-block-content[data-content-type="heading"][data-level="2"] {
+  --level: 24px;
+}
+
+.bn-block-content[data-content-type="heading"][data-level="3"] {
+  --level: 20px;
+}
+
+.bn-block-content[data-content-type="heading"][data-level="4"] {
+  --level: 16px;
+}
+
+.bn-block-content[data-content-type="heading"][data-level="5"] {
+  --level: 16px;
+}
+
+.bn-block-content[data-content-type="heading"][data-level="6"] {
+  --level: 16px;
+}
+
+/* Stated rather than left to BlockNote's own heading rule, which is gated on
+   `.bn-block-outer:not([data-prev-type])` and so drops out for the frame a
+   block is changing type. The 1.3 was editor-only, living in PageEditor's
+   inline <style>, which is why site and in-app-viewer headings inherited
+   BlockNote's 1.5 instead. */
+.bn-block-content[data-content-type="heading"] {
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+/* The editor's own copy of the scale above. It is still load-bearing HERE:
+   PageEditor's inline `<style>` pins `.page-editor .bn-block-content` to
+   `16px !important`, which defeats `font-size: var(--level)` on the wrapper, so
+   the editor is sized by these tag-level rules rather than by `--level`. They
+   must agree with the `--level` values above — site-render.spec.ts fails until
+   they do. Removing the pin so `--level` governs the editor too is a separate,
+   riskier change: `.bn-inline-content` IS the heading tag, so a broadened
+   selector that forgets to exclude headings collapses every one of them to
+   16px, silently. */
 .page-editor .bn-editor h1,
 .page-editor .bn-block-content h1 {
   font-size: 30px !important;

--- a/apps/pages/tests/unit/site-render.spec.ts
+++ b/apps/pages/tests/unit/site-render.spec.ts
@@ -742,6 +742,98 @@ test.describe('editor parity', () => {
     expect(editor, 'page-viewer.css should still size .page-header-image').not.toHaveLength(0);
     expect(coverHeights(SITE_STYLES)).toEqual(editor);
   });
+
+  /** Comments stripped, so prose in these files cannot be parsed as selectors. */
+  const uncommented = (css: string): string => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+  /** Every `rule { … }` pair in a stylesheet, as [selector, body]. */
+  const rules = (css: string): [string, string][] =>
+    [...uncommented(css).matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(([, sel, body]) => [sel, body]);
+
+  /**
+   * The shared heading scale, keyed by level: every `--level` in
+   * blocknote-overrides.css.
+   *
+   * An H1 carries no `data-level` — BlockNote omits a prop equal to its default
+   * and heading's default level is 1 — so the `:not([data-level])` selector is
+   * the H1 rule, and the `[data-level="1"]` twin covers any export path that
+   * ever does write the attribute.
+   */
+  const sharedScale = (css: string): Record<string, string> => {
+    const scale: Record<string, string> = {};
+    for (const [selector, body] of rules(css)) {
+      const level = body.match(/--level:\s*([^;]+)/);
+      if (!level) continue;
+      const value = level[1].trim();
+      if (selector.includes(':not([data-level])')) scale['1'] = value;
+      for (const [, n] of selector.matchAll(/\[data-level="([1-6])"\]/g)) scale[n] = value;
+    }
+    return scale;
+  };
+
+  /** The editor's surviving tag-level copy: `.page-editor … hN { font-size }`. */
+  const editorHeadingSizes = (css: string): Record<string, string> => {
+    const sizes: Record<string, string> = {};
+    for (const [selector, body] of rules(css)) {
+      if (!selector.includes('.page-editor')) continue;
+      const size = body.match(/font-size:\s*([^;!]+)/);
+      if (!size) continue;
+      for (const [, level] of selector.matchAll(/(?:^|[\s>+~,])h([1-6])\b/g)) {
+        sizes[level] = size[1].trim();
+      }
+    }
+    return sizes;
+  };
+
+  const overridesCss = (): string =>
+    fs.readFileSync(new URL('../../app/styles/blocknote-overrides.css', import.meta.url), 'utf-8');
+
+  test('the heading scale is shared, not scoped to the editor', () => {
+    // The bug this pins: the sizes lived only under `.page-editor`, a class a
+    // server-rendered site page does not have, so the site fell through to
+    // BlockNote's 3em/2em/1.3em and published a 48px H1 where the editor showed
+    // 30px (#288). The scale is now unscoped `--level`, which reaches every
+    // surface — so a scoped selector here would re-break exactly one of them.
+    const scale = sharedScale(overridesCss());
+
+    expect(Object.keys(scale).sort()).toEqual(['1', '2', '3', '4', '5', '6']);
+
+    for (const [selector, body] of rules(overridesCss())) {
+      if (!/--level:/.test(body)) continue;
+      expect(selector, '--level must not be scoped to one surface').not.toMatch(
+        /\.page-editor|\.site-article|\.page-viewer/
+      );
+    }
+  });
+
+  test("the editor's own heading rules agree with the shared scale", () => {
+    // PageEditor's inline `16px !important` pin defeats `font-size: var(--level)`
+    // in the editor, so these tag-level rules are what it actually renders. Two
+    // live copies of one scale: this is the assertion that keeps them equal.
+    const scale = sharedScale(overridesCss());
+    const editor = editorHeadingSizes(overridesCss());
+
+    expect(
+      Object.keys(editor),
+      'blocknote-overrides.css should still size .page-editor headings'
+    ).not.toHaveLength(0);
+
+    for (const [level, size] of Object.entries(editor)) {
+      expect(size, `editor h${level} should match the shared --level`).toBe(scale[level]);
+    }
+  });
+
+  test('the site stylesheet does not fork the heading scale', () => {
+    // The recurrence this guards: "site headings look wrong" is a tempting
+    // one-line fix in SITE_STYLES, and it would move the site alone while the
+    // editor and the in-app viewer stayed on the shared scale.
+    for (const [selector, body] of rules(SITE_STYLES)) {
+      if (!/heading/.test(selector) && !/--level:/.test(body)) continue;
+      expect(body, `SITE_STYLES should not size headings (${selector.trim()})`).not.toMatch(
+        /font-size:|--level:/
+      );
+    }
+  });
 });
 
 test.describe('article width', () => {

--- a/apps/webapp/app/components/features/modules/studentTree.tsx
+++ b/apps/webapp/app/components/features/modules/studentTree.tsx
@@ -1,4 +1,5 @@
 import { Tag } from 'antd';
+import { Link } from 'react-router';
 import Emoji from '~/components/ui/display/Emoji';
 import {
   type ModuleTreeNode,
@@ -41,6 +42,15 @@ export interface StudentTreeCtx {
   studentRepoByRepositoryId?: Record<string, { name: string }>;
   /** The viewer's latest autograding result per repository unit, keyed by id. */
   autogradingByRepositoryId?: Record<string, AutogradingResultData>;
+  /**
+   * Self-formed group repos on this page, keyed by repository id, with the
+   * viewer's team state. Present only where the loader resolved it; a repo
+   * missing from this map renders exactly as it always did.
+   */
+  selfFormedByRepositoryId?: Record<
+    string,
+    { slug: string; hasTeam: boolean; deadlinePassed: boolean }
+  >;
   /**
    * Whether the viewer is teaching staff, taken from the membership the route's
    * gate returned — never inferred from `rolePrefix`, which is only the URL the
@@ -246,12 +256,55 @@ export const buildRepositoryNode = (
   const sourceRepoUrl = repository.template
     ? repoGithubUrl(repository.template, ctx.gitOrgLogin)
     : null;
-  const repositoryUrl = directRepoUrl ?? ownRepoUrl ?? sourceRepoUrl;
+  // The template fallback is deliberately NOT offered on a self-formed row: a
+  // student with no team has no repo of their own, and a "View" pointing at the
+  // instructor's template is how they end up committing and filing issues on
+  // it. Their own team repo still links normally once it exists.
+  const selfFormed = ctx.selfFormedByRepositoryId?.[String(repository.id)];
+  const repositoryUrl = selfFormed
+    ? (directRepoUrl ?? ownRepoUrl)
+    : (directRepoUrl ?? ownRepoUrl ?? sourceRepoUrl);
 
   const autogradingResult = ctx.autogradingByRepositoryId?.[String(repository.id)];
 
   const total = assignments.length;
   const done = assignments.filter(a => raByAssignmentId[String(a.id)]?.status === 'CLOSED').length;
+
+  const repositoryAction = repositoryUrl ? (
+    <a
+      href={repositoryUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="text-sm font-medium text-sky-600 hover:text-sky-700 dark:text-sky-400"
+    >
+      View
+    </a>
+  ) : null;
+
+  // A self-formed group repo is the one case where the row's job is to send the
+  // viewer somewhere in the app rather than to GitHub: until they are on a team
+  // there is no repo to open, and the team page was previously reachable only
+  // by a link the instructor pasted by hand (#313).
+  const teamHref = selfFormed
+    ? `/${ctx.rolePrefix ?? 'student'}/${ctx.classSlug}/repos/${selfFormed.slug}/team`
+    : null;
+  const selfFormedAction =
+    selfFormed && teamHref && !(selfFormed.deadlinePassed && !selfFormed.hasTeam) ? (
+      <Link
+        to={teamHref}
+        className="text-sm font-medium text-sky-600 hover:text-sky-700 dark:text-sky-400"
+      >
+        {selfFormed.hasTeam ? 'View team' : 'Form a team'}
+      </Link>
+    ) : null;
+  // Only when there is no submission count to show, which is the state a repo
+  // awaiting a team is always in.
+  const selfFormedStatus =
+    selfFormed && !selfFormed.hasTeam ? (
+      <span className="text-xs font-medium text-ink-3">
+        {selfFormed.deadlinePassed ? 'Team formation closed' : 'No team yet'}
+      </span>
+    ) : null;
 
   return {
     key: `repository-${repository.id}`,
@@ -270,23 +323,15 @@ export const buildRepositoryNode = (
           repoName={directRepo?.name}
         />
       ) : null,
-    actionNode:
-      baseLevel === 0 && repositoryUrl ? (
-        <a
-          href={repositoryUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="text-sm font-medium text-sky-600 hover:text-sky-700 dark:text-sky-400"
-        >
-          View
-        </a>
-      ) : null,
+    actionNode: baseLevel === 0 ? (selfFormedAction ?? repositoryAction) : null,
     statusNode:
       total > 0 ? (
         <span className="text-xs font-medium text-ink-2 tabular-nums">
           {done}/{total} submitted
         </span>
-      ) : null,
+      ) : (
+        selfFormedStatus
+      ),
     children: repositoryChildren,
   };
 };

--- a/apps/webapp/app/routes/__tests__/selfFormedRepoVisibility.test.ts
+++ b/apps/webapp/app/routes/__tests__/selfFormedRepoVisibility.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the student repositories loader's visibility rule.
+ *
+ * A GROUP + SELF_FORMED repository creates no GitRepo until the student forms a
+ * team, so the "only show repos the student owns" filter used to hide the one
+ * page they needed to reach — the team-formation page — leaving it reachable
+ * only by a link an instructor pasted by hand (#313).
+ *
+ * These pin both halves of the rule: the self-formed repo is visible with its
+ * team state resolved, and the filter still hides an unprovisioned individual
+ * repo, which is what it was written for.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  assertClassroomAccess: vi.fn(),
+  repositoryFindMany: vi.fn(),
+  gitRepoFindMany: vi.fn(),
+  findAllAssignmentsForStudent: vi.fn(),
+  findLatestByGitRepoIds: vi.fn(),
+  classroomFindUnique: vi.fn(),
+  findByClassroomIdAndName: vi.fn(),
+  findUserTeamByTag: vi.fn(),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    repository: { findMany: (...a: unknown[]) => mocks.repositoryFindMany(...a) },
+    gitRepo: { findMany: (...a: unknown[]) => mocks.gitRepoFindMany(...a) },
+    classroom: { findUnique: (...a: unknown[]) => mocks.classroomFindUnique(...a) },
+  }),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    helper: {
+      findAllAssignmentsForStudent: (...a: unknown[]) => mocks.findAllAssignmentsForStudent(...a),
+    },
+    autogradingResult: {
+      findLatestByGitRepoIds: (...a: unknown[]) => mocks.findLatestByGitRepoIds(...a),
+    },
+    organizationTag: {
+      findByClassroomIdAndName: (...a: unknown[]) => mocks.findByClassroomIdAndName(...a),
+    },
+    team: { findUserTeamByTag: (...a: unknown[]) => mocks.findUserTeamByTag(...a) },
+  },
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  assertClassroomAccess: (...a: unknown[]) => mocks.assertClassroomAccess(...a),
+}));
+vi.mock('~/components/features/modules/ReadOnlyModulesTree', () => ({ default: () => null }));
+vi.mock('~/components/features/modules/studentTree', () => ({
+  buildRepositoryNode: () => ({}),
+}));
+
+const CLASS_SLUG = 'cs52-26f';
+
+const loaderArgs = () =>
+  ({
+    params: { class: CLASS_SLUG },
+    request: new Request(`http://localhost/student/${CLASS_SLUG}/repos`),
+  }) as never;
+
+const selfFormedRepo = (overrides: Record<string, unknown> = {}) => ({
+  id: 'repo-self',
+  title: 'Student Self-Formed Repo',
+  slug: 'student-self-formed-repo',
+  type: 'GROUP',
+  team_formation_mode: 'SELF_FORMED',
+  team_formation_deadline: null,
+  ...overrides,
+});
+
+const runLoader = async () => {
+  const { loader } = await import('../student.$class.repos/route.tsx');
+  return (await loader(loaderArgs())) as {
+    repositories: { id: string }[];
+    selfFormedByRepositoryId: Record<
+      string,
+      { slug: string; hasTeam: boolean; deadlinePassed: boolean }
+    >;
+  };
+};
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.assertClassroomAccess.mockResolvedValue({
+    userId: 'student-1',
+    classroom: { id: 'class-1', slug: CLASS_SLUG, settings: {}, git_organization: null },
+    membership: { role: 'STUDENT' },
+  });
+  mocks.repositoryFindMany.mockResolvedValue([]);
+  mocks.gitRepoFindMany.mockResolvedValue([]);
+  mocks.classroomFindUnique.mockResolvedValue({ git_organization: { login: 'cs52' } });
+  mocks.findAllAssignmentsForStudent.mockResolvedValue([]);
+  mocks.findLatestByGitRepoIds.mockResolvedValue(new Map());
+  mocks.findByClassroomIdAndName.mockResolvedValue({ id: 'tag-1' });
+  mocks.findUserTeamByTag.mockResolvedValue(null);
+});
+
+describe('a self-formed group repo stays visible before the student has a team', () => {
+  it('survives the ownership filter and reports no team', async () => {
+    mocks.repositoryFindMany.mockResolvedValue([selfFormedRepo()]);
+
+    const data = await runLoader();
+
+    expect(data.repositories.map(r => r.id)).toEqual(['repo-self']);
+    expect(data.selfFormedByRepositoryId['repo-self']).toEqual({
+      slug: 'student-self-formed-repo',
+      hasTeam: false,
+      deadlinePassed: false,
+    });
+  });
+
+  it('reports the team once the student has joined one', async () => {
+    mocks.repositoryFindMany.mockResolvedValue([selfFormedRepo()]);
+    mocks.findUserTeamByTag.mockResolvedValue({ id: 'team-1', name: 'Team Rocket' });
+
+    const data = await runLoader();
+
+    expect(data.selfFormedByRepositoryId['repo-self'].hasTeam).toBe(true);
+  });
+
+  it('marks a passed team-formation deadline', async () => {
+    mocks.repositoryFindMany.mockResolvedValue([
+      selfFormedRepo({ team_formation_deadline: new Date('2020-01-01') }),
+    ]);
+
+    const data = await runLoader();
+
+    expect(data.selfFormedByRepositoryId['repo-self'].deadlinePassed).toBe(true);
+  });
+
+  it('is skipped when the repository has no slug, since the team URL needs one', async () => {
+    mocks.repositoryFindMany.mockResolvedValue([selfFormedRepo({ slug: null })]);
+
+    const data = await runLoader();
+
+    expect(data.repositories).toEqual([]);
+    expect(mocks.findByClassroomIdAndName).not.toHaveBeenCalled();
+  });
+});
+
+describe('the ownership filter still does its original job', () => {
+  it('hides an individual repository the student has no git repo for', async () => {
+    mocks.repositoryFindMany.mockResolvedValue([
+      { id: 'repo-individual', title: 'HW1', slug: 'hw1', type: 'INDIVIDUAL' },
+    ]);
+
+    const data = await runLoader();
+
+    expect(data.repositories).toEqual([]);
+  });
+
+  it('hides an instructor-formed group repo the student has no git repo for', async () => {
+    mocks.repositoryFindMany.mockResolvedValue([
+      selfFormedRepo({ id: 'repo-instructor', team_formation_mode: 'INSTRUCTOR' }),
+    ]);
+
+    const data = await runLoader();
+
+    expect(data.repositories).toEqual([]);
+  });
+
+  it('shows every published repository to staff previewing the student view', async () => {
+    mocks.assertClassroomAccess.mockResolvedValue({
+      userId: 'teacher-1',
+      classroom: { id: 'class-1', slug: CLASS_SLUG, settings: {}, git_organization: null },
+      membership: { role: 'TEACHER' },
+    });
+    mocks.repositoryFindMany.mockResolvedValue([
+      { id: 'repo-individual', title: 'HW1', slug: 'hw1', type: 'INDIVIDUAL' },
+    ]);
+
+    const data = await runLoader();
+
+    expect(data.repositories.map(r => r.id)).toEqual(['repo-individual']);
+  });
+});

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -79,7 +79,30 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     // landing screen can show them in the Archived section.
     typedUser.memberships = (typedUser.memberships ?? []) as SelectOrganizationMembership[];
 
-    const hasExampleClassroom = typedUser.memberships.some(
+    // Claim any classroom invite addressed to this user before the page renders.
+    // This is the post-login seam: it is the default OAuth callbackURL, `email`
+    // is guaranteed above, and the claim is idempotent — so a student invited at
+    // an address they did not register with is picked up on their next sign-in
+    // instead of being stranded forever (#307). Never let it block the picker.
+    try {
+      const { claimed } = await ClassmojiService.classroomInvite.claimPendingInvites(typedUser.id);
+      if (claimed > 0) {
+        const refreshedUser = await ClassmojiService.user.findById(typedUser.id, {
+          includeMemberships: true,
+        });
+        if (refreshedUser) {
+          user = refreshedUser;
+          typedUser = user as AppUser;
+          typedUser.memberships = (typedUser.memberships ?? []) as SelectOrganizationMembership[];
+        }
+      }
+    } catch (error) {
+      console.error('Failed to claim pending classroom invites:', error);
+    }
+
+    // `?? []` because the claim above may have swapped in a refreshed user, which
+    // costs TypeScript the narrowing the initial assignment gave it.
+    const hasExampleClassroom = (typedUser.memberships ?? []).some(
       m => (m.organization as { is_example?: boolean }).is_example === true
     );
     if (!hasExampleClassroom && typedUser.login) {

--- a/apps/webapp/app/routes/admin.$class.gitrepos/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.gitrepos/route.tsx
@@ -58,8 +58,8 @@ async function fetchOrgRepositories(
         search: { nodes: { name: string }[]; repositoryCount: number };
       }>(
         `
-          query ($query: String!, $first: Int!, $after: String) {
-            search(query: $query, type: REPOSITORY, first: $first, after: $after) {
+          query ($searchQuery: String!, $first: Int!, $after: String) {
+            search(query: $searchQuery, type: REPOSITORY, first: $first, after: $after) {
               repositoryCount
               nodes {
                 ... on Repository {
@@ -74,7 +74,10 @@ async function fetchOrgRepositories(
           }
         `,
         {
-          query: searchQuery,
+          // NOT `query:` — @octokit/graphql reserves that option key (along with
+          // `method` and `url`) and rejects the call before it reaches GitHub.
+          // The GraphQL argument is still `query:`; only the variable is renamed.
+          searchQuery,
           first: pageSize,
           after: page > 1 ? btoa(`cursor:${(page - 1) * pageSize}`) : null,
         }

--- a/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/StudentsTable.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate, useParams } from 'react-router';
-import { Table, Tag, Popconfirm } from 'antd';
+import { Table, Tag, Popconfirm, Tooltip } from 'antd';
 import { IconUserSearch, IconTrash } from '@tabler/icons-react';
 import { useState } from 'react';
 
@@ -18,6 +18,10 @@ interface Student {
   school_id?: string | null;
   has_accepted_invite: boolean;
   _isInvite?: boolean;
+  /** Invites only, OWNER only: does any account use this address? */
+  _hasAccount?: boolean;
+  /** Invites only, OWNER only: when the invite was issued. */
+  _invitedAt?: string | Date | null;
   [key: string]: unknown;
 }
 
@@ -162,11 +166,38 @@ const StudentsTable = ({ students, query, isOwner, canManage }: StudentsTablePro
       key: 'has_accepted_invite',
       width: 110,
       render: (_: unknown, student: Student) => {
-        return student.has_accepted_invite ? (
-          <Tag color="green" className="font-semibold">
-            Active
-          </Tag>
-        ) : (
+        if (student.has_accepted_invite) {
+          return (
+            <Tag color="green" className="font-semibold">
+              Active
+            </Tag>
+          );
+        }
+        // An invite nobody can claim looks identical to one that is merely
+        // waiting, which is what let a mistyped address sit pending for six
+        // days in production. `_hasAccount` is false only when no account uses
+        // this address under either email we hold, so the invite cannot resolve
+        // itself no matter how many times that person signs in.
+        if (student._isInvite && student._hasAccount === false) {
+          const days = student._invitedAt
+            ? Math.floor(
+                (Date.now() - new Date(student._invitedAt).getTime()) / (1000 * 60 * 60 * 24)
+              )
+            : null;
+          return (
+            <Tooltip
+              title={
+                'No Classmoji account uses this address, so this invite cannot be claimed. ' +
+                'Check the address, or ask the student which one they signed up with.'
+              }
+            >
+              <Tag color="red" className="font-semibold">
+                No account{days !== null && days > 0 ? ` · ${days}d` : ''}
+              </Tag>
+            </Tooltip>
+          );
+        }
+        return (
           <Tag color="orange" className="font-semibold">
             Pending
           </Tag>

--- a/apps/webapp/app/routes/admin.$class.students/__tests__/roster.test.ts
+++ b/apps/webapp/app/routes/admin.$class.students/__tests__/roster.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   findUsersByRole: vi.fn(),
   findInvitesByClassroomId: vi.fn(),
   deleteInvite: vi.fn(),
+  findRegisteredEmails: vi.fn(),
   taskTrigger: vi.fn(),
   waitForRunCompletion: vi.fn(),
 }));
@@ -42,6 +43,7 @@ vi.mock('@classmoji/services', () => ({
       findInvitesByClassroomId: (...a: unknown[]) => mocks.findInvitesByClassroomId(...a),
       deleteInvite: (...a: unknown[]) => mocks.deleteInvite(...a),
     },
+    user: { findRegisteredEmails: (...a: unknown[]) => mocks.findRegisteredEmails(...a) },
   },
 }));
 
@@ -101,6 +103,7 @@ const INVITE_ROW = {
   student_name: 'Grace Hopper',
   school_email: 'grace@school.test',
   classroom_id: 'class-1',
+  created_at: new Date('2026-09-01T00:00:00Z'),
 };
 
 const OWNER_ONLY_FIELDS = [
@@ -134,6 +137,50 @@ beforeEach(() => {
   mocks.taskTrigger.mockResolvedValue({ id: 'run-1' });
   mocks.waitForRunCompletion.mockResolvedValue(undefined);
   mocks.deleteInvite.mockResolvedValue(undefined);
+  mocks.findRegisteredEmails.mockResolvedValue(new Set<string>());
+});
+
+// ─── Loader: an invite nobody can claim is distinguishable from a patient one ─
+
+describe('pending invites report whether any account uses the address', () => {
+  it('flags an invited address that belongs to no account', async () => {
+    grantLoader('OWNER');
+    mocks.findRegisteredEmails.mockResolvedValue(new Set<string>());
+
+    const invite = (await loader(loaderArgs())).invitations[0];
+
+    // The state that used to be invisible: this invite cannot resolve itself on
+    // any number of logins, because there is no account to match it against.
+    expect(invite.has_account).toBe(false);
+    expect(invite.invited_at).toBeDefined();
+  });
+
+  it('does not flag an address that an account already uses', async () => {
+    grantLoader('OWNER');
+    mocks.findRegisteredEmails.mockResolvedValue(new Set(['grace@school.test']));
+
+    expect((await loader(loaderArgs())).invitations[0].has_account).toBe(true);
+  });
+
+  it('compares case-insensitively, since the address is stored as typed', async () => {
+    grantLoader('OWNER');
+    mocks.findInvitesByClassroomId.mockResolvedValue([
+      { ...INVITE_ROW, school_email: '  Grace@School.test ' },
+    ]);
+    mocks.findRegisteredEmails.mockResolvedValue(new Set(['grace@school.test']));
+
+    expect((await loader(loaderArgs())).invitations[0].has_account).toBe(true);
+  });
+
+  it('is withheld from non-owners, like the address it is derived from', async () => {
+    grantLoader('TEACHER');
+
+    const invite = (await loader(loaderArgs())).invitations[0];
+
+    expect(invite).not.toHaveProperty('has_account');
+    expect(invite).not.toHaveProperty('school_email');
+    expect(mocks.findRegisteredEmails).not.toHaveBeenCalled();
+  });
 });
 
 function grantLoader(role: 'OWNER' | 'TEACHER' | 'ASSISTANT') {

--- a/apps/webapp/app/routes/admin.$class.students/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.students/route.tsx
@@ -108,12 +108,27 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     ...(isOwner ? { letter_grade: s.letter_grade, comment: s.comment } : {}),
   }));
 
+  // Is anyone actually reachable at each invited address? An invite whose
+  // address belongs to no account at all is the shape of a typo, or of a student
+  // who signed up with a different address — and until now it looked exactly
+  // like an invite that is merely waiting, which is how one sat unnoticed in
+  // production for six days (#307). Owner-only, like the address itself.
+  const registeredEmails = isOwner
+    ? await ClassmojiService.user.findRegisteredEmails(invitations.map(inv => inv.school_email))
+    : new Set<string>();
+
   // Pending invites are shaped the same way: an invite's school_email is a
   // contact field, so only an OWNER receives it.
   const rosterInvitations = invitations.map(inv => ({
     id: inv.id,
     student_name: inv.student_name,
-    ...(isOwner ? { school_email: inv.school_email } : {}),
+    ...(isOwner
+      ? {
+          school_email: inv.school_email,
+          has_account: registeredEmails.has(inv.school_email.trim().toLowerCase()),
+          invited_at: inv.created_at,
+        }
+      : {}),
   }));
 
   return {
@@ -137,6 +152,8 @@ const StudentsScreen = ({ loaderData }: Route.ComponentProps) => {
       name: inv.student_name,
       // Present for an OWNER only — the loader omits it for other staff.
       email: inv.school_email,
+      _hasAccount: inv.has_account,
+      _invitedAt: inv.invited_at,
       school_id: null,
       login: 'pending-invite',
       has_accepted_invite: false,

--- a/apps/webapp/app/routes/registration/route.tsx
+++ b/apps/webapp/app/routes/registration/route.tsx
@@ -502,6 +502,12 @@ export const action = async ({ request }: Route.ActionArgs) => {
       name: formData.name,
       email: formData.email,
       school_id: formData.school_id || null,
+      // `provider_email` is otherwise written on create only, so a returning
+      // user keeps whatever better-auth stored at first sign-in. The invite
+      // claim below reads the stored row rather than this form, so a stale
+      // value here silently costs the student their invite. Conditional: a
+      // profile whose email went private must not null out what we hold.
+      ...(formData.githubEmail ? { provider_email: formData.githubEmail } : {}),
     },
     create: {
       provider: 'GITHUB',
@@ -538,23 +544,11 @@ export const action = async ({ request }: Route.ActionArgs) => {
     data: { user_id: user.id },
   });
 
-  // Claim any pending classroom invites — match against the school email the student entered
-  // AND the email on their GitHub account, since instructors invite by either.
-  const invites = await ClassmojiService.classroomInvite.findInvitesByAnyEmail([
-    formData.email,
-    formData.githubEmail,
-  ]);
-  if (invites.length > 0) {
-    for (const invite of invites) {
-      await ClassmojiService.classroomMembership.create({
-        classroom_id: invite.classroom_id,
-        user_id: user.id,
-        role: 'STUDENT',
-        has_accepted_invite: false,
-      });
-    }
-    await ClassmojiService.classroomInvite.deleteManyInvites(invites.map(i => i.id));
-  }
+  // Claim any pending classroom invites addressed to either email we now hold
+  // for this user. The same call runs on login and on an email change, so a
+  // student invited at an address they did not register with is no longer
+  // stranded (#307).
+  await ClassmojiService.classroomInvite.claimPendingInvites(user.id);
 
   // Give every brand-new user a populated "Example Course" sandbox to explore
   // (the in-classroom onboarding tour runs here). Never let this break signup.

--- a/apps/webapp/app/routes/student.$class.dashboard/RetroTabsCard.tsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/RetroTabsCard.tsx
@@ -187,7 +187,11 @@ const TeamPanel = ({
     const footer = (
       <>
         <Link
-          to={`/student/${classSlug}/repos`}
+          to={
+            team.moduleSlug
+              ? `/student/${classSlug}/repos/${team.moduleSlug}/team`
+              : `/student/${classSlug}/repos`
+          }
           className="text-xs font-medium text-gray-700 dark:text-gray-200 px-3 py-1.5 rounded-full ring-1 ring-line hover:bg-nav-hover transition-colors"
         >
           View group
@@ -241,7 +245,11 @@ const TeamPanel = ({
       <PanelShell title="No team yet" subtitle={`${needsTeam.moduleTitle} is self-formed.`}>
         <div className="h-full flex flex-col items-center justify-center text-center">
           <Link
-            to={`/student/${classSlug}/repos`}
+            to={
+              needsTeam.moduleSlug
+                ? `/student/${classSlug}/repos/${needsTeam.moduleSlug}/team`
+                : `/student/${classSlug}/repos`
+            }
             className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 px-3 py-1.5 rounded-full ring-1 ring-line hover:bg-nav-hover transition-colors"
           >
             Choose a team

--- a/apps/webapp/app/routes/student.$class.dashboard/route.tsx
+++ b/apps/webapp/app/routes/student.$class.dashboard/route.tsx
@@ -151,7 +151,11 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     // Team: first SELF_FORMED repository where student is on a team, otherwise prompt
     let team: TeamSummary | null = null;
     let needsTeam: SelfFormedNeedsTeam | null = null;
-    const selfFormedModules = repositories.filter(m => m.team_formation_mode === 'SELF_FORMED');
+    // Both halves of the gate, matching the team route, which 400s on a repo
+    // that is SELF_FORMED but not GROUP.
+    const selfFormedModules = repositories.filter(
+      m => m.type === 'GROUP' && m.team_formation_mode === 'SELF_FORMED'
+    );
     for (const m of selfFormedModules) {
       if (!m.slug) continue;
       const tag = await ClassmojiService.organizationTag.findByClassroomIdAndName(

--- a/apps/webapp/app/routes/student.$class.repos/route.tsx
+++ b/apps/webapp/app/routes/student.$class.repos/route.tsx
@@ -100,12 +100,58 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     ownedRepositoryIds.add(r.repository_id);
   });
 
-  // Students only see repositories they actually have a repo for. Instructors
-  // previewing the student view still see every published repository.
+  // A SELF_FORMED group repo has NO GitRepo until the student forms a team, so
+  // the ownership filter alone hid the one page they need to reach (#313). The
+  // filter's original purpose — hiding unprovisioned individual repos — is
+  // unchanged.
+  const isSelfFormed = (repository: (typeof repositories)[number]) =>
+    repository.type === 'GROUP' &&
+    repository.team_formation_mode === 'SELF_FORMED' &&
+    !!repository.slug;
+
+  // Students only see repositories they actually have a repo for, plus any
+  // self-formed group repo still waiting on a team. Instructors previewing the
+  // student view still see every published repository.
   const visibleRepositories =
     membership?.role === 'STUDENT'
-      ? repositories.filter(r => ownedRepositoryIds.has(r.id))
+      ? repositories.filter(r => ownedRepositoryIds.has(r.id) || isSelfFormed(r))
       : repositories;
+
+  // Team state for the self-formed repos on this page. There is no
+  // Repository -> Team foreign key: a team is tied to a repo by the convention
+  // `Tag.name === Repository.slug`, so each costs a tag lookup plus a
+  // membership lookup. Bounded by the number of self-formed repos in one
+  // classroom, which is a handful at most.
+  //
+  // Only for viewers the team page itself admits: it allows STUDENT, OWNER and
+  // TEACHER, so an ASSISTANT — who can read THIS page — would follow the link
+  // into a full-page 403. No state means no link, and their rows render exactly
+  // as they did before.
+  const canReachTeamPage =
+    membership?.role === 'STUDENT' ||
+    membership?.role === 'OWNER' ||
+    membership?.role === 'TEACHER';
+  const selfFormedByRepositoryId: Record<
+    string,
+    { slug: string; hasTeam: boolean; deadlinePassed: boolean }
+  > = {};
+  for (const repository of canReachTeamPage ? visibleRepositories : []) {
+    if (!isSelfFormed(repository)) continue;
+    const tag = await ClassmojiService.organizationTag.findByClassroomIdAndName(
+      classroom.id,
+      repository.slug!
+    );
+    const userTeam = tag
+      ? await ClassmojiService.team.findUserTeamByTag(classroom.id, tag.id, userId)
+      : null;
+    selfFormedByRepositoryId[repository.id] = {
+      slug: repository.slug!,
+      hasTeam: !!userTeam,
+      deadlinePassed: repository.team_formation_deadline
+        ? new Date() > new Date(repository.team_formation_deadline)
+        : false,
+    };
+  }
   // Latest autograding result per repository unit — rendered as a pill in the
   // repos table, with the per-test breakdown one click away in a modal.
   const latestAutograding = await ClassmojiService.autogradingResult.findLatestByGitRepoIds(
@@ -123,6 +169,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     gitOrgLogin,
     studentRepoByRepositoryId,
     autogradingByRepositoryId,
+    selfFormedByRepositoryId,
     slidesUrl: process.env.SLIDES_URL || 'http://localhost:6500',
     pagesUrl: process.env.PAGES_URL || 'http://localhost:7100',
     classSlug,
@@ -137,6 +184,7 @@ const StudentRepositories = ({ loaderData }: Route.ComponentProps) => {
     gitOrgLogin,
     studentRepoByRepositoryId,
     autogradingByRepositoryId,
+    selfFormedByRepositoryId,
     slidesUrl,
     pagesUrl,
     classSlug,
@@ -151,6 +199,7 @@ const StudentRepositories = ({ loaderData }: Route.ComponentProps) => {
     gitOrgLogin,
     studentRepoByRepositoryId,
     autogradingByRepositoryId,
+    selfFormedByRepositoryId,
     rolePrefix,
   };
   const nodes = (repositories as AnyRepository[]).map(r =>

--- a/packages/services/src/classmoji/__tests__/claimPendingInvites.test.ts
+++ b/packages/services/src/classmoji/__tests__/claimPendingInvites.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for classroomInvite.claimPendingInvites — the shared claim now run
+ * on login, on an email change, and at registration. Prisma is mocked; the test
+ * pins the two addresses that are matched, the exact membership payload, the
+ * transactional pairing of "create membership" with "delete invite", and the
+ * idempotency the repeated callers depend on.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const userFindUnique = vi.fn();
+const inviteFindMany = vi.fn();
+const membershipCreateMany = vi.fn();
+const inviteDeleteMany = vi.fn();
+const transaction = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    user: { findUnique: (...a: unknown[]) => userFindUnique(...a) },
+    classroomInvite: {
+      findMany: (...a: unknown[]) => inviteFindMany(...a),
+      deleteMany: (...a: unknown[]) => inviteDeleteMany(...a),
+    },
+    classroomMembership: { createMany: (...a: unknown[]) => membershipCreateMany(...a) },
+    $transaction: (...a: unknown[]) => transaction(...a),
+  }),
+}));
+
+const invites = await import('../classroomInvite.service.ts');
+
+beforeEach(() => {
+  userFindUnique.mockReset();
+  inviteFindMany.mockReset();
+  membershipCreateMany.mockReset();
+  inviteDeleteMany.mockReset();
+  transaction.mockReset();
+  transaction.mockResolvedValue([{ count: 1 }, { count: 1 }]);
+  membershipCreateMany.mockReturnValue('createMany-op');
+  inviteDeleteMany.mockReturnValue('deleteMany-op');
+});
+
+describe('claimPendingInvites', () => {
+  it('matches against both the app email and the provider email', async () => {
+    userFindUnique.mockResolvedValue({ email: 'a@school.edu', provider_email: 'b@gmail.com' });
+    inviteFindMany.mockResolvedValue([]);
+
+    await invites.claimPendingInvites('user-1');
+
+    const where = inviteFindMany.mock.calls[0][0].where;
+    expect(where.OR).toEqual([
+      { school_email: { equals: 'a@school.edu', mode: 'insensitive' } },
+      { school_email: { equals: 'b@gmail.com', mode: 'insensitive' } },
+    ]);
+  });
+
+  it('writes the membership and deletes the invite in one transaction', async () => {
+    userFindUnique.mockResolvedValue({ email: 'a@school.edu', provider_email: null });
+    inviteFindMany.mockResolvedValue([
+      { id: 'invite-1', classroom_id: 'class-1' },
+      { id: 'invite-2', classroom_id: 'class-2' },
+    ]);
+
+    const result = await invites.claimPendingInvites('user-1');
+
+    expect(membershipCreateMany).toHaveBeenCalledWith({
+      data: [
+        {
+          classroom_id: 'class-1',
+          user_id: 'user-1',
+          role: 'STUDENT',
+          has_accepted_invite: false,
+        },
+        {
+          classroom_id: 'class-2',
+          user_id: 'user-1',
+          role: 'STUDENT',
+          has_accepted_invite: false,
+        },
+      ],
+      skipDuplicates: true,
+    });
+    expect(inviteDeleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ['invite-1', 'invite-2'] } },
+    });
+    expect(transaction).toHaveBeenCalledWith(['createMany-op', 'deleteMany-op']);
+    expect(result).toEqual({ claimed: 2, classroomIds: ['class-1', 'class-2'] });
+  });
+
+  it('relies on skipDuplicates so a repeated claim cannot throw P2002', async () => {
+    // Both callers run repeatedly by construction: every login, every email
+    // write. A plain `create` threw on the second run — that was the old bug.
+    userFindUnique.mockResolvedValue({ email: 'a@school.edu', provider_email: null });
+    inviteFindMany.mockResolvedValue([{ id: 'invite-1', classroom_id: 'class-1' }]);
+
+    await invites.claimPendingInvites('user-1');
+
+    expect(membershipCreateMany.mock.calls[0][0].skipDuplicates).toBe(true);
+  });
+
+  it('creates one membership when two invites name the same classroom', async () => {
+    // `school_email` is stored as typed and its unique key is case-sensitive, so
+    // one classroom can hold two invite rows for one person.
+    userFindUnique.mockResolvedValue({ email: 'A@school.edu', provider_email: 'a@school.edu' });
+    inviteFindMany.mockResolvedValue([
+      { id: 'invite-1', classroom_id: 'class-1' },
+      { id: 'invite-2', classroom_id: 'class-1' },
+    ]);
+
+    const result = await invites.claimPendingInvites('user-1');
+
+    expect(membershipCreateMany.mock.calls[0][0].data).toHaveLength(1);
+    expect(inviteDeleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ['invite-1', 'invite-2'] } },
+    });
+    expect(result.claimed).toBe(1);
+  });
+
+  it('writes nothing when there are no pending invites', async () => {
+    userFindUnique.mockResolvedValue({ email: 'a@school.edu', provider_email: null });
+    inviteFindMany.mockResolvedValue([]);
+
+    const result = await invites.claimPendingInvites('user-1');
+
+    expect(transaction).not.toHaveBeenCalled();
+    expect(result).toEqual({ claimed: 0, classroomIds: [] });
+  });
+
+  it('writes nothing when the user does not exist', async () => {
+    userFindUnique.mockResolvedValue(null);
+
+    const result = await invites.claimPendingInvites('ghost');
+
+    expect(inviteFindMany).not.toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
+    expect(result).toEqual({ claimed: 0, classroomIds: [] });
+  });
+});

--- a/packages/services/src/classmoji/classroomInvite.service.ts
+++ b/packages/services/src/classmoji/classroomInvite.service.ts
@@ -18,25 +18,6 @@ export const createManyInvites = async (
 };
 
 /**
- * Find all invites by school email
- * Used during registration to auto-claim invites for a student
- * @param {string} schoolEmail - Student's school email
- * @returns {Promise<Object[]>}
- */
-export const findInvitesByEmail = async (
-  schoolEmail: string
-): Promise<Prisma.ClassroomInviteGetPayload<{ include: { classroom: true } }>[]> => {
-  return getPrisma().classroomInvite.findMany({
-    where: {
-      school_email: { equals: schoolEmail, mode: 'insensitive' },
-    },
-    include: {
-      classroom: true,
-    },
-  });
-};
-
-/**
  * Find invites matching any of the given emails (case-insensitive).
  * Used during registration to claim invites issued to either the student's
  * school email or the email on their GitHub profile.
@@ -96,4 +77,68 @@ export const deleteManyInvites = async (ids: string[]): Promise<{ count: number 
   return getPrisma().classroomInvite.deleteMany({
     where: { id: { in: ids } },
   });
+};
+
+/**
+ * Claim every pending invite addressed to this user, under either address we
+ * hold for them (`email` and `provider_email`).
+ *
+ * Called on login and whenever an email changes, NOT only at registration. An
+ * invite issued to an address the student did not register with used to strand
+ * them permanently: the single claim path ran once and never again, so the
+ * membership was never created and the invite sat pending forever, with nothing
+ * surfacing the failure to either party.
+ *
+ * Idempotent by construction, because both callers run repeatedly:
+ * `createMany({ skipDuplicates: true })` against the
+ * `(classroom_id, user_id, role)` unique key. A plain `create` throws P2002 the
+ * second time, which is exactly what the registration loop used to do.
+ *
+ * The membership write and the invite delete share one transaction, so an
+ * invite is never consumed without the membership landing.
+ *
+ * Deliberately does NOT filter by classroom status, matching `roster.addStudents`,
+ * which enrols an existing user with no status check either — one rule for how a
+ * student lands on a roster, whether or not they already had an account.
+ *
+ * Be precise about what that means, because the obvious reassurance is wrong:
+ * `canEnterClassroom` only refuses UNPUBLISHED, so an ARCHIVED classroom's invite
+ * really does resolve, and the student gets a card in the Archived section. That
+ * is the same card `addStudents` would have given them.
+ */
+export const claimPendingInvites = async (
+  userId: string
+): Promise<{ claimed: number; classroomIds: string[] }> => {
+  const prisma = getPrisma();
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true, provider_email: true },
+  });
+  if (!user) return { claimed: 0, classroomIds: [] };
+
+  const invites = await findInvitesByAnyEmail([user.email, user.provider_email]);
+  if (invites.length === 0) return { claimed: 0, classroomIds: [] };
+
+  // One membership per classroom even if the same classroom invited both of the
+  // user's addresses, or the same address under two casings — `school_email` is
+  // stored as typed and its unique key is case-sensitive.
+  const classroomIds = Array.from(new Set(invites.map(invite => invite.classroom_id)));
+
+  await prisma.$transaction([
+    prisma.classroomMembership.createMany({
+      data: classroomIds.map(classroom_id => ({
+        classroom_id,
+        user_id: userId,
+        role: 'STUDENT' as const,
+        has_accepted_invite: false,
+      })),
+      skipDuplicates: true,
+    }),
+    prisma.classroomInvite.deleteMany({
+      where: { id: { in: invites.map(invite => invite.id) } },
+    }),
+  ]);
+
+  return { claimed: classroomIds.length, classroomIds };
 };

--- a/packages/services/src/classmoji/user.service.ts
+++ b/packages/services/src/classmoji/user.service.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import getPrisma from '@classmoji/database';
+import { claimPendingInvites } from './classroomInvite.service.ts';
 import type { GitProvider, Prisma, GitRepo, Role } from '@prisma/client';
 import type {
   Repository as GradeModule,
@@ -141,10 +142,24 @@ export const findBy = ({ where }: { where: Prisma.UserWhereUniqueInput }) => {
 };
 
 export const update = async (userId: string, updates: Prisma.UserUpdateInput) => {
-  return getPrisma().user.update({
+  const user = await getPrisma().user.update({
     where: { id: userId },
     data: updates,
   });
+
+  // Correcting a mistyped address is exactly what someone does after noticing
+  // they were invited to a classroom they never joined, so a pending invite for
+  // the NEW address is claimed here rather than waiting for the next login
+  // (#307). Never let it fail the update it is following.
+  if (updates.email !== undefined || updates.provider_email !== undefined) {
+    try {
+      await claimPendingInvites(userId);
+    } catch (error) {
+      console.error('Failed to claim pending invites after email change:', error);
+    }
+  }
+
+  return user;
 };
 
 export const deleteByLogin = async (login: string) => {

--- a/packages/services/src/classmoji/user.service.ts
+++ b/packages/services/src/classmoji/user.service.ts
@@ -135,6 +135,44 @@ export const create = async (
   });
 };
 
+/**
+ * Which of these addresses belong to an existing account, under EITHER address
+ * we hold (`email` or `provider_email`), compared case-insensitively.
+ *
+ * Answers one question for the roster: is a pending invite waiting on someone
+ * who has simply not signed up yet, or on an address nobody on Classmoji uses?
+ * The second is the shape of a typo, and it is invisible today — a mistyped
+ * invite looks exactly like a patient one.
+ *
+ * Returned lowercased, because that is the only form the caller can compare
+ * against an invite's `school_email`, which is stored as the instructor typed it.
+ */
+export const findRegisteredEmails = async (emails: string[]): Promise<Set<string>> => {
+  const candidates = Array.from(
+    new Set(emails.filter(e => !!e && e.trim().length > 0).map(e => e.trim().toLowerCase()))
+  );
+  if (candidates.length === 0) return new Set();
+
+  const users = await getPrisma().user.findMany({
+    where: {
+      OR: candidates.flatMap(email => [
+        { email: { equals: email, mode: 'insensitive' as const } },
+        { provider_email: { equals: email, mode: 'insensitive' as const } },
+      ]),
+    },
+    select: { email: true, provider_email: true },
+  });
+
+  const registered = new Set<string>();
+  for (const user of users) {
+    for (const address of [user.email, user.provider_email]) {
+      const normalized = address?.trim().toLowerCase();
+      if (normalized && candidates.includes(normalized)) registered.add(normalized);
+    }
+  }
+  return registered;
+};
+
 export const findBy = ({ where }: { where: Prisma.UserWhereUniqueInput }) => {
   return getPrisma().user.findUnique({
     where,


### PR DESCRIPTION
Four bugs, plus the roster visibility that would have caught the invite one in a day instead of six.

Fixes #312, fixes #313, fixes #307, fixes #288.

## #312 — every git repo search errored

GitHub's GraphQL `search` field takes an argument called `query`, so the variable was named to match. `@octokit/graphql` reserves that name as an option key and rejects the call **before it reaches the network**, so search failed 100% of the time and the unfiltered listing never did. Renamed the variable to `$searchQuery`; the GraphQL argument is still `query:`.

## #313 — self-formed group repos were invisible to students

Publishing a GROUP + SELF_FORMED repository creates no `GitRepo` (repos appear when teams form), and the student repos list filtered down to repositories the student already owned a repo for. The row didn't lack a link, the row didn't exist — so the team page was reachable only through a URL an instructor pasted by hand. Instructors previewing were exempt from that filter, which is why staff view always looked right.

Self-formed repos now stay visible with the viewer's team state resolved:

| state | action | status |
|---|---|---|
| no team, before deadline | Form a team | No team yet |
| no team, deadline passed | — | Team formation closed |
| on a team | View team | (GitHub link once the repo exists) |

State is resolved only for roles the team page itself admits (STUDENT, OWNER, TEACHER) — an ASSISTANT can read the repos page but would be 403'd there. The template URL is no longer offered as a fallback on a self-formed row: a student with no team has no repo, and "View" pointing at the instructor's template is how they end up committing to it. The filter's original job is intact: unprovisioned INDIVIDUAL repos and INSTRUCTOR-mode group repos are still hidden.

Also repoints the dashboard's two CTAs, which detected this state and then linked to the page that hid it, and adds the `type === 'GROUP'` half of the gate its self-formed check was missing.

## #307 — invites claimed only at registration

An invite was claimed in exactly one place, the registration action. Registration also checked the live GitHub profile email, so "invited before signup" worked. Nothing handled the reverse order: `addStudents` matches only `users.email` with a case-sensitive `in`, so inviting a student's **GitHub address** creates an invite row for someone who already has an account — and registration never runs for them again.

`claimPendingInvites(userId)` now runs on login (the select-organization loader, the default OAuth callbackURL), on an email change, and at registration. It reads both addresses case-insensitively, dedupes by classroom, and writes memberships and the invite delete in one transaction.

**Against production data today:** 493 pending invites, of which **10 are students with an account who are not enrolled** and will be let in on their next sign-in, plus 7 stale invite rows cleared. The oldest is from April 28 — four months of signing in to a classroom that simply wasn't there.

Two independent bugs fall out of sharing one implementation:

- The old loop called `create` per invite against a `(classroom_id, user_id, role)` unique key, so two invites naming one classroom threw P2002 mid-loop and **failed the whole registration action** after the user, session and account rows had committed.
- The registration upsert wrote `provider_email` on create only, so a returning user's stored GitHub address was never refreshed — and the claim reads the stored row.

### Roster visibility (refs #307)

The remaining 476 pending invites match no account at all, and a mistyped invite rendered identically to a patient one. That is how the production case sat unnoticed for six days. Those now show a **No account · 6d** chip with the invite's age, instead of the same orange "Pending" as everyone else. Owner-only, deriving from the invited address, which is already owner-only on that screen.

This does not overlap with the claim: the claim settles what a machine can (an account exists under a different address we hold), the chip surfaces what needs a person (no account exists at all, so no amount of logging in will help).

## #288 — heading sizes differed between the editor and the published page

Heading sizes were scoped to `.page-editor`, which a server-rendered class-site page never has — it serves BlockNote markup under `.site-article`. The site fell through to BlockNote's own em ladder off a 16px base, so an author who wrote a 30px H1 published a 48px one with nothing in the editor saying so.

The scale now lives unscoped as BlockNote's own `--level` custom property, so the editor, the in-app viewer and the published page read one definition, with no `!important` and no dependence on stylesheet order. Three parity assertions in `site-render.spec.ts`, each verified to fail when broken.

(That commit came from a separate session on this branch; its full reasoning is in the commit message.)

## Tests

17 new unit tests: 6 for the claim (both addresses, exact membership payload, transaction pairing, same-classroom dedupe, both no-op paths), 7 for self-formed visibility (including that unprovisioned individual repos are still hidden and assistants get no state), 4 for the roster flag. Plus the 3 parity assertions from #288.

`apps/webapp` route suites 683/683. Typecheck clean in `apps/webapp` and `packages/services`.

The 14 failures in `packages/services` and the 9 prettier errors in the dashboard files are **pre-existing** — verified by stashing this branch's changes and re-running, which reproduces both exactly. Untouched rather than swept into this diff.

## Test steps

1. `/admin/:class/gitrepos?search=devops` filters with no red "Technical details" banner.
2. Publish a GROUP + Student Self-Formed repo; as a student, `/student/:class/repos` lists it with **Form a team**; forming one flips the row to **View team**, and the GitHub link returns once `create_git_repos` finishes.
3. Insert a `classroom_invites` row matching an existing user's `email` or `provider_email`, load `/select-organization` as them: the class appears and the invite row is gone. Reload: no duplicate membership, no error.
4. On a roster with a pending invite for an address nobody uses, the status reads **No account** rather than **Pending**.
5. Publish a page with an H1 and compare the heading size in the editor against the class site.

Note: `/test-login` bypasses OAuth, so step 3 can't be reached by clicking through — it's covered by unit tests and the manual insert above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152e3TdpwbtvjYktXUPSufk