### PR TITLE
fix(content): serve byte ranges instead of the whole file

### DIFF
--- a/apps/content/src/blob.ts
+++ b/apps/content/src/blob.ts
@@ -1,5 +1,6 @@
 import {
   SHORT_CACHE_CONTROL,
+  blobHeaders,
   blobKey,
   contentHeaders,
   errorResponse,
@@ -9,6 +10,16 @@ import { contentTypeForExtension, isRasterExtension } from './content-type.ts';
 import type { Env } from './env.ts';
 import { GitHubOrigin } from './origins/github.ts';
 import { deliveryStrategy, type OriginAdapter } from './origins/types.ts';
+import {
+  contentRangeHeader,
+  ifRangeMatches,
+  parseRange,
+  rangeLength,
+  sliceStream,
+  unsatisfiedRangeHeader,
+  type ByteRange,
+  type RangeOutcome,
+} from './range.ts';
 import { withOriginRetry } from './token.ts';
 import type { OriginTokenTiming } from './token.ts';
 import {
@@ -35,13 +46,31 @@ type VerifiedBlob = Extract<BlobVerification, { ok: true }>;
 // though the GitHub origin cannot presign.
 const origin: OriginAdapter = new GitHubOrigin();
 
-interface ServeOptions {
+export interface ServeOptions {
   classroomId: string;
   sha: string;
   contentType: string;
   cacheControl: string;
   /** HEAD: answer from R2 metadata when the object is there, and never buffer. */
   head?: boolean;
+  /** The request's `Range` header verbatim, or null when it sent none. */
+  range?: string | null;
+  /** The request's `If-Range` header verbatim, or null when it sent none. */
+  ifRange?: string | null;
+}
+
+/**
+ * The parts of a request that decide HOW a blob is served rather than WHICH
+ * one — so the blob route and the theme route cannot drift on it.
+ */
+export function deliveryOptions(
+  request: Request
+): Pick<ServeOptions, 'head' | 'range' | 'ifRange'> {
+  return {
+    head: request.method === 'HEAD',
+    range: request.headers.get('Range'),
+    ifRange: request.headers.get('If-Range'),
+  };
 }
 
 /**
@@ -61,7 +90,7 @@ interface ServeOptions {
  * different caller's answer to a different question.
  */
 function storedHeaders(object: R2Object, contentType: string, cacheControl: string): Headers {
-  const headers = contentHeaders(contentType, cacheControl);
+  const headers = blobHeaders(contentType, cacheControl);
   headers.set('ETag', object.httpEtag);
   // R2 knows the length without reading a byte, so there is no reason to make a
   // client guess at download progress.
@@ -87,6 +116,59 @@ async function storedHead(
   const object = await env.CACHE.head(key);
   if (!object) return null;
   return new Response(null, { headers: storedHeaders(object, contentType, cacheControl) });
+}
+
+/**
+ * A 206 for one byte range.
+ *
+ * Everything a full 200 carries — the type the signed extension names, the
+ * tier's cache-control, CORS, nosniff, the sandboxing CSP — plus the two
+ * headers that make it partial. `Content-Length` is the length of the RANGE and
+ * not of the object; `Content-Range` is what says where the rest of it went.
+ *
+ * `etag` is null on the origin-miss path, where the object is still on its way
+ * into R2 and has no stored validator yet. An `ETag` is not required on a 206,
+ * and inventing one the R2 write would then disagree with is worse than leaving
+ * it off: the next request is a cache hit and carries the real one.
+ */
+function partialResponse(
+  body: BodyInit | null,
+  options: ServeOptions,
+  etag: string | null,
+  range: ByteRange,
+  total: number
+): Response {
+  const headers = blobHeaders(options.contentType, options.cacheControl);
+  if (etag !== null) headers.set('ETag', etag);
+  headers.set('Content-Range', contentRangeHeader(range, total));
+  headers.set('Content-Length', String(rangeLength(range)));
+  return new Response(body, { status: 206, headers });
+}
+
+/**
+ * 416 for a range naming bytes the object does not have.
+ *
+ * The unsatisfied-range form of `Content-Range` is required by RFC 7233 §4.4,
+ * and it is the only thing that makes the refusal actionable: it tells the
+ * client how big the object really is, so the retry can be right.
+ */
+function rangeNotSatisfiable(total: number): Response {
+  const headers = blobHeaders('application/json; charset=utf-8', 'no-store');
+  headers.set('Content-Range', unsatisfiedRangeHeader(total));
+  return new Response(JSON.stringify({ error: 'range not satisfiable' }), { status: 416, headers });
+}
+
+/**
+ * What to do about this request's `Range`, given the object we actually hold.
+ *
+ * `If-Range` is weighed first and its failure is a full 200, never an error:
+ * a client saying "the range, but only if this is still the same file" and
+ * being wrong must get the whole new file rather than a slice of it.
+ */
+function rangeOutcome(options: ServeOptions, etag: string, total: number): RangeOutcome {
+  if (options.range === undefined || options.range === null) return { kind: 'full' };
+  if (!ifRangeMatches(options.ifRange, etag)) return { kind: 'full' };
+  return parseRange(options.range, total);
 }
 
 /**
@@ -184,7 +266,7 @@ function streamAndCache(
 ): Response {
   const [toClient, toCache] = body.tee();
   ctx.waitUntil(putCacheBranch(env, key, toCache, contentType, contentLength));
-  const headers = contentHeaders(contentType, cacheControl);
+  const headers = blobHeaders(contentType, cacheControl);
   // Only ever forwarded, never computed: working it out would mean buffering
   // the very stream this path exists to avoid buffering.
   if (contentLength !== null) headers.set('Content-Length', String(contentLength));
@@ -280,9 +362,143 @@ function warnOversizedSource(sha: string, size: number | null): void {
 }
 
 /**
+ * Answer from an object R2 already holds, with its metadata already in hand.
+ *
+ * Returns null when the object went away between the `head` and the `get` — an
+ * expiry or a lifecycle delete landing mid-request — so the caller falls
+ * through to the origin rather than inventing a 404 for a blob that exists.
+ */
+async function serveStored(
+  env: Env,
+  key: string,
+  stored: R2Object,
+  options: ServeOptions
+): Promise<Response | null> {
+  const outcome = rangeOutcome(options, stored.httpEtag, stored.size);
+
+  if (outcome.kind === 'unsatisfiable') return rangeNotSatisfiable(stored.size);
+
+  if (outcome.kind === 'full') {
+    const headers = storedHeaders(stored, options.contentType, options.cacheControl);
+    if (options.head) return new Response(null, { headers });
+    const hit = await env.CACHE.get(key);
+    if (!hit) return null;
+    return new Response(hit.body, { headers });
+  }
+
+  const { range } = outcome;
+  if (options.head) return partialResponse(null, options, stored.httpEtag, range, stored.size);
+
+  // R2's own ranged read: only these bytes leave storage, which is what makes a
+  // seek into the middle of a video cost the same as a seek into the start.
+  const hit = await env.CACHE.get(key, {
+    range: { offset: range.start, length: rangeLength(range) },
+  });
+  if (!hit) return null;
+  return partialResponse(hit.body, options, stored.httpEtag, range, stored.size);
+}
+
+/**
+ * A ranged request that missed the cache.
+ *
+ * Answering it with the whole object is the exact bug this file exists to fix,
+ * so the miss path has to produce a 206 as well — and it has to do so without
+ * giving up the cache write, because the point is that the SECOND request for
+ * that video is an R2 hit.
+ *
+ * Two shapes, chosen by whether the origin said how long the body is:
+ *
+ *   - Length known. The body is tee'd: one branch runs to the end and lands in
+ *     R2 exactly as an unranged miss would, and the client is handed a slice of
+ *     the other. Nothing is buffered, so this is a path a 40 MB video can take —
+ *     and it is the path media does take, because GitHub serves media
+ *     identity-encoded with a real `Content-Length`.
+ *   - Length unknown. `Content-Range` needs a total and the only way to learn
+ *     one is to count, so the body is held — under the same ceiling, and for the
+ *     same reason, as `putCacheBranch`. Text arrives this way (GitHub gzips it
+ *     and the runtime decodes it); media does not.
+ */
+async function serveRangeFromOrigin(
+  env: Env,
+  ctx: ExecutionContext,
+  key: string,
+  body: ReadableStream<Uint8Array>,
+  options: ServeOptions,
+  declared: number | null
+): Promise<Response> {
+  const full = () =>
+    streamAndCache(env, ctx, key, body, options.contentType, options.cacheControl, declared);
+
+  // Nothing is stored, so there is no validator to weigh an `If-Range` against.
+  // RFC 7233 §3.2: a server that cannot evaluate it treats the request as an
+  // ordinary GET, which is the conditional working as designed.
+  if (options.ifRange !== undefined && options.ifRange !== null) return full();
+
+  if (declared !== null) {
+    const outcome = parseRange(options.range, declared);
+    if (outcome.kind === 'full') return full();
+
+    const [toClient, toCache] = body.tee();
+    ctx.waitUntil(putCacheBranch(env, key, toCache, options.contentType, declared));
+
+    if (outcome.kind === 'unsatisfiable') {
+      // The client gets no bytes, but the pull is already paid for: cancel only
+      // this branch and let the other finish, so the corrected retry is a hit.
+      await toClient.cancel().catch(() => {});
+      return rangeNotSatisfiable(declared);
+    }
+
+    const { range } = outcome;
+    return partialResponse(
+      sliceStream(toClient, range.start, range.end),
+      options,
+      null,
+      range,
+      declared
+    );
+  }
+
+  const bytes = await readBounded(body, MAX_UNKNOWN_LENGTH_CACHE_BYTES);
+  if (bytes === null) {
+    // Counting was the only way to a total and the count blew the ceiling, so
+    // there is no `Content-Range` to send and the counted bytes went with the
+    // cancelled stream. The object is re-pulled and streamed whole: a 200 to a
+    // range request, and the one case left where that still happens. Only an
+    // enormous body whose length the origin never declared reaches here, which
+    // no media type does.
+    console.warn(
+      `[content] serving ${key} whole: unknown-length origin body over the ` +
+        `${MAX_UNKNOWN_LENGTH_CACHE_BYTES} byte ceiling, so no range could be resolved`
+    );
+    return serveBlobBySha(env, ctx, { ...options, range: null, ifRange: null });
+  }
+
+  const total = bytes.byteLength;
+  ctx.waitUntil(
+    env.CACHE.put(key, bytes, { httpMetadata: { contentType: options.contentType } }).catch(
+      error => {
+        console.warn(`[content] failed to cache ${key}: ${messageOf(error)}`);
+      }
+    )
+  );
+
+  const outcome = parseRange(options.range, total);
+  if (outcome.kind === 'unsatisfiable') return rangeNotSatisfiable(total);
+  if (outcome.kind === 'full') {
+    const headers = blobHeaders(options.contentType, options.cacheControl);
+    headers.set('Content-Length', String(total));
+    return new Response(bytes, { headers });
+  }
+
+  const { range } = outcome;
+  return partialResponse(bytes.slice(range.start, range.end + 1), options, null, range, total);
+}
+
+/**
  * Serve a blob by sha: R2 first, otherwise pull it from the origin and stream
  * it to the client while a tee'd copy lands in R2. Bytes are never buffered on
- * this path.
+ * this path unless a range has to be resolved against a length the origin never
+ * declared.
  */
 export async function serveBlobBySha(
   env: Env,
@@ -291,13 +507,20 @@ export async function serveBlobBySha(
 ): Promise<Response> {
   const key = blobKey(options.sha);
 
-  if (options.head) {
-    const head = await storedHead(env, key, options.contentType, options.cacheControl);
-    if (head) return head;
+  // A HEAD and a ranged GET are both settled from metadata: the stored size and
+  // etag decide the status, the headers and the byte positions before a single
+  // byte is read — and only then is a `get` issued, for exactly those bytes.
+  // A plain GET still takes the one-call path it always did.
+  if (options.head || (options.range !== undefined && options.range !== null)) {
+    const stored = await env.CACHE.head(key);
+    if (stored) {
+      const served = await serveStored(env, key, stored, options);
+      if (served) return served;
+    }
+  } else {
+    const hit = await env.CACHE.get(key);
+    if (hit) return storedResponse(hit, options.contentType, options.cacheControl);
   }
-
-  const hit = await env.CACHE.get(key);
-  if (hit) return storedResponse(hit, options.contentType, options.cacheControl);
 
   // Size is unknown before the fetch, so this always proxies today. The branch
   // is the seam for an origin that knows sizes and can presign large objects.
@@ -322,6 +545,12 @@ export async function serveBlobBySha(
     return errorResponse(502, 'origin unavailable');
   }
 
+  const declared = declaredLength(response.headers);
+
+  if (options.range !== undefined && options.range !== null) {
+    return serveRangeFromOrigin(env, ctx, key, response.body, options, declared);
+  }
+
   return streamAndCache(
     env,
     ctx,
@@ -329,7 +558,7 @@ export async function serveBlobBySha(
     response.body,
     options.contentType,
     options.cacheControl,
-    declaredLength(response.headers)
+    declared
   );
 }
 
@@ -462,12 +691,21 @@ export async function serveBlob(
     sha: verified.sha,
     contentType: contentTypeForExtension(verified.ext),
     cacheControl: cacheControlFor(verified.tier, verified.exp, nowSeconds()),
-    head: request.method === 'HEAD',
+    ...deliveryOptions(request),
   };
 
   const width = verified.transform?.w;
   if (width && isRasterExtension(verified.ext)) {
-    return serveVariant(env, ctx, request, verified, width, options);
+    // A `Range` on a `?w=…&fmt=…` URL is dropped rather than served. The
+    // variant path answers out of a DIFFERENT object than the one the range was
+    // computed against by whoever sent it, the clients that seek are media
+    // players, and no media player fetches a resized still. RFC 7233 §3.1 lets
+    // a server ignore a `Range`; the reply is the full 200 it has always been.
+    return serveVariant(env, ctx, request, verified, width, {
+      ...options,
+      range: null,
+      ifRange: null,
+    });
   }
 
   return serveBlobBySha(env, ctx, options);

--- a/apps/content/src/cache.ts
+++ b/apps/content/src/cache.ts
@@ -22,8 +22,12 @@ export function treeKey(treeSha: string): string {
 export const CORS_HEADERS: Readonly<Record<string, string>> = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-  'Access-Control-Allow-Headers': 'Accept, Range, If-None-Match',
-  'Access-Control-Expose-Headers': 'Content-Type, Content-Length, ETag',
+  'Access-Control-Allow-Headers': 'Accept, Range, If-Range, If-None-Match',
+  // `Range` is in the allowed list above, so the range headers belong in this
+  // one: a cross-origin reader that cannot see `Content-Range` or
+  // `Accept-Ranges` cannot tell a 206 apart from a truncated 200.
+  'Access-Control-Expose-Headers':
+    'Content-Type, Content-Length, ETag, Accept-Ranges, Content-Range',
   'Access-Control-Max-Age': '86400',
 };
 
@@ -97,6 +101,31 @@ export function contentHeaders(
   // unconditionally — the header is static, so it costs nothing.
   headers.set('Vary', 'Accept');
   return finalizeHeaders(headers);
+}
+
+/**
+ * Headers for a reply that carries object bytes, as opposed to JSON or an error.
+ *
+ * `contentHeaders` plus `Accept-Ranges: bytes`. The line is drawn there on
+ * purpose: advertising range support on a 403 or on `/healthz` would be noise,
+ * and a client that never sees `Accept-Ranges` on the object itself has no way
+ * to know it may seek — which is the whole reason Chrome's `<video>` element
+ * gave up on these URLs.
+ *
+ * Every byte-carrying reply gets it, including the image-variant path, which
+ * then ignores any `Range` it is sent and answers a full 200. That is
+ * deliberate and RFC 7233 §3.1 permits it: variants are raster images, the only
+ * clients that seek are media players, and no media player ever asks for a
+ * `?w=800&fmt=webp` URL.
+ */
+export function blobHeaders(
+  contentType: string,
+  cacheControl: string,
+  extra?: HeadersInit
+): Headers {
+  const headers = contentHeaders(contentType, cacheControl, extra);
+  headers.set('Accept-Ranges', 'bytes');
+  return headers;
 }
 
 export function jsonResponse(body: unknown, status: number, cacheControl = 'no-store'): Response {

--- a/apps/content/src/index.ts
+++ b/apps/content/src/index.ts
@@ -160,7 +160,7 @@ async function handle(request: Request, env: Env, ctx: ExecutionContext): Promis
   try {
     return verified.kind === 'blob'
       ? await serveBlob(env, ctx, request, verified)
-      : await serveTheme(env, ctx, verified, request.method === 'HEAD');
+      : await serveTheme(env, ctx, verified, request);
   } catch (error) {
     if (error instanceof OriginError) {
       console.warn('[content] origin error:', error.message);

--- a/apps/content/src/range.ts
+++ b/apps/content/src/range.ts
@@ -1,0 +1,197 @@
+/**
+ * RFC 7233 single byte-range support.
+ *
+ * ## Why this exists
+ *
+ * Before this, every blob was answered `200` with the whole body no matter what
+ * `Range` the client asked for, and no `Accept-Ranges` was ever sent. Safari
+ * tolerates that; Chrome does not. Chrome's `<video>` element issues
+ * `Range: bytes=0-<n>` to sniff the container, and a `200` carrying the whole
+ * file in reply is treated as "this server cannot seek" — the element stays at
+ * `readyState 0`, reports no duration, and never plays. A 1.35 MB `.webm` served
+ * out of R2 reproduced it exactly.
+ *
+ * ## What is implemented
+ *
+ * One range, the common case and the only one a media element ever sends. A
+ * multi-range request (`bytes=0-99,200-299`) is answered with the full `200`,
+ * which RFC 7233 §3.1 explicitly allows — a server MAY ignore a `Range` it does
+ * not wish to satisfy, and nothing in the fleet asks for two.
+ *
+ * Syntactically broken specs are IGNORED (full `200`), while syntactically valid
+ * specs that fall outside the representation are `416`. That split is the
+ * standard's, not ours: a garbled header is not a claim about the object, but
+ * `bytes=9999999-` against a 1 MB file is, and it is a claim that is false.
+ */
+
+/** An inclusive byte range, already resolved against a known total size. */
+export interface ByteRange {
+  /** First byte position, inclusive. */
+  readonly start: number;
+  /** Last byte position, inclusive. Always >= `start`. */
+  readonly end: number;
+}
+
+/**
+ * What a `Range` header amounts to once the object's size is known.
+ *
+ * `full` covers three different reasons to send the whole thing — no header, a
+ * header we are entitled to ignore, and a header that is not addressed to the
+ * version we hold — because the response is identical in all three and the
+ * caller has no reason to tell them apart.
+ */
+export type RangeOutcome =
+  | { readonly kind: 'full' }
+  | { readonly kind: 'partial'; readonly range: ByteRange }
+  | { readonly kind: 'unsatisfiable' };
+
+const FULL: RangeOutcome = { kind: 'full' };
+const UNSATISFIABLE: RangeOutcome = { kind: 'unsatisfiable' };
+
+/** `bytes=` and then at least one character, case-insensitive per RFC 7230. */
+const BYTES_UNIT = /^bytes\s*=\s*(.+)$/i;
+
+/** `first-last`, `first-`, or `-suffix`. Digits only — no signs, no spaces inside. */
+const BYTE_RANGE_SPEC = /^(\d*)-(\d*)$/;
+
+export function rangeLength(range: ByteRange): number {
+  return range.end - range.start + 1;
+}
+
+/** `Content-Range` for a 206: the bytes served, and the size of the whole. */
+export function contentRangeHeader(range: ByteRange, total: number): string {
+  return `bytes ${range.start}-${range.end}/${total}`;
+}
+
+/** `Content-Range` for a 416: no bytes, and the size the client got wrong. */
+export function unsatisfiedRangeHeader(total: number): string {
+  return `bytes */${total}`;
+}
+
+/**
+ * Resolve a `Range` header against an object of `total` bytes.
+ *
+ * `total` must be the size of the WHOLE object — the point of the exercise is
+ * to turn an open-ended or suffix spec into concrete first/last positions, and
+ * only the full size can do that.
+ */
+export function parseRange(header: string | null | undefined, total: number): RangeOutcome {
+  if (header === null || header === undefined) return FULL;
+
+  const unit = BYTES_UNIT.exec(header.trim());
+  if (!unit) return FULL;
+
+  const specs = unit[1].split(',');
+  // More than one range is legal to ask for and legal to refuse. We refuse:
+  // a multipart/byteranges body is a lot of machinery for a request shape no
+  // client of this Worker sends.
+  if (specs.length !== 1) return FULL;
+
+  const spec = BYTE_RANGE_SPEC.exec(specs[0].trim());
+  if (!spec) return FULL;
+
+  const [, firstDigits, lastDigits] = spec;
+
+  // `-` on its own is neither a suffix nor a position: malformed, so ignored.
+  if (firstDigits === '' && lastDigits === '') return FULL;
+
+  if (firstDigits === '') {
+    // `bytes=-N`: the last N bytes. N=0 asks for nothing, which RFC 7233 §2.1
+    // makes unsatisfiable rather than an empty 206.
+    const suffix = Number(lastDigits);
+    if (!Number.isSafeInteger(suffix) || suffix === 0 || total === 0) return UNSATISFIABLE;
+    return { kind: 'partial', range: { start: Math.max(0, total - suffix), end: total - 1 } };
+  }
+
+  const start = Number(firstDigits);
+  if (!Number.isSafeInteger(start)) return FULL;
+  // Past the end of what we hold — a valid ask about bytes that do not exist.
+  if (total === 0 || start >= total) return UNSATISFIABLE;
+
+  if (lastDigits === '') {
+    // `bytes=N-`: everything from N on.
+    return { kind: 'partial', range: { start, end: total - 1 } };
+  }
+
+  const last = Number(lastDigits);
+  if (!Number.isSafeInteger(last)) return FULL;
+  // last < first is not a range at all. Malformed, so ignored rather than 416.
+  if (last < start) return FULL;
+  // A last position past the end is clamped, not refused: the client asked for
+  // "up to here", and here is the end.
+  return { kind: 'partial', range: { start, end: Math.min(last, total - 1) } };
+}
+
+/**
+ * Whether an `If-Range` validator still names the representation we hold.
+ *
+ * Deliberately only the strong-ETag comparison. `If-Range` also accepts an
+ * HTTP-date, and a date will never equal a quoted etag, so a dated `If-Range`
+ * falls out of here as "no match" and the client is sent the whole object —
+ * which is exactly what `If-Range` is for: it is a conditional whose failure
+ * mode is a correct full response, never an error. Weak etags (`W/"…"`) are
+ * excluded by the same equality, and RFC 7232 §2.3.2 forbids using them for
+ * range requests anyway.
+ */
+export function ifRangeMatches(ifRange: string | null | undefined, etag: string): boolean {
+  if (ifRange === null || ifRange === undefined) return true;
+  return ifRange.trim() === etag;
+}
+
+/**
+ * A stream carrying only `[start, end]` of `source`, in bytes.
+ *
+ * The origin path needs this because a cache MISS still has to write the whole
+ * object into R2 while answering the client with a slice of it. The body is
+ * `tee()`d: one branch runs to the end and lands in R2, and this wraps the
+ * other. Bytes before the range are read and dropped rather than held, and once
+ * the last byte of the range is out the reader is cancelled — which, per the
+ * streams spec, cancels only this branch and leaves the R2-bound one pulling.
+ *
+ * Chunks are copied rather than sub-viewed: both `tee()` branches receive the
+ * same chunk object, and handing a view of it to the client while the other
+ * branch is also holding it is a needless aliasing hazard for the few bytes it
+ * saves.
+ */
+export function sliceStream(
+  source: ReadableStream<Uint8Array>,
+  start: number,
+  end: number
+): ReadableStream<Uint8Array> {
+  const reader = source.getReader();
+  const stop = end + 1;
+  let position = 0;
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      for (;;) {
+        if (position >= stop) {
+          controller.close();
+          await reader.cancel().catch(() => {});
+          return;
+        }
+        const { done, value } = await reader.read();
+        if (done) {
+          // The origin was shorter than its own declared length. Nothing more
+          // to send; the length we already promised is the caller's problem,
+          // and it is the same promise a full 200 would have made.
+          controller.close();
+          return;
+        }
+        const chunkStart = position;
+        position += value.byteLength;
+        if (position <= start) continue;
+
+        const from = Math.max(0, start - chunkStart);
+        const to = Math.min(value.byteLength, stop - chunkStart);
+        if (to > from) {
+          controller.enqueue(value.slice(from, to));
+          return;
+        }
+      }
+    },
+    async cancel(reason) {
+      await reader.cancel(reason).catch(() => {});
+    },
+  });
+}

--- a/apps/content/src/theme.ts
+++ b/apps/content/src/theme.ts
@@ -3,7 +3,7 @@ import { contentTypeForPath } from './content-type.ts';
 import type { Env } from './env.ts';
 import { GitHubOrigin } from './origins/github.ts';
 import type { TreeEntry } from './origins/types.ts';
-import { serveBlobBySha } from './blob.ts';
+import { deliveryOptions, serveBlobBySha } from './blob.ts';
 import { withOriginRetry } from './token.ts';
 import { cacheControlFor, nowSeconds, type ThemeVerification } from './verify.ts';
 
@@ -60,7 +60,7 @@ export async function serveTheme(
   env: Env,
   ctx: ExecutionContext,
   verified: VerifiedTheme,
-  head = false
+  request: Request
 ): Promise<Response> {
   // The tree is read either way: a theme URL names a path, and only the listing
   // turns that into the sha a HEAD would look up.
@@ -68,11 +68,14 @@ export async function serveTheme(
   const entry = findEntry(entries, verified.relPath);
   if (!entry) return errorResponse(404, 'not found');
 
+  // The whole request shape — HEAD, `Range`, `If-Range` — is handed on rather
+  // than re-derived, so a theme asset and a blob cannot answer a seek
+  // differently for a file that is byte-for-byte the same object in R2.
   return serveBlobBySha(env, ctx, {
     classroomId: verified.classroomId,
     sha: entry.sha,
     contentType: contentTypeForPath(verified.relPath),
     cacheControl: cacheControlFor(verified.tier, verified.exp, nowSeconds()),
-    head,
+    ...deliveryOptions(request),
   });
 }

--- a/apps/content/tests/cache.test.ts
+++ b/apps/content/tests/cache.test.ts
@@ -28,7 +28,14 @@ describe('response headers', () => {
     const headers = finalizeHeaders(new Headers());
     expect(headers.get('Access-Control-Allow-Origin')).toBe('*');
     expect(headers.get('Access-Control-Allow-Methods')).toBe('GET, HEAD, OPTIONS');
-    expect(headers.get('Access-Control-Expose-Headers')).toBe('Content-Type, Content-Length, ETag');
+    expect(headers.get('Access-Control-Expose-Headers')).toBe(
+      'Content-Type, Content-Length, ETag, Accept-Ranges, Content-Range'
+    );
+    // A cross-origin reader that is allowed to SEND `Range` but cannot READ
+    // `Content-Range` cannot tell a 206 from a truncated 200.
+    expect(headers.get('Access-Control-Allow-Headers')).toBe(
+      'Accept, Range, If-Range, If-None-Match'
+    );
     expect(headers.get('X-Content-Type-Options')).toBe('nosniff');
     // content.classmoji.io sits under the app's .classmoji.io cookie domain:
     // an SVG with inline script, opened top-level, must not run there.

--- a/apps/content/tests/helpers.ts
+++ b/apps/content/tests/helpers.ts
@@ -43,8 +43,15 @@ export interface FakeBucketOptions {
   originDeclaresLength?: boolean;
 }
 
+/** The three shapes R2's `get` accepts for a ranged read. */
+export interface FakeRange {
+  offset?: number;
+  length?: number;
+  suffix?: number;
+}
+
 export interface FakeBucket {
-  get(key: string): Promise<unknown>;
+  get(key: string, options?: { range?: FakeRange }): Promise<unknown>;
   head(key: string): Promise<unknown>;
   put(
     key: string,
@@ -54,6 +61,24 @@ export interface FakeBucket {
   readonly puts: Array<{ key: string; contentType?: string; bytes: number; streamed: boolean }>;
   readonly gets: string[];
   readonly heads: string[];
+  /**
+   * Every ranged read, so a test can prove R2 was asked for exactly the bytes
+   * the client wanted rather than for the whole object and then sliced.
+   */
+  readonly ranges: Array<{ key: string; range: FakeRange }>;
+}
+
+/**
+ * The bytes a ranged read returns, resolved the way R2 resolves one: a suffix
+ * counts back from the end, a length reaching past the end returns fewer bytes
+ * rather than failing, and an absent length means "to the end".
+ */
+function sliceFor(all: Uint8Array, range: FakeRange): Uint8Array {
+  if (range.suffix !== undefined) return all.subarray(Math.max(0, all.byteLength - range.suffix));
+  const offset = range.offset ?? 0;
+  const end =
+    range.length === undefined ? all.byteLength : Math.min(all.byteLength, offset + range.length);
+  return all.subarray(offset, end);
 }
 
 /**
@@ -90,7 +115,10 @@ export function fakeBucket(
   const puts: Array<{ key: string; contentType?: string; bytes: number; streamed: boolean }> = [];
   const gets: string[] = [];
   const heads: string[] = [];
+  const ranges: Array<{ key: string; range: FakeRange }> = [];
 
+  // `size` is the size of the WHOLE object even on a ranged read — that is what
+  // real R2 reports, and it is the number `Content-Range` has to end with.
   const metadata = (key: string, object: StoredObject) => ({
     httpMetadata: { contentType: object.contentType },
     httpEtag: `"${key}"`,
@@ -101,16 +129,23 @@ export function fakeBucket(
     puts,
     gets,
     heads,
-    async get(key: string) {
+    ranges,
+    async get(key: string, getOptions?: { range?: FakeRange }) {
       gets.push(key);
       const object = store.get(key);
       if (!object) return null;
+      const all = new TextEncoder().encode(object.body);
+      const range = getOptions?.range;
+      if (range) ranges.push({ key, range });
+      const served = range ? sliceFor(all, range) : all;
       return {
         ...metadata(key, object),
-        body: new Response(object.body).body,
-        arrayBuffer: async () => new TextEncoder().encode(object.body).buffer,
-        json: async () => JSON.parse(object.body),
-        text: async () => object.body,
+        range,
+        body: new Response(served).body,
+        arrayBuffer: async () =>
+          served.buffer.slice(served.byteOffset, served.byteOffset + served.byteLength),
+        json: async () => JSON.parse(new TextDecoder().decode(served)),
+        text: async () => new TextDecoder().decode(served),
       };
     },
     async head(key: string) {
@@ -136,6 +171,34 @@ export function fakeBucket(
       return {};
     },
   };
+}
+
+/**
+ * Route the two upstreams the Worker talks to — the token endpoint and
+ * GitHub — through canned handlers, by replacing `globalThis.fetch`.
+ *
+ * The caller is responsible for putting the real `fetch` back; every suite that
+ * uses this does so in `afterEach`.
+ */
+export function stubUpstreams(handlers: { blob?: () => Response; tree?: () => Response } = {}) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/content/token')) {
+      return new Response(
+        JSON.stringify({
+          org: 'classmoji',
+          repo: 'content-cs1',
+          token: 'ghs_x',
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+    if (url.includes('/git/trees/'))
+      return handlers.tree?.() ?? new Response(JSON.stringify({ tree: [] }));
+    if (url.includes('/git/blobs/')) return handlers.blob?.() ?? new Response('origin-bytes');
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
 }
 
 export function fakeContext(): ExecutionContext & { settled(): Promise<void> } {

--- a/apps/content/tests/range.test.ts
+++ b/apps/content/tests/range.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Byte ranges, from the parser up to the delivered response.
+ *
+ * The bug this suite exists for: a `.webm` served out of R2 answered
+ * `Range: bytes=0-1023` with a `200` and the whole 1.35 MB body, and sent no
+ * `Accept-Ranges` at all. Chrome's `<video>` element reads that as "cannot
+ * seek", stays at `readyState 0`, reports no duration and never plays. Safari
+ * tolerates it, which is why it survived review.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import worker, { clearRotationLog } from '../src/index.ts';
+import { parseRange, sliceStream } from '../src/range.ts';
+import { clearOriginCache } from '../src/token.ts';
+import {
+  BLOB_SHA,
+  fakeBucket,
+  fakeContext,
+  fakeEnv,
+  signedBlobUrl,
+  stubUpstreams,
+} from './helpers.ts';
+
+const realFetch = globalThis.fetch;
+
+/**
+ * 4 KiB standing in for a video: printable ASCII, so one byte is one character
+ * and a served range can be compared against a plain string slice.
+ */
+const MEDIA = Array.from({ length: 4096 }, (_, index) =>
+  String.fromCharCode(33 + (index % 90))
+).join('');
+
+const KEY = `blobs/${BLOB_SHA}`;
+const ETAG = `"${KEY}"`;
+
+function cachedMedia() {
+  return fakeBucket({ [KEY]: { body: MEDIA, contentType: 'video/webm' } });
+}
+
+async function fetchMedia(
+  bucket: ReturnType<typeof fakeBucket>,
+  headers: Record<string, string>,
+  init: RequestInit = {}
+) {
+  const url = await signedBlobUrl({ sha: BLOB_SHA, ext: 'webm' });
+  const ctx = fakeContext();
+  const response = await worker.fetch(
+    new Request(url, { ...init, headers }),
+    fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+    ctx
+  );
+  return { response, ctx };
+}
+
+beforeEach(() => {
+  clearOriginCache();
+  clearRotationLog();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('parseRange', () => {
+  it('resolves a closed range', () => {
+    expect(parseRange('bytes=0-1023', 4096)).toEqual({
+      kind: 'partial',
+      range: { start: 0, end: 1023 },
+    });
+  });
+
+  it('resolves an open-ended range to the last byte', () => {
+    expect(parseRange('bytes=1000-', 4096)).toEqual({
+      kind: 'partial',
+      range: { start: 1000, end: 4095 },
+    });
+  });
+
+  it('resolves a suffix range from the end', () => {
+    expect(parseRange('bytes=-500', 4096)).toEqual({
+      kind: 'partial',
+      range: { start: 3596, end: 4095 },
+    });
+  });
+
+  it('clamps a suffix longer than the object to the whole object', () => {
+    expect(parseRange('bytes=-9999', 4096)).toEqual({
+      kind: 'partial',
+      range: { start: 0, end: 4095 },
+    });
+  });
+
+  it('clamps a last position past the end rather than refusing it', () => {
+    // "up to here" where here is past the end is a request for the rest.
+    expect(parseRange('bytes=4000-99999', 4096)).toEqual({
+      kind: 'partial',
+      range: { start: 4000, end: 4095 },
+    });
+  });
+
+  it('calls a first position at or past the end unsatisfiable', () => {
+    expect(parseRange('bytes=4096-', 4096)).toEqual({ kind: 'unsatisfiable' });
+    expect(parseRange('bytes=9999-10000', 4096)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('calls a zero-length suffix unsatisfiable', () => {
+    expect(parseRange('bytes=-0', 4096)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('calls any range against an empty object unsatisfiable', () => {
+    expect(parseRange('bytes=0-', 0)).toEqual({ kind: 'unsatisfiable' });
+  });
+
+  it('ignores a multi-range request rather than refusing it', () => {
+    // Legal to ask for, legal to answer whole. Nothing in the fleet asks.
+    expect(parseRange('bytes=0-99,200-299', 4096)).toEqual({ kind: 'full' });
+  });
+
+  it('ignores a malformed spec instead of turning it into a 416', () => {
+    // Garbage is not a claim about the object, so it is not an error about one.
+    for (const header of ['bytes=abc-def', 'items=0-10', 'bytes=', 'bytes=-', 'bytes=10-5', '']) {
+      expect(parseRange(header, 4096)).toEqual({ kind: 'full' });
+    }
+  });
+
+  it('accepts the whitespace and casing RFC 7230 allows', () => {
+    expect(parseRange('  Bytes = 0-9  ', 4096)).toEqual({
+      kind: 'partial',
+      range: { start: 0, end: 9 },
+    });
+  });
+
+  it('treats an absent header as a request for everything', () => {
+    expect(parseRange(null, 4096)).toEqual({ kind: 'full' });
+  });
+});
+
+describe('sliceStream', () => {
+  it('emits only the requested bytes across chunk boundaries', async () => {
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const chunk of ['abcde', 'fghij', 'klmno']) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    });
+
+    expect(await new Response(sliceStream(source, 3, 11)).text()).toBe('defghijkl');
+  });
+});
+
+describe('byte ranges out of the cache', () => {
+  it('answers a closed range with 206 and exactly those bytes', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=0-1023' });
+
+    expect(response.status).toBe(206);
+    expect(await response.text()).toBe(MEDIA.slice(0, 1024));
+    expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/4096');
+    expect(response.headers.get('Content-Length')).toBe('1024');
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(response.headers.get('Content-Type')).toBe('video/webm');
+    expect(response.headers.get('ETag')).toBe(ETAG);
+    expect(response.headers.get('Cache-Control')).toMatch(/^public, max-age=\d+, immutable$/);
+    expect(response.headers.get('Content-Security-Policy')).toBe("default-src 'none'; sandbox");
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+
+    // R2 read 1 KiB, not 4 KiB and then a slice — that is what makes a seek
+    // into a large video cheap.
+    expect(bucket.ranges).toEqual([{ key: KEY, range: { offset: 0, length: 1024 } }]);
+  });
+
+  it('serves an open-ended range to the last byte', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=1000-' });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('Content-Range')).toBe('bytes 1000-4095/4096');
+    expect(response.headers.get('Content-Length')).toBe('3096');
+    expect(await response.text()).toBe(MEDIA.slice(1000));
+    expect(bucket.ranges).toEqual([{ key: KEY, range: { offset: 1000, length: 3096 } }]);
+  });
+
+  it('serves a suffix range from the end', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=-500' });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('Content-Range')).toBe('bytes 3596-4095/4096');
+    expect(response.headers.get('Content-Length')).toBe('500');
+    expect(await response.text()).toBe(MEDIA.slice(3596));
+    // Resolved to concrete positions before R2 sees it, so the total in
+    // `Content-Range` and the bytes served cannot disagree.
+    expect(bucket.ranges).toEqual([{ key: KEY, range: { offset: 3596, length: 500 } }]);
+  });
+
+  it('416s a range past the end, and says how big the object really is', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=8192-9000' });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get('Content-Range')).toBe('bytes */4096');
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(await response.json()).toEqual({ error: 'range not satisfiable' });
+    // Decided from metadata: not one byte was read to refuse it.
+    expect(bucket.heads).toEqual([KEY]);
+    expect(bucket.gets).toEqual([]);
+  });
+
+  it('answers a multi-range request with the whole object', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=0-99,200-299' });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Range')).toBeNull();
+    expect(response.headers.get('Content-Length')).toBe('4096');
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(await response.text()).toBe(MEDIA);
+    expect(bucket.ranges).toEqual([]);
+  });
+
+  it('advertises Accept-Ranges on a full 200 with no Range at all', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, {});
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    // No `Range` means the one-call path: a `head` would be a wasted round trip.
+    expect(bucket.heads).toEqual([]);
+    expect(bucket.gets).toEqual([KEY]);
+  });
+});
+
+describe('byte ranges on HEAD', () => {
+  it('advertises Accept-Ranges and keeps Content-Length', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, {}, { method: 'HEAD' });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(response.headers.get('Content-Length')).toBe('4096');
+    expect(bucket.gets).toEqual([]);
+  });
+
+  it('answers a ranged HEAD with 206 headers and no bytes read', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=0-1023' }, { method: 'HEAD' });
+
+    expect(response.status).toBe(206);
+    expect(await response.text()).toBe('');
+    expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/4096');
+    expect(response.headers.get('Content-Length')).toBe('1024');
+    expect(bucket.heads).toEqual([KEY]);
+    expect(bucket.gets).toEqual([]);
+  });
+});
+
+describe('If-Range', () => {
+  it('serves the range when the validator still matches', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, { Range: 'bytes=0-9', 'If-Range': ETAG });
+
+    expect(response.status).toBe(206);
+    expect(await response.text()).toBe(MEDIA.slice(0, 10));
+  });
+
+  it('serves the whole object when the validator has moved on', async () => {
+    const bucket = cachedMedia();
+    const { response } = await fetchMedia(bucket, {
+      Range: 'bytes=0-9',
+      'If-Range': '"some-older-version"',
+    });
+
+    // A failed `If-Range` is a 200, never an error: the client asked for a
+    // slice of a file it turns out not to have.
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Range')).toBeNull();
+    expect(await response.text()).toBe(MEDIA);
+  });
+});
+
+describe('byte ranges on a cache miss', () => {
+  it('serves 206 from the pull and still lands the whole object in R2', async () => {
+    stubUpstreams({
+      blob: () => new Response(MEDIA, { headers: { 'Content-Length': String(MEDIA.length) } }),
+    });
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const { response, ctx } = await fetchMedia(bucket, { Range: 'bytes=0-1023' });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/4096');
+    expect(response.headers.get('Content-Length')).toBe('1024');
+    expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+    expect(await response.text()).toBe(MEDIA.slice(0, 1024));
+
+    // The client took 1 KiB; the cache branch still ran to the end, so the next
+    // request for this video is an R2 hit rather than a second GitHub pull.
+    await ctx.settled();
+    expect(bucket.puts).toEqual([
+      { key: KEY, contentType: 'video/webm', bytes: 4096, streamed: true },
+    ]);
+  });
+
+  it('serves a mid-object range from a pull without buffering the object', async () => {
+    stubUpstreams({
+      blob: () => new Response(MEDIA, { headers: { 'Content-Length': String(MEDIA.length) } }),
+    });
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const { response, ctx } = await fetchMedia(bucket, { Range: 'bytes=2000-2099' });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('Content-Range')).toBe('bytes 2000-2099/4096');
+    expect(await response.text()).toBe(MEDIA.slice(2000, 2100));
+    await ctx.settled();
+    expect(bucket.puts.map(put => put.bytes)).toEqual([4096]);
+  });
+
+  it('416s an unsatisfiable range on a miss, and still caches the pull', async () => {
+    stubUpstreams({
+      blob: () => new Response(MEDIA, { headers: { 'Content-Length': String(MEDIA.length) } }),
+    });
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const { response, ctx } = await fetchMedia(bucket, { Range: 'bytes=9000-' });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get('Content-Range')).toBe('bytes */4096');
+    // The pull is already paid for; only the client's half of the tee was
+    // cancelled, so the corrected retry is a hit.
+    await ctx.settled();
+    expect(bucket.puts.map(put => put.bytes)).toEqual([4096]);
+  });
+
+  it('buffers to resolve a range when the origin declared no length', async () => {
+    // GitHub gzips text and the runtime decodes it, so the length is gone. A
+    // total has to be counted before `Content-Range` can name one.
+    stubUpstreams({ blob: () => new Response(MEDIA) });
+    const bucket = fakeBucket();
+    const { response, ctx } = await fetchMedia(bucket, { Range: 'bytes=-100' });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('Content-Range')).toBe('bytes 3996-4095/4096');
+    expect(await response.text()).toBe(MEDIA.slice(3996));
+    await ctx.settled();
+    expect(bucket.puts).toEqual([
+      { key: KEY, contentType: 'video/webm', bytes: 4096, streamed: false },
+    ]);
+  });
+
+  it('falls back to a full 200 for a multi-range miss', async () => {
+    stubUpstreams({
+      blob: () => new Response(MEDIA, { headers: { 'Content-Length': String(MEDIA.length) } }),
+    });
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const { response, ctx } = await fetchMedia(bucket, { Range: 'bytes=0-9,20-29' });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(MEDIA);
+    await ctx.settled();
+    expect(bucket.puts.map(put => put.bytes)).toEqual([4096]);
+  });
+
+  it('ignores an If-Range on a miss, because there is no validator to check', async () => {
+    stubUpstreams({
+      blob: () => new Response(MEDIA, { headers: { 'Content-Length': String(MEDIA.length) } }),
+    });
+    const bucket = fakeBucket({}, { originDeclaresLength: true });
+    const { response } = await fetchMedia(bucket, {
+      Range: 'bytes=0-9',
+      'If-Range': '"anything"',
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(MEDIA);
+  });
+});
+
+describe('byte ranges and image variants', () => {
+  it('answers a Range on a ?w= URL with the full variant', async () => {
+    // Variants are raster stills; the clients that seek are media players, and
+    // none of them fetch a resized image. RFC 7233 §3.1 permits ignoring it.
+    const bucket = fakeBucket({
+      [`blobs/${BLOB_SHA}/w800.webp`]: { body: 'webp-bytes', contentType: 'image/webp' },
+    });
+    const url = await signedBlobUrl({
+      sha: BLOB_SHA,
+      ext: 'jpg',
+      transform: { w: 800, fmt: 'webp' },
+    });
+
+    const response = await worker.fetch(
+      new Request(url, { headers: { Range: 'bytes=0-3' } }),
+      fakeEnv({ CACHE: bucket as unknown as R2Bucket }),
+      fakeContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Range')).toBeNull();
+    expect(response.headers.get('Content-Type')).toBe('image/webp');
+    expect(await response.text()).toBe('webp-bytes');
+    expect(bucket.ranges).toEqual([]);
+  });
+});

--- a/apps/content/tests/routing.test.ts
+++ b/apps/content/tests/routing.test.ts
@@ -18,6 +18,7 @@ import {
   futureExp,
   signedBlobUrl,
   signedThemeUrl,
+  stubUpstreams,
 } from './helpers.ts';
 
 const realFetch = globalThis.fetch;
@@ -33,28 +34,6 @@ async function countBytes(response: Response): Promise<number> {
     if (done) return total;
     total += value.byteLength;
   }
-}
-
-/** Routes the two upstreams the Worker talks to: the token endpoint and GitHub. */
-function stubUpstreams(handlers: { blob?: () => Response; tree?: () => Response } = {}) {
-  globalThis.fetch = (async (input: RequestInfo | URL) => {
-    const url = String(input);
-    if (url.includes('/api/content/token')) {
-      return new Response(
-        JSON.stringify({
-          org: 'classmoji',
-          repo: 'content-cs1',
-          token: 'ghs_x',
-          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-        }),
-        { headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-    if (url.includes('/git/trees/'))
-      return handlers.tree?.() ?? new Response(JSON.stringify({ tree: [] }));
-    if (url.includes('/git/blobs/')) return handlers.blob?.() ?? new Response('origin-bytes');
-    throw new Error(`unexpected fetch: ${url}`);
-  }) as unknown as typeof fetch;
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Symptom

Verified in prod on 2026-09-09 with curl against a 1.35 MB `.webm` on
`content.classmoji.io`:

- `Range: bytes=0-1023` → `200`, `content-length: 1347937` (the whole file)
- no `Accept-Ranges` on any blob response
- `HEAD` → `200` with `Content-Length` but still no `Accept-Ranges`

Chrome's `<video>` element reads that as "this server cannot seek": the element
never leaves `readyState 0`, reports no duration, and never plays. Safari
tolerates it, which is why it got through. The CORS layer already advertised
`Range` in `Access-Control-Allow-Headers`, so the header was invited and then
ignored — the pre-staging review had flagged exactly this ("`Range` is
advertised via CORS but not served; `Accept-Ranges` unset").

## What is implemented

RFC 7233 single-range support on the blob delivery paths (`apps/content` only).

**Cache hit.** A `Range` (like a `HEAD`) is settled from R2 metadata first: the
stored size and etag decide the status and the byte positions before anything is
read, and only then is a `get` issued with R2's native `range` option — so a seek
into the middle of a video reads that slice and nothing else. The reply is `206`
with `Content-Range: bytes start-end/total`, a range-sized `Content-Length`,
`Accept-Ranges: bytes`, and the same `Content-Type` (from the signed extension),
`Cache-Control`, `ETag`, CORS, `nosniff` and sandboxing CSP as the full response.

**Unsatisfiable.** `416` with `Content-Range: bytes */total`, decided from
metadata — no bytes read to refuse it.

**Cache miss.** The origin pull is tee'd: one branch runs to the end and lands in
R2 exactly as an unranged miss does, and the client is handed a slice of the
other, so nothing is buffered and the second request for that video is an R2 hit.
When the origin declared no length (GitHub gzips text and the runtime decodes it)
a `Content-Range` total can only be counted, so the body is buffered under the
existing `MAX_UNKNOWN_LENGTH_CACHE_BYTES` ceiling — the same rule
`putCacheBranch` already followed. A range request never gets a full 200 back
except in the cases below.

**Answered whole, deliberately.** Multi-range requests, and any `Range` on a
`?w=&fmt=` image variant. RFC 7233 §3.1 permits ignoring a `Range`; variants are
raster stills and the only clients that seek are media players.

**`If-Range`.** Matching strong etag → the range; anything else (a different
etag, a date, a cache miss with no stored validator) → a full 200, which is what
a conditional whose failure mode is correctness is supposed to do.

**Other.** `Accept-Ranges: bytes` now rides on every byte-carrying reply
(`blobHeaders`) and on no JSON or error reply. `Content-Range` and
`Accept-Ranges` were added to `Access-Control-Expose-Headers`, and `If-Range` to
`Access-Control-Allow-Headers` — a cross-origin reader allowed to send `Range`
but unable to read `Content-Range` cannot tell a 206 from a truncated 200.

Signing, tiers, cache keys and the `[content] origin pull …` log line are
untouched.

## Test steps

`npm test -w @classmoji/content-worker` — 191 pass (30 new). Also clean:
`npx tsc --noEmit`, `npx eslint .`, and
`npx wrangler deploy --dry-run --env staging` from `apps/content`.

New coverage in `apps/content/tests/range.test.ts`: the parser (closed,
open-ended, suffix, clamping, unsatisfiable, multi-range, malformed, whitespace
and casing); `sliceStream` across chunk boundaries; and end-to-end 206 from a
cache hit with exact bytes and headers, `bytes=1000-`, `bytes=-500`, 416 past
EOF, multi-range → 200, ranged miss → 206 with the full object in R2 afterwards,
mid-object ranged miss, 416 on a miss that still caches, unknown-length miss,
`HEAD` carrying `Accept-Ranges`, ranged `HEAD` → 206 with no bytes read,
`If-Range` matching and not, and `Range` on a transform variant → 200.

Once on staging, against a `.webm` content URL:

```
curl -sD- -o /dev/null -H 'Range: bytes=0-1023' '<signed webm url>'
```

Expect `HTTP/2 206`, `accept-ranges: bytes`, `content-range: bytes 0-1023/<size>`
and `content-length: 1024`. Then load a page with that video in Chrome and
confirm the element gets a duration and plays/seeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA
