### PR TITLE
feat(github): repair missing app installations and harden installation webhooks

### DIFF
--- a/apps/hook-station/src/routes/github.ts
+++ b/apps/hook-station/src/routes/github.ts
@@ -13,45 +13,73 @@ const webhooks = new Webhooks({
   secret: githubWebhookSecret,
 });
 
+/**
+ * Handlers keyed `${X-GitHub-Event}.${action}`.
+ *
+ * `action` alone does not identify a webhook: GitHub reuses the same words
+ * across unrelated events. `created` is sent for an installation, a repository,
+ * a project card, an issue comment and more; `deleted` likewise. Dispatching on
+ * it alone made this router's job to *guess* which event it was looking at from
+ * the payload's shape — and one wrong guess writes or clears an org's GitHub
+ * App installation id. The event name is in the header; use it.
+ *
+ * The payload guards that remain answer a different question — "does this
+ * delivery carry the object the task needs" — and are not a substitute for the
+ * event name.
+ */
 const githubWebhookHandlers: Record<string, (data: WebhookEvent) => Promise<void>> = {
-  closed: async (data: WebhookEvent) => {
+  // Assignment repos are tracked as issues in the classroom's org.
+  'issues.closed': async (data: WebhookEvent) => {
     if ('issue' in data && data.issue) {
       await Tasks.repositoryAssignmentClosedHandlerTask.trigger(data);
     }
   },
 
-  member_added: async (data: WebhookEvent) => {
+  'issues.deleted': async (data: WebhookEvent) => {
+    if ('issue' in data && data.issue) {
+      await Tasks.repositoryAssignmentDeletedHandlerTask.trigger(data);
+    }
+  },
+
+  // A brand-new member of a classroom's GitHub org.
+  'organization.member_added': async (data: WebhookEvent) => {
     await Tasks.memberAddedHandlerTask.trigger(
       data as unknown as Parameters<typeof Tasks.memberAddedHandlerTask.trigger>[0]
     );
   },
 
-  created: async (data: WebhookEvent) => {
-    if (
-      !('repository' in data) &&
-      !('issues' in data) &&
-      'installation' in data &&
-      data.installation
-    ) {
+  'installation.created': async (data: WebhookEvent) => {
+    if ('installation' in data && data.installation) {
       await Tasks.newInstallationHandlerTask.trigger(
         data as unknown as Parameters<typeof Tasks.newInstallationHandlerTask.trigger>[0]
       );
     }
   },
 
-  deleted: async (data: WebhookEvent) => {
-    if ('issue' in data && data.issue) {
-      await Tasks.repositoryAssignmentDeletedHandlerTask.trigger(data);
-    }
-
-    if (
-      'installation' in data &&
-      data.installation &&
-      !('issue' in data) &&
-      !('repository' in data)
-    ) {
+  'installation.deleted': async (data: WebhookEvent) => {
+    if ('installation' in data && data.installation) {
       await Tasks.appUninstalledHandlerTask.trigger(
         data as unknown as Parameters<typeof Tasks.appUninstalledHandlerTask.trigger>[0]
+      );
+    }
+  },
+
+  // A suspended installation still exists but mints no tokens, so the org has
+  // to stop claiming it is connected — and `unsuspend` has to put the id back,
+  // or a suspend/unsuspend round trip silently leaves the org disconnected
+  // forever with nothing in the log to say why.
+  'installation.suspend': async (data: WebhookEvent) => {
+    if ('installation' in data && data.installation) {
+      await Tasks.appSuspendedHandlerTask.trigger(
+        data as unknown as Parameters<typeof Tasks.appSuspendedHandlerTask.trigger>[0]
+      );
+    }
+  },
+
+  'installation.unsuspend': async (data: WebhookEvent) => {
+    if ('installation' in data && data.installation) {
+      await Tasks.appUnsuspendedHandlerTask.trigger(
+        data as unknown as Parameters<typeof Tasks.appUnsuspendedHandlerTask.trigger>[0]
       );
     }
   },
@@ -200,16 +228,20 @@ export default async function githubRoutes(fastify: FastifyInstance): Promise<vo
     },
     handler: async function handler(request: FastifyRequest, reply: FastifyReply) {
       const data = request.body as WebhookEvent;
+      const event = request.headers['x-github-event'];
 
       // `push` has no `action` field, so the handler map below can never see
       // it — the event name lives in the header instead.
-      if (request.headers['x-github-event'] === 'push') {
+      if (event === 'push') {
         await handlePush(data as PushEventPayload);
         return reply.status(200).send({ success: true });
       }
 
       const action = 'action' in data ? data.action : undefined;
-      const handler = action ? githubWebhookHandlers[action] : undefined;
+      const handler =
+        typeof event === 'string' && action
+          ? githubWebhookHandlers[`${event}.${action}`]
+          : undefined;
 
       if (handler) {
         await handler(data);

--- a/apps/hook-station/tests/github.test.ts
+++ b/apps/hook-station/tests/github.test.ts
@@ -12,6 +12,8 @@ const triggers = {
   newInstall: vi.fn().mockResolvedValue(undefined),
   deleted: vi.fn().mockResolvedValue(undefined),
   appUninstalled: vi.fn().mockResolvedValue(undefined),
+  appSuspended: vi.fn().mockResolvedValue(undefined),
+  appUnsuspended: vi.fn().mockResolvedValue(undefined),
 };
 
 vi.mock('@classmoji/tasks', () => ({
@@ -21,6 +23,8 @@ vi.mock('@classmoji/tasks', () => ({
     newInstallationHandlerTask: { trigger: triggers.newInstall },
     repositoryAssignmentDeletedHandlerTask: { trigger: triggers.deleted },
     appUninstalledHandlerTask: { trigger: triggers.appUninstalled },
+    appSuspendedHandlerTask: { trigger: triggers.appSuspended },
+    appUnsuspendedHandlerTask: { trigger: triggers.appUnsuspended },
   },
 }));
 
@@ -29,6 +33,16 @@ const sign = (body: string): string => {
   hmac.update(body);
   return `sha256=${hmac.digest('hex')}`;
 };
+
+/**
+ * Deliveries are identified by event name AND action, so every fixture below
+ * has to send the header a real GitHub delivery would.
+ */
+const headersFor = (event: string, body: string): Record<string, string> => ({
+  'x-hub-signature-256': sign(body),
+  'x-github-event': event,
+  'content-type': 'application/json',
+});
 
 const buildApp = async (): Promise<FastifyInstance> => {
   const app = Fastify();
@@ -55,6 +69,7 @@ describe('github webhook route', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
+      headers: { 'x-github-event': 'issues' },
       payload: { action: 'closed' },
     });
     expect(res.statusCode).toBe(401);
@@ -65,7 +80,7 @@ describe('github webhook route', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': 'sha256=deadbeef' },
+      headers: { 'x-hub-signature-256': 'sha256=deadbeef', 'x-github-event': 'issues' },
       payload,
     });
     expect(res.statusCode).toBe(401);
@@ -77,7 +92,7 @@ describe('github webhook route', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('issues', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
@@ -97,40 +112,70 @@ describe('github webhook route', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('issues', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
     expect(triggers.closed).not.toHaveBeenCalled();
   });
 
-  it('triggers memberAdded for member_added action', async () => {
+  it('does not trigger closed handler for a pull_request close', async () => {
+    // `pull_request.closed` shares the action word but carries no issue and is
+    // not an assignment repo event.
+    const payload = { action: 'closed', pull_request: { id: 1, number: 7 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('pull_request', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.closed).not.toHaveBeenCalled();
+  });
+
+  it('triggers memberAdded for organization.member_added', async () => {
     const payload = { action: 'member_added', member: { login: 'alice' } };
     const body = JSON.stringify(payload);
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('organization', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
     expect(triggers.memberAdded).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers newInstallation when created carries an installation but no repository/issues', async () => {
+  it('does not trigger memberAdded for team.member_added', async () => {
+    const payload = { action: 'member_added', member: { login: 'alice' } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('team', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.memberAdded).not.toHaveBeenCalled();
+  });
+
+  it('triggers newInstallation for installation.created', async () => {
     const payload = { action: 'created', installation: { id: 99 } };
     const body = JSON.stringify(payload);
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('installation', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
     expect(triggers.newInstall).toHaveBeenCalledTimes(1);
   });
 
-  it('does not trigger newInstallation when created carries a repository', async () => {
+  it('does not trigger newInstallation for a created action on another event', async () => {
+    // GitHub reuses `created` across events (repository, project_card, issue
+    // comment, …). Only the `installation` event may write an installation id.
     const payload = {
       action: 'created',
       installation: { id: 99 },
@@ -140,20 +185,33 @@ describe('github webhook route', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('repository', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
     expect(triggers.newInstall).not.toHaveBeenCalled();
   });
 
-  it('triggers appUninstalled for deleted+installation without issue/repository', async () => {
+  it('does not trigger newInstallation for installation_repositories.added', async () => {
+    const payload = { action: 'added', installation: { id: 99 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('installation_repositories', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.newInstall).not.toHaveBeenCalled();
+  });
+
+  it('triggers appUninstalled for installation.deleted', async () => {
     const payload = { action: 'deleted', installation: { id: 99 } };
     const body = JSON.stringify(payload);
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('installation', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
@@ -161,21 +219,107 @@ describe('github webhook route', () => {
     expect(triggers.deleted).not.toHaveBeenCalled();
   });
 
-  it('triggers repositoryAssignmentDeleted for deleted+issue', async () => {
+  it('does not trigger appUninstalled for a deleted action on another event', async () => {
+    const payload = { action: 'deleted', installation: { id: 99 }, repository: { id: 1 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('repository', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.appUninstalled).not.toHaveBeenCalled();
+  });
+
+  it('triggers appSuspended for installation.suspend', async () => {
+    // A suspended installation mints no tokens, so the org has to stop
+    // claiming it is connected — the same clear an uninstall does.
+    const payload = { action: 'suspend', installation: { id: 99 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('installation', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.appSuspended).toHaveBeenCalledTimes(1);
+    expect(triggers.appUninstalled).not.toHaveBeenCalled();
+    expect(triggers.newInstall).not.toHaveBeenCalled();
+  });
+
+  it('triggers appUnsuspended for installation.unsuspend', async () => {
+    const payload = { action: 'unsuspend', installation: { id: 99 } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('installation', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.appUnsuspended).toHaveBeenCalledTimes(1);
+    expect(triggers.appSuspended).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger the suspend handlers for another event', async () => {
+    // `suspend`/`unsuspend` are also sent for `member`, so the event name is
+    // what decides — never the action word on its own.
+    const payload = { action: 'suspend', installation: { id: 99 }, member: { login: 'alice' } };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('member', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.appSuspended).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger the suspend handler when the payload carries no installation', async () => {
+    const payload = { action: 'suspend' };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('installation', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(triggers.appSuspended).not.toHaveBeenCalled();
+  });
+
+  it('triggers repositoryAssignmentDeleted for issues.deleted', async () => {
     const payload = { action: 'deleted', issue: { id: 1 } };
     const body = JSON.stringify(payload);
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/callback/github',
-      headers: { 'x-hub-signature-256': sign(body), 'content-type': 'application/json' },
+      headers: headersFor('issues', body),
       payload: body,
     });
     expect(res.statusCode).toBe(200);
     expect(triggers.deleted).toHaveBeenCalledTimes(1);
+    expect(triggers.appUninstalled).not.toHaveBeenCalled();
   });
 
   it('returns 200 with success but no trigger for unknown action', async () => {
     const payload = { action: 'totally_unknown_action_xyz' };
+    const body = JSON.stringify(payload);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/callback/github',
+      headers: headersFor('issues', body),
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(Object.values(triggers).every(t => t.mock.calls.length === 0)).toBe(true);
+  });
+
+  it('returns 200 with success but no trigger when the event header is absent', async () => {
+    const payload = { action: 'closed', issue: { id: 1, number: 7 } };
     const body = JSON.stringify(payload);
     const res = await app.inject({
       method: 'POST',
@@ -195,7 +339,7 @@ describe('github webhook route', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/webhooks/callback/github',
-        headers: { 'x-hub-signature-256': sign(rawBody), 'content-type': 'application/json' },
+        headers: headersFor('issues', rawBody),
         payload: rawBody,
       });
       expect(res.statusCode).toBe(200);
@@ -210,6 +354,7 @@ describe('github webhook route', () => {
         url: '/webhooks/callback/github',
         headers: {
           'x-hub-signature-256': sign(reSerialized),
+          'x-github-event': 'issues',
           'content-type': 'application/json',
         },
         payload: rawBody,
@@ -219,14 +364,17 @@ describe('github webhook route', () => {
     });
 
     it('accepts a signature over a non-ASCII (multibyte UTF-8) raw body', async () => {
-      const payload = { action: 'closed', issue: { id: 1, number: 7, title: 'café — 日本語 — 🎓' } };
+      const payload = {
+        action: 'closed',
+        issue: { id: 1, number: 7, title: 'café — 日本語 — 🎓' },
+      };
       const rawBody = JSON.stringify(payload);
       expect(Buffer.byteLength(rawBody, 'utf8')).toBeGreaterThan(rawBody.length);
 
       const res = await app.inject({
         method: 'POST',
         url: '/webhooks/callback/github',
-        headers: { 'x-hub-signature-256': sign(rawBody), 'content-type': 'application/json' },
+        headers: headersFor('issues', rawBody),
         payload: rawBody,
       });
       expect(res.statusCode).toBe(200);
@@ -238,7 +386,7 @@ describe('github webhook route', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/webhooks/callback/github',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'x-github-event': 'issues', 'content-type': 'application/json' },
         payload: rawBody,
       });
       expect(res.statusCode).toBe(401);
@@ -253,6 +401,7 @@ describe('github webhook route', () => {
         headers: {
           'x-hub-signature-256':
             'sha256=0000000000000000000000000000000000000000000000000000000000000000',
+          'x-github-event': 'issues',
           'content-type': 'application/json',
         },
         payload: rawBody,
@@ -267,7 +416,7 @@ describe('github webhook route', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/webhooks/callback/github',
-        headers: { 'x-hub-signature-256': 'sha256=deadbeef' },
+        headers: { 'x-hub-signature-256': 'sha256=deadbeef', 'x-github-event': 'issues' },
       });
       expect(res.statusCode).toBe(401);
       expect(triggers.closed).not.toHaveBeenCalled();

--- a/apps/webapp/app/components/features/InstallAppBanner.tsx
+++ b/apps/webapp/app/components/features/InstallAppBanner.tsx
@@ -1,51 +1,61 @@
-import { useState } from 'react';
+import { useCallback } from 'react';
 import { Alert, Button } from 'antd';
+import { useFetcher } from 'react-router';
 import { useGitHubAppInstallPopup } from '~/hooks';
+import {
+  describeInstallCheck,
+  installCheckToneClass,
+  type InstallCheckResult,
+} from './githubInstallStatus';
 
 interface Props {
   /** The GitHub org login this classroom belongs to. */
   orgLogin: string;
   /** Classmoji GitHub App name (from the loader's process.env.GITHUB_APP_NAME). */
   githubAppName?: string;
+  /** Classroom slug, for the "check again" endpoint URL. */
+  classSlug: string;
 }
 
 /**
- * Non-blocking, dismissible prompt to install the Classmoji GitHub App on a
- * classroom's org. Shown on classrooms with no app installation (e.g. ones
- * imported from GitHub Classroom), where the live GitHub features are dormant
- * until the app is installed. Installing fills in the org's
- * `github_installation_id` (via the existing installation webhook), after which
+ * Non-blocking prompt to install the Classmoji GitHub App on a classroom's org.
+ * Shown on classrooms with no app installation (e.g. ones imported from GitHub
+ * Classroom), where the live GitHub features are dormant until the app is
+ * installed. Installing fills in the org's `github_installation_id`, after which
  * every GitHub-touching view lights up — no re-import needed.
  *
- * Dismissal is remembered per org in localStorage so it doesn't nag each visit.
+ * Deliberately NOT dismissible. Dismissal hid the only entry point back to a
+ * working classroom for the rest of the term, and the banner already disappears
+ * the moment the installation is found — the one exit that actually fixes
+ * anything. (The old `cm-install-banner-dismissed:*` localStorage keys are left
+ * where they are; nothing reads them any more.)
+ *
+ * The webhook that normally fills the id in can be missed, or replayed stale, so
+ * "Check again" asks GitHub directly rather than waiting on it — and closing the
+ * install popup asks on the instructor's behalf.
  */
-export default function InstallAppBanner({ orgLogin, githubAppName }: Props) {
-  const { openInstallPopup, isRefreshing } = useGitHubAppInstallPopup(githubAppName);
-  const storageKey = `cm-install-banner-dismissed:${orgLogin}`;
+export default function InstallAppBanner({ orgLogin, githubAppName, classSlug }: Props) {
+  const fetcher = useFetcher<InstallCheckResult>();
+  const checking = fetcher.state !== 'idle';
 
-  const [dismissed, setDismissed] = useState(() => {
-    try {
-      return typeof window !== 'undefined' && window.localStorage.getItem(storageKey) === '1';
-    } catch {
-      return false;
-    }
-  });
+  const checkInstallation = useCallback(() => {
+    fetcher.submit(null, {
+      method: 'post',
+      action: `/api/classrooms/${encodeURIComponent(classSlug)}/github-installation`,
+    });
+  }, [fetcher, classSlug]);
 
-  if (dismissed) return null;
+  // Closing the popup runs the same check the button does. React Router
+  // revalidates every loader on the page once a fetcher's action resolves, so a
+  // successful reconnect removes this banner with no explicit refresh here.
+  const { openInstallPopup } = useGitHubAppInstallPopup(githubAppName, checkInstallation);
+
+  const result = fetcher.state === 'idle' ? fetcher.data : undefined;
 
   return (
     <Alert
       type="info"
       showIcon
-      closable
-      onClose={() => {
-        try {
-          window.localStorage.setItem(storageKey, '1');
-        } catch {
-          /* ignore storage errors */
-        }
-        setDismissed(true);
-      }}
       message="Connect this classroom to GitHub"
       description={
         <div className="flex flex-col gap-2">
@@ -54,13 +64,41 @@ export default function InstallAppBanner({ orgLogin, githubAppName }: Props) {
             enable live repository syncing, grading, and creating new assignments. Your imported
             roster and assignments are already here.
           </span>
-          <div>
-            <Button type="primary" onClick={openInstallPopup} loading={isRefreshing}>
-              Install GitHub App
+          <div className="flex flex-wrap items-center gap-2">
+            {/* No configured app name means the install URL would be
+                `apps/undefined` — a GitHub 404 dressed up as our fix. Drop the
+                button rather than offer it: "Check again" still works, and the
+                banner still names the problem. */}
+            {githubAppName && (
+              <Button type="primary" onClick={openInstallPopup}>
+                Install GitHub App
+              </Button>
+            )}
+            <Button onClick={checkInstallation} loading={checking} disabled={checking}>
+              Check again
             </Button>
           </div>
+          {result && <CheckOutcome result={result} orgLogin={orgLogin} />}
         </div>
       }
     />
+  );
+}
+
+/**
+ * One sentence per outcome of the check, inline under the buttons.
+ * `connected`/`already-connected` are shown too: the revalidation that unmounts
+ * this banner is a round trip away, so without them the click looks inert.
+ *
+ * The wording itself lives in `githubInstallStatus` so the import wizard's copy
+ * of this check tells the instructor exactly the same thing.
+ */
+function CheckOutcome({ result, orgLogin }: { result: InstallCheckResult; orgLogin: string }) {
+  const { tone, text } = describeInstallCheck(result, orgLogin);
+
+  return (
+    <div role="status" aria-live="polite" className={`text-sm ${installCheckToneClass(tone)}`}>
+      {text}
+    </div>
   );
 }

--- a/apps/webapp/app/components/features/githubInstallStatus.ts
+++ b/apps/webapp/app/components/features/githubInstallStatus.ts
@@ -1,0 +1,85 @@
+/**
+ * The one place that turns a `POST /api/classrooms/:class/github-installation`
+ * outcome into a sentence.
+ *
+ * Two surfaces ask that endpoint — the dashboard/repos install banner and the
+ * end of the GitHub Classroom import wizard — and an instructor who sees
+ * "not installed yet" in one place and something differently worded in the
+ * other has no way to tell whether they are the same answer. Keeping the map
+ * here is what makes them the same answer.
+ *
+ * Deliberately free of any `@classmoji/services` import: this module is pulled
+ * into the client bundle by both callers.
+ */
+
+/** What `POST /api/classrooms/:class/github-installation` answers with. */
+export interface InstallCheckResult {
+  status: string;
+  login?: string | null;
+  retryAfterSeconds?: number;
+}
+
+export type InstallCheckTone = 'success' | 'warning' | 'error';
+
+/**
+ * The two outcomes that mean the org is connected and the caller may stop
+ * asking. `already-connected` is not a no-op: it is what a successful install
+ * looks like when the webhook won the race with the instructor closing the
+ * popup.
+ */
+export const isInstallConnected = (status: string) =>
+  status === 'connected' || status === 'already-connected';
+
+/**
+ * One sentence per outcome, plus the tone it should be shown in.
+ *
+ * `login` falls back to the caller's known org login: the endpoint echoes the
+ * row's login, but a client that never got one still has to name the org.
+ */
+export function describeInstallCheck(
+  result: InstallCheckResult,
+  fallbackLogin: string
+): { tone: InstallCheckTone; text: string } {
+  const login = result.login || fallbackLogin;
+
+  switch (result.status) {
+    case 'connected':
+    case 'already-connected':
+      return { tone: 'success', text: 'Connected to GitHub' };
+    case 'not-installed':
+      return { tone: 'warning', text: `The Classmoji app isn't installed on ${login} yet.` };
+    case 'login-moved':
+      return {
+        tone: 'warning',
+        text: `The GitHub organization ${login} appears to have been renamed or moved. Contact support.`,
+      };
+    case 'suspended':
+      return {
+        tone: 'warning',
+        text: `The Classmoji app is suspended on ${login}. Un-suspend it in GitHub's app settings.`,
+      };
+    case 'rate-limited':
+      return {
+        tone: 'warning',
+        text: `Checked recently. Try again in ${result.retryAfterSeconds ?? 15} s.`,
+      };
+    case 'not-github':
+      return { tone: 'error', text: 'This classroom is not hosted on GitHub.' };
+    case 'not-eligible':
+      return { tone: 'error', text: "This classroom can't be connected to GitHub." };
+    default:
+      // wrong-app, not-found, error — all one thing to the instructor, and the
+      // specifics are in the server log and the audit row.
+      return {
+        tone: 'error',
+        text: "Couldn't verify the installation. Try again or contact support.",
+      };
+  }
+}
+
+/** Tailwind text colour for a tone, in both themes. */
+export function installCheckToneClass(tone: InstallCheckTone): string {
+  if (tone === 'success') return 'text-emerald-700 dark:text-emerald-300';
+  if (tone === 'error') return 'text-rose-700 dark:text-rose-300';
+  return 'text-amber-700 dark:text-amber-300';
+}

--- a/apps/webapp/app/hooks/useGitHubAppInstallPopup.ts
+++ b/apps/webapp/app/hooks/useGitHubAppInstallPopup.ts
@@ -6,13 +6,35 @@ import { useRevalidator } from 'react-router';
  * Opens installation in a popup, detects when it closes, and refreshes loader data.
  *
  * @param {string} githubAppName - The GitHub App name (e.g., "classmoji")
+ * @param {() => void} [onClosed] - Called INSTEAD of the plain revalidate when
+ *   the popup closes. Callers that need more than a loader refresh supply this:
+ *   the install banner posts to the "check again" endpoint, whose action
+ *   reconciles the installation id and revalidates the page's loaders itself.
+ *   Left out, the popup revalidates exactly as before — create-classroom relies
+ *   on that, because its loader syncs installations live from GitHub.
  * @returns {{ openInstallPopup: () => void, isRefreshing: boolean }}
  */
-export const useGitHubAppInstallPopup = (githubAppName: string | undefined) => {
+export const useGitHubAppInstallPopup = (
+  githubAppName: string | undefined,
+  onClosed?: () => void
+) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const revalidator = useRevalidator();
   const popupRef = useRef<Window | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Held in a ref so callers may pass an inline arrow without re-creating
+  // `openInstallPopup`, and so the poll always invokes the CURRENT callback
+  // rather than the one captured when the popup was opened.
+  //
+  // Written in an effect rather than during render: a render-phase ref write is
+  // a side effect React is free to throw away (a discarded concurrent render,
+  // StrictMode's double invoke), and the popup poll reads this ref long after
+  // the render that set it.
+  const onClosedRef = useRef(onClosed);
+  useEffect(() => {
+    onClosedRef.current = onClosed;
+  }, [onClosed]);
 
   const openInstallPopup = useCallback(() => {
     // Don't open multiple popups
@@ -44,6 +66,15 @@ export const useGitHubAppInstallPopup = (githubAppName: string | undefined) => {
         clearInterval(pollIntervalRef.current!);
         pollIntervalRef.current = null;
         popupRef.current = null;
+
+        // A supplied callback OWNS the refresh: revalidating as well would race
+        // its request against a loader read of the same row and report "still
+        // not installed" from the stale answer that happened to land last.
+        if (onClosedRef.current) {
+          onClosedRef.current();
+          return;
+        }
+
         setIsRefreshing(true);
 
         // Revalidate immediately. The create-classroom loader syncs the user's

--- a/apps/webapp/app/routes/__tests__/staffGateIdentity.test.ts
+++ b/apps/webapp/app/routes/__tests__/staffGateIdentity.test.ts
@@ -69,6 +69,7 @@ vi.mock('~/components', () => ({
   RegradeRequestsTable: () => null,
 }));
 vi.mock('~/components/features/pages', () => ({ PagePeekProvider: () => null }));
+vi.mock('~/components/features/InstallAppBanner', () => ({ default: () => null }));
 vi.mock('~/components/features/dashboard', () => ({
   CockpitPanel: () => null,
   StaffCockpit: () => null,

--- a/apps/webapp/app/routes/_user.create-classroom/__tests__/action.installationGuard.test.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/__tests__/action.installationGuard.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The installation guard inside the create-classroom action.
+ *
+ * It is the last thing standing between a GitOrganization row with no
+ * `github_installation_id` and a half-built classroom: `getGitProvider` throws
+ * on such a row, and it throws AFTER the transaction has created the classroom,
+ * its settings and the owner membership — leaving a wreck that also holds the
+ * slug the retry wants.
+ *
+ * Two properties are pinned here, both of which used to be wrong.
+ *
+ * 1. The repair is asked with `bypassCooldown`. The service keeps a 15 s
+ *    per-org cooldown for mashed buttons; honouring it on a deliberate form
+ *    submit made the action say "GitHub is rate limiting" about a limit that
+ *    only ever existed in this process, with GitHub never asked.
+ * 2. A repaired row whose `login` has MOVED is refused. The org-admin check
+ *    upstream ran against the old login; adopting the new one would provision
+ *    into an organization nobody verified this user administers.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getAuthSession: vi.fn(),
+  getAuthenticated: vi.fn(),
+  findByLogin: vi.fn(),
+  repairInstallation: vi.fn(),
+  graphql: vi.fn(),
+  findUniqueGitOrg: vi.fn(),
+}));
+
+vi.mock('@classmoji/auth/server', () => ({
+  getAuthSession: (...a: unknown[]) => mocks.getAuthSession(...a),
+}));
+
+// `checkAuth` normally resolves the session and injects `user`; the action here
+// never reads that argument, so the wrapper is the identity.
+vi.mock('~/utils/helpers', () => ({
+  checkAuth: (fn: (args: unknown) => unknown) => fn,
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    user: { findByLogin: (...a: unknown[]) => mocks.findByLogin(...a) },
+    gitOrganization: {
+      repairInstallation: (...a: unknown[]) => mocks.repairInstallation(...a),
+    },
+  },
+  ClassroomSlugUnavailableError: class ClassroomSlugUnavailableError extends Error {},
+  GitHubProvider: {
+    getUserOctokit: () => ({
+      rest: { users: { getAuthenticated: (...a: unknown[]) => mocks.getAuthenticated(...a) } },
+      graphql: (...a: unknown[]) => mocks.graphql(...a),
+    }),
+  },
+  createWithUniqueClassroomSlug: vi.fn(),
+  describeTokenMintError: vi.fn(() => 'mint failed'),
+  getGitProvider: vi.fn(),
+  ensureClassroomTeam: vi.fn(),
+}));
+
+vi.mock('@classmoji/services/import-progress', () => ({
+  applyPhaseUpdates: vi.fn(),
+  buildInitialProgress: vi.fn(),
+  buildSummaryParts: vi.fn(),
+  withCounts: vi.fn(),
+  withIdMaps: vi.fn(),
+}));
+
+vi.mock('@classmoji/tasks', () => ({ default: {} }));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    gitOrganization: { findUnique: (...a: unknown[]) => mocks.findUniqueGitOrg(...a) },
+    classroom: { findMany: vi.fn().mockResolvedValue([]) },
+  }),
+}));
+
+vi.mock('@classmoji/utils', () => ({
+  defaultContentRepoName: vi.fn((ns: string) => `content-${ns}`),
+  sanitizeRepoName: vi.fn((n: string) => n),
+  suggestContentNamespace: vi.fn(({ slug }: { slug: string }) => slug),
+}));
+
+vi.mock('~/constants', () => ({ ActionTypes: {} }));
+
+const { action } = await import('../action.ts');
+
+const GIT_ORG = {
+  id: 'org-1',
+  provider: 'GITHUB',
+  login: 'cs52-org',
+  github_installation_id: null,
+};
+
+/**
+ * The name deliberately slugifies to nothing. The slug check sits immediately
+ * AFTER the guard, so its refusal is the cheapest available proof that the
+ * guard let the request through — without dragging the whole provisioning
+ * transaction into a unit test.
+ */
+const PAST_THE_GUARD =
+  'That name has no letters or numbers to build a URL from — add some, or set a slug';
+
+const call = (body: Record<string, unknown> = {}) =>
+  (
+    action as unknown as (args: { request: Request; params: Record<string, string> }) => Promise<{
+      error?: string;
+    }>
+  )({
+    request: new Request('http://localhost/create-classroom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ git_org_id: 'org-1', name: '???', ...body }),
+    }),
+    params: {},
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getAuthSession.mockResolvedValue({ userId: 'user-1', token: 'gh-token' });
+  mocks.getAuthenticated.mockResolvedValue({ data: { login: 'instructor' } });
+  mocks.findByLogin.mockResolvedValue({ id: 'user-1', login: 'instructor' });
+  mocks.findUniqueGitOrg.mockResolvedValue({ ...GIT_ORG });
+  mocks.graphql.mockResolvedValue({
+    organization: { login: 'cs52-org', viewerCanAdminister: true },
+  });
+  mocks.repairInstallation.mockResolvedValue({
+    status: 'connected',
+    org: { ...GIT_ORG, github_installation_id: '4242' },
+  });
+});
+
+describe('create-classroom installation guard', () => {
+  it('bypasses the local cooldown — a form submit is deliberate, not a poll', async () => {
+    await call();
+    expect(mocks.repairInstallation).toHaveBeenCalledWith('org-1', { bypassCooldown: true });
+  });
+
+  it('carries on once the repair hands back an installation id', async () => {
+    const result = await call();
+    expect(result.error).toBe(PAST_THE_GUARD);
+  });
+
+  it('refuses when the repaired row came back under a different login', async () => {
+    mocks.repairInstallation.mockResolvedValue({
+      status: 'connected',
+      org: { ...GIT_ORG, login: 'cs52-org-renamed', github_installation_id: '4242' },
+    });
+
+    const result = await call();
+    expect(result.error).toBe(
+      'The GitHub organization for this classroom has changed name; reload and try again.'
+    );
+  });
+
+  // `already-connected` is the same adoption path, and the same trap.
+  it('refuses a moved login on an already-connected answer too', async () => {
+    mocks.repairInstallation.mockResolvedValue({
+      status: 'already-connected',
+      org: { ...GIT_ORG, login: 'somewhere-else', github_installation_id: '4242' },
+    });
+
+    const result = await call();
+    expect(result.error).toBe(
+      'The GitHub organization for this classroom has changed name; reload and try again.'
+    );
+  });
+
+  it('names GitHub in the rate-limited message, since only GitHub can cause it now', async () => {
+    mocks.repairInstallation.mockResolvedValue({ status: 'rate-limited', retryAfterSeconds: 37 });
+
+    const result = await call();
+    expect(result.error).toBe(
+      'GitHub is rate limiting installation checks; try again in 37 seconds.'
+    );
+  });
+
+  it('asks the owner to install the app on every other outcome', async () => {
+    for (const status of ['not-installed', 'suspended', 'wrong-app', 'not-found', 'error']) {
+      mocks.repairInstallation.mockResolvedValue({ status });
+      const result = await call();
+      expect(result.error).toBe(
+        'Connect the Classmoji GitHub app to cs52-org before creating a classroom.'
+      );
+    }
+  });
+
+  // A "connected" answer carrying no id is a contradiction, and adopting it
+  // would put the wreck back — the guard exists to keep that row out.
+  it('refuses a connected answer that carries no installation id', async () => {
+    mocks.repairInstallation.mockResolvedValue({ status: 'connected', org: { ...GIT_ORG } });
+
+    const result = await call();
+    expect(result.error).toBe(
+      'Connect the Classmoji GitHub app to cs52-org before creating a classroom.'
+    );
+  });
+
+  it('never asks about an org that already has an installation id', async () => {
+    mocks.findUniqueGitOrg.mockResolvedValue({ ...GIT_ORG, github_installation_id: '99' });
+
+    const result = await call();
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+    expect(result.error).toBe(PAST_THE_GUARD);
+  });
+
+  it('never asks about a non-GitHub org', async () => {
+    mocks.findUniqueGitOrg.mockResolvedValue({ ...GIT_ORG, provider: 'GITLAB' });
+
+    await call();
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/_user.create-classroom/action.ts
+++ b/apps/webapp/app/routes/_user.create-classroom/action.ts
@@ -131,8 +131,9 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     return { error: 'Classroom name is required' };
   }
 
-  // Get GitOrganization
-  const gitOrg = await getPrisma().gitOrganization.findUnique({
+  // Get GitOrganization. Reassigned by the installation guard below, which may
+  // hand back a repaired row carrying the installation id (and current login).
+  let gitOrg = await getPrisma().gitOrganization.findUnique({
     where: { id: git_org_id },
   });
 
@@ -166,6 +167,61 @@ export const action = checkAuth(async ({ request }: { request: Request }) => {
     return {
       error: 'Unable to verify organization membership',
     };
+  }
+
+  // An org with no installation id cannot be provisioned: `getGitProvider`
+  // throws on it, and it throws AFTER the transaction has already created the
+  // classroom, its settings and the owner membership — leaving a half-built
+  // classroom that also holds the slug the retry wants. Refuse here instead.
+  //
+  // The id is missing far more often than the app is: rows created GitHub-free
+  // by the Classroom ZIP import never had one, and a stale `installation.deleted`
+  // could clear one that a reinstall had replaced. So ask GitHub before
+  // refusing — most of these are one lookup away from working.
+  if (gitOrg.provider === 'GITHUB' && !gitOrg.github_installation_id) {
+    // `bypassCooldown` because this is a deliberate form submit, not a poll.
+    // The service's 15 s per-org cooldown exists to stop a button being mashed;
+    // honouring it here would have refused the create with "GitHub is rate
+    // limiting" when GitHub had never been asked — the instructor would have
+    // been told to wait on a limit that only ever lived in this process. One
+    // GitHub call per create is fine, and the in-flight map still collapses
+    // genuinely simultaneous callers into one request.
+    const repair = await ClassmojiService.gitOrganization.repairInstallation(gitOrg.id, {
+      bypassCooldown: true,
+    });
+
+    if (repair.status === 'connected' || repair.status === 'already-connected') {
+      if (!repair.org?.github_installation_id) {
+        return {
+          error: `Connect the Classmoji GitHub app to ${gitOrg.login} before creating a classroom.`,
+        };
+      }
+
+      // The org admin check above ran against the login as it stood BEFORE the
+      // repair. A repaired row can come back under a different login (a rename
+      // GitHub reports on the installation), and adopting it here would mean
+      // provisioning into an organization nobody verified this user administers.
+      // Refuse and make the next attempt re-run the check against the new name.
+      if (repair.org.login !== gitOrg.login) {
+        return {
+          error:
+            'The GitHub organization for this classroom has changed name; reload and try again.',
+        };
+      }
+
+      gitOrg = repair.org;
+    } else if (repair.status === 'rate-limited') {
+      // With the local cooldown bypassed, this can now only be GitHub's own
+      // 403/429 (a `GitHubRateLimitedError` out of the lookup), so the sentence
+      // is allowed to name GitHub — which is what it always claimed.
+      return {
+        error: `GitHub is rate limiting installation checks; try again in ${repair.retryAfterSeconds} seconds.`,
+      };
+    } else {
+      return {
+        error: `Connect the Classmoji GitHub app to ${gitOrg.login} before creating a classroom.`,
+      };
+    }
   }
 
   // Slug: prefer client-provided (user override / suggestion) when present, else derive from name.

--- a/apps/webapp/app/routes/_user.import-classroom/StepProgress.tsx
+++ b/apps/webapp/app/routes/_user.import-classroom/StepProgress.tsx
@@ -1,7 +1,16 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { TriggerAuthContext, useRealtimeRunsWithTag } from '@trigger.dev/react-hooks';
 import { Progress, Tag, Button, Alert, Spin } from 'antd';
 import { CheckCircleFilled, WarningFilled } from '@ant-design/icons';
+
+import { useGitHubAppInstallPopup } from '~/hooks';
+import {
+  describeInstallCheck,
+  installCheckToneClass,
+  isInstallConnected,
+  type InstallCheckResult,
+} from '~/components/features/githubInstallStatus';
 
 const TASK_ID = 'import_github_classroom';
 const TERMINAL = new Set([
@@ -21,6 +30,10 @@ interface ImportSummaryOutput {
   reposLinked?: number;
   gradesRecorded?: number;
   warnings?: string[];
+  /** The GitHub org this classroom was imported into. */
+  organizationLogin?: string;
+  /** Whether that org already had a Classmoji App installation at import time. */
+  appInstalled?: boolean;
 }
 
 interface RunLike {
@@ -38,6 +51,8 @@ interface Props {
   expected: number;
   /** One classroom imported → land on it; several → back to the org picker. */
   single: boolean;
+  /** Classmoji GitHub App name, for the "Connect GitHub" install popup. */
+  githubAppName?: string;
 }
 
 /**
@@ -46,17 +61,36 @@ interface Props {
  * everything finishes, offers a button to the new classroom (single import) or
  * back to the org picker (multiple).
  */
-export default function StepProgress({ accessToken, sessionId, expected, single }: Props) {
+export default function StepProgress({
+  accessToken,
+  sessionId,
+  expected,
+  single,
+  githubAppName,
+}: Props) {
   return (
     <TriggerAuthContext.Provider value={{ accessToken }}>
-      <ProgressInner sessionId={sessionId} expected={expected} single={single} />
+      <ProgressInner
+        sessionId={sessionId}
+        expected={expected}
+        single={single}
+        githubAppName={githubAppName}
+      />
     </TriggerAuthContext.Provider>
   );
 }
 
-function ProgressInner({ sessionId, expected, single }: Omit<Props, 'accessToken'>) {
+function ProgressInner({ sessionId, expected, single, githubAppName }: Omit<Props, 'accessToken'>) {
   const navigate = useNavigate();
   const { runs, error } = useRealtimeRunsWithTag(`session_${sessionId}`);
+
+  // Orgs this wizard has since confirmed connected, and the last check outcome
+  // per org for the ones it could not confirm. Nothing on this page revalidates
+  // — the run output is a finished Trigger.dev payload, not a loader — so the
+  // "isn't installed" line can only be retired by what we learn here.
+  const [connectedOrgs, setConnectedOrgs] = useState<string[]>([]);
+  const [checkResults, setCheckResults] = useState<Record<string, InstallCheckResult>>({});
+  const [checking, setChecking] = useState(false);
 
   const importRuns = (runs as unknown as RunLike[]).filter(r => r.taskIdentifier === TASK_ID);
   const terminal = importRuns.filter(r => TERMINAL.has(r.status));
@@ -73,6 +107,97 @@ function ProgressInner({ sessionId, expected, single }: Omit<Props, 'accessToken
   // wizard submitted is not necessarily the one that got stored. With no run
   // output there is no slug to trust, and the org picker is the safe landing.
   const destinationSlug = single ? (succeeded[0]?.output?.classroomSlug ?? null) : null;
+
+  // The import never touches GitHub, so an org with no Classmoji App
+  // installation imports fine and then sits inert — no repo syncing, no new
+  // assignments. Offer the install here, where the instructor still has the
+  // context, rather than making them find the banner on the dashboard later.
+  //
+  // Only SUCCEEDED runs are consulted (a failed run imported nothing to connect)
+  // and orgs are deduped: several classrooms routinely share one org, and the
+  // popup installs on whichever the instructor picks, so one button covers them.
+  //
+  // One org maps to whichever of its succeeded classrooms answered first: the
+  // check is per-ORG (it reconciles the GitOrganization row), so any classroom
+  // in the org is an equally good address for it.
+  const slugByOrg = new Map<string, string>();
+  for (const run of succeeded) {
+    const login = run.output?.organizationLogin;
+    const slug = run.output?.classroomSlug;
+    if (login && slug && !slugByOrg.has(login)) slugByOrg.set(login, slug);
+  }
+
+  const orgsNeedingInstall = Array.from(
+    new Set(
+      succeeded
+        .filter(r => r.output?.appInstalled === false)
+        .map(r => r.output?.organizationLogin)
+        .filter((login): login is string => Boolean(login))
+    )
+  ).filter(login => !connectedOrgs.includes(login));
+  const needsInstall = orgsNeedingInstall.length > 0 && Boolean(githubAppName);
+
+  // Closing the install popup is the only signal we get that the instructor
+  // did anything — GitHub redirects the popup, not this page. So ask the
+  // "check again" endpoint on their behalf, once per org still outstanding,
+  // and retire the ones that come back connected. Without this the notice and
+  // its button sit there for the rest of the session no matter what the
+  // instructor just installed.
+  //
+  // Deliberately NOT memoized: `useGitHubAppInstallPopup` holds its callback in
+  // a ref precisely so an inline closure is safe, and memoizing this one would
+  // mean memoizing every derived value it reads (all of which are rebuilt from
+  // `runs` on each realtime tick anyway) to buy an identity nothing depends on.
+  const confirmInstalls = async () => {
+    const pending = orgsNeedingInstall
+      .map(login => ({ login, slug: slugByOrg.get(login) }))
+      .filter((o): o is { login: string; slug: string } => Boolean(o.slug));
+
+    if (pending.length === 0) return;
+
+    setChecking(true);
+    try {
+      const checked = await Promise.all(
+        pending.map(async ({ login, slug }) => {
+          try {
+            const res = await fetch(
+              `/api/classrooms/${encodeURIComponent(slug)}/github-installation`,
+              { method: 'POST', headers: { Accept: 'application/json' } }
+            );
+            const body = (await res.json()) as InstallCheckResult;
+            return { login, result: body };
+          } catch {
+            // A failed round trip is indistinguishable to the instructor from a
+            // failed check, and both mean "we still don't know".
+            return { login, result: { status: 'error' } as InstallCheckResult };
+          }
+        })
+      );
+
+      const nowConnected = checked
+        .filter(c => isInstallConnected(c.result?.status ?? ''))
+        .map(c => c.login);
+
+      setCheckResults(prev => {
+        const next = { ...prev };
+        for (const { login, result } of checked) next[login] = result;
+        return next;
+      });
+      if (nowConnected.length > 0) {
+        setConnectedOrgs(prev => Array.from(new Set([...prev, ...nowConnected])));
+      }
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const { openInstallPopup } = useGitHubAppInstallPopup(githubAppName, confirmInstalls);
+
+  // Only outcomes for orgs still listed as needing the app are worth showing;
+  // a connected org has already left the list, and saying so twice is noise.
+  const outstandingResults = orgsNeedingInstall
+    .map(login => ({ login, result: checkResults[login] }))
+    .filter((o): o is { login: string; result: InstallCheckResult } => Boolean(o.result));
 
   const goToDestination = () => {
     if (destinationSlug) {
@@ -160,10 +285,43 @@ function ProgressInner({ sessionId, expected, single }: Omit<Props, 'accessToken
       </div>
 
       {allDone && (
-        <div className="mt-6 flex justify-end">
-          <Button type="primary" onClick={goToDestination}>
-            {destinationSlug ? 'Go to classroom' : 'Done'}
-          </Button>
+        <div className="mt-6 flex flex-col gap-3">
+          <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
+            {needsInstall && (
+              <span className="text-xs text-gray-500 dark:text-gray-400 sm:mr-auto">
+                The Classmoji GitHub App isn&apos;t installed on{' '}
+                <span className="font-medium text-gray-700 dark:text-gray-200">
+                  {orgsNeedingInstall.join(', ')}
+                </span>
+                , so repository syncing and grading stay off until you connect it.
+              </span>
+            )}
+            <div className="flex justify-end gap-3">
+              {needsInstall && (
+                <Button onClick={openInstallPopup} loading={checking} disabled={checking}>
+                  Connect GitHub
+                </Button>
+              )}
+              <Button type="primary" onClick={goToDestination}>
+                {destinationSlug ? 'Go to classroom' : 'Done'}
+              </Button>
+            </div>
+          </div>
+
+          {/* What the post-popup check found, in the banner's own words, for
+              every org that is still not connected. */}
+          {needsInstall && outstandingResults.length > 0 && (
+            <div role="status" aria-live="polite" className="flex flex-col gap-1 sm:items-end">
+              {outstandingResults.map(({ login, result }) => {
+                const { tone, text } = describeInstallCheck(result, login);
+                return (
+                  <span key={login} className={`text-xs ${installCheckToneClass(tone)}`}>
+                    {text}
+                  </span>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/webapp/app/routes/_user.import-classroom/route.tsx
+++ b/apps/webapp/app/routes/_user.import-classroom/route.tsx
@@ -18,6 +18,10 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   if (!authData) return redirect('/');
   return {
     triggerConfigured: Boolean(process.env.TRIGGER_SECRET_KEY || process.env.TRIGGER_ACCESS_TOKEN),
+    // The import is deliberately GitHub-free, so a freshly imported classroom's
+    // org routinely has no App installation. The completion screen offers to
+    // install one, which needs the app's name to build the popup URL.
+    githubAppName: process.env.GITHUB_APP_NAME,
   };
 };
 
@@ -37,7 +41,7 @@ interface ImportActionData {
 const ImportClassroom = ({ loaderData }: Route.ComponentProps) => {
   const navigate = useNavigate();
   const fetcher = useFetcher<ImportActionData>();
-  const { triggerConfigured } = loaderData;
+  const { triggerConfigured, githubAppName } = loaderData;
 
   const [currentStep, setCurrentStep] = useState(0);
   const [classrooms, setClassrooms] = useState<ListedClassroom[]>([]);
@@ -123,6 +127,7 @@ const ImportClassroom = ({ loaderData }: Route.ComponentProps) => {
             sessionId={session.id}
             expected={session.expected}
             single={session.single}
+            githubAppName={githubAppName}
           />
         )}
 

--- a/apps/webapp/app/routes/admin.$class.dashboard/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.dashboard/route.tsx
@@ -112,6 +112,9 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     appInstalled: Boolean(classroom.git_organization?.github_installation_id),
     isExample: classroom.is_example,
     gitOrgLogin: classroom.git_organization?.login ?? null,
+    // Only GitHub orgs have an App to install; a GitLab/Gitea classroom must
+    // never be told to install one.
+    gitProvider: classroom.git_organization?.provider ?? null,
     githubAppName: process.env.GITHUB_APP_NAME,
   };
 };
@@ -247,20 +250,33 @@ const AdminDashboard = ({ loaderData }: Route.ComponentProps) => {
     appInstalled,
     isExample,
     gitOrgLogin,
+    gitProvider,
     githubAppName,
   } = loaderData;
   const { class: classSlug } = useParams();
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
+  // `githubOrganization` is fetched ONLY when the app is installed, so with no
+  // installation it is null and `undefined !== 'none'` used to be true — the
+  // page then asserted "students can see each other's repositories" about an org
+  // whose settings it had never read, on a classroom where GitHub is not
+  // connected at all. Nothing here may speak about the org's live state unless
+  // that state was actually fetched.
   const showBanner =
-    !bannerDismissed && githubOrganization?.default_repository_permission !== 'none';
+    !bannerDismissed &&
+    Boolean(githubOrganization) &&
+    githubOrganization?.default_repository_permission !== 'none';
 
   return (
     <div className="min-h-full flex flex-col gap-4">
       <h1 className="mt-2 mb-1 text-lg font-semibold text-ink-0">Dashboard</h1>
 
-      {!appInstalled && !isExample && gitOrgLogin && (
-        <InstallAppBanner orgLogin={gitOrgLogin} githubAppName={githubAppName} />
+      {!appInstalled && !isExample && gitOrgLogin && gitProvider === 'GITHUB' && (
+        <InstallAppBanner
+          orgLogin={gitOrgLogin}
+          githubAppName={githubAppName}
+          classSlug={classSlug!}
+        />
       )}
 
       {showBanner && (

--- a/apps/webapp/app/routes/admin.$class.gitrepos/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.gitrepos/route.tsx
@@ -11,6 +11,7 @@ import { useDebounce } from '@uidotdev/usehooks';
 
 import { ActionTypes } from '~/constants';
 import { ClassmojiService, getGitProvider, GitHubProvider } from '@classmoji/services';
+import InstallAppBanner from '~/components/features/InstallAppBanner';
 import { useGlobalFetcher } from '~/hooks';
 import { waitForRunCompletion } from '~/utils/helpers';
 import { requireClassroomAdmin, assertClassroomMutationAllowed } from '~/utils/routeAuth.server';
@@ -41,6 +42,17 @@ async function fetchOrgRepositories(
   { page = 1, pageSize = 25, search = '' }
 ) {
   const gitOrgLogin = gitOrganization?.login;
+
+  // This whole page is GitHub's GraphQL API. A GitLab/Gitea classroom has no
+  // installation id and never will, so the "install the GitHub App" answer
+  // below is advice it can never act on — say what is actually true instead.
+  if (gitOrganization && gitOrganization.provider !== 'GITHUB') {
+    return {
+      repositories: [],
+      totalCount: 0,
+      error: 'Repository listing is only available for GitHub organizations.',
+    };
+  }
 
   if (!gitOrganization?.github_installation_id) {
     return {
@@ -235,6 +247,13 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
       search,
     }),
     gitOrgLogin,
+    // With no installation id every repository call fails in the same place, and
+    // the resulting "couldn't load repositories" describes a symptom. Surface the
+    // fixable cause so the page can offer the repair instead of the dead end.
+    appInstalled: Boolean(classroom.git_organization?.github_installation_id),
+    isExample: classroom.is_example,
+    gitProvider: classroom.git_organization?.provider ?? null,
+    githubAppName: process.env.GITHUB_APP_NAME,
     page,
     pageSize,
     search,
@@ -264,6 +283,13 @@ interface RepositoriesTableProps {
   search: string;
   onDelete: (record: { name: string }) => void;
   loading: boolean;
+  /**
+   * The org has no App installation. The page is already showing the install
+   * banner, which names the cause and offers the fix, so the generic
+   * "couldn't load repositories … try reinstalling" block below is suppressed
+   * rather than shown twice with the vaguer wording second.
+   */
+  installMissing: boolean;
 }
 
 const RepositoriesTable = ({
@@ -274,6 +300,7 @@ const RepositoriesTable = ({
   search,
   onDelete,
   loading,
+  installMissing,
 }: RepositoriesTableProps) => {
   const { repositories, totalCount, lastRefresh, error } = data;
   const [searchParams, setSearchParams] = useSearchParams();
@@ -368,7 +395,7 @@ const RepositoriesTable = ({
       )}
 
       {/* Error state */}
-      {error && (
+      {error && !installMissing && (
         <div className="mb-4 rounded-xl bg-rose-50/70 dark:bg-rose-900/20 ring-1 ring-rose-200 dark:ring-rose-800/60 p-4 flex items-start gap-3">
           <div className="shrink-0 mt-0.5 text-rose-600 dark:text-rose-300">
             <IconAlertTriangle size={18} strokeWidth={2} />
@@ -441,7 +468,20 @@ const RepositoriesTable = ({
 };
 
 const GithubRepositories = ({ loaderData }: Route.ComponentProps) => {
-  const { repositoriesPromise, gitOrgLogin, page, pageSize, search } = loaderData;
+  const {
+    repositoriesPromise,
+    gitOrgLogin,
+    appInstalled,
+    isExample,
+    gitProvider,
+    githubAppName,
+    page,
+    pageSize,
+    search,
+  } = loaderData;
+  const showInstallBanner =
+    !appInstalled && !isExample && Boolean(gitOrgLogin) && gitProvider === 'GITHUB';
+  const { class: classSlug } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { revalidate, state } = useRevalidator();
   const [localSearch, setLocalSearch] = useState(search);
@@ -528,6 +568,16 @@ const GithubRepositories = ({ loaderData }: Route.ComponentProps) => {
         </div>
       </div>
 
+      {showInstallBanner && (
+        <div className="mb-4">
+          <InstallAppBanner
+            orgLogin={gitOrgLogin!}
+            githubAppName={githubAppName}
+            classSlug={classSlug!}
+          />
+        </div>
+      )}
+
       <TriggerProgress
         operation="DELETE_REPOS"
         validIdentifiers={['delete_git_repo']}
@@ -548,6 +598,7 @@ const GithubRepositories = ({ loaderData }: Route.ComponentProps) => {
                 search={search}
                 onDelete={deleteSingleRepository}
                 loading={isLoading}
+                installMissing={showInstallBanner}
               />
             )}
           </Await>

--- a/apps/webapp/app/routes/admin.$class.settings.repos/route.tsx
+++ b/apps/webapp/app/routes/admin.$class.settings.repos/route.tsx
@@ -1,8 +1,10 @@
 import { Select, Switch, Alert } from 'antd';
+import { useParams } from 'react-router';
 import { useNotifiedFetcher } from '~/hooks';
 
 import { assertClassroomAccess, assertClassroomMutationAllowed } from '~/utils/helpers';
 import { getGitProvider } from '@classmoji/services';
+import InstallAppBanner from '~/components/features/InstallAppBanner';
 import type { Route } from './+types/route';
 
 export const loader = async ({ params, request }: Route.LoaderArgs) => {
@@ -18,10 +20,23 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   });
 
   const gitOrgLogin = classroom.git_organization?.login ?? null;
+
+  // Everything the install banner needs, on EVERY branch below. The page's
+  // "the App isn't installed" message was already correct and already dead:
+  // it named the fix and offered no way to run it. Same fields, same condition
+  // as the dashboard, so an owner meets one repair path rather than two.
+  const install = {
+    appInstalled: Boolean(classroom.git_organization?.github_installation_id),
+    isExample: classroom.is_example,
+    gitProvider: classroom.git_organization?.provider ?? null,
+    githubAppName: process.env.GITHUB_APP_NAME,
+  };
+
   if (!gitOrgLogin) {
     return {
       githubOrganization: null,
       gitOrgLogin: null,
+      ...install,
       error: 'This classroom is not connected to a GitHub organization.',
     };
   }
@@ -30,6 +45,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     return {
       githubOrganization: null,
       gitOrgLogin,
+      ...install,
       error: `The Classmoji GitHub App isn't installed on "${gitOrgLogin}". Install it to manage repository settings.`,
     };
   }
@@ -37,7 +53,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   try {
     const gitProvider = getGitProvider(classroom.git_organization);
     const githubOrganization = await gitProvider.getOrganization(gitOrgLogin);
-    return { githubOrganization, gitOrgLogin, error: null };
+    return { githubOrganization, gitOrgLogin, ...install, error: null };
   } catch (err: unknown) {
     const status =
       err && typeof err === 'object' && 'status' in err
@@ -48,6 +64,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     return {
       githubOrganization: null,
       gitOrgLogin,
+      ...install,
       error:
         status === 404
           ? `GitHub couldn't find the "${gitOrgLogin}" organization or the Classmoji App installation. The App may have been uninstalled or the org renamed.`
@@ -75,13 +92,37 @@ const Section = ({
 );
 
 const SettingsRepos = ({ loaderData }: Route.ComponentProps) => {
-  const { githubOrganization, error } = loaderData;
+  const {
+    githubOrganization,
+    error,
+    gitOrgLogin,
+    appInstalled,
+    isExample,
+    gitProvider,
+    githubAppName,
+  } = loaderData;
+  const { class: classSlug } = useParams();
   const { fetcher } = useNotifiedFetcher();
+
+  const showInstallBanner =
+    !appInstalled && !isExample && Boolean(gitOrgLogin) && gitProvider === 'GITHUB';
 
   if (error || !githubOrganization) {
     return (
-      <div className="pt-4">
-        <Alert message={error ?? 'Repository settings unavailable.'} type="warning" showIcon />
+      <div className="flex flex-col gap-4 pt-4">
+        {showInstallBanner && (
+          <InstallAppBanner
+            orgLogin={gitOrgLogin!}
+            githubAppName={githubAppName}
+            classSlug={classSlug!}
+          />
+        )}
+        {/* Suppressed behind the banner: the banner says the same thing and
+            offers the fix, so showing both repeats the diagnosis in vaguer
+            words underneath the cure. */}
+        {!showInstallBanner && (
+          <Alert message={error ?? 'Repository settings unavailable.'} type="warning" showIcon />
+        )}
       </div>
     );
   }

--- a/apps/webapp/app/routes/api.classrooms.$class.github-installation/__tests__/route.test.ts
+++ b/apps/webapp/app/routes/api.classrooms.$class.github-installation/__tests__/route.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The "check again" endpoint behind the install banner.
+ *
+ * Two things are pinned here.
+ *
+ * 1. WHO may run it. The gate is `requireClassroomStaff` (OWNER/TEACHER), not
+ *    `requireClassroomTeachingTeam` — an assistant cannot install the app on the
+ *    org, and the banner is not offered to them, but the button's absence is not
+ *    a permission check. Swapping this gate is the mistake the first test exists
+ *    to catch, so it asserts the identity of the helper the route imports.
+ *
+ * 2. That every status the service can return survives the trip to the client
+ *    intact, including `rate-limited`'s retry hint — the banner renders these
+ *    verbatim, so a dropped field silently becomes a wrong sentence.
+ */
+
+const mocks = vi.hoisted(() => ({
+  requireClassroomStaff: vi.fn(),
+  requireClassroomTeachingTeam: vi.fn(),
+  repairInstallation: vi.fn(),
+  addClassroomAuditLog: vi.fn(),
+}));
+
+vi.mock('~/utils/routeAuth.server', () => ({
+  requireClassroomStaff: (...a: unknown[]) => mocks.requireClassroomStaff(...a),
+  requireClassroomTeachingTeam: (...a: unknown[]) => mocks.requireClassroomTeachingTeam(...a),
+  requireClassroomAdmin: vi.fn(),
+  assertClassroomAccess: vi.fn(),
+  assertClassroomMutationAllowed: vi.fn(),
+}));
+
+vi.mock('~/utils/helpers', () => ({
+  addClassroomAuditLog: (...a: unknown[]) => mocks.addClassroomAuditLog(...a),
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    gitOrganization: {
+      repairInstallation: (...a: unknown[]) => mocks.repairInstallation(...a),
+    },
+  },
+}));
+
+const { action } = await import('../route.ts');
+
+const GITHUB_ORG = {
+  id: 'org-1',
+  provider: 'GITHUB',
+  login: 'cs52-org',
+  github_installation_id: null,
+};
+
+const gateResult = (overrides: Record<string, unknown> = {}) => ({
+  userId: 'user-1',
+  classroom: {
+    id: 'class-1',
+    slug: 'cs52-26f',
+    is_example: false,
+    git_organization: GITHUB_ORG,
+    ...overrides,
+  },
+  membership: { role: 'TEACHER' },
+});
+
+const args = (method = 'POST') =>
+  ({
+    params: { class: 'cs52-26f' },
+    request: new Request('http://localhost/api/classrooms/cs52-26f/github-installation', {
+      method,
+    }),
+  }) as unknown as Parameters<typeof action>[0];
+
+// `data()` hands back a DataWithResponseInit rather than a Response.
+const unwrap = (result: unknown) =>
+  result as { data: Record<string, unknown>; init?: ResponseInit };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireClassroomStaff.mockResolvedValue(gateResult());
+  mocks.repairInstallation.mockResolvedValue({ status: 'connected', org: GITHUB_ORG });
+  mocks.addClassroomAuditLog.mockResolvedValue(undefined);
+});
+
+describe('POST /api/classrooms/:class/github-installation', () => {
+  it('refuses anything but POST, before it authorizes anything', async () => {
+    const res = (await action(args('GET'))) as Response;
+    expect(res.status).toBe(405);
+    expect(res.headers.get('Allow')).toBe('POST');
+    expect(mocks.requireClassroomStaff).not.toHaveBeenCalled();
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+
+  it('gates on OWNER/TEACHER, never on the teaching team', async () => {
+    await action(args());
+    expect(mocks.requireClassroomStaff).toHaveBeenCalledTimes(1);
+    expect(mocks.requireClassroomTeachingTeam).not.toHaveBeenCalled();
+    expect(mocks.requireClassroomStaff).toHaveBeenCalledWith(
+      expect.any(Request),
+      'cs52-26f',
+      expect.objectContaining({ action: 'check_github_installation' })
+    );
+  });
+
+  it('propagates the gate refusal instead of repairing anything', async () => {
+    mocks.requireClassroomStaff.mockRejectedValue(new Response('Forbidden', { status: 403 }));
+    await expect(action(args())).rejects.toBeInstanceOf(Response);
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+
+  it('reports the outcome and audits the attempt', async () => {
+    const result = unwrap(await action(args()));
+
+    expect(mocks.repairInstallation).toHaveBeenCalledWith('org-1');
+    expect(result.data).toEqual({ status: 'connected', login: 'cs52-org' });
+    expect(mocks.addClassroomAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classroomId: 'class-1',
+        userId: 'user-1',
+        role: 'TEACHER',
+        action: 'UPDATE',
+        resourceType: 'GIT_ORGANIZATION',
+        resourceId: 'org-1',
+        metadata: expect.objectContaining({ git_org_login: 'cs52-org', outcome: 'connected' }),
+      })
+    );
+  });
+
+  it.each([
+    ['already-connected'],
+    ['not-installed'],
+    ['login-moved'],
+    ['suspended'],
+    ['wrong-app'],
+    ['not-found'],
+  ])('passes the %s status straight through', async status => {
+    mocks.repairInstallation.mockResolvedValue({ status });
+    const result = unwrap(await action(args()));
+    expect(result.data).toEqual({ status, login: 'cs52-org' });
+    expect(mocks.addClassroomAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ outcome: status }) })
+    );
+  });
+
+  it('keeps the retry hint on a rate-limited answer', async () => {
+    mocks.repairInstallation.mockResolvedValue({ status: 'rate-limited', retryAfterSeconds: 12 });
+    const result = unwrap(await action(args()));
+    expect(result.data).toEqual({
+      status: 'rate-limited',
+      login: 'cs52-org',
+      retryAfterSeconds: 12,
+    });
+  });
+
+  it('never leaks the internal error message to the client', async () => {
+    mocks.repairInstallation.mockResolvedValue({
+      status: 'error',
+      message: 'app-jwt signing failed for app 12345',
+    });
+    const result = unwrap(await action(args()));
+    expect(result.data).toEqual({ status: 'error', login: 'cs52-org' });
+  });
+
+  it('refuses a non-GitHub org without calling GitHub', async () => {
+    mocks.requireClassroomStaff.mockResolvedValue(
+      gateResult({ git_organization: { ...GITHUB_ORG, provider: 'GITLAB' } })
+    );
+    const result = unwrap(await action(args()));
+    expect(result.init?.status).toBe(400);
+    expect(result.data).toMatchObject({ status: 'not-github' });
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+
+  // Its own status, not `not-github`. The example classroom IS on GitHub and
+  // its owner can read the org login on the very page that asked, so the
+  // "not hosted on GitHub" sentence would be a lie; the banner renders
+  // `not-eligible` as "can't be connected", which is true.
+  it('refuses the example classroom, whose org is a fixture', async () => {
+    mocks.requireClassroomStaff.mockResolvedValue(gateResult({ is_example: true }));
+    const result = unwrap(await action(args()));
+    expect(result.init?.status).toBe(400);
+    expect(result.data).toEqual({ status: 'not-eligible', login: 'cs52-org' });
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+
+  it('refuses a classroom with no git organization at all', async () => {
+    mocks.requireClassroomStaff.mockResolvedValue(gateResult({ git_organization: null }));
+    const result = unwrap(await action(args()));
+    expect(result.init?.status).toBe(400);
+    expect(result.data).toEqual({ status: 'not-github', login: null });
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/api.classrooms.$class.github-installation/route.ts
+++ b/apps/webapp/app/routes/api.classrooms.$class.github-installation/route.ts
@@ -1,0 +1,81 @@
+import { data } from 'react-router';
+
+import { ClassmojiService } from '@classmoji/services';
+import { requireClassroomStaff } from '~/utils/routeAuth.server';
+import { addClassroomAuditLog } from '~/utils/helpers';
+import type { Route } from './+types/route';
+
+/**
+ * POST /api/classrooms/:class/github-installation
+ *
+ * "Check again" behind the install banner: ask GitHub whether the Classmoji App
+ * is installed on this classroom's org and, if it is, reconnect the row.
+ *
+ * OWNER/TEACHER only. Assistants are deliberately excluded — they cannot install
+ * the app on the org either, so the button is never offered to them, and this
+ * gate is what actually enforces that rather than the button's absence.
+ *
+ * Every outcome that reached GitHub comes back 200 with a `status` the client
+ * renders as a sentence; only a request that could never have reached it is a
+ * 4xx, and those two cases are told apart: `not-github` for a classroom hosted
+ * somewhere else, `not-eligible` for the example classroom, which IS on GitHub
+ * and would be misdescribed by the first. Everything else is
+ * `repairInstallation`'s own union, unchanged, so the banner, the import
+ * wizard, the create-classroom guard and the operator sweep all describe
+ * installations in the same words.
+ */
+export const action = async ({ params, request }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { 'Content-Type': 'text/plain', Allow: 'POST' },
+    });
+  }
+
+  const classSlug = params.class!;
+
+  const { userId, classroom, membership } = await requireClassroomStaff(request, classSlug, {
+    resourceType: 'GIT_ORGANIZATION',
+    action: 'check_github_installation',
+  });
+
+  const org = classroom.git_organization;
+
+  // Nothing to look up: a non-GitHub provider has no App to install.
+  if (!org || org.provider !== 'GITHUB') {
+    return data({ status: 'not-github' as const, login: org?.login ?? null }, { status: 400 });
+  }
+
+  // The example classroom's org is a fixture that must never be reconciled
+  // against a real GitHub account. It is not "not on GitHub" — telling its
+  // owner that would be a lie about a classroom they can see the org login of —
+  // so it gets its own status and its own sentence.
+  if (classroom.is_example) {
+    return data({ status: 'not-eligible' as const, login: org.login }, { status: 400 });
+  }
+
+  const result = await ClassmojiService.gitOrganization.repairInstallation(org.id);
+
+  // Audit the attempt, not just the success: a run of `not-installed` against
+  // one org is the trail that explains why an instructor filed a ticket. This
+  // never fails the request — `addClassroomAuditLog` contains its write errors.
+  await addClassroomAuditLog({
+    classroomId: classroom.id,
+    userId,
+    role: membership?.role,
+    action: 'UPDATE',
+    resourceType: 'GIT_ORGANIZATION',
+    resourceId: org.id,
+    metadata: {
+      tool: 'api.classrooms.github-installation',
+      git_org_login: org.login,
+      outcome: result.status,
+    },
+  });
+
+  return data({
+    status: result.status,
+    login: org.login,
+    ...(result.status === 'rate-limited' ? { retryAfterSeconds: result.retryAfterSeconds } : {}),
+  });
+};

--- a/apps/webapp/app/routes/assistant.$class_.dashboard/route.tsx
+++ b/apps/webapp/app/routes/assistant.$class_.dashboard/route.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from 'react';
-import { Await } from 'react-router';
+import { Await, useParams } from 'react-router';
 import { Skeleton } from 'antd';
 
 import type { Route } from './+types/route';
 import { ClassmojiService } from '@classmoji/services';
 import { requireClassroomTeachingTeam } from '~/utils/routeAuth.server';
+import InstallAppBanner from '~/components/features/InstallAppBanner';
 import GradingTabsCard from '../admin.$class.dashboard/GradingTabsCard';
 import {
   MyDayQueue,
@@ -21,10 +22,14 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   // This loader is served under both /assistant and /teacher (which re-exports
   // it), and the name describes the resource, not the prefix, so it is right
   // for both consumers.
-  const { userId, classroom } = await requireClassroomTeachingTeam(request, classSlug!, {
-    resourceType: 'STAFF_DASHBOARD',
-    action: 'view_dashboard',
-  });
+  const { userId, classroom, membership } = await requireClassroomTeachingTeam(
+    request,
+    classSlug!,
+    {
+      resourceType: 'STAFF_DASHBOARD',
+      action: 'view_dashboard',
+    }
+  );
 
   const cockpitPromise = Promise.all([
     ClassmojiService.taDashboard.overdueQueue(userId, classroom.id),
@@ -41,6 +46,16 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
       ClassmojiService.gitRepoAssignmentGrader.findGradersProgress(classroom.id),
     ]),
     cockpit: cockpitPromise,
+    // Teachers cannot browse /admin (that namespace is owner-only), so this is
+    // the only dashboard where a teacher can be shown that their classroom's
+    // GitHub App is missing. Assistants get the same loader and must NOT see it:
+    // they can neither install the app on the org nor pass the repair gate.
+    role: membership?.role ?? null,
+    appInstalled: Boolean(classroom.git_organization?.github_installation_id),
+    isExample: classroom.is_example,
+    gitOrgLogin: classroom.git_organization?.login ?? null,
+    gitProvider: classroom.git_organization?.provider ?? null,
+    githubAppName: process.env.GITHUB_APP_NAME,
   };
 };
 
@@ -61,23 +76,36 @@ const StatItem = ({ label, value, subtitle, valueColor }: StatItemProps) => (
       >
         {value}
       </div>
-      {subtitle && (
-        <div className="mt-0.5 text-xs text-ink-3 truncate">
-          {subtitle}
-        </div>
-      )}
+      {subtitle && <div className="mt-0.5 text-xs text-ink-3 truncate">{subtitle}</div>}
     </div>
   </div>
 );
 
 const AssistantDashboard = ({ loaderData }: Route.ComponentProps) => {
-  const { data, cockpit } = loaderData;
+  const { data, cockpit, role, appInstalled, isExample, gitOrgLogin, gitProvider, githubAppName } =
+    loaderData;
+  const { class: classSlug } = useParams();
+
+  // Owners land here too when they browse under /teacher; assistants never
+  // see it (they can't pass the repair gate).
+  const showInstallBanner =
+    (role === 'TEACHER' || role === 'OWNER') &&
+    !appInstalled &&
+    !isExample &&
+    Boolean(gitOrgLogin) &&
+    gitProvider === 'GITHUB';
 
   return (
     <div className="min-h-full flex flex-col gap-4">
-      <h1 className="mt-2 mb-1 text-lg font-semibold text-ink-1">
-        Dashboard
-      </h1>
+      <h1 className="mt-2 mb-1 text-lg font-semibold text-ink-1">Dashboard</h1>
+
+      {showInstallBanner && (
+        <InstallAppBanner
+          orgLogin={gitOrgLogin!}
+          githubAppName={githubAppName}
+          classSlug={classSlug!}
+        />
+      )}
 
       <Suspense fallback={<Skeleton active />}>
         <Await resolve={data} errorElement={null}>

--- a/packages/services/src/classmoji/__tests__/gitOrganization.repair.test.ts
+++ b/packages/services/src/classmoji/__tests__/gitOrganization.repair.test.ts
@@ -1,0 +1,649 @@
+/**
+ * Unit tests for GitHub App installation repair.
+ *
+ * 45 orgs with real classrooms carry a NULL `github_installation_id`, and every
+ * path that tries to put one back is a chance to put back the WRONG one. These
+ * tests are mostly about refusals:
+ *
+ *  - a login is not an identity. GitHub org logins are renamed and recycled, so
+ *    `GET /orgs/{login}/installation` answering 200 proves nothing until the
+ *    account id matches. Adopting that answer would hand one customer's org to
+ *    whoever now owns the name.
+ *  - "not installed" may only be concluded after the account-id scan comes up
+ *    empty; a 404 on the login alone means the login moved, not that the app is
+ *    gone.
+ *  - the write is conditional on the column still being NULL, because the
+ *    repair races the `installation.created` webhook and the user's other tabs.
+ *  - a rate limit is not a "no". It has to surface as "try again in N", never
+ *    as "go install the app".
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  updateMany: vi.fn(),
+  upsert: vi.fn(),
+  getOrgInstallation: vi.fn(),
+  paginate: vi.fn(),
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    gitOrganization: {
+      findUnique: (...a: unknown[]) => mocks.findUnique(...a),
+      updateMany: (...a: unknown[]) => mocks.updateMany(...a),
+      upsert: (...a: unknown[]) => mocks.upsert(...a),
+    },
+  }),
+}));
+
+const { GitHubProvider } = await import('../../git/GitHubProvider.ts');
+const {
+  GitHubRateLimitedError,
+  validateInstallationIdentity,
+  lookupInstallationForOrg,
+  listAppInstallations,
+  claimInstallationIfNull,
+  clearInstallationIfMatches,
+  repairInstallation,
+  syncUserInstallations,
+  __resetRepairThrottleForTests,
+  __repairCooldownCountForTests,
+} = await import('../gitOrganization.service.ts');
+
+const APP_ID = '424242';
+const APP_SLUG = 'classmoji-test';
+const PROVIDER_ID = '9001';
+const INSTALLATION_ID = 55501;
+const ORG_ID = 'git-org-uuid-1';
+
+const installation = (overrides: Record<string, unknown> = {}) => ({
+  id: INSTALLATION_ID,
+  app_id: Number(APP_ID),
+  app_slug: APP_SLUG,
+  suspended_at: null,
+  account: {
+    id: Number(PROVIDER_ID),
+    login: 'dartmouth-cs',
+    type: 'Organization',
+    avatar_url: 'https://avatars.example/1',
+  },
+  ...overrides,
+});
+
+/** A GitOrganization row with no installation id — the thing being repaired. */
+const disconnectedOrg = (overrides: Record<string, unknown> = {}) => ({
+  id: ORG_ID,
+  provider: 'GITHUB',
+  provider_id: PROVIDER_ID,
+  login: 'dartmouth-cs',
+  github_installation_id: null,
+  ...overrides,
+});
+
+const octokitStub = () =>
+  ({
+    rest: {
+      apps: {
+        getOrgInstallation: mocks.getOrgInstallation,
+        listInstallations: 'LIST',
+        listInstallationsForAuthenticatedUser: 'USER_LIST',
+      },
+    },
+    paginate: mocks.paginate,
+  }) as never;
+
+const httpError = (status: number, headers: Record<string, string> = {}) =>
+  Object.assign(new Error(`http ${status}`), { status, response: { headers } });
+
+beforeEach(() => {
+  mocks.findUnique.mockReset();
+  mocks.updateMany.mockReset();
+  mocks.upsert.mockReset().mockResolvedValue({});
+  mocks.getOrgInstallation.mockReset();
+  mocks.paginate.mockReset().mockResolvedValue([]);
+  process.env.GITHUB_APP_ID = APP_ID;
+  process.env.GITHUB_APP_NAME = APP_SLUG;
+  __resetRepairThrottleForTests();
+  vi.spyOn(GitHubProvider, 'getAppOctokit').mockReturnValue(octokitStub());
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('validateInstallationIdentity', () => {
+  it('accepts a live organization installation of this app', () => {
+    const result = validateInstallationIdentity(installation(), { providerId: PROVIDER_ID });
+    expect(result).toEqual({
+      ok: true,
+      synced: {
+        provider_id: PROVIDER_ID,
+        login: 'dartmouth-cs',
+        github_installation_id: String(INSTALLATION_ID),
+        avatar_url: 'https://avatars.example/1',
+      },
+    });
+  });
+
+  it('refuses a personal-account installation', () => {
+    const result = validateInstallationIdentity(
+      installation({ account: { id: Number(PROVIDER_ID), login: 'someone', type: 'User' } }),
+      { providerId: PROVIDER_ID }
+    );
+    expect(result).toEqual({ ok: false, reason: 'not-organization' });
+  });
+
+  it('refuses an installation belonging to a different account', () => {
+    const result = validateInstallationIdentity(installation(), { providerId: '7777' });
+    expect(result).toEqual({ ok: false, reason: 'account-mismatch' });
+  });
+
+  it('refuses another app id', () => {
+    const result = validateInstallationIdentity(installation({ app_id: 111 }), {
+      providerId: PROVIDER_ID,
+    });
+    expect(result).toEqual({ ok: false, reason: 'wrong-app' });
+  });
+
+  it('refuses another app slug', () => {
+    const result = validateInstallationIdentity(installation({ app_slug: 'someone-elses-app' }), {
+      providerId: PROVIDER_ID,
+    });
+    expect(result).toEqual({ ok: false, reason: 'wrong-app' });
+  });
+
+  it('matches the app slug regardless of case or stray whitespace', () => {
+    // GITHUB_APP_NAME is hand-entered per environment; a capital letter or a
+    // trailing space in the secret must not read as "somebody else's app" and
+    // disconnect every org on the platform.
+    process.env.GITHUB_APP_NAME = `  ${APP_SLUG.toUpperCase()} `;
+
+    const result = validateInstallationIdentity(installation({ app_slug: APP_SLUG }), {
+      providerId: PROVIDER_ID,
+    });
+
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  it('still refuses an installation with no app slug at all when one is expected', () => {
+    const result = validateInstallationIdentity(installation({ app_slug: undefined }), {
+      providerId: PROVIDER_ID,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'wrong-app' });
+  });
+
+  it('skips the slug check when GITHUB_APP_NAME is not configured', () => {
+    delete process.env.GITHUB_APP_NAME;
+    const result = validateInstallationIdentity(installation({ app_slug: 'anything' }), {
+      providerId: PROVIDER_ID,
+    });
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  it('refuses a suspended installation', () => {
+    const result = validateInstallationIdentity(
+      installation({ suspended_at: '2026-09-01T00:00:00Z' }),
+      { providerId: PROVIDER_ID }
+    );
+    expect(result).toEqual({ ok: false, reason: 'suspended' });
+  });
+});
+
+describe('lookupInstallationForOrg', () => {
+  const org = { provider_id: PROVIDER_ID, login: 'dartmouth-cs' };
+
+  it('finds the installation from the login lookup', async () => {
+    mocks.getOrgInstallation.mockResolvedValue({ data: installation() });
+
+    const result = await lookupInstallationForOrg(octokitStub(), org);
+
+    expect(result).toMatchObject({ status: 'found' });
+    expect(mocks.paginate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the account-id scan when the login 404s', async () => {
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([installation({ account: { ...installation().account } })]);
+
+    const result = await lookupInstallationForOrg(octokitStub(), org);
+
+    expect(result).toMatchObject({ status: 'found' });
+    expect(mocks.paginate).toHaveBeenCalledWith('LIST', { per_page: 100 });
+  });
+
+  it('never adopts the installation of the account that now holds the login', async () => {
+    // The login resolves, but to a different account — and no installation
+    // anywhere carries our account id. That is a moved org, not a repair.
+    mocks.getOrgInstallation.mockResolvedValue({
+      data: installation({
+        account: { id: 424243, login: 'dartmouth-cs', type: 'Organization', avatar_url: '' },
+      }),
+    });
+    mocks.paginate.mockResolvedValue([]);
+
+    const result = await lookupInstallationForOrg(octokitStub(), org);
+
+    expect(result).toEqual({ status: 'login-moved' });
+  });
+
+  it('still finds us by account id when someone else took our login', async () => {
+    mocks.getOrgInstallation.mockResolvedValue({
+      data: installation({
+        account: { id: 424243, login: 'dartmouth-cs', type: 'Organization', avatar_url: '' },
+      }),
+    });
+    mocks.paginate.mockResolvedValue([
+      installation({
+        account: {
+          id: Number(PROVIDER_ID),
+          login: 'dartmouth-cs-2',
+          type: 'Organization',
+          avatar_url: '',
+        },
+      }),
+    ]);
+
+    const result = await lookupInstallationForOrg(octokitStub(), org);
+
+    expect(result).toMatchObject({ status: 'found', synced: { login: 'dartmouth-cs-2' } });
+  });
+
+  it('uses a preloaded installation list instead of re-paginating', async () => {
+    // What makes a 45-org sweep affordable: the account-id scan is read once
+    // per run and handed in, not repeated per org.
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+
+    const result = await lookupInstallationForOrg(octokitStub(), org, {
+      installations: [installation()],
+    });
+
+    expect(result).toMatchObject({ status: 'found' });
+    expect(mocks.paginate).not.toHaveBeenCalled();
+  });
+
+  it('reports not-installed only after the id scan comes up empty', async () => {
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([]);
+
+    const result = await lookupInstallationForOrg(octokitStub(), org);
+
+    expect(result).toEqual({ status: 'not-installed' });
+  });
+
+  it('reports suspended rather than not-installed', async () => {
+    mocks.getOrgInstallation.mockResolvedValue({
+      data: installation({ suspended_at: '2026-09-01T00:00:00Z' }),
+    });
+    mocks.paginate.mockResolvedValue([installation({ suspended_at: '2026-09-01T00:00:00Z' })]);
+
+    const result = await lookupInstallationForOrg(octokitStub(), org);
+
+    expect(result).toEqual({ status: 'suspended' });
+  });
+
+  it('raises a typed rate-limit error on a primary limit (403 + remaining 0)', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 90;
+    mocks.getOrgInstallation.mockRejectedValue(
+      httpError(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(reset) })
+    );
+
+    await expect(lookupInstallationForOrg(octokitStub(), org)).rejects.toBeInstanceOf(
+      GitHubRateLimitedError
+    );
+    expect(mocks.paginate).not.toHaveBeenCalled();
+  });
+
+  it('raises a typed rate-limit error on a secondary limit (429 + retry-after)', async () => {
+    mocks.getOrgInstallation.mockRejectedValue(httpError(429, { 'retry-after': '30' }));
+
+    await expect(lookupInstallationForOrg(octokitStub(), org)).rejects.toMatchObject({
+      name: 'GitHubRateLimitedError',
+      retryAfterSeconds: 30,
+    });
+  });
+
+  it('propagates a non-404, non-rate-limit failure', async () => {
+    mocks.getOrgInstallation.mockRejectedValue(httpError(500));
+
+    await expect(lookupInstallationForOrg(octokitStub(), org)).rejects.toThrow('http 500');
+  });
+});
+
+describe('listAppInstallations', () => {
+  it('paginates the app-wide installation list', async () => {
+    mocks.paginate.mockResolvedValue([installation()]);
+
+    await expect(listAppInstallations(octokitStub())).resolves.toEqual([installation()]);
+    expect(mocks.paginate).toHaveBeenCalledWith('LIST', { per_page: 100 });
+  });
+
+  it('reports a throttle as a rate limit rather than a bare 403', async () => {
+    // A sweep preloads this list once; if a throttle here came back as a
+    // generic failure the sweep would report `error` and lose the retry-after.
+    mocks.paginate.mockRejectedValue(httpError(403, { 'retry-after': '61' }));
+
+    await expect(listAppInstallations(octokitStub())).rejects.toMatchObject({
+      name: 'GitHubRateLimitedError',
+      retryAfterSeconds: 61,
+    });
+  });
+});
+
+describe('claimInstallationIfNull', () => {
+  const args = {
+    orgId: ORG_ID,
+    providerId: PROVIDER_ID,
+    installationId: String(INSTALLATION_ID),
+    login: 'dartmouth-cs',
+  };
+
+  it('writes only while the column is still NULL', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(claimInstallationIfNull(args)).resolves.toEqual({ claimed: true });
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: ORG_ID,
+        provider: 'GITHUB',
+        provider_id: PROVIDER_ID,
+        github_installation_id: null,
+      },
+      data: { github_installation_id: String(INSTALLATION_ID), login: 'dartmouth-cs' },
+    });
+  });
+
+  it('rereads the row when somebody else claimed it first', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+    const winner = disconnectedOrg({ github_installation_id: '77777' });
+    mocks.findUnique.mockResolvedValue(winner);
+
+    await expect(claimInstallationIfNull(args)).resolves.toEqual({
+      claimed: false,
+      current: winner,
+    });
+  });
+});
+
+describe('clearInstallationIfMatches', () => {
+  it('scopes the clear to the installation that was actually removed', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      clearInstallationIfMatches({ providerId: PROVIDER_ID, installationId: '55501' })
+    ).resolves.toBe(1);
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: {
+        provider: 'GITHUB',
+        provider_id: PROVIDER_ID,
+        github_installation_id: '55501',
+      },
+      data: { github_installation_id: null },
+    });
+  });
+
+  it('clears nothing when the stored id has already moved on', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      clearInstallationIfMatches({ providerId: PROVIDER_ID, installationId: '55501' })
+    ).resolves.toBe(0);
+  });
+});
+
+describe('repairInstallation', () => {
+  it('connects an org whose installation is live', async () => {
+    const repaired = disconnectedOrg({ github_installation_id: String(INSTALLATION_ID) });
+    mocks.findUnique.mockResolvedValueOnce(disconnectedOrg()).mockResolvedValueOnce(repaired);
+    mocks.getOrgInstallation.mockResolvedValue({ data: installation() });
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({
+      status: 'connected',
+      org: repaired,
+    });
+  });
+
+  it('short-circuits an org that already has an installation id', async () => {
+    const connected = disconnectedOrg({ github_installation_id: '123' });
+    mocks.findUnique.mockResolvedValue(connected);
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({
+      status: 'already-connected',
+      org: connected,
+    });
+    expect(mocks.getOrgInstallation).not.toHaveBeenCalled();
+  });
+
+  it('reports already-connected when the conditional write loses the race', async () => {
+    const winner = disconnectedOrg({ github_installation_id: '77777' });
+    mocks.findUnique.mockResolvedValueOnce(disconnectedOrg()).mockResolvedValueOnce(winner);
+    mocks.getOrgInstallation.mockResolvedValue({ data: installation() });
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({
+      status: 'already-connected',
+      org: winner,
+    });
+  });
+
+  it('refuses a non-GitHub org without calling GitHub', async () => {
+    mocks.findUnique.mockResolvedValue(disconnectedOrg({ provider: 'GITLAB' }));
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({ status: 'not-github' });
+    expect(mocks.getOrgInstallation).not.toHaveBeenCalled();
+  });
+
+  it('passes a not-installed lookup straight through', async () => {
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([]);
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({ status: 'not-installed' });
+  });
+
+  it('turns a GitHub rate limit into a retry-after answer, not a refusal', async () => {
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(429, { 'retry-after': '42' }));
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({
+      status: 'rate-limited',
+      retryAfterSeconds: 42,
+    });
+  });
+
+  it('reports an unexpected failure as an error', async () => {
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(500));
+
+    await expect(repairInstallation(ORG_ID)).resolves.toMatchObject({ status: 'error' });
+  });
+
+  it('refuses a second lookup for the same org inside the cooldown', async () => {
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([]);
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({ status: 'not-installed' });
+
+    const second = await repairInstallation(ORG_ID);
+    expect(second).toMatchObject({ status: 'rate-limited' });
+    expect(mocks.getOrgInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves concurrent callers from one in-flight lookup', async () => {
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([]);
+
+    const [a, b, c] = await Promise.all([
+      repairInstallation(ORG_ID),
+      repairInstallation(ORG_ID),
+      repairInstallation(ORG_ID),
+    ]);
+
+    expect([a, b, c]).toEqual([
+      { status: 'not-installed' },
+      { status: 'not-installed' },
+      { status: 'not-installed' },
+    ]);
+    expect(mocks.getOrgInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not spend the cooldown on an org it never asked GitHub about', async () => {
+    const connected = disconnectedOrg({ github_installation_id: '123' });
+    mocks.findUnique.mockResolvedValue(connected);
+
+    await repairInstallation(ORG_ID);
+    await expect(repairInstallation(ORG_ID)).resolves.toMatchObject({
+      status: 'already-connected',
+    });
+  });
+
+  it('surfaces a 403 rate limit immediately instead of sleeping until reset', async () => {
+    // The `octokit` umbrella's throttling plugin would answer a primary limit
+    // by scheduling a retry for time-until-reset — up to an hour — inside a
+    // request handler. `getAppOctokit` disables that, so the 403 arrives here
+    // with its headers and becomes a retry-after answer. Fake timers make the
+    // regression loud: if anything waits, nothing resolves and no timer is
+    // pending to explain why.
+    vi.useFakeTimers();
+    const reset = Math.floor(Date.now() / 1000) + 3600;
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(
+      httpError(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(reset) })
+    );
+
+    // No timer is advanced anywhere in this test.
+    const result = await repairInstallation(ORG_ID);
+
+    expect(result).toEqual({ status: 'rate-limited', retryAfterSeconds: 3600 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('measures the cooldown from when the lookup finished, not when it started', async () => {
+    vi.useFakeTimers();
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.paginate.mockResolvedValue([]);
+
+    let finish: () => void = () => {};
+    mocks.getOrgInstallation.mockImplementation(
+      () =>
+        new Promise((_resolve, rejectLookup) => {
+          finish = () => rejectLookup(httpError(404));
+        })
+    );
+
+    const first = repairInstallation(ORG_ID);
+    // GitHub takes 14s to answer. Stamped only at the start, the cooldown would
+    // now have one second left on it and the next click would sail through.
+    await vi.advanceTimersByTimeAsync(14_000);
+    finish();
+    await expect(first).resolves.toEqual({ status: 'not-installed' });
+
+    const second = await repairInstallation(ORG_ID);
+
+    expect(second).toEqual({ status: 'rate-limited', retryAfterSeconds: 15 });
+    expect(mocks.getOrgInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops expired cooldown stamps rather than holding one per org forever', async () => {
+    vi.useFakeTimers();
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([]);
+
+    await repairInstallation('org-a');
+    await repairInstallation('org-b');
+    expect(__repairCooldownCountForTests()).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(16_000);
+    await repairInstallation('org-c');
+
+    // a and b expired and were swept on the way in; only c's stamp is live.
+    expect(__repairCooldownCountForTests()).toBe(1);
+  });
+
+  it('lets a sweep past the local cooldown with bypassCooldown', async () => {
+    // A re-triggered sweep asks about each org once per run; being refused
+    // because the previous run (or the instructor's own button) touched the
+    // same org seconds ago would abort the repair for no benefit.
+    mocks.findUnique.mockResolvedValue(disconnectedOrg());
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.paginate.mockResolvedValue([]);
+
+    await expect(repairInstallation(ORG_ID)).resolves.toEqual({ status: 'not-installed' });
+    await expect(repairInstallation(ORG_ID, { bypassCooldown: true })).resolves.toEqual({
+      status: 'not-installed',
+    });
+
+    expect(mocks.getOrgInstallation).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses a caller-supplied Octokit and installation list', async () => {
+    const repaired = disconnectedOrg({ github_installation_id: String(INSTALLATION_ID) });
+    mocks.findUnique.mockResolvedValueOnce(disconnectedOrg()).mockResolvedValueOnce(repaired);
+    mocks.getOrgInstallation.mockRejectedValue(httpError(404));
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      repairInstallation(ORG_ID, {
+        appOctokit: octokitStub(),
+        installations: [installation()],
+      })
+    ).resolves.toEqual({ status: 'connected', org: repaired });
+
+    // Neither a fresh app client nor a fresh paginated scan per org.
+    expect(GitHubProvider.getAppOctokit).not.toHaveBeenCalled();
+    expect(mocks.paginate).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncUserInstallations', () => {
+  const otherAccount = (id: number, overrides: Record<string, unknown> = {}) => ({
+    id,
+    login: `org-${id}`,
+    type: 'Organization',
+    avatar_url: '',
+    ...overrides,
+  });
+
+  it('upserts only the installations that pass the identity gate', async () => {
+    // `GET /user/installations` is scoped to the USER, so it lists every
+    // installation they administer — other apps included — and suspended ones.
+    // Writing those straight through is how an org ends up "connected" to an id
+    // that mints no token.
+    mocks.paginate.mockResolvedValue([
+      installation(),
+      installation({ id: 2, suspended_at: '2026-09-01T00:00:00Z', account: otherAccount(9002) }),
+      installation({ id: 3, app_slug: 'some-other-app', account: otherAccount(9003) }),
+      installation({ id: 4, account: otherAccount(9004, { type: 'User' }) }),
+    ]);
+
+    const synced = await syncUserInstallations(octokitStub());
+
+    expect(synced).toEqual([
+      {
+        provider_id: PROVIDER_ID,
+        login: 'dartmouth-cs',
+        github_installation_id: String(INSTALLATION_ID),
+        avatar_url: 'https://avatars.example/1',
+      },
+    ]);
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { provider_provider_id: { provider: 'GITHUB', provider_id: PROVIDER_ID } },
+      })
+    );
+    // The suspended and wrong-app rows are worth a line each; a personal
+    // account is the documented filter, not an anomaly, so it stays quiet.
+    expect(console.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/services/src/classmoji/gitOrganization.service.ts
+++ b/packages/services/src/classmoji/gitOrganization.service.ts
@@ -1,6 +1,7 @@
 import getPrisma from '@classmoji/database';
-import type { GitProvider, Prisma } from '@prisma/client';
+import type { GitOrganization, GitProvider, Prisma } from '@prisma/client';
 import type { Octokit } from 'octokit';
+import { GitHubProvider } from '../git/GitHubProvider.ts';
 
 /**
  * Find a GitOrganization by its UUID
@@ -137,6 +138,14 @@ export interface SyncedInstallation {
  * Only Organization accounts are returned — the create-classroom action verifies
  * org admin rights, so personal-account installations aren't selectable orgs.
  *
+ * Every row written here goes through `validateInstallationIdentity` first. The
+ * list is read with the USER's token, so it is a list of installations that user
+ * can see — including installations of OTHER GitHub Apps they administer, and
+ * suspended ones. Upserting those straight through would write an id that mints
+ * no token and then show the org as connected; the same gate the webhook and the
+ * repair path run keeps them out. A personal account is skipped quietly (that is
+ * the documented filter, not an anomaly); anything else is logged.
+ *
  * @param {Octokit} octokit - Octokit authenticated with the user's token
  *   (from `GitHubProvider.getUserOctokit`).
  * @returns {Promise<SyncedInstallation[]>} the synced Organization installations.
@@ -147,17 +156,27 @@ export const syncUserInstallations = async (octokit: Octokit): Promise<SyncedIns
     { per_page: 100 }
   );
 
-  const orgInstallations: SyncedInstallation[] = installations
-    .filter(inst => inst.account && 'type' in inst.account && inst.account.type === 'Organization')
-    .map(inst => {
-      const account = inst.account as { id: number; login: string; avatar_url: string };
-      return {
-        provider_id: String(account.id),
-        login: account.login,
-        github_installation_id: String(inst.id),
-        avatar_url: account.avatar_url,
-      };
+  const orgInstallations: SyncedInstallation[] = [];
+
+  for (const inst of installations) {
+    const accountId = inst.account && 'id' in inst.account ? inst.account.id : undefined;
+    if (accountId === undefined || accountId === null) continue;
+
+    const validation = validateInstallationIdentity(inst as InstallationLike, {
+      providerId: String(accountId),
     });
+
+    if (!validation.ok) {
+      if (validation.reason !== 'not-organization') {
+        console.warn(
+          `[git-org-sync] user installation=${inst.id} account=${accountId} skipped: ${validation.reason}`
+        );
+      }
+      continue;
+    }
+
+    orgInstallations.push(validation.synced);
+  }
 
   await Promise.all(
     orgInstallations.map(inst =>
@@ -199,16 +218,24 @@ export const syncInstallationById = async (
   });
 
   const account = data.account;
-  if (!account || !('type' in account) || account.type !== 'Organization') {
+  if (!account || account.id === undefined || account.id === null) {
     return null;
   }
 
-  const synced: SyncedInstallation = {
-    provider_id: String(account.id),
-    login: account.login,
-    github_installation_id: String(data.id),
-    avatar_url: account.avatar_url,
-  };
+  // The installation GitHub just handed back has to be OURS, for an
+  // Organization, and live. Note what this call can and cannot check: the
+  // provider id passed in comes from the SAME response, so the account-mismatch
+  // arm cannot fire here — this path enforces org-type, app identity and
+  // suspension only. What stops a post-install redirect carrying somebody
+  // else's `installation_id` from minting or moving a GitOrganization is the
+  // caller's org-admin check, not this validation.
+  const validation = validateInstallationIdentity(data, { providerId: String(account.id) });
+  if (!validation.ok) {
+    console.warn(`[git-org-sync] installation=${installationId} rejected: ${validation.reason}`);
+    return null;
+  }
+
+  const synced = validation.synced;
 
   await upsert({
     provider: 'GITHUB',
@@ -278,3 +305,591 @@ export const deleteIfOrphaned = async (gitOrgId: string) => {
 
   return true;
 };
+
+// ---------------------------------------------------------------------------
+// Installation repair
+//
+// 45 orgs with real classrooms carry `github_installation_id = NULL` — either
+// they were created GitHub-free by the Classroom ZIP import, or a stale
+// `installation.deleted` webhook cleared an id that a reinstall had already
+// replaced. Everything below exists to put a NULL id back, and to make sure the
+// id we put back is the one that actually belongs to that org.
+// ---------------------------------------------------------------------------
+
+/**
+ * GitHub answered "not now" rather than "no".
+ *
+ * A rate limit is the one lookup failure that must not read as "the app isn't
+ * installed" — the caller has to say "try again in N seconds" instead of
+ * telling an instructor to go reinstall an app that is already there.
+ */
+export class GitHubRateLimitedError extends Error {
+  readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number, message = 'GitHub rate limit exceeded') {
+    super(message);
+    this.name = 'GitHubRateLimitedError';
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+/** The shape of an account on an installation payload, across GitHub's unions. */
+export interface InstallationAccountLike {
+  id?: number | string;
+  login?: string;
+  type?: string;
+  avatar_url?: string;
+}
+
+/**
+ * The subset of a GitHub App installation this module reads.
+ *
+ * Structural on purpose: the same validation runs over `apps.getInstallation`,
+ * `apps.getOrgInstallation`, `apps.listInstallations` and a raw webhook payload,
+ * and Octokit types those four differently.
+ */
+export interface InstallationLike {
+  id: number | string;
+  app_id?: number | string;
+  app_slug?: string;
+  suspended_at?: string | null;
+  account?: InstallationAccountLike | null;
+}
+
+/** Why an installation is not one we may write a row for. */
+export type InstallationRejection =
+  | 'not-organization'
+  | 'account-mismatch'
+  | 'wrong-app'
+  | 'suspended';
+
+export type InstallationValidation =
+  | { ok: true; synced: SyncedInstallation }
+  | { ok: false; reason: InstallationRejection };
+
+/**
+ * Is this installation ours, for this org, for an Organization, and live?
+ *
+ * Every write of `github_installation_id` goes through here. The four checks
+ * answer four different ways the id in hand can be the wrong one:
+ *
+ * - **not-organization** — a personal-account install; classrooms need an org.
+ * - **account-mismatch** — the login we asked about now belongs to a DIFFERENT
+ *   account (org renamed, name recycled). Adopting that installation would
+ *   hand one customer's org to another.
+ * - **wrong-app** — an installation of some other GitHub App, or of this app in
+ *   another environment. Staging holds production-cloned rows, so this is real.
+ * - **suspended** — installed but suspended; the token mint would fail anyway,
+ *   and storing the id would make the UI claim it is connected.
+ *
+ * `app_slug` is only compared when `GITHUB_APP_NAME` is configured — it is the
+ * slug the install URL is built from, and an environment that never set it must
+ * not have every installation rejected. The comparison is trimmed and
+ * case-folded: GitHub slugs are lowercase, but the env var is hand-entered and
+ * a stray capital or trailing space must not disconnect every org.
+ *
+ * @param {InstallationLike} installation - The installation as GitHub returned it.
+ * @param {{ providerId: string }} expected - The org we believe it belongs to.
+ * @returns {InstallationValidation} ok + the synced shape, or the refusal reason.
+ */
+export const validateInstallationIdentity = (
+  installation: InstallationLike,
+  expected: { providerId: string }
+): InstallationValidation => {
+  const account = installation.account;
+
+  if (!account || account.type !== 'Organization' || !account.login) {
+    return { ok: false, reason: 'not-organization' };
+  }
+
+  if (String(account.id) !== String(expected.providerId)) {
+    return { ok: false, reason: 'account-mismatch' };
+  }
+
+  const expectedAppId = process.env.GITHUB_APP_ID;
+  if (expectedAppId && String(installation.app_id) !== String(expectedAppId)) {
+    return { ok: false, reason: 'wrong-app' };
+  }
+
+  const expectedAppSlug = process.env.GITHUB_APP_NAME?.trim().toLowerCase();
+  if (expectedAppSlug && installation.app_slug?.trim().toLowerCase() !== expectedAppSlug) {
+    return { ok: false, reason: 'wrong-app' };
+  }
+
+  if (installation.suspended_at) {
+    return { ok: false, reason: 'suspended' };
+  }
+
+  return {
+    ok: true,
+    synced: {
+      provider_id: String(account.id),
+      login: account.login,
+      github_installation_id: String(installation.id),
+      avatar_url: account.avatar_url ?? '',
+    },
+  };
+};
+
+/**
+ * Read a rate-limit refusal out of an Octokit error.
+ *
+ * GitHub answers a primary limit with 403 + `x-ratelimit-remaining: 0` and a
+ * secondary limit with 403/429 + `retry-after`. Neither is "not found", so
+ * neither may be swallowed by the 404 fallback path.
+ *
+ * @param {unknown} error - The thrown Octokit error.
+ * @returns {number|null} seconds to wait, or null if this isn't a rate limit.
+ */
+const rateLimitRetryAfterSeconds = (error: unknown): number | null => {
+  const err = error as {
+    status?: number;
+    response?: { headers?: Record<string, string | number | undefined> };
+  };
+
+  if (err?.status !== 403 && err?.status !== 429) return null;
+
+  const headers = err.response?.headers ?? {};
+  const retryAfter = Number(headers['retry-after']);
+  if (Number.isFinite(retryAfter) && retryAfter > 0) return Math.ceil(retryAfter);
+
+  if (String(headers['x-ratelimit-remaining']) === '0') {
+    const reset = Number(headers['x-ratelimit-reset']);
+    if (Number.isFinite(reset) && reset > 0) {
+      return Math.max(1, Math.ceil(reset - Date.now() / 1000));
+    }
+    return 60;
+  }
+
+  return null;
+};
+
+/** Rethrow a rate limit as the typed error; leave everything else alone. */
+const rethrowIfRateLimited = (error: unknown): void => {
+  const retryAfterSeconds = rateLimitRetryAfterSeconds(error);
+  if (retryAfterSeconds !== null) {
+    throw new GitHubRateLimitedError(retryAfterSeconds);
+  }
+};
+
+/**
+ * Every installation of this app, paginated.
+ *
+ * Split out so a sweep can read it ONCE and hand the same list to every org it
+ * repairs — the scan is the expensive half of a lookup, and doing it per org is
+ * how a 45-org run spends the app's whole hourly budget. A throttle here comes
+ * back as `GitHubRateLimitedError` like every other lookup failure, so a caller
+ * can stop rather than mistake it for "nothing installed".
+ *
+ * @param {Octokit} appOctokit - App-JWT Octokit (`GitHubProvider.getAppOctokit`).
+ * @returns {Promise<InstallationLike[]>}
+ * @throws {GitHubRateLimitedError} when GitHub is throttling us.
+ */
+export const listAppInstallations = async (appOctokit: Octokit): Promise<InstallationLike[]> => {
+  try {
+    return (await appOctokit.paginate(appOctokit.rest.apps.listInstallations, {
+      per_page: 100,
+    })) as unknown as InstallationLike[];
+  } catch (error: unknown) {
+    rethrowIfRateLimited(error);
+    throw error;
+  }
+};
+
+export type InstallationLookup =
+  | { status: 'found'; installation: InstallationLike; synced: SyncedInstallation }
+  | { status: 'not-installed' }
+  | { status: 'login-moved' }
+  | { status: 'suspended' }
+  | { status: 'wrong-app' };
+
+/**
+ * Find the live installation for an org we already have a row for.
+ *
+ * Two lookups, in this order, because they fail in opposite directions:
+ *
+ * 1. `GET /orgs/{login}/installation` — one cheap request, but keyed on a LOGIN,
+ *    which is not stable. If the account behind that login is no longer ours,
+ *    the answer is discarded, never adopted.
+ * 2. `GET /app/installations` — keyed on the account id, which is stable, but
+ *    costs a full paginated scan. It is the only thing that finds an org that
+ *    was renamed out from under us.
+ *
+ * "Not installed" is therefore only ever concluded after the id scan came up
+ * empty; a 404 on the login alone proves nothing.
+ *
+ * A caller sweeping MANY orgs passes `installations` — one preloaded
+ * `GET /app/installations` shared across the whole run — so step 2 costs one
+ * paginated scan for the sweep instead of one per org.
+ *
+ * @param {Octokit} appOctokit - App-JWT Octokit (`GitHubProvider.getAppOctokit`).
+ * @param {{ provider_id: string; login: string }} org - The stored org row.
+ * @param {Object} [opts]
+ * @param {InstallationLike[]} [opts.installations] - Preloaded `GET /app/installations`.
+ * @returns {Promise<InstallationLookup>}
+ * @throws {GitHubRateLimitedError} when GitHub is throttling us.
+ */
+export const lookupInstallationForOrg = async (
+  appOctokit: Octokit,
+  org: { provider_id: string; login: string },
+  opts: { installations?: InstallationLike[] } = {}
+): Promise<InstallationLookup> => {
+  /** The login resolved, but to somebody else's account. */
+  let loginMoved = false;
+  /** The login resolved to us, but the installation was unusable. */
+  let byLoginRefusal: 'suspended' | 'wrong-app' | null = null;
+
+  try {
+    const { data } = await appOctokit.rest.apps.getOrgInstallation({ org: org.login });
+    const validation = validateInstallationIdentity(data as InstallationLike, {
+      providerId: org.provider_id,
+    });
+
+    if (validation.ok) {
+      return { status: 'found', installation: data as InstallationLike, synced: validation.synced };
+    }
+
+    if (validation.reason === 'account-mismatch') loginMoved = true;
+    else if (validation.reason === 'suspended') byLoginRefusal = 'suspended';
+    else if (validation.reason === 'wrong-app') byLoginRefusal = 'wrong-app';
+  } catch (error: unknown) {
+    rethrowIfRateLimited(error);
+    if ((error as { status?: number })?.status !== 404) throw error;
+  }
+
+  const installations = opts.installations ?? (await listAppInstallations(appOctokit));
+
+  const match = installations.find(
+    inst => inst.account && String(inst.account.id) === String(org.provider_id)
+  );
+
+  if (match) {
+    const validation = validateInstallationIdentity(match, { providerId: org.provider_id });
+    if (validation.ok) {
+      return { status: 'found', installation: match, synced: validation.synced };
+    }
+    if (validation.reason === 'suspended') return { status: 'suspended' };
+    if (validation.reason === 'wrong-app') return { status: 'wrong-app' };
+    return { status: 'not-installed' };
+  }
+
+  // The login answered for an account that is not ours AND no installation
+  // anywhere carries our account id — the org itself moved or was renamed.
+  if (loginMoved) return { status: 'login-moved' };
+  if (byLoginRefusal) return { status: byLoginRefusal };
+
+  return { status: 'not-installed' };
+};
+
+/**
+ * Claim an installation id for an org, but only while the column is still NULL.
+ *
+ * A conditional `updateMany` rather than an `update`: the repair path races the
+ * `installation.created` webhook and any other tab the instructor has open, and
+ * whoever writes second must not be able to overwrite a good id with a stale
+ * one. `provider` and `provider_id` are in the WHERE for the same reason — the
+ * id we found was found FOR that account, and must not land on a row that has
+ * since been repointed.
+ *
+ * Never creates a row: repair fixes orgs we already know about.
+ *
+ * @param {Object} params
+ * @param {string} params.orgId - GitOrganization UUID.
+ * @param {string} params.providerId - The GitHub org account id we validated against.
+ * @param {string} params.installationId - The installation id to store.
+ * @param {string} params.login - The login GitHub reports now (may have changed).
+ * @returns {Promise<{claimed: true} | {claimed: false, current: GitOrganization|null}>}
+ */
+export const claimInstallationIfNull = async ({
+  orgId,
+  providerId,
+  installationId,
+  login,
+}: {
+  orgId: string;
+  providerId: string;
+  installationId: string;
+  login: string;
+}): Promise<{ claimed: true } | { claimed: false; current: GitOrganization | null }> => {
+  const { count } = await getPrisma().gitOrganization.updateMany({
+    where: {
+      id: orgId,
+      provider: 'GITHUB',
+      provider_id: providerId,
+      github_installation_id: null,
+    },
+    data: {
+      github_installation_id: installationId,
+      login,
+    },
+  });
+
+  if (count > 0) return { claimed: true };
+
+  const current = await getPrisma().gitOrganization.findUnique({ where: { id: orgId } });
+  return { claimed: false, current };
+};
+
+/**
+ * Clear an installation id, but only where it is still THAT installation.
+ *
+ * The uninstall webhook used to clear by account id alone, so a stale or
+ * replayed `installation.deleted` could wipe the id a later reinstall had
+ * already written — which is half of why 45 orgs are disconnected. Matching the
+ * id makes the clear idempotent and makes a late delivery a no-op.
+ *
+ * @param {Object} params
+ * @param {string} params.providerId - The GitHub org account id from the payload.
+ * @param {string} params.installationId - The installation being uninstalled.
+ * @returns {Promise<number>} rows cleared (0 when the delivery was stale).
+ */
+export const clearInstallationIfMatches = async ({
+  providerId,
+  installationId,
+}: {
+  providerId: string;
+  installationId: string;
+}): Promise<number> => {
+  const { count } = await getPrisma().gitOrganization.updateMany({
+    where: {
+      provider: 'GITHUB',
+      provider_id: providerId,
+      github_installation_id: installationId,
+    },
+    data: {
+      github_installation_id: null,
+    },
+  });
+
+  return count;
+};
+
+export type RepairInstallationResult =
+  | { status: 'connected'; org: GitOrganization }
+  | { status: 'already-connected'; org: GitOrganization | null }
+  | { status: 'not-installed' }
+  | { status: 'login-moved' }
+  | { status: 'suspended' }
+  | { status: 'wrong-app' }
+  | { status: 'not-github' }
+  | { status: 'not-found' }
+  | { status: 'rate-limited'; retryAfterSeconds: number }
+  | { status: 'error'; message: string };
+
+/**
+ * How long one org must wait between GitHub lookups, in ms.
+ *
+ * Per process, not per user: the "Check again" button, the create-classroom
+ * guard and the operator task all land here, and a frustrated instructor
+ * clicking repeatedly must not spend the app's whole rate-limit budget.
+ */
+const REPAIR_COOLDOWN_MS = 15_000;
+
+/** orgId → timestamp (ms) before which another GitHub lookup is refused. */
+const repairCooldowns = new Map<string, number>();
+/** orgId → the lookup already running, so concurrent callers share one result. */
+const repairInFlight = new Map<string, Promise<RepairInstallationResult>>();
+
+/**
+ * Forget cooldown stamps that have already run out.
+ *
+ * An expired entry is indistinguishable from an absent one, so keeping it only
+ * grows the map — one dead key per org this process was ever asked about, for
+ * the life of the process. Swept on the way into every `repairInstallation`,
+ * which keeps the map to the orgs asked about in the last 15 seconds.
+ */
+const pruneExpiredCooldowns = (now: number): void => {
+  for (const [id, until] of repairCooldowns) {
+    if (until <= now) repairCooldowns.delete(id);
+  }
+};
+
+/** `login` is omitted rather than printed as a placeholder when unknown. */
+const logRepair = (orgId: string, login: string | null, status: string): void => {
+  console.log(`[git-org-repair] org=${orgId}${login ? ` login=${login}` : ''} status=${status}`);
+};
+
+/**
+ * Options shared by `repairInstallation` and the sweep that drives it.
+ */
+export interface RepairInstallationOptions {
+  /**
+   * Reuse this app-JWT Octokit instead of minting one. A sweep mints one per
+   * RUN; without this every org would build a fresh JWT client.
+   */
+  appOctokit?: Octokit;
+  /**
+   * A preloaded `GET /app/installations`, shared across a sweep so the
+   * account-id fallback scan happens once rather than once per org.
+   */
+  installations?: InstallationLike[];
+  /**
+   * Skip the local 15 s per-org cooldown. For the operator sweep, which asks
+   * about each org exactly once per run and must not be aborted mid-sweep
+   * because an earlier run (or the instructor's own button) touched the same
+   * org. In-flight sharing still applies — this never doubles a live request.
+   */
+  bypassCooldown?: boolean;
+}
+
+/**
+ * The lookup-and-claim itself. Wrapped by `repairInstallation`, which owns the
+ * cooldown and the in-flight sharing.
+ */
+const performRepair = async (
+  orgId: string,
+  opts: RepairInstallationOptions
+): Promise<RepairInstallationResult> => {
+  let login: string | null = null;
+
+  try {
+    const org = await getPrisma().gitOrganization.findUnique({ where: { id: orgId } });
+
+    if (!org) {
+      logRepair(orgId, login, 'not-found');
+      return { status: 'not-found' };
+    }
+
+    login = org.login;
+
+    if (org.provider !== 'GITHUB') {
+      logRepair(orgId, login, 'not-github');
+      return { status: 'not-github' };
+    }
+
+    if (org.github_installation_id) {
+      logRepair(orgId, login, 'already-connected');
+      return { status: 'already-connected', org };
+    }
+
+    // Stamped BEFORE the network call so a second caller arriving mid-flight is
+    // turned away by the cooldown (or joined to the in-flight promise) rather
+    // than let through — and stamped AGAIN once GitHub answers, so the 15 s is
+    // measured from completion. A lookup that itself took 14 s would otherwise
+    // leave a window with a second left on it. A FOUND installation clears the
+    // stamp instead: the row is about to hold an id, so the next call answers
+    // `already-connected` from the database without touching GitHub.
+    let lookup: InstallationLookup;
+    let found = false;
+    try {
+      repairCooldowns.set(orgId, Date.now() + REPAIR_COOLDOWN_MS);
+      lookup = await lookupInstallationForOrg(
+        opts.appOctokit ?? GitHubProvider.getAppOctokit(),
+        org,
+        {
+          installations: opts.installations,
+        }
+      );
+      found = lookup.status === 'found';
+    } finally {
+      if (found) {
+        repairCooldowns.delete(orgId);
+      } else {
+        repairCooldowns.set(orgId, Date.now() + REPAIR_COOLDOWN_MS);
+      }
+    }
+
+    if (lookup.status !== 'found') {
+      logRepair(orgId, login, lookup.status);
+      return { status: lookup.status };
+    }
+
+    const claim = await claimInstallationIfNull({
+      orgId,
+      providerId: org.provider_id,
+      installationId: lookup.synced.github_installation_id,
+      login: lookup.synced.login,
+    });
+
+    if (!claim.claimed) {
+      // Somebody (the webhook, another tab) filled the column first. Their id
+      // came from the same validation, so it stands.
+      logRepair(orgId, login, 'already-connected');
+      return { status: 'already-connected', org: claim.current };
+    }
+
+    const fresh = await getPrisma().gitOrganization.findUnique({ where: { id: orgId } });
+    logRepair(orgId, login, 'connected');
+    return fresh
+      ? { status: 'connected', org: fresh }
+      : { status: 'error', message: 'Organization disappeared while connecting' };
+  } catch (error: unknown) {
+    if (error instanceof GitHubRateLimitedError) {
+      logRepair(orgId, login, 'rate-limited');
+      return { status: 'rate-limited', retryAfterSeconds: error.retryAfterSeconds };
+    }
+
+    // Only ids, logins and GitHub's own message ever reach the log here — an
+    // Octokit failure's `message` is the API's text, never the credential.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[git-org-repair] org=${orgId}${login ? ` login=${login}` : ''} failed:`,
+      message
+    );
+    logRepair(orgId, login, 'error');
+    return { status: 'error', message };
+  }
+};
+
+/**
+ * Reconnect one GitOrganization to its GitHub App installation.
+ *
+ * The single entry point for every repair caller — the "Check again" button,
+ * the create-classroom guard, and the operator sweep task — so they cannot
+ * disagree about what counts as connected or spend the rate limit separately.
+ *
+ * Rate-limit protection is two layered mechanisms:
+ * - an in-flight map, so N simultaneous callers for one org make ONE request
+ *   and all receive the same answer;
+ * - a 15 s per-org cooldown, stamped before the request goes out and again when
+ *   it settles, so a caller arriving just after one finishes is told to wait
+ *   rather than asking again.
+ *
+ * The in-flight map is keyed by org alone, so a caller that joins somebody
+ * else's live lookup gets THAT lookup's answer — its own `opts` are not applied
+ * to a request already in the air.
+ *
+ * @param {string} orgId - GitOrganization UUID.
+ * @param {RepairInstallationOptions} [opts] - Sweep-friendly overrides.
+ * @returns {Promise<RepairInstallationResult>}
+ */
+export const repairInstallation = (
+  orgId: string,
+  opts: RepairInstallationOptions = {}
+): Promise<RepairInstallationResult> => {
+  const now = Date.now();
+  pruneExpiredCooldowns(now);
+
+  const inFlight = repairInFlight.get(orgId);
+  if (inFlight) return inFlight;
+
+  if (!opts.bypassCooldown) {
+    const until = repairCooldowns.get(orgId) ?? 0;
+    if (until > now) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((until - now) / 1000));
+      logRepair(orgId, null, 'rate-limited');
+      return Promise.resolve({ status: 'rate-limited', retryAfterSeconds });
+    }
+  }
+
+  const run = performRepair(orgId, opts).finally(() => {
+    repairInFlight.delete(orgId);
+  });
+  repairInFlight.set(orgId, run);
+  return run;
+};
+
+/**
+ * Drop the repair cooldown and in-flight state. Tests only — the maps are
+ * process-lifetime by design.
+ */
+export const __resetRepairThrottleForTests = (): void => {
+  repairCooldowns.clear();
+  repairInFlight.clear();
+};
+
+/**
+ * How many cooldown stamps are being held. Tests only — the point of the number
+ * is to prove expired entries are swept rather than accumulated.
+ */
+export const __repairCooldownCountForTests = (): number => repairCooldowns.size;

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -35,6 +35,26 @@ import * as subscriptionService from './subscription.service.ts';
 import * as entitlementService from './entitlement.service.ts';
 import * as instructorAudienceService from './instructorAudience.service.ts';
 export { ClassroomSettingsEntitlementError } from './classroom.service.ts';
+// Installation repair: the refusal every caller has to tell apart from "not
+// installed", plus the shapes its results come back in.
+export {
+  GitHubRateLimitedError,
+  validateInstallationIdentity,
+  lookupInstallationForOrg,
+  listAppInstallations,
+  claimInstallationIfNull,
+  clearInstallationIfMatches,
+  repairInstallation,
+} from './gitOrganization.service.ts';
+export type {
+  InstallationLike,
+  InstallationAccountLike,
+  InstallationRejection,
+  InstallationValidation,
+  InstallationLookup,
+  RepairInstallationResult,
+  RepairInstallationOptions,
+} from './gitOrganization.service.ts';
 import * as teamMembershipService from './teamMembership.service.ts';
 import * as teamService from './team.service.ts';
 import * as teamTagService from './teamTag.service.ts';

--- a/packages/services/src/git/GitHubProvider.ts
+++ b/packages/services/src/git/GitHubProvider.ts
@@ -18,6 +18,34 @@ const privateKey: string | null = process.env.GITHUB_PRIVATE_KEY_BASE64
   : null;
 
 /**
+ * An Octokit that REPORTS a rate limit instead of waiting one out.
+ *
+ * The `octokit` umbrella ships the throttling plugin pre-wired to retry once,
+ * and that retry is a `setTimeout` for however long GitHub asks for — on a
+ * primary limit that is time-until-reset, up to an hour. Every app-JWT caller
+ * here is either a web request or an operator sweep whose job is to say "try
+ * again in N seconds"; none of them may block for an hour, and a 403 slept
+ * through is a 403 the `GitHubRateLimitedError` detector never sees.
+ *
+ * Returning `false` from both hooks tells the plugin not to retry, so the
+ * original 403/429 — rate-limit headers intact — is thrown straight back.
+ *
+ * The retry plugin is the other sleeper: its default `doNotRetry` list skips
+ * 403 but not 429, so a secondary limit would still be retried three times
+ * (~14 s, four requests at the very limit complaining about volume) before
+ * surfacing. 429 is added to the list for the same reason.
+ */
+const ImmediateOctokit = Octokit.defaults({
+  throttle: {
+    onRateLimit: () => false,
+    onSecondaryRateLimit: () => false,
+  },
+  retry: {
+    doNotRetry: [400, 401, 403, 404, 422, 429, 451],
+  },
+});
+
+/**
  * Generate a GitHub App JWT for direct API authentication
  * Used for simple installation token requests without Octokit overhead
  * @returns {string} JWT token (valid for 10 minutes)
@@ -1745,12 +1773,21 @@ export class GitHubProvider extends GitProvider {
    * Get an app-authenticated (JWT) Octokit instance for app-level endpoints
    * such as `GET /app/installations/{installation_id}`. Not scoped to a single
    * installation — use the instance methods for installation-scoped calls.
+   *
+   * Throttling is DISABLED on this client: a rate limit is thrown immediately
+   * rather than slept off. See `ImmediateOctokit`.
    * @returns {Octokit}
    */
   static getAppOctokit(): Octokit {
     const app = new App({
       appId: process.env.GITHUB_APP_ID!,
       privateKey: privateKey!,
+      // A rate limit has to come back as an error, not as an hour-long sleep —
+      // see `ImmediateOctokit`. Every caller of this (the repair lookup, the
+      // installation webhooks, the post-install redirect) turns a throttle into
+      // a "try again in N seconds" answer, which it cannot do if the throttling
+      // plugin swallowed the 403 first.
+      Octokit: ImmediateOctokit,
     });
     return app.octokit;
   }

--- a/packages/services/src/git/__tests__/GitHubProvider.getAppOctokit.test.ts
+++ b/packages/services/src/git/__tests__/GitHubProvider.getAppOctokit.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The app-JWT client must REPORT a rate limit, not wait one out.
+ *
+ * `octokit`'s umbrella client ships the throttling plugin pre-wired to retry
+ * once, and its retry is a `setTimeout` for however long GitHub asks — for a
+ * primary limit that is time-until-reset, up to an hour. Every caller of
+ * `getAppOctokit` (the installation repair lookup, the installation webhooks,
+ * the post-install redirect) is supposed to turn a throttle into "try again in
+ * N seconds", and none of them can do that from inside an hour-long sleep.
+ *
+ * This drives the REAL client — a real JWT, a real request pipeline — against a
+ * stub `fetch`, because the bug being guarded lives in the plugin wiring rather
+ * than in any of our own code, and only a real client exercises it.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+
+const { privateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+// The module reads both of these once, at import time.
+process.env.GITHUB_APP_ID = '424242';
+process.env.GITHUB_PRIVATE_KEY_BASE64 = Buffer.from(privateKey).toString('base64');
+
+let GitHubProvider: typeof import('../GitHubProvider.ts').GitHubProvider;
+
+beforeAll(async () => {
+  ({ GitHubProvider } = await import('../GitHubProvider.ts'));
+});
+
+// Octokit's own plugins narrate rate limits through `console`, and that output
+// lands after the assertion has already passed — enough to race the worker's
+// teardown and fail the whole run. Swallow it; the assertions here are about
+// what the client DOES, not what it says.
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** A primary rate limit: 403, nothing left, and an hour until it resets. */
+const rateLimitedFetch = (resetEpochSeconds: number) =>
+  vi.fn(
+    async () =>
+      new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+        status: 403,
+        headers: {
+          'content-type': 'application/json',
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(resetEpochSeconds),
+        },
+      })
+  );
+
+describe('GitHubProvider.getAppOctokit', () => {
+  it('throws a 403 rate limit straight through instead of retrying after the reset', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 3600;
+    const fetch = rateLimitedFetch(reset);
+    const octokit = GitHubProvider.getAppOctokit();
+
+    const startedAt = Date.now();
+    await expect(
+      octokit.request('GET /app/installations', { request: { fetch } })
+    ).rejects.toMatchObject({ status: 403 });
+    const elapsed = Date.now() - startedAt;
+
+    // ONE attempt. With the umbrella's default throttling the plugin would
+    // answer this 403 by scheduling a second attempt for the reset — an hour
+    // away — and this expectation is what catches that wiring coming back.
+    // (Fake timers cannot stand in here: the plugin schedules through
+    // Bottleneck, which never fires on a faked clock.)
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it('keeps the rate-limit headers on the error so the retry-after is readable', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 90;
+    const fetch = rateLimitedFetch(reset);
+    const octokit = GitHubProvider.getAppOctokit();
+
+    const error = await octokit
+      .request('GET /app/installations', { request: { fetch } })
+      .then(() => null)
+      .catch((e: unknown) => e as { response?: { headers?: Record<string, string> } });
+
+    expect(error?.response?.headers?.['x-ratelimit-remaining']).toBe('0');
+    expect(error?.response?.headers?.['x-ratelimit-reset']).toBe(String(reset));
+  });
+
+  it('throws a 429 secondary limit straight through instead of retrying with backoff', async () => {
+    // The retry plugin's default doNotRetry list skips 403 but not 429, so
+    // without the override this would take four attempts and ~14 s.
+    const fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ message: 'You have exceeded a secondary rate limit' }), {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '60' },
+        })
+    );
+    const octokit = GitHubProvider.getAppOctokit();
+
+    const startedAt = Date.now();
+    const error = await octokit
+      .request('GET /app/installations', { request: { fetch } })
+      .then(() => null)
+      .catch(
+        (e: unknown) => e as { status?: number; response?: { headers?: Record<string, string> } }
+      );
+    const elapsed = Date.now() - startedAt;
+
+    expect(error?.status).toBe(429);
+    expect(error?.response?.headers?.['retry-after']).toBe('60');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -52,6 +52,27 @@ export {
 
 export { ClassmojiService, HelperService, StripeService, FlyCertService, MarkdownImporter };
 
+// GitHub App installation repair, shared by the "Check again" action, the
+// create-classroom guard, the uninstall webhook and the operator sweep task.
+export {
+  GitHubRateLimitedError,
+  validateInstallationIdentity,
+  lookupInstallationForOrg,
+  listAppInstallations,
+  claimInstallationIfNull,
+  clearInstallationIfMatches,
+  repairInstallation,
+} from './classmoji/gitOrganization.service.ts';
+export type {
+  InstallationLike,
+  InstallationAccountLike,
+  InstallationRejection,
+  InstallationValidation,
+  InstallationLookup,
+  RepairInstallationResult,
+  RepairInstallationOptions,
+} from './classmoji/gitOrganization.service.ts';
+
 // Admin service result/error shapes shared by the web routes and the MCP tools.
 export { StaffServiceError } from './classmoji/staff.service.ts';
 export type { AddStaffResult, RemoveStaffResult, StaffRole } from './classmoji/staff.service.ts';

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -5,6 +5,7 @@ import * as autogradeTasks from './workflows/autograde.ts';
 import * as emailTasks from './workflows/email.ts';
 import * as extensionTasks from './workflows/extension.ts';
 import * as installationTasks from './workflows/installation.ts';
+import * as gitOrgInstallationRepairTasks from './workflows/gitOrgInstallationRepair.ts';
 import * as tokenTasks from './workflows/token.ts';
 import * as contributionTasks from './workflows/contribution.ts';
 import * as repoAnalyticsTasks from './workflows/repoAnalytics.ts';
@@ -26,6 +27,7 @@ const Tasks = {
   ...emailTasks,
   ...extensionTasks,
   ...installationTasks,
+  ...gitOrgInstallationRepairTasks,
   ...tokenTasks,
   ...contributionTasks,
   ...repoAnalyticsTasks,

--- a/packages/tasks/src/workflows/__tests__/gitOrgInstallationRepair.test.ts
+++ b/packages/tasks/src/workflows/__tests__/gitOrgInstallationRepair.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Unit tests for the operator installation-repair sweep.
+ *
+ * The task's whole job is to be safe to point at production, so what is tested
+ * is the safety, not the happy path:
+ *
+ *  - the default payload must WRITE NOTHING — a dry run reads through
+ *    `lookupInstallationForOrg` and never reaches `repairInstallation`;
+ *  - an applying run must go through `repairInstallation` for every org, so the
+ *    write is the same conditional claim the UI button uses and never a raw
+ *    update from this task;
+ *  - a rate limit must STOP the sweep and hand back what it already learned,
+ *    rather than marching through the remaining orgs turning one throttle into
+ *    45 false "not installed" verdicts;
+ *  - the scan must never pick up an example-course org or an org outside an
+ *    explicitly requested subset;
+ *  - the payload must be validated STRICTLY, because the safe default and the
+ *    dangerous mode are one key apart and `{ "limt": 5 }` would otherwise be an
+ *    applying sweep of everything;
+ *  - the GitHub budget must be spent once per RUN, not once per org: one app
+ *    client, one `GET /app/installations`.
+ *
+ * Prisma is mocked; the two service entry points are mocked so each test can
+ * choose an outcome, but `GitHubRateLimitedError` is the REAL class, because
+ * the stop-early branch turns on `instanceof`.
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findManyOrgs: vi.fn(),
+  findManyMemberships: vi.fn(),
+  lookupInstallationForOrg: vi.fn(),
+  listAppInstallations: vi.fn(),
+  repairInstallation: vi.fn(),
+  getAppOctokit: vi.fn(),
+}));
+
+interface SchemaTaskConfig {
+  schema: (payload: unknown) => unknown;
+  run: (payload: never) => unknown;
+  [key: string]: unknown;
+}
+
+// `task()`/`schemaTask()` normally return a trigger handle; return the config so
+// the test can call `run` directly. `schemaTask` keeps the real contract — the
+// schema runs BEFORE `run` — so a rejected payload is rejected here too.
+vi.mock('@trigger.dev/sdk', () => ({
+  task: (config: unknown) => config,
+  schemaTask: (config: SchemaTaskConfig) => ({
+    ...config,
+    run: async (payload: unknown) => config.run(config.schema(payload) as never),
+  }),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    gitOrganization: { findMany: (...a: unknown[]) => mocks.findManyOrgs(...a) },
+    classroomMembership: { findMany: (...a: unknown[]) => mocks.findManyMemberships(...a) },
+  }),
+}));
+
+vi.mock('@classmoji/services', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    GitHubProvider: { getAppOctokit: (...a: unknown[]) => mocks.getAppOctokit(...a) },
+    lookupInstallationForOrg: (...a: unknown[]) => mocks.lookupInstallationForOrg(...a),
+    listAppInstallations: (...a: unknown[]) => mocks.listAppInstallations(...a),
+    repairInstallation: (...a: unknown[]) => mocks.repairInstallation(...a),
+  };
+});
+
+const { GitHubRateLimitedError } = await import('@classmoji/services');
+const { gitOrgInstallationRepairTask } = await import('../gitOrgInstallationRepair.ts');
+
+interface RepairReport {
+  dryRun: boolean;
+  candidates: number;
+  scanned: number;
+  results: Array<{
+    orgId: string;
+    login: string;
+    classrooms: number;
+    owners: number;
+    outcome: string;
+    installationId?: string;
+    message?: string;
+  }>;
+  summary: { byOutcome: Record<string, number> };
+  unmatchedOrgIds: string[];
+  stoppedEarly?: boolean;
+  retryAfterSeconds?: number;
+}
+
+/** The single app client and single installation list a run is allowed. */
+const APP_OCTOKIT = { rest: {} };
+const INSTALLATIONS = [{ id: 55501 }];
+
+const runTask = (payload: unknown = {}): Promise<RepairReport> =>
+  (
+    gitOrgInstallationRepairTask as unknown as {
+      run: (payload: unknown) => Promise<RepairReport>;
+    }
+  ).run(payload);
+
+/** An org row as the task's `select` shapes it. */
+const orgRow = (n: number, classroomIds: string[] = [`c${n}`]) => ({
+  id: `org-${n}`,
+  login: `org${n}`,
+  provider_id: `${9000 + n}`,
+  classrooms: classroomIds.map(id => ({ id })),
+});
+
+const foundLookup = (installationId: string) => ({
+  status: 'found' as const,
+  installation: { id: installationId },
+  synced: {
+    provider_id: '9001',
+    login: 'org1',
+    github_installation_id: installationId,
+    avatar_url: '',
+  },
+});
+
+beforeEach(() => {
+  mocks.findManyOrgs.mockReset().mockResolvedValue([]);
+  mocks.findManyMemberships.mockReset().mockResolvedValue([]);
+  mocks.lookupInstallationForOrg.mockReset();
+  mocks.listAppInstallations.mockReset().mockResolvedValue(INSTALLATIONS);
+  mocks.repairInstallation.mockReset();
+  mocks.getAppOctokit.mockReset().mockReturnValue(APP_OCTOKIT);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('scan query', () => {
+  it('asks only for GitHub orgs with a null id and a non-example classroom', async () => {
+    await runTask();
+
+    expect(mocks.findManyOrgs).toHaveBeenCalledTimes(1);
+    expect(mocks.findManyOrgs.mock.calls[0][0]).toMatchObject({
+      where: {
+        provider: 'GITHUB',
+        github_installation_id: null,
+        classrooms: { some: { is_example: false } },
+      },
+      orderBy: { login: 'asc' },
+    });
+    // No `id: { in: … }` unless a subset was asked for.
+    expect(mocks.findManyOrgs.mock.calls[0][0].where).not.toHaveProperty('id');
+  });
+
+  it('counts only non-example classrooms per org', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1, ['c1', 'c2'])]);
+    mocks.lookupInstallationForOrg.mockResolvedValue({ status: 'not-installed' });
+
+    const report = await runTask();
+
+    expect(mocks.findManyOrgs.mock.calls[0][0].select.classrooms).toMatchObject({
+      where: { is_example: false },
+    });
+    expect(report.results[0].classrooms).toBe(2);
+  });
+
+  it('restricts the scan to an explicit orgIds subset', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(2)]);
+    mocks.lookupInstallationForOrg.mockResolvedValue({ status: 'not-installed' });
+
+    const report = await runTask({ orgIds: ['org-2'] });
+
+    expect(mocks.findManyOrgs.mock.calls[0][0].where).toMatchObject({
+      id: { in: ['org-2'] },
+      provider: 'GITHUB',
+      github_installation_id: null,
+      classrooms: { some: { is_example: false } },
+    });
+    expect(report.results.map(r => r.orgId)).toEqual(['org-2']);
+  });
+
+  it('passes a limit through as `take`', async () => {
+    await runTask({ limit: 5 });
+
+    expect(mocks.findManyOrgs.mock.calls[0][0].take).toBe(5);
+  });
+
+  it('reports the number of distinct OWNERs per org', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1, ['c1', 'c2'])]);
+    // One person owning two classrooms is ONE person to contact.
+    mocks.findManyMemberships.mockResolvedValue([
+      { user_id: 'u1', classroom_id: 'c1' },
+      { user_id: 'u1', classroom_id: 'c2' },
+      { user_id: 'u2', classroom_id: 'c2' },
+    ]);
+    mocks.lookupInstallationForOrg.mockResolvedValue({ status: 'not-installed' });
+
+    const report = await runTask();
+
+    expect(mocks.findManyMemberships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { classroom_id: { in: ['c1', 'c2'] }, role: 'OWNER' },
+      })
+    );
+    expect(report.results[0].owners).toBe(2);
+  });
+
+  it('skips the membership query entirely when nothing matched', async () => {
+    const report = await runTask();
+
+    expect(mocks.findManyMemberships).not.toHaveBeenCalled();
+    expect(report).toMatchObject({ dryRun: true, scanned: 0, results: [] });
+  });
+});
+
+describe('dry run (the default)', () => {
+  it('writes nothing and reports what it would have done', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2)]);
+    mocks.lookupInstallationForOrg
+      .mockResolvedValueOnce(foundLookup('55501'))
+      .mockResolvedValueOnce({ status: 'not-installed' });
+
+    const report = await runTask();
+
+    expect(report.dryRun).toBe(true);
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+    expect(mocks.lookupInstallationForOrg).toHaveBeenCalledTimes(2);
+    expect(report.results).toEqual([
+      {
+        orgId: 'org-1',
+        login: 'org1',
+        classrooms: 1,
+        owners: 0,
+        outcome: 'would-connect',
+        installationId: '55501',
+      },
+      { orgId: 'org-2', login: 'org2', classrooms: 1, owners: 0, outcome: 'not-installed' },
+    ]);
+    expect(report.summary.byOutcome).toEqual({ 'would-connect': 1, 'not-installed': 1 });
+  });
+
+  it('treats an explicit dryRun:true the same as the default', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1)]);
+    mocks.lookupInstallationForOrg.mockResolvedValue(foundLookup('55501'));
+
+    const report = await runTask({ dryRun: true });
+
+    expect(report.dryRun).toBe(true);
+    expect(mocks.repairInstallation).not.toHaveBeenCalled();
+  });
+
+  it('records a lookup failure as `error` and keeps going', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2)]);
+    mocks.lookupInstallationForOrg
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ status: 'not-installed' });
+
+    const report = await runTask();
+
+    expect(report.results.map(r => r.outcome)).toEqual(['error', 'not-installed']);
+    expect(report.stoppedEarly).toBeUndefined();
+  });
+});
+
+describe('applying run', () => {
+  it('goes through repairInstallation once per org', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2)]);
+    mocks.repairInstallation
+      .mockResolvedValueOnce({
+        status: 'connected',
+        org: { github_installation_id: '55501' },
+      })
+      .mockResolvedValueOnce({ status: 'not-installed' });
+
+    const report = await runTask({ dryRun: false });
+
+    expect(report.dryRun).toBe(false);
+    expect(mocks.lookupInstallationForOrg).not.toHaveBeenCalled();
+    expect(mocks.repairInstallation).toHaveBeenCalledTimes(2);
+    expect(mocks.repairInstallation).toHaveBeenNthCalledWith(1, 'org-1', {
+      appOctokit: APP_OCTOKIT,
+      installations: INSTALLATIONS,
+      bypassCooldown: true,
+    });
+    expect(mocks.repairInstallation).toHaveBeenNthCalledWith(2, 'org-2', {
+      appOctokit: APP_OCTOKIT,
+      installations: INSTALLATIONS,
+      bypassCooldown: true,
+    });
+    expect(report.results).toEqual([
+      {
+        orgId: 'org-1',
+        login: 'org1',
+        classrooms: 1,
+        owners: 0,
+        outcome: 'connected',
+        installationId: '55501',
+      },
+      { orgId: 'org-2', login: 'org2', classrooms: 1, owners: 0, outcome: 'not-installed' },
+    ]);
+  });
+
+  it('reports an org another writer had already connected', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1)]);
+    mocks.repairInstallation.mockResolvedValue({
+      status: 'already-connected',
+      org: { github_installation_id: '77701' },
+    });
+
+    const report = await runTask({ dryRun: false });
+
+    expect(report.results[0]).toMatchObject({
+      outcome: 'already-connected',
+      installationId: '77701',
+    });
+  });
+});
+
+describe('rate limiting', () => {
+  it('stops the dry run at the throttle and returns partial results', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2), orgRow(3)]);
+    mocks.lookupInstallationForOrg
+      .mockResolvedValueOnce({ status: 'not-installed' })
+      .mockRejectedValueOnce(new GitHubRateLimitedError(120));
+
+    const report = await runTask();
+
+    // The third org was never asked about.
+    expect(mocks.lookupInstallationForOrg).toHaveBeenCalledTimes(2);
+    expect(report.stoppedEarly).toBe(true);
+    expect(report.retryAfterSeconds).toBe(120);
+    expect(report.scanned).toBe(2);
+    expect(report.results.map(r => r.outcome)).toEqual(['not-installed', 'rate-limited']);
+    expect(report.results[1].login).toBe('org2');
+  });
+
+  it('stops an applying run when repairInstallation reports the throttle', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2), orgRow(3)]);
+    mocks.repairInstallation
+      .mockResolvedValueOnce({ status: 'connected', org: { github_installation_id: '55501' } })
+      .mockResolvedValueOnce({ status: 'rate-limited', retryAfterSeconds: 45 });
+
+    const report = await runTask({ dryRun: false });
+
+    expect(mocks.repairInstallation).toHaveBeenCalledTimes(2);
+    expect(report).toMatchObject({ stoppedEarly: true, retryAfterSeconds: 45, scanned: 2 });
+    expect(report.summary.byOutcome).toEqual({ connected: 1, 'rate-limited': 1 });
+  });
+});
+
+describe('payload validation', () => {
+  it('rejects an unknown key rather than running a full applying sweep', async () => {
+    // `{ "limt": 5 }` used to mean "no limit, dry run" — the typo silently
+    // becoming a different, larger run is exactly the failure this guards.
+    await expect(runTask({ limt: 5 })).rejects.toThrow(/unknown payload key/);
+    expect(mocks.findManyOrgs).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dryRun that is not a boolean', async () => {
+    // The JSON string "false" is truthy; letting it through would report a dry
+    // run while doing nothing, or worse.
+    await expect(runTask({ dryRun: 'false' })).rejects.toThrow(/dryRun must be a boolean/);
+    expect(mocks.findManyOrgs).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-positive limit and a non-string orgIds entry', async () => {
+    await expect(runTask({ limit: 0 })).rejects.toThrow(/limit must be a positive integer/);
+    await expect(runTask({ orgIds: ['ok', 7] })).rejects.toThrow(/orgIds must be an array/);
+  });
+
+  it('accepts an empty payload, and no payload at all, as a dry run', async () => {
+    await expect(runTask({})).resolves.toMatchObject({ dryRun: true });
+    await expect(runTask(undefined)).resolves.toMatchObject({ dryRun: true });
+  });
+});
+
+describe('GitHub budget', () => {
+  it('mints one app client and reads /app/installations once for a dry run', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2), orgRow(3)]);
+    mocks.lookupInstallationForOrg.mockResolvedValue({ status: 'not-installed' });
+
+    await runTask();
+
+    expect(mocks.getAppOctokit).toHaveBeenCalledTimes(1);
+    expect(mocks.listAppInstallations).toHaveBeenCalledTimes(1);
+    expect(mocks.listAppInstallations).toHaveBeenCalledWith(APP_OCTOKIT);
+    expect(mocks.lookupInstallationForOrg).toHaveBeenCalledTimes(3);
+    // Every org reads the SAME preloaded list — the paginated scan is the
+    // expensive half of a lookup, and 45 of them is the whole hourly budget.
+    for (const call of mocks.lookupInstallationForOrg.mock.calls) {
+      expect(call[0]).toBe(APP_OCTOKIT);
+      expect(call[2]).toEqual({ installations: INSTALLATIONS });
+    }
+  });
+
+  it('mints one app client and reads /app/installations once for an applying run', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2)]);
+    mocks.repairInstallation.mockResolvedValue({ status: 'not-installed' });
+
+    await runTask({ dryRun: false });
+
+    expect(mocks.getAppOctokit).toHaveBeenCalledTimes(1);
+    expect(mocks.listAppInstallations).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks GitHub nothing at all when the scan matched no orgs', async () => {
+    await runTask();
+
+    expect(mocks.getAppOctokit).not.toHaveBeenCalled();
+    expect(mocks.listAppInstallations).not.toHaveBeenCalled();
+  });
+
+  it('stops before touching any org when the preload is throttled', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1), orgRow(2)]);
+    mocks.listAppInstallations.mockRejectedValue(new GitHubRateLimitedError(300));
+
+    const report = await runTask();
+
+    expect(report).toMatchObject({
+      candidates: 2,
+      scanned: 0,
+      stoppedEarly: true,
+      retryAfterSeconds: 300,
+    });
+    expect(mocks.lookupInstallationForOrg).not.toHaveBeenCalled();
+  });
+});
+
+describe('report', () => {
+  it('counts candidates and names requested ids that matched nothing', async () => {
+    // An org already connected, or example-only, or simply absent, is not in
+    // the scan's result at all — the operator who named it needs telling.
+    mocks.findManyOrgs.mockResolvedValue([orgRow(2)]);
+    mocks.lookupInstallationForOrg.mockResolvedValue({ status: 'not-installed' });
+
+    const report = await runTask({ orgIds: ['org-2', 'org-404'] });
+
+    expect(report.candidates).toBe(1);
+    expect(report.unmatchedOrgIds).toEqual(['org-404']);
+  });
+
+  it('leaves unmatchedOrgIds empty when no subset was requested', async () => {
+    const report = await runTask();
+
+    expect(report.unmatchedOrgIds).toEqual([]);
+    expect(report.candidates).toBe(0);
+  });
+
+  it("carries repairInstallation's own message onto an error row", async () => {
+    // `repairInstallation` swallows unexpected failures into a status, so
+    // without its message the report says `error` and nothing else.
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1)]);
+    mocks.repairInstallation.mockResolvedValue({
+      status: 'error',
+      message: 'Organization disappeared while connecting',
+    });
+
+    const report = await runTask({ dryRun: false });
+
+    expect(report.results[0]).toMatchObject({
+      outcome: 'error',
+      message: 'Organization disappeared while connecting',
+    });
+  });
+
+  it('carries a thrown failure message onto an error row', async () => {
+    mocks.findManyOrgs.mockResolvedValue([orgRow(1)]);
+    mocks.lookupInstallationForOrg.mockRejectedValue(new Error('boom'));
+
+    const report = await runTask();
+
+    expect(report.results[0]).toMatchObject({ outcome: 'error', message: 'boom' });
+  });
+});

--- a/packages/tasks/src/workflows/__tests__/installation.test.ts
+++ b/packages/tasks/src/workflows/__tests__/installation.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for the four GitHub App installation webhooks.
+ *
+ * Both tasks write the column that decides whether a classroom can talk to
+ * GitHub at all, and both are fed by deliveries that GitHub retries, delays and
+ * replays. So the thing under test is not the happy path — it is what happens
+ * when the delivery is a lie:
+ *
+ *  - `created` for an installation that has since been removed (404) must write
+ *    nothing, or the org ends up pointing at an id that mints no token;
+ *  - `created` whose live account does not match the payload's must write
+ *    nothing, or one customer's org gets another's installation;
+ *  - `deleted` must only clear the installation it names, or a replayed
+ *    uninstall silently disconnects an org that has since reinstalled;
+ *  - `suspend` is an uninstall for our purposes — a suspended installation
+ *    mints no tokens — and has to be scoped the same way;
+ *  - `unsuspend` puts the id back, but only after re-reading live state, so a
+ *    replayed unsuspend for an installation since removed writes nothing.
+ *
+ * The GitHub call is stubbed at `GitHubProvider.getAppOctokit`; the identity
+ * validation and the conditional clear are the REAL implementations from
+ * `@classmoji/services`, running against a mocked Prisma client.
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  upsert: vi.fn(),
+  updateMany: vi.fn(),
+  getInstallation: vi.fn(),
+}));
+
+// `task()` normally returns a trigger handle; return the config so the test can
+// call `run` directly.
+vi.mock('@trigger.dev/sdk', () => ({
+  task: (config: unknown) => config,
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    gitOrganization: {
+      upsert: (...a: unknown[]) => mocks.upsert(...a),
+      updateMany: (...a: unknown[]) => mocks.updateMany(...a),
+    },
+  }),
+}));
+
+const { GitHubProvider } = await import('@classmoji/services');
+const {
+  newInstallationHandlerTask,
+  appUninstalledHandlerTask,
+  appSuspendedHandlerTask,
+  appUnsuspendedHandlerTask,
+} = await import('../installation.ts');
+
+const APP_ID = '424242';
+const APP_SLUG = 'classmoji-test';
+const ACCOUNT_ID = 9001;
+const INSTALLATION_ID = 55501;
+
+/** A live installation as `GET /app/installations/{id}` would return it. */
+const liveInstallation = (overrides: Record<string, unknown> = {}) => ({
+  id: INSTALLATION_ID,
+  app_id: Number(APP_ID),
+  app_slug: APP_SLUG,
+  suspended_at: null,
+  account: {
+    id: ACCOUNT_ID,
+    login: 'dartmouth-cs',
+    type: 'Organization',
+    avatar_url: 'https://avatars.example/1',
+  },
+  ...overrides,
+});
+
+const payload = () => ({
+  installation: {
+    id: INSTALLATION_ID,
+    account: { id: ACCOUNT_ID, login: 'dartmouth-cs' },
+  },
+});
+
+const runCreated = (p = payload()) =>
+  (
+    newInstallationHandlerTask as unknown as {
+      run: (payload: unknown) => Promise<{ success: boolean; skipped?: string }>;
+    }
+  ).run(p);
+
+const runDeleted = (p = payload()) =>
+  (
+    appUninstalledHandlerTask as unknown as {
+      run: (payload: unknown) => Promise<{ success: boolean; cleared: number }>;
+    }
+  ).run(p);
+
+const runSuspended = (p = payload()) =>
+  (
+    appSuspendedHandlerTask as unknown as {
+      run: (payload: unknown) => Promise<{ success: boolean; cleared: number }>;
+    }
+  ).run(p);
+
+const runUnsuspended = (p = payload()) =>
+  (
+    appUnsuspendedHandlerTask as unknown as {
+      run: (payload: unknown) => Promise<{ success: boolean; skipped?: string }>;
+    }
+  ).run(p);
+
+beforeEach(() => {
+  mocks.upsert.mockReset().mockResolvedValue({});
+  mocks.updateMany.mockReset().mockResolvedValue({ count: 0 });
+  mocks.getInstallation.mockReset();
+  process.env.GITHUB_APP_ID = APP_ID;
+  process.env.GITHUB_APP_NAME = APP_SLUG;
+  vi.spyOn(GitHubProvider, 'getAppOctokit').mockReturnValue({
+    rest: { apps: { getInstallation: mocks.getInstallation } },
+  } as never);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('newInstallationHandlerTask', () => {
+  it('writes the installation id when GitHub confirms it is live for this account', async () => {
+    mocks.getInstallation.mockResolvedValue({ data: liveInstallation() });
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.getInstallation).toHaveBeenCalledWith({ installation_id: INSTALLATION_ID });
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          provider_provider_id: { provider: 'GITHUB', provider_id: String(ACCOUNT_ID) },
+        },
+        update: {
+          github_installation_id: String(INSTALLATION_ID),
+          login: 'dartmouth-cs',
+        },
+        create: {
+          provider: 'GITHUB',
+          provider_id: String(ACCOUNT_ID),
+          login: 'dartmouth-cs',
+          github_installation_id: String(INSTALLATION_ID),
+        },
+      })
+    );
+  });
+
+  it('records the login GitHub reports now, not the one in the stale payload', async () => {
+    mocks.getInstallation.mockResolvedValue({
+      data: liveInstallation({
+        account: {
+          id: ACCOUNT_ID,
+          login: 'dartmouth-cs-renamed',
+          type: 'Organization',
+          avatar_url: '',
+        },
+      }),
+    });
+
+    await runCreated();
+
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ login: 'dartmouth-cs-renamed' }),
+      })
+    );
+  });
+
+  it('skips a stale delivery whose installation no longer exists (404)', async () => {
+    mocks.getInstallation.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }));
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true, skipped: 'stale' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips when the live installation belongs to a different account', async () => {
+    mocks.getInstallation.mockResolvedValue({
+      data: liveInstallation({
+        account: { id: 7777, login: 'someone-else', type: 'Organization', avatar_url: '' },
+      }),
+    });
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true, skipped: 'account-mismatch' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips a suspended installation', async () => {
+    mocks.getInstallation.mockResolvedValue({
+      data: liveInstallation({ suspended_at: '2026-09-01T00:00:00Z' }),
+    });
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true, skipped: 'suspended' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips a personal-account installation', async () => {
+    mocks.getInstallation.mockResolvedValue({
+      data: liveInstallation({
+        account: { id: ACCOUNT_ID, login: 'someuser', type: 'User', avatar_url: '' },
+      }),
+    });
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true, skipped: 'not-organization' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips an installation of a different GitHub App', async () => {
+    mocks.getInstallation.mockResolvedValue({ data: liveInstallation({ app_id: 999999 }) });
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true, skipped: 'wrong-app' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips an installation whose app slug is not ours', async () => {
+    mocks.getInstallation.mockResolvedValue({ data: liveInstallation({ app_slug: 'other-app' }) });
+
+    const result = await runCreated();
+
+    expect(result).toEqual({ success: true, skipped: 'wrong-app' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-404 GitHub failure so Trigger retries it', async () => {
+    mocks.getInstallation.mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+
+    await expect(runCreated()).rejects.toThrow('boom');
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('appUninstalledHandlerTask', () => {
+  it('clears only the row still holding THIS installation id', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await runDeleted();
+
+    expect(result).toEqual({ success: true, cleared: 1 });
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: {
+        provider: 'GITHUB',
+        provider_id: String(ACCOUNT_ID),
+        github_installation_id: String(INSTALLATION_ID),
+      },
+      data: { github_installation_id: null },
+    });
+  });
+
+  it('clears nothing when the org has since reinstalled under a new id', async () => {
+    // The WHERE no longer matches, so Prisma reports zero rows — the stale
+    // delivery is a no-op instead of disconnecting a working org.
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await runDeleted();
+
+    expect(result).toEqual({ success: true, cleared: 0 });
+  });
+});
+
+describe('appSuspendedHandlerTask', () => {
+  it('clears the id, scoped to the installation that was suspended', async () => {
+    // A suspended installation still exists but mints no tokens, so leaving the
+    // id in place would show the org as connected while every call fails.
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await runSuspended();
+
+    expect(result).toEqual({ success: true, cleared: 1 });
+    expect(mocks.updateMany).toHaveBeenCalledWith({
+      where: {
+        provider: 'GITHUB',
+        provider_id: String(ACCOUNT_ID),
+        github_installation_id: String(INSTALLATION_ID),
+      },
+      data: { github_installation_id: null },
+    });
+  });
+
+  it('clears nothing when the stored id has already moved on', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(runSuspended()).resolves.toEqual({ success: true, cleared: 0 });
+  });
+
+  it('never touches the org row directly', async () => {
+    mocks.updateMany.mockResolvedValue({ count: 1 });
+
+    await runSuspended();
+
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('appUnsuspendedHandlerTask', () => {
+  it('writes the id back once GitHub confirms the installation is live again', async () => {
+    mocks.getInstallation.mockResolvedValue({ data: liveInstallation() });
+
+    const result = await runUnsuspended();
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.getInstallation).toHaveBeenCalledWith({ installation_id: INSTALLATION_ID });
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          provider_provider_id: { provider: 'GITHUB', provider_id: String(ACCOUNT_ID) },
+        },
+        update: {
+          github_installation_id: String(INSTALLATION_ID),
+          login: 'dartmouth-cs',
+        },
+      })
+    );
+  });
+
+  it('writes nothing when the installation is still suspended', async () => {
+    // A replayed `unsuspend` for an installation that has since been suspended
+    // again would otherwise re-connect an org to an id that mints no token.
+    mocks.getInstallation.mockResolvedValue({
+      data: liveInstallation({ suspended_at: '2026-09-01T00:00:00Z' }),
+    });
+
+    const result = await runUnsuspended();
+
+    expect(result).toEqual({ success: true, skipped: 'suspended' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips a stale delivery whose installation no longer exists (404)', async () => {
+    mocks.getInstallation.mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 }));
+
+    const result = await runUnsuspended();
+
+    expect(result).toEqual({ success: true, skipped: 'stale' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('skips when the live installation belongs to a different account', async () => {
+    mocks.getInstallation.mockResolvedValue({
+      data: liveInstallation({
+        account: { id: 7777, login: 'someone-else', type: 'Organization', avatar_url: '' },
+      }),
+    });
+
+    const result = await runUnsuspended();
+
+    expect(result).toEqual({ success: true, skipped: 'account-mismatch' });
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a non-404 GitHub failure so Trigger retries it', async () => {
+    mocks.getInstallation.mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+
+    await expect(runUnsuspended()).rejects.toThrow('boom');
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tasks/src/workflows/gitOrgInstallationRepair.ts
+++ b/packages/tasks/src/workflows/gitOrgInstallationRepair.ts
@@ -1,0 +1,433 @@
+import { schemaTask, logger } from '@trigger.dev/sdk';
+import getPrisma from '@classmoji/database';
+import {
+  GitHubProvider,
+  GitHubRateLimitedError,
+  listAppInstallations,
+  lookupInstallationForOrg,
+  repairInstallation,
+} from '@classmoji/services';
+import type { InstallationLike } from '@classmoji/services';
+
+/**
+ * Operator sweep: reconnect GitOrganizations whose `github_installation_id` is
+ * NULL to the GitHub App installation they already have.
+ *
+ * ── HOW TO RUN ─────────────────────────────────────────────────────────────
+ * From the Trigger.dev dashboard (Tasks → `git-org-installation-repair` → Test)
+ * or locally with `npm run trigger:dev -w @classmoji/tasks` and the same Test
+ * panel. ALWAYS do a dry run first and read the report:
+ *
+ *   {}                                  // dry run — the default, writes nothing
+ *   { "dryRun": true, "limit": 5 }      // dry run, first 5 orgs by login
+ *   { "dryRun": true, "orgIds": ["…"] } // dry run, just these orgs
+ *   { "dryRun": false }                 // APPLY — writes the ids it found
+ *
+ * `dryRun` defaults to TRUE, so a mis-typed payload can only report. Only
+ * `{ "dryRun": false }` writes, and even then every write goes through the same
+ * conditional claim the "Check again" button uses: an org whose column stopped
+ * being NULL in the meantime is left exactly as it is.
+ *
+ * The payload is validated STRICTLY: an unrecognised key fails the run before
+ * anything is read. `{ "limt": 5 }` would otherwise be an applying sweep of
+ * every org, because the typo drops through to defaults.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+ * ~45 orgs with real classrooms have a NULL installation id — either they were
+ * created GitHub-free by the Classroom ZIP import, or a stale
+ * `installation.deleted` webhook cleared an id a reinstall had already replaced.
+ * Most of them have the app installed and just don't know it. This finds those.
+ *
+ * ── RATE LIMITS ────────────────────────────────────────────────────────────
+ * Orgs are processed ONE AT A TIME with a short pause between them, never in
+ * parallel. `GET /app/installations` — the paginated account-id scan, and the
+ * expensive half of a lookup — is read ONCE per run and handed to every org, so
+ * a 45-org sweep costs one scan plus one cheap by-login request each, not 45
+ * scans. When GitHub does throttle us the sweep STOPS rather than grinding
+ * through the remaining orgs collecting the same refusal — the partial report
+ * comes back with `stoppedEarly: true` and `retryAfterSeconds`, and the run is
+ * simply re-triggered after that.
+ *
+ * The 15 s per-org cooldown inside `repairInstallation` is bypassed here: this
+ * task asks about each org exactly once per run, and a re-triggered sweep must
+ * not be turned away just because the previous run (or an instructor's own
+ * "Check again") touched the same org seconds ago. In-flight sharing still
+ * applies, so this can never double a request already in the air.
+ */
+
+/** Only orgs that carry real coursework — an example-course org has no GitHub. */
+const NON_EXAMPLE_CLASSROOM = { is_example: false } as const;
+
+/**
+ * Pause between two orgs' GitHub lookups.
+ *
+ * Not a rate-limit guarantee (that's what stopping early is for) — just enough
+ * spacing that a sweep reads as a trickle rather than a burst, which is what
+ * GitHub's secondary limits actually watch for.
+ */
+const DELAY_BETWEEN_ORGS_MS = 250;
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+export interface GitOrgInstallationRepairPayload {
+  /** Report only. TRUE unless explicitly set to false. */
+  dryRun?: boolean;
+  /** Restrict the sweep to these GitOrganization ids (still filtered as below). */
+  orgIds?: string[];
+  /** Stop after this many orgs, ordered by login. */
+  limit?: number;
+}
+
+/** Everything the payload may contain. Anything else is a typo, not an option. */
+const PAYLOAD_KEYS = ['dryRun', 'orgIds', 'limit'] as const;
+
+const reject = (message: string): never => {
+  throw new Error(`[git-org-installation-repair] ${message}`);
+};
+
+/**
+ * Strict payload validation, run by `schemaTask` BEFORE `run`.
+ *
+ * Hand-written rather than a Zod schema because `@classmoji/tasks` does not
+ * depend on Zod and no sibling task pulls one in; `schemaTask` accepts a plain
+ * validator function, which is all this needs.
+ *
+ * Unknown keys are a hard failure on purpose. This task's default is safe and
+ * its dangerous mode is one key away, so a payload the operator believed
+ * narrowed the run — `{ "limt": 5 }`, `{ "dry_run": false }` — must fail loudly
+ * rather than silently mean something else.
+ *
+ * @param {unknown} input - The raw trigger payload.
+ * @returns {GitOrgInstallationRepairPayload}
+ */
+export const parseRepairPayload = (input: unknown): GitOrgInstallationRepairPayload => {
+  if (input === undefined || input === null) return {};
+
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    reject('payload must be an object');
+  }
+
+  const raw = input as Record<string, unknown>;
+  const unknown = Object.keys(raw).filter(
+    key => !(PAYLOAD_KEYS as readonly string[]).includes(key)
+  );
+  if (unknown.length > 0) {
+    reject(
+      `unknown payload key(s): ${unknown.join(', ')} — expected only ${PAYLOAD_KEYS.join(', ')}`
+    );
+  }
+
+  const payload: GitOrgInstallationRepairPayload = {};
+
+  if (raw.dryRun !== undefined) {
+    if (typeof raw.dryRun !== 'boolean') reject('dryRun must be a boolean');
+    payload.dryRun = raw.dryRun as boolean;
+  }
+
+  if (raw.orgIds !== undefined) {
+    if (!Array.isArray(raw.orgIds) || raw.orgIds.some(id => typeof id !== 'string' || id === '')) {
+      reject('orgIds must be an array of non-empty strings');
+    }
+    payload.orgIds = raw.orgIds as string[];
+  }
+
+  if (raw.limit !== undefined) {
+    if (typeof raw.limit !== 'number' || !Number.isInteger(raw.limit) || raw.limit <= 0) {
+      reject('limit must be a positive integer');
+    }
+    payload.limit = raw.limit as number;
+  }
+
+  return payload;
+};
+
+/**
+ * What happened for one org.
+ *
+ * `would-connect` is the dry-run twin of `connected`: an installation was found
+ * and validated, and a real run would have claimed it.
+ */
+export type GitOrgRepairOutcome =
+  | 'would-connect'
+  | 'connected'
+  | 'already-connected'
+  | 'not-installed'
+  | 'login-moved'
+  | 'suspended'
+  | 'wrong-app'
+  | 'not-github'
+  | 'not-found'
+  | 'rate-limited'
+  | 'error';
+
+export interface GitOrgRepairResult {
+  orgId: string;
+  login: string;
+  /** Non-example classrooms in this org. */
+  classrooms: number;
+  /** Distinct users holding OWNER on any of them — who to email. */
+  owners: number;
+  outcome: GitOrgRepairOutcome;
+  /** The installation id found (dry run) or written (apply). */
+  installationId?: string;
+  /** Why it failed, on `error` only — without it the report says nothing useful. */
+  message?: string;
+}
+
+export interface GitOrgInstallationRepairReport {
+  dryRun: boolean;
+  /** Orgs the scan matched. `scanned` is smaller when a throttle stopped us. */
+  candidates: number;
+  scanned: number;
+  results: GitOrgRepairResult[];
+  summary: { byOutcome: Record<string, number> };
+  /**
+   * Ids passed in `orgIds` that matched no candidate — already connected, not
+   * a GitHub org, example-only, or no such row. (A `limit` small enough to
+   * truncate the scan also lands ids here.)
+   */
+  unmatchedOrgIds: string[];
+  /** GitHub throttled us; the orgs after the last result were not looked at. */
+  stoppedEarly?: boolean;
+  retryAfterSeconds?: number;
+}
+
+/**
+ * Owners per org, in one query.
+ *
+ * Distinct on (user_id, classroom_id) because one person can hold OWNER on
+ * several classrooms in the same org and would otherwise be counted twice; the
+ * per-org de-dupe below turns that into "how many people to contact".
+ */
+const countOwnersByOrg = async (
+  classroomIdsByOrg: Map<string, string[]>
+): Promise<Map<string, number>> => {
+  const classroomIds = [...classroomIdsByOrg.values()].flat();
+  const owners = new Map<string, number>();
+  if (classroomIds.length === 0) return owners;
+
+  const memberships = await getPrisma().classroomMembership.findMany({
+    where: { classroom_id: { in: classroomIds }, role: 'OWNER' },
+    select: { user_id: true, classroom_id: true },
+    distinct: ['user_id', 'classroom_id'],
+  });
+
+  const orgByClassroom = new Map<string, string>();
+  for (const [orgId, ids] of classroomIdsByOrg) {
+    for (const id of ids) orgByClassroom.set(id, orgId);
+  }
+
+  const userIdsByOrg = new Map<string, Set<string>>();
+  for (const membership of memberships) {
+    const orgId = orgByClassroom.get(membership.classroom_id);
+    if (!orgId) continue;
+    const set = userIdsByOrg.get(orgId) ?? new Set<string>();
+    set.add(membership.user_id);
+    userIdsByOrg.set(orgId, set);
+  }
+
+  for (const [orgId, set] of userIdsByOrg) owners.set(orgId, set.size);
+  return owners;
+};
+
+const summarize = (results: GitOrgRepairResult[]): Record<string, number> => {
+  const byOutcome: Record<string, number> = {};
+  for (const result of results) {
+    byOutcome[result.outcome] = (byOutcome[result.outcome] ?? 0) + 1;
+  }
+  return byOutcome;
+};
+
+export const gitOrgInstallationRepairTask = schemaTask({
+  id: 'git-org-installation-repair',
+  schema: parseRepairPayload,
+  /**
+   * ONE sweep at a time, platform-wide.
+   *
+   * Two operators triggering this together would double the GitHub traffic for
+   * a run whose whole design is not to spike it, and would race each other on
+   * the same rows. The second run queues behind the first instead.
+   */
+  queue: { concurrencyLimit: 1 },
+  /** 45 orgs × (a by-login request + 250ms) with room to spare. */
+  maxDuration: 600,
+  /**
+   * No retries. A failed sweep is re-triggered by a human who has read the
+   * partial report — an automatic second attempt would just re-ask GitHub the
+   * questions that already failed, which is exactly what the rate limit is
+   * complaining about.
+   */
+  retry: { maxAttempts: 1 },
+  run: async (
+    payload: GitOrgInstallationRepairPayload
+  ): Promise<GitOrgInstallationRepairReport> => {
+    const dryRun = payload.dryRun !== false;
+    const { orgIds, limit } = payload;
+
+    const orgs = await getPrisma().gitOrganization.findMany({
+      where: {
+        provider: 'GITHUB',
+        github_installation_id: null,
+        classrooms: { some: NON_EXAMPLE_CLASSROOM },
+        ...(orgIds && orgIds.length > 0 ? { id: { in: orgIds } } : {}),
+      },
+      select: {
+        id: true,
+        login: true,
+        provider_id: true,
+        classrooms: { where: NON_EXAMPLE_CLASSROOM, select: { id: true } },
+      },
+      orderBy: { login: 'asc' },
+      ...(limit && limit > 0 ? { take: limit } : {}),
+    });
+
+    // An id an operator explicitly asked about and that the scan did not
+    // return is the one thing a per-org report cannot show — the row is simply
+    // absent — so it is called out rather than left to be noticed.
+    const foundIds = new Set(orgs.map(org => org.id));
+    const unmatchedOrgIds = (orgIds ?? []).filter(id => !foundIds.has(id));
+
+    if (orgs.length === 0) {
+      logger.info(
+        `[git-org-installation-repair] ${dryRun ? 'dry-run' : 'applied'}: nothing to do` +
+          (unmatchedOrgIds.length > 0
+            ? ` (${unmatchedOrgIds.length} requested id(s) unmatched)`
+            : '')
+      );
+      return {
+        dryRun,
+        candidates: 0,
+        scanned: 0,
+        results: [],
+        summary: { byOutcome: {} },
+        unmatchedOrgIds,
+      };
+    }
+
+    const ownersByOrg = await countOwnersByOrg(
+      new Map(orgs.map(org => [org.id, org.classrooms.map(classroom => classroom.id)]))
+    );
+
+    const results: GitOrgRepairResult[] = [];
+    let stoppedEarly = false;
+    let retryAfterSeconds: number | undefined;
+
+    // ONE app-JWT client and ONE `GET /app/installations` for the whole run,
+    // handed to every org below. Both paths take them: the dry run reads
+    // through `lookupInstallationForOrg` (which writes nothing), the applying
+    // run through `repairInstallation` (which owns the conditional claim). What
+    // selects the path is `dryRun` itself — never the presence of a client.
+    const appOctokit = GitHubProvider.getAppOctokit();
+
+    let installations: InstallationLike[];
+    try {
+      installations = await listAppInstallations(appOctokit);
+    } catch (error: unknown) {
+      if (error instanceof GitHubRateLimitedError) {
+        logger.warn('[git-org-installation-repair] throttled before the sweep began', {
+          retryAfterSeconds: error.retryAfterSeconds,
+        });
+        return {
+          dryRun,
+          candidates: orgs.length,
+          scanned: 0,
+          results: [],
+          summary: { byOutcome: {} },
+          unmatchedOrgIds,
+          stoppedEarly: true,
+          retryAfterSeconds: error.retryAfterSeconds,
+        };
+      }
+      throw error;
+    }
+
+    for (const [index, org] of orgs.entries()) {
+      if (index > 0) await sleep(DELAY_BETWEEN_ORGS_MS);
+
+      const base = {
+        orgId: org.id,
+        login: org.login,
+        classrooms: org.classrooms.length,
+        owners: ownersByOrg.get(org.id) ?? 0,
+      };
+
+      try {
+        if (dryRun) {
+          const lookup = await lookupInstallationForOrg(appOctokit, org, { installations });
+          results.push(
+            lookup.status === 'found'
+              ? {
+                  ...base,
+                  outcome: 'would-connect',
+                  installationId: lookup.synced.github_installation_id,
+                }
+              : { ...base, outcome: lookup.status }
+          );
+          continue;
+        }
+
+        const repair = await repairInstallation(org.id, {
+          appOctokit,
+          installations,
+          bypassCooldown: true,
+        });
+
+        if (repair.status === 'rate-limited') {
+          results.push({ ...base, outcome: 'rate-limited' });
+          stoppedEarly = true;
+          retryAfterSeconds = repair.retryAfterSeconds;
+          break;
+        }
+
+        results.push({
+          ...base,
+          outcome: repair.status,
+          ...(repair.status === 'connected' || repair.status === 'already-connected'
+            ? { installationId: repair.org?.github_installation_id ?? undefined }
+            : {}),
+          // `repairInstallation` swallows unexpected failures into a status, so
+          // its message is the only account of what actually went wrong.
+          ...(repair.status === 'error' ? { message: repair.message } : {}),
+        });
+      } catch (error: unknown) {
+        // A throttle is the one failure that must stop the sweep: every
+        // remaining org would collect the same refusal and read as
+        // "not installed", which is the wrong thing to tell an instructor.
+        if (error instanceof GitHubRateLimitedError) {
+          results.push({ ...base, outcome: 'rate-limited' });
+          stoppedEarly = true;
+          retryAfterSeconds = error.retryAfterSeconds;
+          break;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error('Installation repair failed for org', {
+          orgId: org.id,
+          login: org.login,
+          error: message,
+        });
+        results.push({ ...base, outcome: 'error', message });
+      }
+    }
+
+    const byOutcome = summarize(results);
+
+    logger.info(
+      `[git-org-installation-repair] ${dryRun ? 'dry-run' : 'applied'}: ${results.length}/${orgs.length} orgs scanned` +
+        `${stoppedEarly ? ` (stopped early, retry in ${retryAfterSeconds}s)` : ''} — ` +
+        (Object.entries(byOutcome)
+          .map(([outcome, count]) => `${outcome}=${count}`)
+          .join(' ') || 'nothing to do')
+    );
+
+    return {
+      dryRun,
+      candidates: orgs.length,
+      scanned: results.length,
+      results,
+      summary: { byOutcome },
+      unmatchedOrgIds,
+      ...(stoppedEarly ? { stoppedEarly, retryAfterSeconds } : {}),
+    };
+  },
+});

--- a/packages/tasks/src/workflows/installation.ts
+++ b/packages/tasks/src/workflows/installation.ts
@@ -1,5 +1,10 @@
 import { task } from '@trigger.dev/sdk';
 import getPrisma from '@classmoji/database';
+import {
+  GitHubProvider,
+  clearInstallationIfMatches,
+  validateInstallationIdentity,
+} from '@classmoji/services';
 
 interface InstallationPayload {
   installation: {
@@ -10,6 +15,87 @@ interface InstallationPayload {
   [key: string]: unknown;
 }
 
+interface AdoptResult {
+  success: true;
+  /** Set when the delivery was refused; absent when the id was written. */
+  skipped?: string;
+}
+
+/**
+ * Read the installation back from GitHub, check it is ours for this account,
+ * and write its id onto the org.
+ *
+ * Shared by `installation.created` and `installation.unsuspend` because they
+ * are the same claim made for two different reasons — one after an install, one
+ * after a suspension is lifted — and the checks that make the claim safe must
+ * not drift apart between them.
+ *
+ * The payload is NOT trusted on its own. Webhook deliveries are retried, can
+ * arrive minutes late, and can be replayed — so a delivery for an installation
+ * that has since been removed would otherwise write an id that mints no token.
+ * The live read answers three things the payload cannot: that the installation
+ * still exists (404 → stale, ignore it), that it belongs to the account the
+ * payload named, and that it is this app's and not suspended.
+ *
+ * @param {InstallationPayload} payload - The webhook delivery.
+ * @param {string} label - Log prefix naming the delivery, e.g. `installation.created`.
+ * @returns {Promise<AdoptResult>}
+ */
+const adoptInstallation = async (
+  payload: InstallationPayload,
+  label: string
+): Promise<AdoptResult> => {
+  const {
+    installation: { id: installationId, account },
+  } = payload;
+
+  let live;
+  try {
+    const { data } = await GitHubProvider.getAppOctokit().rest.apps.getInstallation({
+      installation_id: Number(installationId),
+    });
+    live = data;
+  } catch (error: unknown) {
+    if ((error as { status?: number })?.status === 404) {
+      // The installation is gone — a replayed or long-delayed delivery.
+      // Writing its id would leave the org looking connected to nothing.
+      console.warn(`[${label}] installation=${installationId} no longer exists`);
+      return { success: true, skipped: 'stale' as const };
+    }
+    throw error;
+  }
+
+  const validation = validateInstallationIdentity(live, { providerId: String(account.id) });
+  if (!validation.ok) {
+    console.warn(`[${label}] installation=${installationId} rejected: ${validation.reason}`);
+    return { success: true, skipped: validation.reason };
+  }
+
+  // GitHub has just confirmed this installation is live FOR THIS ACCOUNT, so
+  // the id may be written unconditionally — unlike the repair path, this is
+  // not a guess that could clobber a better answer.
+  await getPrisma().gitOrganization.upsert({
+    where: {
+      provider_provider_id: {
+        provider: 'GITHUB',
+        provider_id: validation.synced.provider_id,
+      },
+    },
+    update: {
+      github_installation_id: validation.synced.github_installation_id,
+      login: validation.synced.login, // Update in case org was renamed
+    },
+    create: {
+      provider: 'GITHUB',
+      provider_id: validation.synced.provider_id,
+      login: validation.synced.login,
+      github_installation_id: validation.synced.github_installation_id,
+    },
+  });
+
+  return { success: true };
+};
+
 /**
  * Handle new GitHub App installation
  * Only creates/updates GitOrganization record.
@@ -17,58 +103,68 @@ interface InstallationPayload {
  */
 export const newInstallationHandlerTask = task({
   id: 'webhook-new_installation_handler',
-  run: async (payload: InstallationPayload) => {
-    const {
-      installation: { id: installationId, account },
-    } = payload;
-
-    // Upsert GitOrganization - that's ALL the webhook does
-    // No user lookup, no classroom, no membership, no teams yet
-    await getPrisma().gitOrganization.upsert({
-      where: {
-        provider_provider_id: {
-          provider: 'GITHUB',
-          provider_id: String(account.id),
-        },
-      },
-      update: {
-        github_installation_id: String(installationId),
-        login: account.login, // Update in case org was renamed
-      },
-      create: {
-        provider: 'GITHUB',
-        provider_id: String(account.id),
-        login: account.login,
-        github_installation_id: String(installationId),
-      },
-    });
-
-    return { success: true };
-  },
+  run: async (payload: InstallationPayload) => adoptInstallation(payload, 'installation.created'),
 });
 
 /**
  * Handle GitHub App uninstallation
  * Clears the installation ID so we know the app is no longer installed
+ *
+ * Scoped to the installation that was actually removed. Clearing by account id
+ * alone let a stale or replayed `installation.deleted` wipe the id a LATER
+ * reinstall had already written, silently disconnecting an org whose app is
+ * installed and fine. A delivery that no longer matches clears nothing.
  */
 export const appUninstalledHandlerTask = task({
   id: 'webhook-app_uninstalled_handler',
   run: async (payload: InstallationPayload) => {
     const {
-      installation: { account },
+      installation: { id: installationId, account },
     } = payload;
 
-    // Clear installation ID - classrooms remain but can't interact with GitHub
-    await getPrisma().gitOrganization.updateMany({
-      where: {
-        provider: 'GITHUB',
-        provider_id: String(account.id),
-      },
-      data: {
-        github_installation_id: null,
-      },
+    const cleared = await clearInstallationIfMatches({
+      providerId: String(account.id),
+      installationId: String(installationId),
     });
 
-    return { success: true };
+    return { success: true, cleared };
   },
+});
+
+/**
+ * Handle a GitHub App installation being SUSPENDED.
+ *
+ * A suspended installation still exists but mints no tokens, so an org holding
+ * its id looks connected and fails every call. Treat it exactly like an
+ * uninstall: clear the id, scoped to the installation the delivery names, so a
+ * replayed suspend cannot wipe an id a later reinstall wrote. `unsuspend` puts
+ * it back after re-validating against live GitHub.
+ */
+export const appSuspendedHandlerTask = task({
+  id: 'webhook-app_suspended_handler',
+  run: async (payload: InstallationPayload) => {
+    const {
+      installation: { id: installationId, account },
+    } = payload;
+
+    const cleared = await clearInstallationIfMatches({
+      providerId: String(account.id),
+      installationId: String(installationId),
+    });
+
+    return { success: true, cleared };
+  },
+});
+
+/**
+ * Handle a suspension being LIFTED.
+ *
+ * The same claim `installation.created` makes, and for the same reason: the id
+ * is usable again. It re-reads live state rather than trusting the delivery,
+ * because a replayed `unsuspend` for an installation that has since been
+ * removed — or re-suspended — must write nothing.
+ */
+export const appUnsuspendedHandlerTask = task({
+  id: 'webhook-app_unsuspended_handler',
+  run: async (payload: InstallationPayload) => adoptInstallation(payload, 'installation.unsuspend'),
 });


### PR DESCRIPTION
## Context

45 GitHub orgs with real classrooms have no `github_installation_id`. Two causes: the GitHub Classroom ZIP import deliberately creates the org record GitHub-free and some instructors never installed the app, and a replayed `installation.deleted` webhook could clear an id after a reinstall (it matched on account id only). Instructors in that state had every GitHub feature silently broken and a banner they could dismiss forever.

## What changes

**Instructor-facing**
- `InstallAppBanner` is sticky (no dismiss) and adds **Check again**, which asks GitHub whether the app is installed on the org and, if so, fills the id. Owners and teachers can trigger it (`requireClassroomStaff`); assistants cannot. Closing the install popup runs the same check.
- Banner now appears on the admin dashboard, the **teacher** dashboard (teachers cannot browse `/admin`), the repositories page, and repository settings. Example classrooms and non-GitHub orgs are excluded everywhere.
- Import completion screen gets a **Connect GitHub** button when an imported org still needs the app. Import stays GitHub-free.
- Creating a classroom in an org with no installation is refused before the transaction with a clear message, instead of erroring after the classroom row was committed.

**Backend**
- `repairInstallation`: app-JWT lookup by login with account-id verification, fallback scan by account id, identity checks (org type, app, suspension), and a **conditional** `updateMany` that only fills a null id, so it can never overwrite a value a webhook just wrote. 15 s per-org cooldown with shared in-flight promise.
- Webhooks: `installation.deleted` and `installation.suspend` clear only a matching id; `installation.created` and `installation.unsuspend` re-read live state before writing. hook-station dispatches on `X-GitHub-Event` + `action` (fixtures updated).
- App-JWT Octokit has throttling and 429 retries disabled so rate limits surface as `rate-limited { retryAfterSeconds }` instead of sleeping.
- New Trigger task `git-org-installation-repair` (dry run by default, strict payload) to scan and repair all affected orgs from the dashboard.

## Test steps
1. On a classroom whose org has a null installation id, open the dashboard as owner and as teacher: banner shows with Install + Check again.
2. Click **Check again** with the app not installed: "isn't installed on {org} yet". Click again within 15 s: "Checked recently".
3. Install the app (or set it up on an org that already has it) and click Check again: banner disappears, `git_organizations.github_installation_id` populated, audit log row with outcome `connected`.
4. As an assistant, the banner does not render and a direct POST to `/api/classrooms/{slug}/github-installation` is refused.
5. Trigger `git-org-installation-repair` with `{}` on staging: report lists candidates with `would-connect` / `not-installed` per org and writes nothing; then `{ "dryRun": false }`.

## Verification
- services 1763 / tasks 227 / hook-station 78 / webapp unit 826 passing (one pre-existing unrelated failure in `navRoles.test.ts`).
- `npm run web:build` green; Trigger `deploy --dry-run` builds.
- Verified in Chrome on a devport: owner and teacher Check again restored the real installation id from live GitHub; not-installed, cooldown, settings and repositories pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA
