### PR TITLE
fix(content-delivery): only sign shas that are in the classroom's own map

### DIFF
--- a/apps/content/eslint.config.js
+++ b/apps/content/eslint.config.js
@@ -15,4 +15,15 @@ export default [
       'import/no-unresolved': 'off',
     },
   },
+  {
+    // The VERIFY seam. The shared config forbids importing the signing package
+    // outside the app's one minting choke point, because a signature is the
+    // Worker's only proof of entitlement. This file is the other side of that
+    // contract: it re-exports the package so every Worker module verifies with
+    // exactly the code the apps signed with, and it mints nothing.
+    files: ['src/verify.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
+    },
+  },
 ];

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -4,6 +4,50 @@ import pluginImport from 'eslint-plugin-import';
 import prettier from 'eslint-config-prettier';
 import pluginPrettier from 'eslint-plugin-prettier';
 
+/**
+ * The content-delivery signing choke point, enforced by lint.
+ *
+ * A signed blob URL is the Cloudflare Worker's ONLY proof that a classroom is
+ * entitled to the bytes behind a sha: the Worker caches blobs by content
+ * (`blobs/{sha}` in R2, shared across classrooms) and cannot know which files
+ * a classroom owns. So a signature over a sha outside that classroom's asset
+ * map would let one classroom read another's cached private bytes — and it
+ * would verify, because the app made the claim.
+ *
+ * `contentDelivery.service.ts` is where that claim is checked. Every mint goes
+ * through its `mintSigned` gate, which requires a row read from the
+ * classroom's own map. A module that imports the signers directly bypasses the
+ * gate, so this makes reaching for them a lint error rather than a code review
+ * someone has to remember to do.
+ *
+ * The allowlist is deliberately tiny:
+ *   - `contentDelivery.service.ts` — the gate itself;
+ *   - `deckRenderToken.service.ts` — render tokens, a different signature over
+ *     a deck id rather than a sha, with no asset map to check against;
+ *   - `apps/content/src/verify.ts` — the Worker's VERIFY seam, allowlisted in
+ *     that app's own config; it re-exports the package and mints nothing;
+ *   - tests, which have to reach the primitives to prove the gate's output.
+ *
+ * Globs are tail-matched (`**\/classmoji/...`) because flat-config `files`
+ * resolve against each PACKAGE's own eslint.config.js, not this file.
+ */
+const CONTENT_SIGNING = {
+  name: '@classmoji/content-signing',
+  message:
+    'Sign through ClassmojiService.contentDelivery instead. Every blob URL must be minted ' +
+    "inside contentDelivery.service.ts, which requires proof the sha is in that classroom's " +
+    'asset map — importing the signers directly bypasses that check.',
+};
+
+const CONTENT_SIGNING_ALLOWED = [
+  '**/classmoji/contentDelivery.service.ts',
+  '**/classmoji/deckRenderToken.service.ts',
+  '**/__tests__/**/*.{js,jsx,ts,tsx}',
+  '**/tests/**/*.{js,jsx,ts,tsx}',
+  '**/*.test.{js,jsx,ts,tsx}',
+  '**/*.spec.{js,jsx,ts,tsx}',
+];
+
 export default [
   js.configs.recommended,
   pluginImport.flatConfigs.recommended,
@@ -43,6 +87,15 @@ export default [
     rules: {
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'prettier/prettier': 'error',
+      'no-restricted-imports': ['error', { paths: [CONTENT_SIGNING] }],
+    },
+  },
+
+  // The other half of the content-signing choke point. See CONTENT_SIGNING.
+  {
+    files: CONTENT_SIGNING_ALLOWED,
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
   {

--- a/packages/services/src/classmoji/__tests__/contentDelivery.signerGuard.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.signerGuard.test.ts
@@ -278,19 +278,50 @@ describe('the choke point', () => {
     expect(refusals()).toHaveLength(0);
   });
 
-  it('will not take a hand-built asset — the proof is nominal', async () => {
+  it('will not take a hand-built asset — the brand is nominal, and that is the point', async () => {
+    // The brand is NOMINAL, not unforgeable: `as unknown as MappedAsset` would
+    // get past it. What it buys is that passing a bare sha stops being possible
+    // by accident and becomes a cast somebody has to write and a reviewer can
+    // see. The wall that actually holds is the runtime `classroom_id` check
+    // above, which a cast cannot satisfy without naming a classroom; the second
+    // wall is the `no-restricted-imports` rule in the shared eslint config,
+    // which stops a module skipping this function entirely by importing
+    // `@classmoji/content-signing` and calling `signBlobUrl` itself.
+    //
+    // This assertion is live: if the brand ever stopped rejecting a plain
+    // object, `tsc --noEmit` would fail the directive as unused.
     await signBlobUrlForClassroom(
       { id: CLASSROOM_A, content_key_version: 7 },
       { origin: ORIGIN, master: MASTER },
       {
-        // @ts-expect-error a bare sha is not proof of anything. The only way to
-        // get a MappedAsset is to read a row out of a classroom's own map, and
-        // that is the entire point of the brand.
+        // @ts-expect-error a bare sha is not proof of anything — the ordinary
+        // way to get a MappedAsset is to read a row out of a classroom's map.
         asset: { classroom_id: CLASSROOM_A, path: REPO_PATH, sha: SHA_ORPHAN, type: 'blob' },
         ext: 'png',
         tier: 'week',
       }
     );
+  });
+
+  it('refuses a FORGED row even when the cast gets past the brand', async () => {
+    // The cast the brand cannot stop, made explicitly. A caller determined
+    // enough to write this still has to name a classroom on the row, and naming
+    // the wrong one is exactly what `mintSigned` refuses.
+    const forged = {
+      classroom_id: CLASSROOM_B,
+      path: REPO_PATH,
+      sha: SHA_ORPHAN,
+      type: 'blob',
+    } as unknown as MappedAsset;
+
+    const url = await signBlobUrlForClassroom(
+      { id: CLASSROOM_A, content_key_version: 7 },
+      { origin: ORIGIN, master: MASTER },
+      { asset: forged, ext: 'png', tier: 'week' }
+    );
+
+    expect(url).toBeNull();
+    expect(refusals()[0]).toContain(SHA_ORPHAN);
   });
 });
 

--- a/packages/services/src/classmoji/__tests__/contentDelivery.signerGuard.test.ts
+++ b/packages/services/src/classmoji/__tests__/contentDelivery.signerGuard.test.ts
@@ -1,0 +1,449 @@
+/**
+ * The signing invariant: a sha is signed for a classroom ONLY when that
+ * classroom's asset map holds it.
+ *
+ * ## Why this is the control that matters
+ *
+ * The Worker caches blobs by CONTENT — `blobs/{sha}` in R2, one object shared
+ * by every classroom holding the same bytes — and it does not know, and must
+ * not have to know, which files a classroom owns. The signature is the entire
+ * proof of entitlement. So a signature over a sha outside the classroom's map
+ * is not a Worker bug: it is a correctly verified claim the app should never
+ * have made, and it is the one thing that would let classroom A read classroom
+ * B's cached private bytes.
+ *
+ * Everything below is therefore about the MINT, not the cache:
+ *
+ *   - a sha the map has never heard of is refused on every path that carries
+ *     one in from outside (a commit response, a pasted URL, a task payload);
+ *   - a row genuinely read from classroom B, handed to a mint for classroom A,
+ *     is refused — at the type level a caller cannot even build one by hand,
+ *     and at runtime the classroom the row came from is asserted;
+ *   - a refusal degrades exactly as a missing row already does (the stored ref,
+ *     a `/missing/` placeholder, a legacy URL) and never throws;
+ *   - a pasted signed URL whose sha has left the map canonicalizes to the
+ *     stored string rather than being re-signed.
+ *
+ * The map is in memory and holds TWO classrooms, because half of what is being
+ * asserted is that one classroom's rows never answer for the other.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+// Type-only: erased at compile time, so it does not defeat the module mock below.
+import type { MappedAsset } from '../contentDelivery.service.ts';
+
+/** The signer refuses anything that is not a lowercase UUID. */
+const CLASSROOM_A = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+const CLASSROOM_B = '9c858901-8a57-4791-81fe-4c455b099bc9';
+
+const SHA_A = 'a'.repeat(40);
+const SHA_B = 'b'.repeat(40);
+/** A well-formed sha no classroom's map has ever held. */
+const SHA_ORPHAN = 'c'.repeat(40);
+const TREE_SHA = 'd'.repeat(40);
+
+const REPO_PATH = 'pages/lab-1/assets/hero.png';
+const THEMES_FOLDER = '.slidesthemes';
+
+interface Row {
+  path: string;
+  sha: string;
+  type: string;
+  size: number;
+}
+
+/** `classroomId → path → row`. Two classrooms, deliberately. */
+const map = new Map<string, Map<string, Row>>();
+
+function setRows(classroomId: string, rows: Row[]): void {
+  map.set(classroomId, new Map(rows.map(row => [row.path, row])));
+}
+
+function rowsOf(classroomId: string): Map<string, Row> {
+  return map.get(classroomId) ?? new Map();
+}
+
+vi.mock('@classmoji/database', () => ({ default: () => ({}) }));
+
+const uploadMock = vi.fn();
+const recordContentAssetMock = vi.fn();
+
+vi.mock('../../content/ContentService.ts', () => ({
+  ContentService: {
+    upload: (...args: unknown[]) => uploadMock(...args),
+    getContent: vi.fn(),
+    getMeta: vi.fn(),
+    uploadBatch: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+vi.mock('../contentAssets.service.ts', () => ({
+  ensureContentAssets: async () => null,
+  resolveContentBranch: async () => 'main',
+  recordContentAsset: (...args: unknown[]) => recordContentAssetMock(...args),
+  recordContentAssets: async () => true,
+
+  lookupContentAsset: async (classroomId: string, path: string) => {
+    const row = rowsOf(classroomId).get(path);
+    return row ? { sha: row.sha, type: row.type, size: row.size } : null;
+  },
+
+  lookupContentAssets: async (classroomId: string, paths: string[]) =>
+    new Map(
+      paths.flatMap(path => {
+        const row = rowsOf(classroomId).get(path);
+        return row ? [[path, { sha: row.sha, type: row.type, size: row.size }] as const] : [];
+      })
+    ),
+
+  lookupContentTree: async (classroomId: string, dirPath: string) => {
+    const row = rowsOf(classroomId).get(dirPath.replace(/\/+$/, ''));
+    return row && row.type === 'tree' ? { sha: row.sha, type: row.type, size: row.size } : null;
+  },
+
+  lookupContentAssetBySha: async (classroomId: string, sha: string) => {
+    for (const row of rowsOf(classroomId).values()) {
+      if (row.sha === sha) return { path: row.path, type: row.type, size: row.size };
+    }
+    return null;
+  },
+
+  // Honours the `type` filter, because the guard depends on it: a tree sha is
+  // 40 hex characters like any other and must not answer a blob lookup.
+  lookupContentAssetsBySha: async (
+    classroomId: string,
+    shas: string[],
+    opts: { type?: string } = {}
+  ) => {
+    const wanted = new Set(shas);
+    const bySha = new Map<string, string>();
+    for (const row of [...rowsOf(classroomId).values()].sort((a, b) =>
+      a.path.localeCompare(b.path)
+    )) {
+      if (!wanted.has(row.sha)) continue;
+      if (opts.type && row.type !== opts.type) continue;
+      if (!bySha.has(row.sha)) bySha.set(row.sha, row.path);
+    }
+    return bySha;
+  },
+}));
+
+const {
+  canonicalizeAssetRef,
+  mappedAssetsBySha,
+  resolveAssetSrcSet,
+  resolveAssetUrl,
+  resolveDelivery,
+  resolveThemeBase,
+  signBlobUrlForClassroom,
+  warmContentBlob,
+  warmContentText,
+} = await import('../contentDelivery.service.ts');
+
+const { uploadPageAsset } = await import('../pageContent.service.ts');
+
+const ORIGIN = 'https://cdn.classmoji.test';
+const MASTER = 'test-master-secret';
+
+function classroomRow(id: string, org: string, repo: string) {
+  return {
+    id,
+    content_key_version: 7,
+    content_repo: repo,
+    content_delivery_enabled: true,
+    git_organization: { login: org },
+  };
+}
+
+const ctxA = { classroom: classroomRow(CLASSROOM_A, 'org-a', 'content-a'), tier: 'week' as const };
+const ctxB = { classroom: classroomRow(CLASSROOM_B, 'org-b', 'content-b'), tier: 'week' as const };
+
+/** The one line an operator is told to search for. */
+const REFUSAL = '[contentDelivery] refused to sign sha outside classroom map';
+
+let warnSpy: MockInstance<typeof console.warn>;
+let fetchSpy: MockInstance<typeof fetch>;
+
+function refusals(): string[] {
+  return warnSpy.mock.calls
+    .map((call: unknown[]) => String(call[0]))
+    .filter((line: string) => line.includes('refused to sign sha outside classroom map'));
+}
+
+beforeEach(() => {
+  process.env.CONTENT_DELIVERY_ORIGIN = ORIGIN;
+  process.env.CONTENT_SIGNING_SECRET = MASTER;
+
+  map.clear();
+  setRows(CLASSROOM_A, [
+    { path: REPO_PATH, sha: SHA_A, type: 'blob', size: 10 },
+    { path: `${THEMES_FOLDER}/cosmo`, sha: TREE_SHA, type: 'tree', size: 0 },
+  ]);
+  // The SAME path, a DIFFERENT sha. Classroom A must never sign B's.
+  setRows(CLASSROOM_B, [{ path: REPO_PATH, sha: SHA_B, type: 'blob', size: 10 }]);
+
+  uploadMock.mockReset();
+  recordContentAssetMock.mockReset().mockResolvedValue(true);
+
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(new Response('ok', { status: 200 }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.CONTENT_DELIVERY_ORIGIN;
+  delete process.env.CONTENT_SIGNING_SECRET;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('proof of map membership', () => {
+  it('hands back no proof for a sha the map has never held, and says so', async () => {
+    const proofs = await mappedAssetsBySha(CLASSROOM_A, [SHA_ORPHAN]);
+
+    expect(proofs.size).toBe(0);
+    expect(refusals()).toHaveLength(1);
+    expect(refusals()[0]).toContain(REFUSAL);
+    expect(refusals()[0]).toContain(CLASSROOM_A);
+    expect(refusals()[0]).toContain(SHA_ORPHAN);
+  });
+
+  it('never names the signing secret in a refusal', async () => {
+    await mappedAssetsBySha(CLASSROOM_A, [SHA_ORPHAN]);
+
+    for (const line of warnSpy.mock.calls.map((call: unknown[]) => JSON.stringify(call))) {
+      expect(line).not.toContain(MASTER);
+    }
+  });
+
+  it('refuses a sha that is in ANOTHER classroom’s map but not this one', async () => {
+    // SHA_B is a real row — in classroom B. Asking classroom A for it is
+    // exactly the cross-classroom read the Worker cannot distinguish.
+    const proofs = await mappedAssetsBySha(CLASSROOM_A, [SHA_B]);
+
+    expect(proofs.size).toBe(0);
+    expect(refusals()[0]).toContain(SHA_B);
+  });
+
+  it('refuses a TREE sha asked for as a blob', async () => {
+    const proofs = await mappedAssetsBySha(CLASSROOM_A, [TREE_SHA]);
+
+    expect(proofs.size).toBe(0);
+    expect(refusals()[0]).toContain(TREE_SHA);
+  });
+
+  it('folds repeat refusals for one sha into a single line per render', async () => {
+    await Promise.all([
+      mappedAssetsBySha(CLASSROOM_A, [SHA_ORPHAN]),
+      mappedAssetsBySha(CLASSROOM_A, [SHA_ORPHAN]),
+      mappedAssetsBySha(CLASSROOM_A, [SHA_ORPHAN]),
+    ]);
+
+    expect(refusals()).toHaveLength(1);
+  });
+});
+
+describe('the choke point', () => {
+  it('refuses a row from classroom B handed to a mint for classroom A', async () => {
+    const proof = (await mappedAssetsBySha(CLASSROOM_B, [SHA_B])).get(SHA_B);
+    expect(proof).toBeDefined();
+
+    const url = await signBlobUrlForClassroom(
+      { id: CLASSROOM_A, content_key_version: 7 },
+      { origin: ORIGIN, master: MASTER },
+      { asset: proof as MappedAsset, ext: 'png', tier: 'week' }
+    );
+
+    expect(url).toBeNull();
+    expect(refusals()).toHaveLength(1);
+    expect(refusals()[0]).toContain(`classroom=${CLASSROOM_A}`);
+    expect(refusals()[0]).toContain(`sha=${SHA_B}`);
+    expect(refusals()[0]).toContain(CLASSROOM_B);
+  });
+
+  it('signs the same row for the classroom it was actually read for', async () => {
+    const proof = (await mappedAssetsBySha(CLASSROOM_B, [SHA_B])).get(SHA_B);
+
+    const url = await signBlobUrlForClassroom(
+      { id: CLASSROOM_B, content_key_version: 7 },
+      { origin: ORIGIN, master: MASTER },
+      { asset: proof as MappedAsset, ext: 'png', tier: 'week' }
+    );
+
+    expect(url).toContain(`/c/${CLASSROOM_B}/blob/${SHA_B}.png`);
+    expect(refusals()).toHaveLength(0);
+  });
+
+  it('will not take a hand-built asset — the proof is nominal', async () => {
+    await signBlobUrlForClassroom(
+      { id: CLASSROOM_A, content_key_version: 7 },
+      { origin: ORIGIN, master: MASTER },
+      {
+        // @ts-expect-error a bare sha is not proof of anything. The only way to
+        // get a MappedAsset is to read a row out of a classroom's own map, and
+        // that is the entire point of the brand.
+        asset: { classroom_id: CLASSROOM_A, path: REPO_PATH, sha: SHA_ORPHAN, type: 'blob' },
+        ext: 'png',
+        tier: 'week',
+      }
+    );
+  });
+});
+
+describe('resolvers stay scoped to their own classroom', () => {
+  it('signs classroom A’s sha, never classroom B’s, for the same path', async () => {
+    const fromA = await resolveAssetUrl(ctxA, REPO_PATH);
+    const fromB = await resolveAssetUrl(ctxB, REPO_PATH);
+
+    expect(fromA).toContain(`/c/${CLASSROOM_A}/blob/${SHA_A}.png`);
+    expect(fromB).toContain(`/c/${CLASSROOM_B}/blob/${SHA_B}.png`);
+    expect(fromA).not.toContain(SHA_B);
+    expect(fromB).not.toContain(SHA_A);
+  });
+
+  it('placeholders a path this classroom has no row for', async () => {
+    setRows(CLASSROOM_A, []);
+
+    const url = await resolveAssetUrl(ctxA, REPO_PATH);
+
+    expect(url).toBe(`${ORIGIN}/c/${CLASSROOM_A}/missing/${encodeURIComponent(REPO_PATH)}`);
+    expect(url).not.toContain(SHA_B);
+  });
+
+  it('emits no srcset — and no signature — for a path with no row', async () => {
+    setRows(CLASSROOM_A, []);
+
+    expect(await resolveAssetSrcSet(ctxA, REPO_PATH)).toBeNull();
+  });
+
+  it('signs a theme folder only from this classroom’s own tree row', async () => {
+    const base = await resolveThemeBase(ctxA, 'cosmo');
+    expect(base).toContain(`/c/${CLASSROOM_A}/theme/cosmo/${TREE_SHA}/`);
+
+    // Classroom B has no `.slidesthemes/cosmo` row at all.
+    expect(await resolveThemeBase(ctxB, 'cosmo')).toBeNull();
+  });
+
+  it('refuses to sign a theme folder from a BLOB row at the theme path', async () => {
+    setRows(CLASSROOM_A, [{ path: `${THEMES_FOLDER}/cosmo`, sha: SHA_A, type: 'blob', size: 10 }]);
+
+    expect(await resolveThemeBase(ctxA, 'cosmo')).toBeNull();
+  });
+});
+
+describe('server-to-server mints', () => {
+  it('warms nothing when the map has no row for the path', async () => {
+    setRows(CLASSROOM_A, []);
+
+    await warmContentText({ classroom: ctxA.classroom }, ['content.json']);
+    await warmContentBlob({ classroom: ctxA.classroom }, ['pages/lab-1/thumbnail.webp']);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('warms at classroom A’s own sha, never a same-path row from B', async () => {
+    await warmContentBlob({ classroom: ctxA.classroom }, [REPO_PATH]);
+
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain(`/c/${CLASSROOM_A}/blob/${SHA_A}.png`);
+    expect(url).not.toContain(SHA_B);
+  });
+});
+
+describe('the upload path — the one sha carried in from outside the map', () => {
+  const page = {
+    id: 'page-1',
+    title: 'Lab 1',
+    content_path: 'pages/lab-1',
+    classroom: {
+      ...classroomRow(CLASSROOM_A, 'org-a', 'content-a'),
+      git_organization: { login: 'org-a', id: 'org-a-id' },
+    },
+  };
+
+  beforeEach(() => {
+    uploadMock.mockResolvedValue({
+      path: `${page.content_path}/assets/new.png`,
+      sha: SHA_ORPHAN,
+      url: `https://raw.githubusercontent.com/org-a/content-a/main/${page.content_path}/assets/new.png`,
+    });
+  });
+
+  it('signs the upload once its row is in the map', async () => {
+    recordContentAssetMock.mockImplementation(async (classroomId: string, entry: Row) => {
+      rowsOf(classroomId).set(entry.path, { ...entry, type: 'blob', size: 0 });
+      map.set(classroomId, rowsOf(classroomId));
+      return true;
+    });
+
+    const result = await uploadPageAsset(
+      page as unknown as Parameters<typeof uploadPageAsset>[0],
+      Buffer.from('bytes'),
+      'new.png'
+    );
+
+    expect(result.displayUrl).toContain(`/c/${CLASSROOM_A}/blob/${SHA_ORPHAN}.png`);
+    // A signable upload stores the repo PATH, which keeps following the file.
+    expect(result.url).toBe(`${page.content_path}/assets/new.png`);
+    expect(refusals()).toHaveLength(0);
+  });
+
+  it('refuses, and stores the legacy URL, when the row was never written', async () => {
+    // `recordContentAsset` declines for a classroom the delivery layer cannot
+    // serve — a non-GitHub provider, no content repo — and it can simply fail.
+    // Before the guard this still minted a signature, and `uploadPageAsset`
+    // then stored a bare repo path no reader could ever resolve.
+    recordContentAssetMock.mockResolvedValue(false);
+
+    const result = await uploadPageAsset(
+      page as unknown as Parameters<typeof uploadPageAsset>[0],
+      Buffer.from('bytes'),
+      'new.png'
+    );
+
+    expect(result.displayUrl).toBeNull();
+    expect(result.url).toBe(
+      `https://raw.githubusercontent.com/org-a/content-a/main/${page.content_path}/assets/new.png`
+    );
+    expect(refusals()[0]).toContain(SHA_ORPHAN);
+  });
+});
+
+describe('a pasted signed URL is never re-signed', () => {
+  it('canonicalizes to the stored ref when the sha has left the map', async () => {
+    const signed = await resolveAssetUrl(ctxA, REPO_PATH);
+    expect(signed).toContain(SHA_A);
+
+    // The file is deleted, or the map re-synced mid-edit.
+    setRows(CLASSROOM_A, []);
+
+    const stored = await canonicalizeAssetRef(ctxA, signed);
+
+    // The caller's own string, unchanged — there is no path to store instead,
+    // and inventing one would silently retarget the reference.
+    expect(stored).toBe(signed);
+
+    // And re-rendering it mints nothing: it is not a repo path, so it passes
+    // straight through rather than becoming a fresh signature over a sha the
+    // map no longer holds.
+    const { urls } = await resolveDelivery(ctxA, [stored]);
+    expect(urls.get(stored)).toBe(stored);
+  });
+
+  it('leaves another classroom’s signed URL alone rather than resolving it here', async () => {
+    const foreign = await resolveAssetUrl(ctxB, REPO_PATH);
+    expect(foreign).toContain(CLASSROOM_B);
+
+    expect(await canonicalizeAssetRef(ctxA, foreign)).toBe(foreign);
+  });
+
+  it('undoes a signed URL to its repo path while the sha is still mapped', async () => {
+    const signed = await resolveAssetUrl(ctxA, REPO_PATH);
+
+    expect(await canonicalizeAssetRef(ctxA, signed)).toBe(REPO_PATH);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/pageContent.service.test.ts
@@ -30,28 +30,56 @@ vi.mock('../../content/ContentService.ts', () => ({
 // The asset map row is written at upload time rather than left to the push
 // webhook — see recordContentAsset. Mocked here so this suite keeps pinning the
 // GitHub interactions and nothing reaches Prisma.
+//
+// The rows a record actually WROTE are kept, because an upload signs only what
+// the map can vouch for: `signUploadedAsset` looks its sha back up rather than
+// trusting the commit response that produced it. A mock that recorded nothing
+// would be a classroom whose map has no row — a refusal, not a signature.
 const recordContentAssetMock = vi.fn();
 const resolveContentBranchMock = vi.fn();
+const recordedRows = new Map<string, string>();
 vi.mock('../contentAssets.service.ts', () => ({
-  recordContentAsset: (...args: unknown[]) => recordContentAssetMock(...args),
+  recordContentAsset: async (classroomId: string, entry: { path: string; sha: string }) => {
+    const ok = await recordContentAssetMock(classroomId, entry);
+    if (ok) recordedRows.set(`${classroomId}|${entry.sha}`, entry.path);
+    return ok;
+  },
   resolveContentBranch: (...args: unknown[]) => resolveContentBranchMock(...args),
+  lookupContentAssetsBySha: async (classroomId: string, shas: string[]) =>
+    new Map(
+      shas.flatMap(sha => {
+        const path = recordedRows.get(`${classroomId}|${sha}`);
+        return path ? ([[sha, path]] as Array<[string, string]>) : [];
+      })
+    ),
 }));
 
 // The map-first read (`viaWorker`). Mocked at the module seam so this suite
 // stays about page-content shapes; contentDelivery.text.test.ts owns the read
 // itself. `canonicalizeMany` is passed through unchanged — the save path calls
 // it and this suite is not testing canonicalization.
+//
+// The two signing-guard exports are the REAL ones. Stubbing them would stub out
+// the very check that decides whether an upload stores a repo path or a legacy
+// URL, which is what the upload assertions below are about.
 const fetchContentTextMock = vi.fn();
 const warmContentTextMock = vi.fn(async (..._args: unknown[]) => {});
-vi.mock('../contentDelivery.service.ts', () => ({
-  fetchContentText: (...args: unknown[]) => fetchContentTextMock(...args),
-  // Real, not a stub: the two probes sharing ONE budget object is the thing
-  // being asserted, and a mock that handed out a fresh object each call would
-  // make that assertion vacuous.
-  textReadBudget: () => ({ workerUnavailable: false }),
-  canonicalizeMany: async (_ctx: unknown, refs: string[]) => new Map(refs.map(r => [r, r])),
-  warmContentText: (...args: unknown[]) => warmContentTextMock(...args),
-}));
+vi.mock('../contentDelivery.service.ts', async () => {
+  const actual = await vi.importActual<typeof import('../contentDelivery.service.ts')>(
+    '../contentDelivery.service.ts'
+  );
+  return {
+    fetchContentText: (...args: unknown[]) => fetchContentTextMock(...args),
+    // Real, not a stub: the two probes sharing ONE budget object is the thing
+    // being asserted, and a mock that handed out a fresh object each call would
+    // make that assertion vacuous.
+    textReadBudget: () => ({ workerUnavailable: false }),
+    canonicalizeMany: async (_ctx: unknown, refs: string[]) => new Map(refs.map(r => [r, r])),
+    warmContentText: (...args: unknown[]) => warmContentTextMock(...args),
+    mappedAssetsBySha: actual.mappedAssetsBySha,
+    signBlobUrlForClassroom: actual.signBlobUrlForClassroom,
+  };
+});
 
 const {
   loadPageContent,
@@ -88,6 +116,7 @@ const writtenWrapper = () => JSON.parse(callArg(putMock).content as string);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  recordedRows.clear();
   putMock.mockResolvedValue({ sha: 'new-sha', commit: 'commit-1' });
 });
 

--- a/packages/services/src/classmoji/contentAssets.service.ts
+++ b/packages/services/src/classmoji/contentAssets.service.ts
@@ -1024,16 +1024,27 @@ export async function lookupContentTree(
  * single-SHA lookup's `orderBy` — content-addressed means they are
  * byte-identical, so the choice cannot be wrong, only arbitrary, and pinning it
  * keeps repeated imports of the same content producing the same output.
+ *
+ * `opts.type` narrows to `blob` or `tree`. Unfiltered by default, because the
+ * import's rewrite only wants to know whether the sha is in this classroom's
+ * map at all. The signing guard asks for `blob`: a tree sha is 40 hex
+ * characters like any other, and "the map holds this sha somewhere" is not a
+ * licence to address a directory as a file.
  */
 export async function lookupContentAssetsBySha(
   classroomId: string,
-  shas: string[]
+  shas: string[],
+  opts: { type?: string } = {}
 ): Promise<Map<string, string>> {
   const wanted = [...new Set(shas)];
   if (wanted.length === 0) return new Map();
 
   const rows = await getPrisma().contentAsset.findMany({
-    where: { classroom_id: classroomId, sha: { in: wanted } },
+    where: {
+      classroom_id: classroomId,
+      sha: { in: wanted },
+      ...(opts.type ? { type: opts.type } : {}),
+    },
     select: { path: true, sha: true },
     orderBy: { path: 'asc' },
   });

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -11,11 +11,11 @@ import {
 } from '@classmoji/content-signing';
 import { ContentService } from '../content/ContentService.ts';
 import {
-  type ContentAssetRecord,
   ensureContentAssets,
   lookupContentAsset,
   lookupContentAssetBySha,
   lookupContentAssets,
+  lookupContentAssetsBySha,
   lookupContentTree,
 } from './contentAssets.service.ts';
 import { extractOwnRepoPath } from './contentRefs.ts';
@@ -245,31 +245,257 @@ export function tierFor({
   return 'week';
 }
 
-/**
- * The signing context for one pass, optionally pinned to one clock.
- *
- * `now` matters more than it looks. Expiries are BUCKETED, so two signatures
- * minted a tick apart usually land in the same bucket and come out identical —
- * usually. Straddle a bucket boundary and they do not, and a caller that pairs
- * a `src` with its `srcset` by string equality (which is the whole contract
- * between `resolveMany` and `resolveSrcSets`) silently drops every set.
- *
- * So a pass that mints more than one URL pins its own `now` and hands the same
- * one to every signature in the batch. `nowSeconds()` is read once, at the top.
- */
-function signingContext(ctx: ResolveContext, master: string, now?: number): SigningContext {
-  return {
-    master,
-    classroomId: ctx.classroom.id,
-    keyVersion: ctx.classroom.content_key_version,
-    tier: ctx.tier,
-    ...(now === undefined ? {} : { now }),
-  };
-}
-
 /** Unix seconds — the one clock read a batched pass pins itself to. */
 function passClock(): number {
   return Math.floor(Date.now() / 1000);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The signing invariant
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * THE INVARIANT: the app only ever signs a sha that is in THAT classroom's map.
+ *
+ * ## Why the signer is where this has to live
+ *
+ * The Worker caches blobs by CONTENT — `blobs/{sha}` in R2, one object shared
+ * by every classroom that happens to hold the same bytes. That sharing is the
+ * whole reason the cache is worth having, and it is safe for exactly one
+ * reason: the signature is the proof of entitlement. The Worker does not know
+ * which files a classroom owns and is not the place to teach it; it knows only
+ * that a URL naming `{classroomId, sha}` carries a signature made with that
+ * classroom's derived key.
+ *
+ * So a signature over a sha that is NOT in the classroom's map is the single
+ * thing that would let classroom A read classroom B's cached private bytes.
+ * Not a Worker bug — a correctly verified signature over a claim the app
+ * should never have made. The control therefore belongs here, at the mint, and
+ * nowhere else.
+ *
+ * ## What counts as proof
+ *
+ * A `MappedAsset`: a row read out of ONE classroom's `content_assets`, carrying
+ * the classroom it was read for. It cannot be constructed outside this file
+ * (the brand is a module-private symbol), which is what makes "I have a sha"
+ * insufficient at the type level — a caller holding a bare 40-hex string has
+ * nothing the signer will accept, and has to go get a row first.
+ *
+ * The brand alone cannot say WHICH classroom, so the runtime half does: every
+ * mint asserts `asset.classroom_id === classroom.id`. A row genuinely read from
+ * classroom B, handed to a mint for classroom A, is refused there.
+ *
+ * ## What a refusal does
+ *
+ * Never throws, never signs. It returns null, and each caller falls back to
+ * exactly what it already does when the map has no row: the stored reference,
+ * a `/missing/` placeholder, or a legacy URL. A refusal is a rendering
+ * degradation, never a 500 and never a silent success.
+ */
+declare const MAPPED_ASSET: unique symbol;
+
+/**
+ * A `content_assets` row, bound to the classroom it was read for.
+ *
+ * The brand is phantom — nothing carries it at runtime — so its only job is to
+ * stop an object literal, a request parameter or another service's DTO from
+ * being passed where a map row is required. Mint one with `mappedAsset`, which
+ * is private to this module and is only ever called on the result of a
+ * classroom-scoped lookup.
+ */
+export interface MappedAsset {
+  readonly [MAPPED_ASSET]: true;
+  /** The classroom whose map this row came out of. Asserted at every mint. */
+  readonly classroom_id: string;
+  readonly path: string;
+  readonly sha: string;
+  /** `blob` or `tree`. A directory is not a file and cannot be signed as one. */
+  readonly type: string;
+}
+
+/** The ONE place a proof is created. Private on purpose. */
+function mappedAsset(
+  classroomId: string,
+  path: string,
+  row: { sha: string; type: string }
+): MappedAsset {
+  return {
+    classroom_id: classroomId,
+    path,
+    sha: row.sha,
+    type: row.type,
+  } as unknown as MappedAsset;
+}
+
+/** One path → the proof for it, or null when this classroom's map has no row. */
+async function mappedAssetByPath(classroomId: string, path: string): Promise<MappedAsset | null> {
+  const row = await lookupContentAsset(classroomId, path);
+  return row ? mappedAsset(classroomId, path, row) : null;
+}
+
+/** Many paths → proofs, in the one query `lookupContentAssets` already batches. */
+async function mappedAssetsByPath(
+  classroomId: string,
+  paths: string[]
+): Promise<Map<string, MappedAsset>> {
+  const rows = await lookupContentAssets(classroomId, paths);
+  const proofs = new Map<string, MappedAsset>();
+  for (const [path, row] of rows) proofs.set(path, mappedAsset(classroomId, path, row));
+  return proofs;
+}
+
+/** One directory → the proof for its tree object, for the folders served whole. */
+async function mappedTreeByPath(classroomId: string, dirPath: string): Promise<MappedAsset | null> {
+  const row = await lookupContentTree(classroomId, dirPath);
+  return row ? mappedAsset(classroomId, dirPath, row) : null;
+}
+
+/**
+ * Many SHAs → proofs, for the callers that only ever have a sha.
+ *
+ * A path lookup is free for the resolvers — they are already reading the row
+ * they need. This is the extra query, and it exists for the paths where the sha
+ * arrives from somewhere that is not the map: a commit response, a task
+ * payload, a URL somebody pasted. Batched, because the alternative is a round
+ * trip per image on a save that rewrites a whole document.
+ *
+ * Filtered to blobs: a tree sha is 40 hex characters like any other, and
+ * "the map has this sha somewhere" is not a licence to address it as a file.
+ *
+ * A sha with no row is simply absent from the result — and logged, because on
+ * these paths that absence IS the refusal. Nothing downstream ever sees a
+ * proof for it, so the mint that would have happened cannot.
+ */
+export async function mappedAssetsBySha(
+  classroomId: string,
+  shas: string[]
+): Promise<Map<string, MappedAsset>> {
+  const wanted = [...new Set(shas.filter(sha => typeof sha === 'string' && sha.length > 0))];
+  if (wanted.length === 0) return new Map();
+
+  const bySha = await lookupContentAssetsBySha(classroomId, wanted, { type: 'blob' });
+  const proofs = new Map<string, MappedAsset>();
+  for (const [sha, path] of bySha) {
+    proofs.set(sha, mappedAsset(classroomId, path, { sha, type: 'blob' }));
+  }
+  for (const sha of wanted) {
+    if (!proofs.has(sha)) refuseToSign(classroomId, sha, 'no blob row for this sha');
+  }
+  return proofs;
+}
+
+/**
+ * A refusal, logged once per render rather than once per reference.
+ *
+ * A document whose refs all point at one absent sha would otherwise write a
+ * line per image. Folded on `{classroom, sha}` and flushed on the next
+ * microtask, the same shape `logTextRead` uses and for the same reason: a
+ * render is a handful of awaits, so the window always closes inside the
+ * request.
+ *
+ * `warn`, not `debug`: unlike a cold cache or a missing row, this one should
+ * never happen. The sha is safe to log — it is a public content address — and
+ * the signing secret is never anywhere near this line.
+ */
+const refusedThisTick = new Set<string>();
+
+function refuseToSign(classroomId: string, sha: string, why: string): null {
+  const key = `${classroomId}|${sha}`;
+  if (!refusedThisTick.has(key)) {
+    if (refusedThisTick.size === 0) queueMicrotask(() => refusedThisTick.clear());
+    refusedThisTick.add(key);
+    console.warn(
+      `[contentDelivery] refused to sign sha outside classroom map: ` +
+        `classroom=${classroomId} sha=${sha} (${why})`
+    );
+  }
+  return null;
+}
+
+/**
+ * The choke point. Every signature this app mints is made inside this function.
+ *
+ * The proof is checked, the signing context is built from the classroom the
+ * proof is bound to, and only then is the caller's `mint` given an origin and a
+ * context to sign with. A caller cannot reach `signBlobUrl`, `signSrcSet` or
+ * `signThemeBase` with a sha of its own choosing, because it never holds a
+ * signing context at all.
+ *
+ * Null on refusal AND on a signer validation error — the two are the same to
+ * every caller, which already renders a legacy ref or a placeholder for a miss.
+ *
+ * ## `now`
+ *
+ * It matters more than it looks. Expiries are BUCKETED, so two signatures
+ * minted a tick apart usually land in the same bucket and come out identical —
+ * usually. Straddle a bucket boundary and they do not, and a caller that pairs
+ * a `src` with its `srcset` by string equality (which is the whole contract
+ * between `resolveMany` and `resolveSrcSets`) silently drops every set. So a
+ * pass that mints more than one URL pins its own clock (`passClock`) and hands
+ * the same one to every mint in the batch.
+ */
+async function mintSigned<T>(
+  classroom: { id: string; content_key_version: number },
+  env: { origin: string; master: string },
+  asset: MappedAsset,
+  tier: ResolveTier,
+  expect: 'blob' | 'tree',
+  now: number | undefined,
+  mint: (origin: string, signing: SigningContext) => Promise<T>
+): Promise<T | null> {
+  // The invariant, in one line. A row read for another classroom names bytes
+  // this classroom has no claim on, and the Worker would honour the signature.
+  if (asset.classroom_id !== classroom.id) {
+    return refuseToSign(classroom.id, asset.sha, `row belongs to classroom ${asset.classroom_id}`);
+  }
+  // A tree is not a file. Signing a directory's sha as a blob mints a
+  // confidently-wrong URL the Worker cannot serve; signing a blob as a theme
+  // folder is the same mistake mirrored.
+  if (asset.type !== expect) {
+    return refuseToSign(classroom.id, asset.sha, `row is a ${asset.type}, not a ${expect}`);
+  }
+
+  const signing: SigningContext = {
+    master: env.master,
+    classroomId: classroom.id,
+    keyVersion: classroom.content_key_version,
+    tier,
+    ...(now === undefined ? {} : { now }),
+  };
+
+  try {
+    return await mint(env.origin, signing);
+  } catch (error) {
+    // A validation error — an ext the signer will not take, a classroom id that
+    // is not a UUID. Never a reason to break the render.
+    console.warn(
+      `[contentDelivery] Could not sign ${asset.path} for classroom ${classroom.id}:`,
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
+}
+
+/**
+ * Sign one blob URL, given proof that its sha is in the classroom's map.
+ *
+ * The exported face of `mintSigned`, for the one caller outside this file that
+ * mints a URL — `pageContent.uploadPageAsset`, which has a sha from a commit
+ * response rather than from a resolve. It gets its proof from
+ * `mappedAssetsBySha` like anything else with only a sha.
+ */
+export async function signBlobUrlForClassroom(
+  classroom: { id: string; content_key_version: number },
+  env: { origin: string; master: string },
+  req: { asset: MappedAsset; ext: string; tier: ResolveTier; transform?: ResolveTransform }
+): Promise<string | null> {
+  return mintSigned(classroom, env, req.asset, req.tier, 'blob', undefined, (origin, signing) =>
+    signBlobUrl(origin, signing, {
+      sha: req.asset.sha,
+      ext: req.ext,
+      ...(req.transform ? { transform: req.transform } : {}),
+    })
+  );
 }
 
 /**
@@ -402,36 +628,39 @@ function parseMissingUrl(ctx: ResolveContext, ref: string): string | null {
   }
 }
 
-/** Sign one already-resolved asset, degrading to the legacy ref on refusal. */
+/**
+ * Sign one already-resolved asset, degrading to the legacy ref on refusal.
+ *
+ * Takes the map ROW, not a sha: the proof is what the signer requires, and
+ * handing this function a bare sha is not something a caller can express.
+ */
 async function signAsset(
   ctx: ResolveContext,
   env: { origin: string; master: string },
   ref: string,
-  path: string,
-  sha: string,
+  asset: MappedAsset,
   transform?: ResolveTransform,
   now?: number
 ): Promise<string> {
-  const ext = extensionOf(path);
+  const ext = extensionOf(asset.path);
   if (!ext) {
-    console.warn(`[contentDelivery] No extension on ${path} (classroom ${ctx.classroom.id})`);
+    console.warn(`[contentDelivery] No extension on ${asset.path} (classroom ${ctx.classroom.id})`);
     return ref;
   }
-  try {
-    return await signBlobUrl(env.origin, signingContext(ctx, env.master, now), {
-      sha,
-      ext,
-      ...(transform ? { transform } : {}),
-    });
-  } catch (error) {
-    // A refusal here is a validation error (an ext the signer will not take, a
-    // classroom id that is not a UUID) — never a reason to break the render.
-    console.warn(
-      `[contentDelivery] Could not sign ${path} for classroom ${ctx.classroom.id}:`,
-      error instanceof Error ? error.message : error
-    );
-    return ref;
-  }
+
+  const url = await mintSigned(
+    ctx.classroom,
+    env,
+    asset,
+    ctx.tier,
+    'blob',
+    now,
+    (origin, signing) =>
+      signBlobUrl(origin, signing, { sha: asset.sha, ext, ...(transform ? { transform } : {}) })
+  );
+  // A refusal degrades exactly as a signer validation error always has: the
+  // stored reference, which is a legacy URL for the classrooms that have one.
+  return url ?? ref;
 }
 
 /**
@@ -453,7 +682,7 @@ async function resolveOne(
   const path = toRepoPath(ctx, ref);
   if (!path) return ref;
 
-  const asset = await lookupContentAsset(ctx.classroom.id, path);
+  const asset = await mappedAssetByPath(ctx.classroom.id, path);
   // A tree row is not a file. `lookupContentAsset` is keyed by path alone, so a
   // reference naming a DIRECTORY comes back with the folder's tree sha — and
   // signing that as a blob would mint a confidently-wrong URL the Worker cannot
@@ -465,7 +694,7 @@ async function resolveOne(
     return mapIsCurrent ? missingUrl(env.origin, ctx.classroom.id, ref) : ref;
   }
 
-  return signAsset(ctx, env, ref, path, asset.sha, transform, now);
+  return signAsset(ctx, env, ref, asset, transform, now);
 }
 
 /**
@@ -508,27 +737,22 @@ export async function resolveAssetUrl(
 async function signResponsive(
   ctx: ResolveContext,
   env: { origin: string; master: string },
-  path: string,
-  sha: string,
+  asset: MappedAsset,
   now?: number
 ): Promise<{ src: string; srcset: string } | null> {
-  const ext = extensionOf(path);
+  const ext = extensionOf(asset.path);
   if (!ext || !RASTER_IMAGE_EXTENSIONS.has(ext)) return null;
 
-  try {
-    const signing = signingContext(ctx, env.master, now);
+  // ONE gate for the whole set. `src` and the ladder are minted inside it under
+  // a single signing context, which is what keeps the plain URL byte-identical
+  // to the one `resolveDelivery` hands back for the same reference.
+  return mintSigned(ctx.classroom, env, asset, ctx.tier, 'blob', now, async (origin, signing) => {
     const [src, ladder] = await Promise.all([
-      signBlobUrl(env.origin, signing, { sha, ext }),
-      signSrcSet(env.origin, signing, { sha, ext, fmt: 'auto' }),
+      signBlobUrl(origin, signing, { sha: asset.sha, ext }),
+      signSrcSet(origin, signing, { sha: asset.sha, ext, fmt: 'auto' }),
     ]);
     return { src, srcset: ladder.srcset };
-  } catch (error) {
-    console.warn(
-      `[contentDelivery] Could not sign a srcset for ${path} in classroom ${ctx.classroom.id}:`,
-      error instanceof Error ? error.message : error
-    );
-    return null;
-  }
+  });
 }
 
 /**
@@ -554,7 +778,7 @@ export async function resolveAssetSrcSet(
   // already `null` — "there is no srcset" — and the caller renders a plain
   // `src`. Nothing here can assert a placeholder into content.
   await ensureMapBounded(ctx.classroom.id);
-  const asset = await lookupContentAsset(ctx.classroom.id, path);
+  const asset = await mappedAssetByPath(ctx.classroom.id, path);
   if (!asset || asset.type !== 'blob') {
     console.warn(
       `[contentDelivery] No blob row for "${ref}" (path ${path}) in classroom ${ctx.classroom.id}`
@@ -562,7 +786,7 @@ export async function resolveAssetSrcSet(
     return null;
   }
 
-  return signResponsive(ctx, env, path, asset.sha);
+  return signResponsive(ctx, env, asset);
 }
 
 /**
@@ -621,7 +845,7 @@ export async function resolveThemeBase(
   // here is `null`, and the caller renders the deck without theme links rather
   // than pointing it at a URL that names no file.
   await ensureMapBounded(ctx.classroom.id);
-  const tree = await lookupContentTree(ctx.classroom.id, `${THEMES_FOLDER}/${themeName}`);
+  const tree = await mappedTreeByPath(ctx.classroom.id, `${THEMES_FOLDER}/${themeName}`);
   if (!tree) {
     console.warn(
       `[contentDelivery] No tree row for theme "${themeName}" in classroom ${ctx.classroom.id}`
@@ -629,18 +853,12 @@ export async function resolveThemeBase(
     return null;
   }
 
-  try {
-    return await signThemeBase(env.origin, signingContext(ctx, env.master), {
-      theme: themeName,
-      treeSha: tree.sha,
-    });
-  } catch (error) {
-    console.warn(
-      `[contentDelivery] Could not sign theme "${themeName}" for classroom ${ctx.classroom.id}:`,
-      error instanceof Error ? error.message : error
-    );
-    return null;
-  }
+  // Through the same gate as a blob. A theme base is a signature over a sha
+  // exactly as a blob URL is — the only differences are where in the URL the
+  // policy sits and that the object is a tree.
+  return mintSigned(ctx.classroom, env, tree, ctx.tier, 'tree', undefined, (origin, signing) =>
+    signThemeBase(origin, signing, { theme: themeName, treeSha: tree.sha })
+  );
 }
 
 /**
@@ -690,7 +908,7 @@ export async function resolveDelivery(
   if (wanted.size === 0) return { urls, srcSets };
 
   const mapIsCurrent = await ensureMapBounded(ctx.classroom.id);
-  const assets = await lookupContentAssets(ctx.classroom.id, [...new Set(wanted.values())]);
+  const assets = await mappedAssetsByPath(ctx.classroom.id, [...new Set(wanted.values())]);
   const now = passClock();
 
   await Promise.all(
@@ -711,7 +929,7 @@ export async function resolveDelivery(
       }
 
       if (opts.srcSets && isRasterImagePath(path)) {
-        const set = await signResponsive(ctx, env, path, asset.sha, now);
+        const set = await signResponsive(ctx, env, asset, now);
         if (set) {
           // The set's `src` IS the plain signed URL under the same clock — so
           // this is not a second signature for the same file, it is the one.
@@ -721,7 +939,7 @@ export async function resolveDelivery(
         }
       }
 
-      urls.set(ref, await signAsset(ctx, env, ref, path, asset.sha, undefined, now));
+      urls.set(ref, await signAsset(ctx, env, ref, asset, undefined, now));
     })
   );
 
@@ -969,20 +1187,11 @@ async function signTextUrl(
   // context type rather than a read's.
   classroom: { id: string; content_key_version: number },
   env: { origin: string; master: string },
-  sha: string,
+  asset: MappedAsset,
   ext: string
-): Promise<string> {
-  return signBlobUrl(
-    env.origin,
-    // Server-to-server: `week` names the cache bucket, not the reader.
-    {
-      master: env.master,
-      classroomId: classroom.id,
-      keyVersion: classroom.content_key_version,
-      tier: 'week',
-    },
-    { sha, ext }
-  );
+): Promise<string | null> {
+  // Server-to-server: `week` names the cache bucket, not the reader.
+  return signBlobUrlForClassroom(classroom, env, { asset, ext, tier: 'week' });
 }
 
 /**
@@ -1109,10 +1318,12 @@ async function warmOneTextFile(
     // The row the save just wrote. No `ensureMap` here: a warm that had to
     // refresh the map would be warming a sha the save did not produce, and the
     // save awaited its own `recordContentAsset` before calling us.
-    const asset = await lookupContentAsset(classroom.id, path);
+    const asset = await mappedAssetByPath(classroom.id, path);
     if (!asset || asset.type !== 'blob') return;
 
-    const url = await signTextUrl(classroom, env, asset.sha, ext);
+    const url = await signTextUrl(classroom, env, asset, ext);
+    // Refused, or unsignable. Nothing to warm — and the read path is unchanged.
+    if (!url) return;
     const response = await fetch(url, { signal: AbortSignal.timeout(WARM_FETCH_TIMEOUT_MS) });
     await response.arrayBuffer();
 
@@ -1219,22 +1430,16 @@ async function warmOneBlob(
     // The row the commit just wrote. No `ensureMap`, for the text warm's
     // reason: a refresh could only move us off the sha the caller just
     // recorded, and the caller awaited that write before calling here.
-    const asset = await lookupContentAsset(classroom.id, path);
+    const asset = await mappedAssetByPath(classroom.id, path);
     if (!asset || asset.type !== 'blob') return;
 
-    // The same three inputs `signingContext` feeds `signAsset` on the read
+    // The same gate, and the same signing inputs, `signAsset` uses on the read
     // side, and no transform — the index renders the untransformed original,
     // so a `w=` or `fmt=` here would warm a URL it never asks for.
-    const url = await signBlobUrl(
-      env.origin,
-      {
-        master: env.master,
-        classroomId: classroom.id,
-        keyVersion: classroom.content_key_version,
-        tier,
-      },
-      { sha: asset.sha, ext }
-    );
+    const url = await signBlobUrlForClassroom(classroom, env, { asset, ext, tier });
+    // Refused, or unsignable. A warm that cannot mint the reader's URL has
+    // nothing to fill, and the reader's own path is untouched either way.
+    if (!url) return;
     const response = await fetch(url, { signal: AbortSignal.timeout(WARM_FETCH_TIMEOUT_MS) });
     await response.arrayBuffer();
 
@@ -1269,7 +1474,7 @@ async function readTextThroughWorker(
   const ext = extensionOf(path);
   if (!ext) return null;
 
-  let asset: ContentAssetRecord | null;
+  let asset: MappedAsset | null;
   try {
     // Bounded: a stale map turns this into three GitHub calls, and a slow
     // GitHub must cost a fallback rather than a held-open render. The refresh
@@ -1283,7 +1488,7 @@ async function readTextThroughWorker(
         );
       }
     );
-    asset = await lookupContentAsset(ctx.classroom.id, path);
+    asset = await mappedAssetByPath(ctx.classroom.id, path);
   } catch (error) {
     // The map itself is unreachable, which is not the Worker's fault — do not
     // trip the circuit, just fall back for this path.
@@ -1300,7 +1505,10 @@ async function readTextThroughWorker(
   if (!asset || asset.type !== 'blob') return null;
 
   try {
-    const url = await signTextUrl(ctx.classroom, env, asset.sha, ext);
+    const url = await signTextUrl(ctx.classroom, env, asset, ext);
+    // A refusal is a MISS, not a dead origin: fall back for this path and leave
+    // the per-render circuit closed, exactly as a map miss above does.
+    if (!url) return null;
 
     const response = await fetch(url, { signal: AbortSignal.timeout(TEXT_FETCH_TIMEOUT_MS) });
     if (!response.ok) {

--- a/packages/services/src/classmoji/contentDelivery.service.ts
+++ b/packages/services/src/classmoji/contentDelivery.service.ts
@@ -276,14 +276,27 @@ function passClock(): number {
  * ## What counts as proof
  *
  * A `MappedAsset`: a row read out of ONE classroom's `content_assets`, carrying
- * the classroom it was read for. It cannot be constructed outside this file
- * (the brand is a module-private symbol), which is what makes "I have a sha"
- * insufficient at the type level — a caller holding a bare 40-hex string has
- * nothing the signer will accept, and has to go get a row first.
+ * the classroom it was read for. The brand is a module-private symbol, so it
+ * cannot be produced by writing an object literal — only by a deliberate cast
+ * that a reader can see. That is what makes "I have a sha" insufficient at the
+ * type level: a caller holding a bare 40-hex string has nothing the signer will
+ * accept, and has to go get a row first.
  *
- * The brand alone cannot say WHICH classroom, so the runtime half does: every
- * mint asserts `asset.classroom_id === classroom.id`. A row genuinely read from
- * classroom B, handed to a mint for classroom A, is refused there.
+ * Three walls, none of them load-bearing alone:
+ *
+ *   1. the brand, which turns "pass a sha" into "write a cast" — a speed bump
+ *      that shows up in a diff, not a proof;
+ *   2. the runtime check, which is the one that actually holds: the brand
+ *      cannot say WHICH classroom, so every mint asserts
+ *      `asset.classroom_id === classroom.id`. A row genuinely read from
+ *      classroom B, handed to a mint for classroom A, is refused there — and a
+ *      cast cannot talk its way past it, because a forged row still has to name
+ *      a classroom;
+ *   3. a `no-restricted-imports` rule in the shared eslint config, which stops
+ *      a module from skipping all of the above by importing
+ *      `@classmoji/content-signing` and calling `signBlobUrl` itself. The
+ *      allowlist is this file, `deckRenderToken.service.ts`, the Worker's
+ *      verify seam, and tests.
  *
  * ## What a refusal does
  *
@@ -299,9 +312,13 @@ declare const MAPPED_ASSET: unique symbol;
  *
  * The brand is phantom — nothing carries it at runtime — so its only job is to
  * stop an object literal, a request parameter or another service's DTO from
- * being passed where a map row is required. Mint one with `mappedAsset`, which
- * is private to this module and is only ever called on the result of a
- * classroom-scoped lookup.
+ * being passed where a map row is required. It is NOMINAL, not unforgeable: a
+ * cast defeats it. That is on purpose and it is enough, because the cast is
+ * visible in review and the thing that actually refuses a wrong sha is the
+ * runtime `classroom_id` assertion in `mintSigned`, which no cast can satisfy
+ * without naming a classroom. Mint one with `mappedAsset`, which is private to
+ * this module and is only ever called on the result of a classroom-scoped
+ * lookup.
  */
 export interface MappedAsset {
   readonly [MAPPED_ASSET]: true;

--- a/packages/services/src/classmoji/pageContent.service.ts
+++ b/packages/services/src/classmoji/pageContent.service.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'node:crypto';
-import { signBlobUrl } from '@classmoji/content-signing';
 import { z } from 'zod';
 import { collectBlockAssetRefs, mapBlockAssetRefs } from '@classmoji/utils';
 import { ContentService } from '../content/ContentService.ts';
@@ -7,6 +6,8 @@ import { recordContentAsset, resolveContentBranch } from './contentAssets.servic
 import {
   canonicalizeMany,
   fetchContentText,
+  mappedAssetsBySha,
+  signBlobUrlForClassroom,
   textReadBudget,
   warmContentText,
   type ResolveContext,
@@ -610,6 +611,21 @@ export async function uploadPageAsset(
  * bare repo path when a display URL came back and the legacy absolute URL when
  * it did not. A classroom the readers do not resolve for must keep getting the
  * legacy URL, or every upload into it would save as a path nothing can read.
+ *
+ * ## The one call site that carries a sha in from outside the map
+ *
+ * Every other signature in the app is minted from a row the resolver just read
+ * by PATH for this classroom. This one starts from the sha a GitHub commit
+ * returned, which is not proof of anything the map knows — so it looks the sha
+ * up (`mappedAssetsBySha`) and signs only what comes back.
+ *
+ * That lookup is not ceremony. `recordContentAsset` above is allowed to decline
+ * — a classroom on a non-GitHub provider, one with no content repo, or a write
+ * that simply failed — and before this check a decline still produced a signed
+ * URL, which then made `uploadPageAsset` store the BARE REPO PATH for a file
+ * with no map row: an upload that saved as a reference no reader can resolve
+ * and no later sync repairs. Refusing here restores the legacy absolute URL for
+ * exactly those uploads, which is the answer that keeps working.
  */
 async function signUploadedAsset(
   page: PageWithContentRepo,
@@ -632,25 +648,21 @@ async function signUploadedAsset(
   const dot = name.lastIndexOf('.');
   if (dot <= 0 || dot === name.length - 1) return null;
 
-  try {
-    return await signBlobUrl(
-      origin,
-      {
-        master,
-        classroomId: classroom.id,
-        keyVersion:
-          typeof classroom.content_key_version === 'number' ? classroom.content_key_version : 0,
-        tier: 'edit',
-      },
-      { sha, ext: name.slice(dot + 1).toLowerCase() }
-    );
-  } catch (error) {
-    console.warn(
-      `[pageContent.uploadPageAsset] Could not sign ${path}:`,
-      error instanceof Error ? error.message : error
-    );
-    return null;
-  }
+  const asset = (await mappedAssetsBySha(classroom.id, [sha])).get(sha);
+  // The row the upload just wrote is missing, so there is nothing to prove this
+  // classroom's claim on these bytes. `mappedAssetsBySha` logs the refusal; the
+  // caller stores the legacy absolute URL, which still resolves.
+  if (!asset) return null;
+
+  return signBlobUrlForClassroom(
+    {
+      id: classroom.id,
+      content_key_version:
+        typeof classroom.content_key_version === 'number' ? classroom.content_key_version : 0,
+    },
+    { origin, master },
+    { asset, ext: name.slice(dot + 1).toLowerCase(), tier: 'edit' }
+  );
 }
 
 // ─── Blank page content ──────────────────────────────────────────────────────


### PR DESCRIPTION
## The invariant

**The app only ever mints a signed blob URL `/c/{classroomId}/blob/{sha}.{ext}` for a sha that is present in THAT classroom's asset map (`content_assets`).**

The Cloudflare Worker caches blobs by **content** — `blobs/{sha}` in R2, one object shared by every classroom that happens to hold the same bytes. That sharing is the whole reason the cache is worth having, and it is safe for exactly one reason: **the signature is the proof of entitlement.** The Worker does not know which files a classroom owns and is not the place to teach it — it knows only that a URL naming `{classroomId, sha}` carries a signature made with that classroom's derived key.

So a signature over a sha that is *not* in the classroom's map is the single thing that would let classroom A read classroom B's cached private bytes. Not a Worker bug — a correctly verified signature over a claim the app should never have made. The control belongs at the mint, which is where this puts it. **The Worker is unchanged, and so are URL shapes, tiers and key versions.**

## Call-site table — where does the sha come from?

Every path that ends in `signBlobUrl` / `signSrcSet` / `signThemeBase`:

| # | Call site | Sha source | Case |
|---|---|---|---|
| 1 | `signAsset` ← `resolveOne` ← `resolveAssetUrl` | `lookupContentAsset(classroomId, path)` | **(a)** row by path, this classroom |
| 2 | `signAsset` ← `resolveDelivery` / `resolveMany` | `lookupContentAssets(classroomId, paths)` (batched) | **(a)** |
| 3 | `signResponsive` ← `resolveAssetSrcSet` | `lookupContentAsset(classroomId, path)` | **(a)** |
| 4 | `signResponsive` ← `resolveDelivery` / `resolveSrcSets` | `lookupContentAssets(classroomId, paths)` | **(a)** |
| 5 | `resolveThemeBase` → `signThemeBase` | `lookupContentTree(classroomId, '.slidesthemes/{name}')` — tree row by path | **(a)** (theme name comes from the deck's `data-theme`, but the *sha* is this classroom's tree row) |
| 6 | `signTextUrl` ← `readTextThroughWorker` ← `fetchContentText` | `lookupContentAsset(classroomId, path)` | **(a)** |
| 7 | `signTextUrl` ← `warmOneTextFile` ← `warmContentText` | `lookupContentAsset(classroomId, path)` | **(a)** |
| 8 | `warmOneBlob` ← `warmContentBlob` (deck thumbnail, `packages/tasks/.../deckThumbnail.ts`) | `lookupContentAsset(classroomId, path)` — the task passes a **path**, never a sha | **(a)** |
| 9 | `pageContent.signUploadedAsset` ← `uploadPageAsset` | **the sha a GitHub commit returned**, signed without any map lookup | **(c)** |

Non-signing sha paths audited and found already scoped, listed so the audit is complete:

- `canonicalizeAssetRef` (pasted / stored signed URL): `lookupContentAssetBySha(ctx.classroom.id, sha)` — classroom-scoped, and it only ever *removes* a signature. On a miss it returns the caller's string unchanged. It never mints.
- Deck thumbnails: `thumbnail_rendered_sha` is `index.html`'s sha and is only ever *compared*, never signed. `slide.thumbnail_path` is a path and goes through `resolveMany`.
- Every `ResolveContext` builder (`apps/pages`, `apps/slides`) is constructed from the classroom that owns the content being rendered, so no (c) arises from a mismatched context.

### The one case (c), and whether it was reachable

`signUploadedAsset` signed `result.sha` straight off the `ContentService.upload` response. `recordContentAsset` is awaited immediately before it — but that call is **allowed to decline**: it returns `false` for a classroom the delivery layer cannot serve (`isDeliverable`: non-GitHub provider, no content repo, no org login) and it swallows write failures. Before this PR a decline still produced a signature.

In practice the sha always originated in the same classroom's own repo, so this was a **structural hole rather than a live cross-classroom read** — I found no path by which another classroom's sha reached it. It did have a concrete non-security consequence: because `uploadPageAsset` stores the bare repo path whenever `displayUrl` is non-null, an upload whose row was never written saved as a reference no reader can resolve and no later sync repairs. The guard now returns the legacy absolute URL for exactly those uploads.

### The one visible behaviour change

**Narrow case:** an image uploaded into a delivery-**enabled** classroom where the `content_assets` row write fails or declines.

- **Before:** the editor showed a working signed URL — for a sha the classroom's map did not have. The reference was then stored as a bare repo path, and once the editor was closed the image was permanently broken for every reader, because nothing could resolve that path.
- **After:** the editor shows the raw GitHub URL until the next sync lands. In a public content repo that renders fine. **In a private content repo it 404s** — a visibly broken image in the editor, right after upload.

That trade is right. The "before" is a signature the app had no business making, and it bought a few minutes of working preview at the cost of a *silently* and *permanently* broken reference — the failure mode was invisible at the moment it was created and unrepairable afterwards. The "after" fails loudly, at the moment of upload, in front of the person who can retry, and it is self-healing: the 24-hour `ensureContentAssets` backstop (or the next push webhook) writes the row, after which the stored path resolves and the image appears. A broken thumbnail for one sync cycle beats a broken image forever, and it beats minting an entitlement claim to cover it up.

It is also rare by construction: `recordContentAsset` only declines for a classroom the delivery layer cannot serve at all (non-GitHub provider, no content repo, no org login) — which is nearly disjoint with having `content_delivery_enabled = true` — or when the row write genuinely fails.

## What the guard is

One choke point, `mintSigned`, in `contentDelivery.service.ts`. Every `signBlobUrl` / `signSrcSet` / `signThemeBase` call in the app is now made *inside* it — a caller never holds a `SigningContext` of its own, so it cannot reach a signer with a sha of its choosing.

It requires a `MappedAsset`: a row read out of one classroom's map, carrying `classroom_id`.

Three walls, and it is worth being precise about which one is load-bearing:

1. **Type level (a speed bump, not a proof)** — the interface is branded with a module-private `unique symbol`, so it **cannot be constructed without a deliberate cast**. `as unknown as MappedAsset` still gets past it; what the brand buys is that passing a bare sha stops being possible *by accident* and becomes a cast someone has to write and a reviewer can see. (Asserted with a `@ts-expect-error` in the test suite, which `tsc --noEmit` would flag as unused if the brand stopped working.)
2. **Runtime (the wall that holds)** — `mintSigned` asserts `asset.classroom_id === classroom.id`, so a row *genuinely* read from classroom B and handed to a mint for classroom A is refused — and a cast cannot talk its way past it, because a forged row still has to name a classroom. A test forges one explicitly and watches it get refused. It also asserts blob-vs-tree, so a directory's sha cannot be signed as a file.
3. **Lint (stops the gate being skipped)** — a `no-restricted-imports` rule in `packages/eslint-config/base.js` forbids importing `@classmoji/content-signing` outside a tiny allowlist: `contentDelivery.service.ts` (the gate), `deckRenderToken.service.ts` (a signature over a deck id, no asset map to check against), `apps/content/src/verify.ts` (the Worker's verify seam — it re-exports the package and mints nothing, allowlisted in that app's own config), and tests. Without this a module could bypass all of the above by calling `signBlobUrl` itself. Verified **inert across every package** (0 hits repo-wide) and firing on a scratch importer with the message *"Sign through ClassmojiService.contentDelivery instead."*

**Sha-carrying paths** get proof from `mappedAssetsBySha(classroomId, shas)`, which batches through `lookupContentAssetsBySha` (now takes an optional `type` filter, so a tree sha cannot answer a blob lookup).

**On a violation it does not sign.** It returns `null`, and each caller degrades to exactly what a missing row already produces today — the stored/legacy ref, a `/missing/` placeholder, or `null` for the entry points whose "no" is an absence. Never throws, never 500s. It logs one folded line per render:

```
[contentDelivery] refused to sign sha outside classroom map: classroom=<id> sha=<sha> (<why>)
```

Classroom and sha only — the sha is a public content address and the signing secret is never near this line (asserted in tests).

**Hot path cost: zero extra queries.** Paths 1–8 already read the row they need; they now just carry it instead of a loose sha. Only path 9 adds a lookup, and it is an upload that has just finished a GitHub round trip.

## Tests

New `contentDelivery.signerGuard.test.ts` — 21 tests over a two-classroom in-memory map (same path, different shas, deliberately):

- a sha the map has never held is refused on every sha-carrying path;
- a sha that is real **in another classroom** is refused here;
- a tree sha asked for as a blob is refused;
- a row from classroom B handed to a mint for classroom A is refused at runtime, and cannot be hand-built at type level without a cast;
- a row **forged past the brand with an explicit cast** is still refused at runtime — the check that matters does not depend on the type system;
- the same row signs fine for the classroom it was read for;
- resolvers, warms and theme bases stay scoped to their own classroom's sha;
- the upload path signs once its row is in the map, and falls back to the legacy absolute URL when the row was never written;
- a pasted signed URL for a sha the classroom no longer has canonicalizes to the stored ref and is **not** re-signed on the next render;
- refusals fold to one log line per render and never name the secret.

`pageContent.service.test.ts`'s mocks were updated to record the rows a save writes, because the upload now signs only what the map can vouch for — a mock that recorded nothing is a refusal, not a signature.

### Verification

| | |
|---|---|
| `@classmoji/services` (`-- contentDelivery`, 7 files) | 156 passed |
| `@classmoji/services` (full) | **1720 passed**, 0 failed, 131 skipped |
| `@classmoji/tasks` | 183 passed |
| `apps/slides` unit | 156 passed |
| typecheck services / tasks / slides | clean |
| eslint on touched files | 0 errors |
| `no-restricted-imports` across all 11 linted packages | 0 hits (inert); fires on a scratch importer |
| `web:build --force`, `pages:build`, `slides:build` | all pass |

The existing warm-vs-read byte-identity tests still pass — the guard changes who may sign, not what a signature looks like.

Pre-existing on `origin/staging` and untouched here: a `@classmoji/web` typecheck error (`useGitProvider` missing from `~/hooks`), and a vitest worker teardown warning in `contentDelivery.canonicalizeSave.test.ts`. Both verified present at `e275c24f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA

