### PR TITLE
fix(webapp): discover the install-check route on render, not on click

### DIFF
--- a/apps/webapp/app/components/features/InstallAppBanner.tsx
+++ b/apps/webapp/app/components/features/InstallAppBanner.tsx
@@ -37,13 +37,11 @@ interface Props {
 export default function InstallAppBanner({ orgLogin, githubAppName, classSlug }: Props) {
   const fetcher = useFetcher<InstallCheckResult>();
   const checking = fetcher.state !== 'idle';
+  const checkAction = `/api/classrooms/${encodeURIComponent(classSlug)}/github-installation`;
 
   const checkInstallation = useCallback(() => {
-    fetcher.submit(null, {
-      method: 'post',
-      action: `/api/classrooms/${encodeURIComponent(classSlug)}/github-installation`,
-    });
-  }, [fetcher, classSlug]);
+    fetcher.submit(null, { method: 'post', action: checkAction });
+  }, [fetcher, checkAction]);
 
   // Closing the popup runs the same check the button does. React Router
   // revalidates every loader on the page once a fetcher's action resolves, so a
@@ -74,9 +72,20 @@ export default function InstallAppBanner({ orgLogin, githubAppName, classSlug }:
                 Install GitHub App
               </Button>
             )}
-            <Button onClick={checkInstallation} loading={checking} disabled={checking}>
-              Check again
-            </Button>
+            {/* A Form, not an onClick: with lazy route discovery the client
+                only learns about the API route the first time something
+                points at it. A rendered Form is discovered on render, so the
+                click posts at once; a bare fetcher.submit discovers on click,
+                which on staging meant a ten-second manifest round trip during
+                which nothing on screen changed. (fetcher.Form is the same Form
+                underneath, with discovery defaulting to "render".) The
+                popup-close path submits to the same action, discovered by
+                this Form by then. */}
+            <fetcher.Form method="post" action={checkAction}>
+              <Button htmlType="submit" loading={checking} disabled={checking}>
+                Check again
+              </Button>
+            </fetcher.Form>
           </div>
           {result && <CheckOutcome result={result} orgLogin={orgLogin} />}
         </div>


### PR DESCRIPTION
Follow-up to #329, found while testing on staging.

"Check again" used `fetcher.submit`, so under lazy route discovery the client only fetched the `/__manifest` entry for the API route at click time. On staging that first manifest request took ~10 s, and nothing on screen changed until it returned, so the click looked dead.

Rendering the button inside `fetcher.Form` (same `Form` underneath, `discover` defaults to `render`) makes the route get discovered when the banner renders, so the POST fires immediately. Verified locally: the form carries `data-discover`, and the click returns its status in ~1 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017meHBtkY9LWerPiwzfX3HA
