### PR TITLE
feat(forms): form_response_create MCP tool + added_by

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -27,6 +27,16 @@ registerAllTools();
 
 const fastify = Fastify({
   logger: true,
+  /**
+   * Bigger than Fastify's 1 MiB default, because form_response_create accepts a
+   * batch of up to 2 MB and enforces that ceiling itself — with a per-row
+   * report the caller can act on. At the default the framework would refuse the
+   * request with a bare HTTP 413 before the MCP layer ever saw it, so the
+   * tool's own cap could never fire and the agent would get no usable reason.
+   * The Streamable HTTP transport is handed the ALREADY-PARSED body (see
+   * routes/mcp.ts), so this limit is the only one on the path.
+   */
+  bodyLimit: 4 * 1024 * 1024,
 });
 
 // S5 process-level safety nets: a stray detached promise rejection (e.g. the

--- a/apps/mcp/src/tools/__tests__/forms.test.ts
+++ b/apps/mcp/src/tools/__tests__/forms.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the forms tool batch — list_forms / form_get / form_create /
  * form_update / form_publish / form_delete / list_form_responses /
- * form_response_get / form_response_update.
+ * form_response_get / form_response_create / form_response_update.
  *
  * Security focus (the S1/S4 audit posture, applied to a surface that holds
  * applicant PII):
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   responseListByFormId: vi.fn(),
   responseStatusLabels: vi.fn(),
   responseUpdateStaff: vi.fn(),
+  responseCreate: vi.fn(),
   withoutTargetEmails: vi.fn(),
   auditCreate: vi.fn(),
 }));
@@ -73,6 +74,7 @@ vi.mock('@classmoji/services', () => ({
       listByFormId: (...a: unknown[]) => mocks.responseListByFormId(...a),
       statusLabelSuggestions: (...a: unknown[]) => mocks.responseStatusLabels(...a),
       updateStaff: (...a: unknown[]) => mocks.responseUpdateStaff(...a),
+      createResponses: (...a: unknown[]) => mocks.responseCreate(...a),
     },
     audit: { create: (...a: unknown[]) => mocks.auditCreate(...a) },
     /**
@@ -99,6 +101,7 @@ const {
   formDeleteTool,
   listFormResponsesTool,
   formResponseGetTool,
+  formResponseCreateTool,
   formResponseUpdateTool,
 } = await import('../forms.ts');
 
@@ -111,6 +114,7 @@ const ALL_TOOLS: ToolDefinition<never>[] = [
   formDeleteTool,
   listFormResponsesTool,
   formResponseGetTool,
+  formResponseCreateTool,
   formResponseUpdateTool,
 ] as unknown as ToolDefinition<never>[];
 
@@ -182,6 +186,9 @@ const RESPONSE_ROW = {
   answers: { 'f-name': 'Maya Chen', 'f-why': 'I want to build things' },
   resolved_context: null,
   draft_token: 'SECRET-DRAFT-TOKEN',
+  // Staff typed this one in (form_response_create). Null on a row the
+  // respondent filled in themselves — the distinction the column exists for.
+  added_by: 'staff-7',
 };
 
 function parse(result: { content: Array<{ text: string }> }) {
@@ -260,6 +267,14 @@ describe('forms tool definitions', () => {
     // Setting the same triage label twice changes nothing.
     expect(formResponseUpdateTool.annotations?.idempotent).toBe(true);
     expect(formResponseUpdateTool.annotations?.destructive).toBe(false);
+    // form_response_create never overwrites an existing row (a repeat address
+    // is reported, not replaced), so the same batch twice creates nothing the
+    // second time — destructive false AND idempotent true are both honest.
+    expect(formResponseCreateTool.annotations).toEqual({
+      destructive: false,
+      idempotent: true,
+      openWorld: false,
+    });
     // No forms tool sends email or touches GitHub.
     for (const tool of ALL_TOOLS) {
       expect(toolAnnotations(tool).openWorldHint).toBe(false);
@@ -303,6 +318,7 @@ describe('Pro gating', () => {
     access: 'PUBLIC',
     confirm: true,
     staff_status: 'on roster',
+    responses: [{ email: 'maya@dartmouth.edu', answers: { 'f-name': 'Maya Chen' } }],
   };
 
   it('denies every tool — reads included — before any service call', async () => {
@@ -322,6 +338,7 @@ describe('Pro gating', () => {
       expect(mocks.formUpdate).not.toHaveBeenCalled();
       expect(mocks.formDelete).not.toHaveBeenCalled();
       expect(mocks.responseUpdateStaff).not.toHaveBeenCalled();
+      expect(mocks.responseCreate).not.toHaveBeenCalled();
     }
   });
 
@@ -348,6 +365,11 @@ describe('cross-classroom scoping (S1)', () => {
       formResponseUpdateTool as never,
       { response_id: 'resp-1', staff_status: 'on roster' },
     ],
+    [
+      'form_response_create',
+      formResponseCreateTool as never,
+      { responses: [{ email: 'maya@dartmouth.edu', answers: { 'f-name': 'Maya Chen' } }] },
+    ],
   ];
 
   it('refuses a form from another classroom, with no data and no writes', async () => {
@@ -371,6 +393,7 @@ describe('cross-classroom scoping (S1)', () => {
       expect(mocks.formPublish).not.toHaveBeenCalled();
       expect(mocks.formDelete).not.toHaveBeenCalled();
       expect(mocks.responseUpdateStaff).not.toHaveBeenCalled();
+      expect(mocks.responseCreate).not.toHaveBeenCalled();
     }
   });
 
@@ -467,6 +490,11 @@ describe('response allowlist', () => {
       expect(json).not.toContain('email_normalized');
       // …while the as-typed email a human reads survives.
       expect(json).toContain('Maya.Chen@dartmouth.edu');
+      // And so does the staff-entry marker: the allowlist ADDS `added_by`
+      // rather than dropping it, because a reader has no other way to tell a
+      // row staff typed in from the respondent's own testimony.
+      expect(json).toContain('added_by');
+      expect(json).toContain('staff-7');
     }
   });
 
@@ -1146,6 +1174,327 @@ describe('form_response_update', () => {
   });
 });
 
+// ─── form_response_create ───────────────────────────────────────────────────
+
+/**
+ * The one tool on this surface that WRITES a response.
+ *
+ * Everything else here either reads submissions or edits the two staff-only
+ * triage columns; this one puts words in a respondent's mouth, so the tests
+ * below pin the four things that keep that honest: the classroom gate runs
+ * before the authorization-free service is handed an id, the form id comes from
+ * the LOADED row rather than the argument, the acting user is stamped on every
+ * created row as `added_by`, and the batch is audited by the same transaction
+ * that writes it.
+ */
+describe('form_response_create', () => {
+  const BATCH = [{ email: 'maya@dartmouth.edu', answers: { 'f-name': 'Maya Chen' } }];
+
+  const COMMITTED = {
+    outcome: 'committed',
+    revision_id: 'rev-1',
+    counts: { would_create: 0, created: 1, duplicate: 0, invalid: 0 },
+    rows: [
+      {
+        input_index: 0,
+        email: 'maya@dartmouth.edu',
+        disposition: 'created',
+        response_id: 'resp-new',
+      },
+    ],
+  };
+
+  const call = (extra: Record<string, unknown> = {}) =>
+    formResponseCreateTool.handler(
+      { classroom: 'org/w26', form_id: 'form-1', responses: BATCH, ...extra } as never,
+      CTX
+    );
+
+  const responsesSchema = () => formResponseCreateTool.inputSchema.responses as z.ZodTypeAny;
+  const row = (i: number) => ({ email: `p${i}@dartmouth.edu`, answers: { 'f-name': `P${i}` } });
+
+  beforeEach(() => {
+    mocks.formFindById.mockResolvedValue(FORM_ROW);
+    mocks.responseCreate.mockResolvedValue(COMMITTED);
+  });
+
+  // ── Schema (the registry validates before the handler ever runs) ──────────
+
+  it('refuses an empty batch and anything past 200 rows', () => {
+    const schema = responsesSchema();
+    expect(schema.safeParse([]).success).toBe(false);
+    expect(schema.safeParse(Array.from({ length: 200 }, (_, i) => row(i))).success).toBe(true);
+    expect(schema.safeParse(Array.from({ length: 201 }, (_, i) => row(i))).success).toBe(false);
+  });
+
+  it('refuses a row whose email is not an address, or whose timestamp is not ISO', () => {
+    const schema = responsesSchema();
+    expect(schema.safeParse([{ email: 'maya at dartmouth', answers: {} }]).success).toBe(false);
+    expect(
+      schema.safeParse([{ email: 'maya@dartmouth.edu', answers: {}, submitted_at: 'August 21' }])
+        .success
+    ).toBe(false);
+    expect(
+      schema.safeParse([
+        { email: 'maya@dartmouth.edu', answers: {}, submitted_at: '2026-08-21T12:00:00.000Z' },
+      ]).success
+    ).toBe(true);
+  });
+
+  // ── Gates ────────────────────────────────────────────────────────────────
+
+  it('denies a non-Pro classroom before it reads or writes anything', async () => {
+    mocks.assertProTier.mockRejectedValue(proDenial());
+    const error = await call().catch(e => e);
+
+    expect(error).toBeInstanceOf(ToolError);
+    expect((error as ToolError).kind).toBe('forbidden');
+    expect(mocks.formFindById).not.toHaveBeenCalled();
+    expect(mocks.responseCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a foreign form with the identical error an unknown id gets (S1)', async () => {
+    mocks.formFindById.mockResolvedValue(FOREIGN_FORM);
+    const foreign = await call().catch(e => e);
+
+    mocks.formFindById.mockResolvedValue(null);
+    const unknown = await call().catch(e => e);
+
+    expect((foreign as ToolError).kind).toBe('not_found');
+    expect((foreign as ToolError).message).toBe('Form not found in this classroom');
+    expect((unknown as ToolError).message).toBe((foreign as ToolError).message);
+    // The authorization-free service was never handed another classroom's id.
+    expect(mocks.responseCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a payload over 2 MB before the form is even read', async () => {
+    const error = await call({
+      responses: [
+        { email: 'maya@dartmouth.edu', answers: { 'f-why': 'x'.repeat(2 * 1024 * 1024) } },
+      ],
+    }).catch(e => e);
+
+    expect(error).toBeInstanceOf(ToolError);
+    expect((error as ToolError).kind).toBe('invalid_params');
+    expect((error as ToolError).message).toBe('Payload exceeds 2 MB');
+    expect(mocks.formFindById).not.toHaveBeenCalled();
+    expect(mocks.responseCreate).not.toHaveBeenCalled();
+  });
+
+  // ── What the service is handed ───────────────────────────────────────────
+
+  it('takes formId from the LOADED form and addedBy from the viewer, never from args', async () => {
+    // The argument and the stored row deliberately disagree: only the loaded
+    // row has passed the classroom check, so only the loaded row's id may go on.
+    mocks.formFindById.mockResolvedValue({ ...FORM_ROW, id: 'form-canonical' });
+
+    await call();
+
+    const input = mocks.responseCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(input.formId).toBe('form-canonical');
+    expect(input.formId).not.toBe('form-1');
+    expect(input.addedBy).toBe('owner-1');
+  });
+
+  it('maps each row field by field into the service’s vocabulary', async () => {
+    await call({
+      revision_id: 'rev-1',
+      responses: [
+        {
+          email: 'maya@dartmouth.edu',
+          name: 'Maya Chen',
+          answers: { 'f-name': 'Maya Chen' },
+          submitted_at: '2026-08-21T12:00:00.000Z',
+          staff_status: 'waitlist',
+          staff_note: 'emailed 8/21',
+        },
+      ],
+    });
+
+    const input = mocks.responseCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(input.revisionId).toBe('rev-1');
+    expect(input.dryRun).toBe(false);
+    expect(input.responses).toEqual([
+      {
+        email: 'maya@dartmouth.edu',
+        name: 'Maya Chen',
+        answers: { 'f-name': 'Maya Chen' },
+        submittedAt: '2026-08-21T12:00:00.000Z',
+        staffStatus: 'waitlist',
+        staffNote: 'emailed 8/21',
+      },
+    ]);
+  });
+
+  it('nulls the optional fields a row omits, and forwards no argument object whole', async () => {
+    await call({ dry_run: undefined, extra_argument: 'ignored' });
+
+    const input = mocks.responseCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(input).not.toHaveProperty('extra_argument');
+    expect(input.revisionId).toBeUndefined();
+    expect(input.responses).toEqual([
+      {
+        email: 'maya@dartmouth.edu',
+        name: null,
+        answers: { 'f-name': 'Maya Chen' },
+        submittedAt: null,
+        staffStatus: null,
+        staffNote: null,
+      },
+    ]);
+  });
+
+  // ── Dry run vs commit ────────────────────────────────────────────────────
+
+  it('audits nothing on a dry run, and says so to the service', async () => {
+    mocks.responseCreate.mockResolvedValue({
+      ...COMMITTED,
+      outcome: 'dry_run',
+      counts: { would_create: 1, created: 0, duplicate: 0, invalid: 0 },
+      rows: [{ input_index: 0, email: 'maya@dartmouth.edu', disposition: 'would_create' }],
+    });
+
+    const payload = parse(await call({ dry_run: true }));
+
+    const input = mocks.responseCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(input.dryRun).toBe(true);
+    // Nothing changed, so nothing is recorded — the same rule the sibling reads
+    // that audit nothing follow.
+    expect(input.audit).toBeUndefined();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+    expect(payload.success).toBe(true);
+    expect(payload.outcome).toBe('dry_run');
+  });
+
+  it('hands the service a complete audit descriptor on a commit', async () => {
+    await call();
+
+    const input = mocks.responseCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(input.audit).toEqual({
+      user_id: 'owner-1',
+      classroom_id: 'class-1',
+      role: 'OWNER',
+      data: {
+        tool: 'forms.responses.create',
+        via: 'mcp',
+        mcp_tool: 'form_response_create',
+        form_slug: 'cs52-waitlist-mcp-test',
+      },
+    });
+    // The row commits inside the transaction that writes the responses, so the
+    // tool must not write a second one of its own.
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  // ── The report ───────────────────────────────────────────────────────────
+
+  it('returns the service’s report verbatim, with success true on a commit', async () => {
+    const payload = parse(await call());
+    expect(payload).toEqual({ success: true, ...COMMITTED });
+  });
+
+  it('reports success false — and every row — when the batch was rejected', async () => {
+    const rejected = {
+      outcome: 'rejected',
+      revision_id: 'rev-1',
+      counts: { would_create: 0, created: 0, duplicate: 0, invalid: 1 },
+      rows: [
+        {
+          input_index: 0,
+          email: 'maya@dartmouth.edu',
+          disposition: 'invalid',
+          issues: [
+            {
+              code: 'invalid_type',
+              field_id: 'f-name',
+              label: 'Your name',
+              path: 'f-name',
+              message: 'Required',
+            },
+          ],
+        },
+      ],
+    };
+    mocks.responseCreate.mockResolvedValue(rejected);
+
+    const payload = parse(await call());
+    expect(payload).toEqual({ success: false, ...rejected });
+    // The per-row detail is the useful part of a refusal and must survive.
+    expect(payload.rows[0].issues[0].field_id).toBe('f-name');
+    expect(payload.rows[0].issues[0].label).toBe('Your name');
+  });
+
+  it('echoes a duplicate’s existing id and state without inventing a new row', async () => {
+    mocks.responseCreate.mockResolvedValue({
+      outcome: 'committed',
+      revision_id: 'rev-1',
+      counts: { would_create: 0, created: 0, duplicate: 1, invalid: 0 },
+      rows: [
+        {
+          input_index: 0,
+          email: 'maya@dartmouth.edu',
+          disposition: 'duplicate',
+          response_id: 'resp-1',
+          existing_state: 'PENDING_VERIFICATION',
+        },
+      ],
+    });
+
+    const payload = parse(await call());
+    expect(payload.rows[0].disposition).toBe('duplicate');
+    expect(payload.rows[0].response_id).toBe('resp-1');
+    expect(payload.rows[0].existing_state).toBe('PENDING_VERIFICATION');
+    expect(payload.counts.created).toBe(0);
+  });
+
+  // ── Service refusals ─────────────────────────────────────────────────────
+
+  it('turns each documented refusal into a ToolError carrying the service’s code', async () => {
+    const codes = [
+      'FORM_NOT_OPEN',
+      'FORM_CLOSED',
+      'FORM_CAP_REACHED',
+      'FORM_REVISION_STALE',
+      'FORM_ACCESS_MISMATCH',
+      'FORM_ALREADY_SUBMITTED',
+      'FORM_BATCH_INVALID',
+      'FORM_ANSWERS_INVALID',
+      'FORM_ANSWERS_TOO_LARGE',
+    ];
+
+    for (const code of codes) {
+      mocks.responseCreate.mockRejectedValue(
+        Object.assign(new Error(`the service’s own words about ${code}`), { code })
+      );
+      const error = await call().catch(e => e);
+
+      expect(error, code).toBeInstanceOf(ToolError);
+      expect((error as ToolError).kind).toBe('invalid_params');
+      expect((error as ToolError).code).toBe(code);
+      // The message is what makes "raise the cap" or "republish" actionable.
+      expect((error as ToolError).message).toBe(`the service’s own words about ${code}`);
+    }
+  });
+
+  it('maps a form deleted mid-call to the uniform not_found', async () => {
+    mocks.responseCreate.mockRejectedValue(
+      Object.assign(new Error('Form form-1 not found'), { code: 'FORM_NOT_FOUND' })
+    );
+    const error = await call().catch(e => e);
+
+    expect((error as ToolError).kind).toBe('not_found');
+    expect((error as ToolError).message).toBe('Form not found in this classroom');
+  });
+
+  it('rethrows an unrecognized failure instead of calling it bad input', async () => {
+    mocks.responseCreate.mockRejectedValue(new Error('connection terminated unexpectedly'));
+    const error = await call().catch(e => e);
+
+    expect(error).not.toBeInstanceOf(ToolError);
+    expect((error as Error).message).toBe('connection terminated unexpectedly');
+  });
+});
+
 // ─── Audit family ───────────────────────────────────────────────────────────
 
 describe('audit naming', () => {
@@ -1205,6 +1554,44 @@ describe('audit naming', () => {
       'forms.responses.view',
       'forms.responses.staff_update',
     ]);
+  });
+
+  /**
+   * form_response_create is the one member of the family that does NOT call
+   * `writeAudit`: its row commits INSIDE the service transaction that writes up
+   * to two hundred responses, so a crashed audit cannot leave a form full of
+   * rows nobody can account for. There is therefore no `audit.create` call to
+   * inspect — the vocabulary is pinned where it is actually handed over, on the
+   * descriptor passed to the service, so this tool cannot drift out of `forms.*`
+   * either.
+   */
+  it('keeps form_response_create in the forms.* family via the service descriptor', async () => {
+    mocks.formFindById.mockResolvedValue(FORM_ROW);
+    mocks.responseCreate.mockResolvedValue({
+      outcome: 'committed',
+      revision_id: 'rev-1',
+      counts: { would_create: 0, created: 1, duplicate: 0, invalid: 0 },
+      rows: [],
+    });
+
+    await formResponseCreateTool.handler(
+      {
+        classroom: 'org/w26',
+        form_id: 'form-1',
+        responses: [{ email: 'maya@dartmouth.edu', answers: { 'f-name': 'Maya Chen' } }],
+      } as never,
+      CTX
+    );
+
+    const { audit } = mocks.responseCreate.mock.calls[0][0] as {
+      audit: { data: { tool: string; via: string; mcp_tool: string } };
+    };
+    expect(audit.data.tool.startsWith('forms.')).toBe(true);
+    expect(audit.data.tool).toBe('forms.responses.create');
+    expect(audit.data.via).toBe('mcp');
+    expect(audit.data.mcp_tool).toBe(formResponseCreateTool.name);
+    // Never twice: the service owns this row.
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
 
   it('does NOT audit the two non-PII reads', async () => {

--- a/apps/mcp/src/tools/__tests__/forms.test.ts
+++ b/apps/mcp/src/tools/__tests__/forms.test.ts
@@ -1241,6 +1241,41 @@ describe('form_response_create', () => {
     ).toBe(true);
   });
 
+  it('accepts a timestamp carrying an offset, and still refuses a date alone', () => {
+    const schema = responsesSchema();
+    const at = (submitted_at: string) =>
+      schema.safeParse([{ email: 'maya@dartmouth.edu', answers: {}, submitted_at }]).success;
+
+    // The service parses with `new Date`, which honours an offset — refusing
+    // one would make a caller convert a real signup time by hand.
+    expect(at('2026-08-21T12:00:00+02:00')).toBe(true);
+    expect(at('2026-08-21T08:00:00-04:00')).toBe(true);
+    // A queue position needs a time of day.
+    expect(at('2026-08-21')).toBe(false);
+  });
+
+  it('refuses a row with no answers at all (a schema error, not a rejected batch)', () => {
+    const schema = responsesSchema();
+    expect(schema.safeParse([{ email: 'maya@dartmouth.edu' }]).success).toBe(false);
+    expect(schema.safeParse([{ email: 'maya@dartmouth.edu', answers: null }]).success).toBe(false);
+    expect(schema.safeParse([{ email: 'maya@dartmouth.edu', answers: 'nope' }]).success).toBe(
+      false
+    );
+    // An object keyed by field id is what the fill page posts; the contract
+    // owns the values, so anything may sit under a key.
+    expect(
+      schema.safeParse([{ email: 'maya@dartmouth.edu', answers: { 'f-name': 7 } }]).success
+    ).toBe(true);
+    expect(schema.safeParse([{ email: 'maya@dartmouth.edu', answers: {} }]).success).toBe(true);
+  });
+
+  it('is a write tool, rate-limited well below the default bucket', () => {
+    expect(formResponseCreateTool.scope).toBe('write');
+    // One call writes up to 200 rows and holds the form's row lock while it
+    // does; the 20-burst / 30-per-minute default is more than that deserves.
+    expect(formResponseCreateTool.rateLimit).toEqual({ capacity: 10, refillPerSecond: 0.1 });
+  });
+
   // ── Gates ────────────────────────────────────────────────────────────────
 
   it('denies a non-Pro classroom before it reads or writes anything', async () => {
@@ -1279,6 +1314,23 @@ describe('form_response_create', () => {
     expect((error as ToolError).message).toBe('Payload exceeds 2 MB');
     expect(mocks.formFindById).not.toHaveBeenCalled();
     expect(mocks.responseCreate).not.toHaveBeenCalled();
+  });
+
+  it('measures the cap in BYTES, not characters', async () => {
+    // 1.2M characters of a two-byte character: under the cap by string length,
+    // well over it once encoded — which is what actually crosses the wire and
+    // lands in the column.
+    const twoByte = 'é'.repeat(1_200_000);
+    expect(twoByte.length).toBeLessThan(2 * 1024 * 1024);
+    expect(new TextEncoder().encode(twoByte).length).toBeGreaterThan(2 * 1024 * 1024);
+
+    const error = await call({
+      responses: [{ email: 'maya@dartmouth.edu', answers: { 'f-why': twoByte } }],
+    }).catch(e => e);
+
+    expect(error).toBeInstanceOf(ToolError);
+    expect((error as ToolError).message).toBe('Payload exceeds 2 MB');
+    expect(mocks.formFindById).not.toHaveBeenCalled();
   });
 
   // ── What the service is handed ───────────────────────────────────────────
@@ -1346,7 +1398,7 @@ describe('form_response_create', () => {
 
   // ── Dry run vs commit ────────────────────────────────────────────────────
 
-  it('audits nothing on a dry run, and says so to the service', async () => {
+  it('audits a dry run as a VIEW — counts only, never the addresses', async () => {
     mocks.responseCreate.mockResolvedValue({
       ...COMMITTED,
       outcome: 'dry_run',
@@ -1358,12 +1410,82 @@ describe('form_response_create', () => {
 
     const input = mocks.responseCreate.mock.calls[0][0] as Record<string, unknown>;
     expect(input.dryRun).toBe(true);
-    // Nothing changed, so nothing is recorded — the same rule the sibling reads
-    // that audit nothing follow.
-    expect(input.audit).toBeUndefined();
-    expect(mocks.auditCreate).not.toHaveBeenCalled();
+    // `audit` is a REQUIRED service parameter now, so the descriptor goes on
+    // every call; the service ignores it on a dry run.
+    expect(input.audit).toBeDefined();
+
+    // A dry run answers "is this person already on the form, and in what
+    // state" for every address supplied — a read of other people's
+    // submissions, recorded like every other one.
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    const row = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      resource_type: string;
+      resource_id: string;
+      data: Record<string, unknown>;
+    };
+    expect(row.action).toBe('VIEW');
+    expect(row.resource_type).toBe('FORMS');
+    expect(row.resource_id).toBe('form-1');
+    expect(row.data.dry_run).toBe(true);
+    expect(row.data.counts).toEqual({ would_create: 1, created: 0, duplicate: 0, invalid: 0 });
+    // The audit log is not a second copy of the applicant list.
+    expect(JSON.stringify(row.data)).not.toContain('maya@dartmouth.edu');
+
     expect(payload.success).toBe(true);
     expect(payload.outcome).toBe('dry_run');
+  });
+
+  it('audits a commit that created nothing as a VIEW too', async () => {
+    mocks.responseCreate.mockResolvedValue({
+      outcome: 'committed',
+      revision_id: 'rev-1',
+      counts: { would_create: 0, created: 0, duplicate: 1, invalid: 0 },
+      rows: [
+        {
+          input_index: 0,
+          email: 'maya@dartmouth.edu',
+          disposition: 'duplicate',
+          response_id: 'resp-1',
+          existing_state: 'SUBMITTED',
+        },
+      ],
+    });
+
+    await call();
+
+    // Nothing was written, so the service wrote no CREATE row — but the call
+    // still disclosed who is already on the form, which is the read this
+    // records.
+    expect(mocks.auditCreate).toHaveBeenCalledTimes(1);
+    const row = mocks.auditCreate.mock.calls[0][0] as {
+      action: string;
+      data: Record<string, unknown>;
+    };
+    expect(row.action).toBe('VIEW');
+    expect(row.data.dry_run).toBe(false);
+    expect(row.data.counts).toEqual({ would_create: 0, created: 0, duplicate: 1, invalid: 0 });
+    expect(JSON.stringify(row.data)).not.toContain('maya@dartmouth.edu');
+  });
+
+  it('audits nothing here when rows were actually created — the service did it', async () => {
+    await call();
+    expect(mocks.responseCreate.mock.calls[0][0]).toMatchObject({ dryRun: false });
+    // The CREATE row commits inside the transaction that writes the responses,
+    // so the tool must not write a second one of its own.
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('does not audit a rejected batch — it returns before any database read', async () => {
+    mocks.responseCreate.mockResolvedValue({
+      outcome: 'rejected',
+      revision_id: 'rev-1',
+      counts: { would_create: 0, created: 0, duplicate: 0, invalid: 1 },
+      rows: [{ input_index: 0, email: 'maya@dartmouth.edu', disposition: 'invalid' }],
+    });
+
+    await call();
+    expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
 
   it('hands the service a complete audit descriptor on a commit', async () => {
@@ -1386,11 +1508,51 @@ describe('form_response_create', () => {
     expect(mocks.auditCreate).not.toHaveBeenCalled();
   });
 
+  it('passes the descriptor on a dry run too — the service requires it', async () => {
+    mocks.responseCreate.mockResolvedValue({
+      ...COMMITTED,
+      outcome: 'dry_run',
+      counts: { would_create: 1, created: 0, duplicate: 0, invalid: 0 },
+      rows: [{ input_index: 0, email: 'maya@dartmouth.edu', disposition: 'would_create' }],
+    });
+
+    await call({ dry_run: true });
+
+    const input = mocks.responseCreate.mock.calls[0][0] as {
+      audit: { data: { tool: string } };
+    };
+    expect(input.audit.data.tool).toBe('forms.responses.create');
+  });
+
   // ── The report ───────────────────────────────────────────────────────────
 
-  it('returns the service’s report verbatim, with success true on a commit', async () => {
+  it('rebuilds the report key by key, and ships nothing the service adds later', async () => {
+    // The service's DTO gains a debugging field. It must NOT reach a client
+    // just because it exists — this payload is an allow-list, like every other
+    // one in this file.
+    mocks.responseCreate.mockResolvedValue({
+      ...COMMITTED,
+      internal_trace_id: 'trace-abc',
+      rows: [
+        {
+          ...COMMITTED.rows[0],
+          email_normalized: 'maya@dartmouth.edu',
+          draft_token: 'SECRET-DRAFT-TOKEN',
+        },
+      ],
+    });
+
     const payload = parse(await call());
     expect(payload).toEqual({ success: true, ...COMMITTED });
+    expect(payload).not.toHaveProperty('internal_trace_id');
+    expect(payload.rows[0]).not.toHaveProperty('email_normalized');
+    expect(payload.rows[0]).not.toHaveProperty('draft_token');
+    expect(Object.keys(payload.counts).sort()).toEqual([
+      'created',
+      'duplicate',
+      'invalid',
+      'would_create',
+    ]);
   });
 
   it('reports success false — and every row — when the batch was rejected', async () => {
@@ -1450,16 +1612,18 @@ describe('form_response_create', () => {
   // ── Service refusals ─────────────────────────────────────────────────────
 
   it('turns each documented refusal into a ToolError carrying the service’s code', async () => {
+    // Exactly what `createResponses` can throw — FORM_NOT_FOUND is covered
+    // below, as the scoped not_found. The fill path's codes are deliberately
+    // NOT here: FORM_CLOSED cannot happen (a closed form is the ordinary
+    // case), FORM_ALREADY_SUBMITTED cannot (nothing is overwritten), and a bad
+    // answer set is a per-row `invalid` in the report, never an exception.
     const codes = [
-      'FORM_NOT_OPEN',
-      'FORM_CLOSED',
-      'FORM_CAP_REACHED',
-      'FORM_REVISION_STALE',
       'FORM_ACCESS_MISMATCH',
-      'FORM_ALREADY_SUBMITTED',
+      'FORM_FIELD_ACCESS_VIOLATION',
+      'FORM_NOT_OPEN',
       'FORM_BATCH_INVALID',
-      'FORM_ANSWERS_INVALID',
-      'FORM_ANSWERS_TOO_LARGE',
+      'FORM_REVISION_STALE',
+      'FORM_CAP_REACHED',
     ];
 
     for (const code of codes) {

--- a/apps/mcp/src/tools/forms.ts
+++ b/apps/mcp/src/tools/forms.ts
@@ -25,11 +25,14 @@
  * on the web, one level down at the response. `formResponse.service` carries no
  * authorization by documented design, so it is only ever as scoped as its caller.
  *
- * RESPONSES ARE ALLOW-LISTED. `formResponse.listByFormId` has no `select` and
- * therefore returns `draft_token` (a bearer credential for an anonymous
- * server-side partial) and `email_normalized`. Never spread a service row: every
- * payload here is built field-by-field by `formSummary` / `responseSummary`,
- * which mirror the web's `toResponseRow` and exclude both.
+ * RESPONSES ARE ALLOW-LISTED. `formResponse.listByFormId` selects through its
+ * own `RESPONSE_SELECT`, which already omits `draft_token` (a bearer credential
+ * for an anonymous server-side partial), but that is the service's guarantee to
+ * keep, not this file's to rely on. The rule here is unchanged and independent:
+ * never spread a service row or a service DTO. Every payload is built
+ * field-by-field — `formSummary` / `responseSummary` mirror the web's
+ * `toResponseRow`, and the create report is rebuilt key by key — so a column or
+ * a debugging field added upstream cannot ship to clients by default.
  *
  * DEFINITIONS ROUND-TRIP, THEY ARE NOT RE-PARSED. `parseFormDefinition` mints
  * field ids; running a stored definition through it a second time would be a
@@ -105,19 +108,24 @@ const FORM_RULE_CODES: ReadonlySet<string> = new Set([
   'FORM_ROSTER_TOO_LARGE',
   // …and the rules `formResponse.service` owns, reached by form_response_create.
   // Same treatment for the same reason: each is a documented refusal a caller can
-  // act on — republish and retry (STALE), raise the cap (CAP_REACHED), publish the
+  // act on — re-read and retry (STALE), raise the cap (CAP_REACHED), publish the
   // form (NOT_OPEN) — and its service message names the specific numbers. Kept as
   // literals rather than imported symbols, exactly like the form-service codes
   // above, so this file never pulls a module that opens a Prisma client.
+  //
+  // ONLY what `createResponses` can actually throw. The codes the fill path
+  // raises — FORM_CLOSED (adding to a closed form is allowed here),
+  // FORM_ALREADY_SUBMITTED (nothing is ever overwritten), and the two answer
+  // codes (a bad answer set is a per-row `invalid` in the report, never an
+  // exception) — are deliberately absent: listing an unreachable code invites
+  // the next reader to write a handler for a case that cannot happen.
+  // FORM_FIELD_ACCESS_VIOLATION is reachable from here too, and already
+  // carried above.
   'FORM_NOT_OPEN',
-  'FORM_CLOSED',
   'FORM_CAP_REACHED',
   'FORM_REVISION_STALE',
   'FORM_ACCESS_MISMATCH',
-  'FORM_ALREADY_SUBMITTED',
   'FORM_BATCH_INVALID',
-  'FORM_ANSWERS_INVALID',
-  'FORM_ANSWERS_TOO_LARGE',
 ]);
 
 /**
@@ -1014,9 +1022,9 @@ const CREATE_RESPONSES_MAX_BYTES = 2 * 1024 * 1024;
  *
  * Declared here rather than imported for the same reason `FormRow` and
  * `ResponseRow` are: the barrel exports `ClassmojiService`, not the service
- * modules' types. It is an allow-listed DTO the service builds field by field —
- * it carries no `draft_token`, no `email_normalized` and no service row — which
- * is why this is the one payload in this file returned whole.
+ * modules' types. It is what the service hands back — NOT what this tool
+ * returns. The payload is rebuilt from it key by key below, on the same
+ * allow-list rule every other payload in this file follows.
  */
 interface CreateResponsesReport {
   outcome: 'dry_run' | 'committed' | 'rejected';
@@ -1045,7 +1053,7 @@ interface FormResponseCreateArgs {
   responses: Array<{
     email: string;
     name?: string;
-    answers: unknown;
+    answers: Record<string, unknown>;
     submitted_at?: string;
     staff_status?: string;
     staff_note?: string;
@@ -1071,18 +1079,30 @@ export const formResponseCreateTool: ToolDefinition<FormResponseCreateArgs> = {
     'the caller’s to supply, or make the field optional with form_update and form_publish first.\n' +
     'NO EMAIL OF ANY KIND IS SENT and no magic link is minted: nobody is contacted.\n' +
     'NEVER OVERWRITES. An address already on the form comes back as `duplicate` with the existing ' +
-    'row’s id and state, untouched; two rows in one call sharing an address are both refused. ALL ' +
-    'OR NOTHING on validation — one invalid row rejects the whole batch, writes nothing, and ' +
-    'reports every row.\n' +
+    'row’s id and state, untouched. Two rows in ONE call sharing an address are a caller error, ' +
+    'not a duplicate: both come back `invalid` and the whole batch is rejected. ALL OR NOTHING on ' +
+    'validation — one invalid row rejects the whole batch, writes nothing, and reports every ' +
+    'row.\n' +
     'Respects response_cap: a batch that does not fit fails naming the cap, what is already taken ' +
     'and the overflow — raise it with form_update. Allowed on OPEN and on CLOSED forms (adding to ' +
     'a closed waitlist is the ordinary case); refused on a DRAFT form and on CLASSROOM-access ' +
     'forms.\n' +
     'RUN IT WITH dry_run: true FIRST — that validates every row, checks duplicates and the cap, ' +
     'and writes nothing. Every created row records the acting staff user as `added_by`, so a ' +
-    'staff-typed row is never mistaken for the respondent’s own testimony.',
+    'staff-typed row is never mistaken for the respondent’s own testimony.\n' +
+    'Every created row is stamped verified at creation time, which is what counts it toward the ' +
+    'cap — and means the person will NOT receive a courtesy verification email if they later type ' +
+    'the same address into the open form (they can still submit and get a link).\n' +
+    'THERE IS NO UNDO TOOL. Rows can be removed one at a time in the web responses view, so run ' +
+    'with dry_run first.',
   scope: 'write',
   roles: FORMS_STAFF,
+  // One call can write up to two hundred rows and holds the form's row lock the
+  // whole time — every public submitter queues behind it — so the default
+  // 20-burst / 30-per-minute bucket is far more than this tool should be
+  // allowed. 10 burst / 6 per minute still leaves room for the intended
+  // dry-run → fix → dry-run → commit loop.
+  rateLimit: { capacity: 10, refillPerSecond: 0.1 },
   inputSchema: {
     classroom: classroomArg,
     form_id: formIdArg,
@@ -1102,19 +1122,27 @@ export const formResponseCreateTool: ToolDefinition<FormResponseCreateArgs> = {
             .email()
             .describe('Respondent email; the identity key. One response per email per form.'),
           name: z.string().min(1).max(200).optional(),
+          // An OBJECT keyed by field id — the contract owns the values, so they
+          // stay `unknown`. Typed here rather than left wholly unknown so that
+          // a row with no `answers` at all is a schema error the caller sees
+          // immediately, instead of a batch the service has to reject row by row.
           answers: z
-            .unknown()
+            .record(z.string(), z.unknown())
             .describe(
               'Keyed by field id from form_get, contract-shaped: real numbers, real booleans, ' +
                 'option ids not labels. Validated exactly as the fill page validates.'
             ),
           submitted_at: z
             .string()
-            .datetime()
+            // `offset: true` because the service parses this with `new Date`,
+            // which honours an offset; refusing "…+02:00" would force callers
+            // to convert a real signup time by hand. Date-only strings are
+            // still refused — a queue position needs a time.
+            .datetime({ offset: true })
             .optional()
             .describe(
-              'ISO 8601. Orders the responses list. Defaults to now. Future timestamps are ' +
-                'rejected.'
+              'ISO 8601 date-time, with Z or an offset. Orders the responses list. Defaults to ' +
+                'now. Future timestamps are rejected.'
             ),
           staff_status: z.string().max(200).optional(),
           staff_note: z.string().max(5000).optional(),
@@ -1134,8 +1162,15 @@ export const formResponseCreateTool: ToolDefinition<FormResponseCreateArgs> = {
     // The aggregate cap. The raw zod shape the registry hands the SDK cannot
     // carry a cross-field rule, so it is applied in-handler (the same place
     // staff_add applies its OWNER-only confirm rule) — and before the form is
-    // read, so an oversized payload costs one string measurement, not a query.
-    if (JSON.stringify(args.responses).length > CREATE_RESPONSES_MAX_BYTES) {
+    // read, so an oversized payload costs one measurement, not a query.
+    //
+    // BYTES, not string length: a name in Chinese or an emoji in an answer is
+    // several bytes per character, and the thing being capped is what goes
+    // over the wire and into the column. `formContract.answersByteSize` sizes
+    // the per-response limit exactly this way.
+    if (
+      new TextEncoder().encode(JSON.stringify(args.responses)).length > CREATE_RESPONSES_MAX_BYTES
+    ) {
       throw new ToolError('invalid_params', 'Payload exceeds 2 MB');
     }
 
@@ -1161,35 +1196,99 @@ export const formResponseCreateTool: ToolDefinition<FormResponseCreateArgs> = {
         })),
         dryRun: args.dry_run ?? false,
         addedBy: ctx.viewer.userId,
-        // The audit row is written INSIDE the service's transaction — up to two
-        // hundred rows commit with their audit or not at all — so this tool
-        // does NOT call writeAudit. A dry run and a rejected batch audit
-        // nothing, matching the sibling tools, which record no row when nothing
-        // changed. The names are still the web's `forms.*` vocabulary, tagged
+        // The CREATE row is written INSIDE the service's transaction — up to
+        // two hundred responses commit with their audit or not at all — so
+        // this tool does NOT call writeAudit for it. Passed on every call,
+        // dry runs included: the parameter is required (there is no unaudited
+        // batch), and the service writes the row only when it actually created
+        // something. The names are the web's `forms.*` vocabulary, tagged
         // `via: 'mcp'`, exactly as every other tool here.
-        ...(args.dry_run
-          ? {}
-          : {
-              audit: {
-                user_id: ctx.viewer.userId,
-                classroom_id: classroom.classroomId,
-                role: classroom.role,
-                data: {
-                  tool: 'forms.responses.create',
-                  via: VIA_MCP,
-                  mcp_tool: 'form_response_create',
-                  form_slug: form.slug,
-                },
-              },
-            }),
+        audit: {
+          user_id: ctx.viewer.userId,
+          classroom_id: classroom.classroomId,
+          role: classroom.role,
+          data: {
+            tool: 'forms.responses.create',
+            via: VIA_MCP,
+            mcp_tool: 'form_response_create',
+            form_slug: form.slug,
+          },
+        },
       })
     )) as CreateResponsesReport;
 
-    // Returned whole, which no other payload in this file is: the report is
-    // already an allow-listed DTO the service assembles field by field — ids,
-    // dispositions, counts and issues — with no service row spread into it, so
-    // there is no `draft_token` or `email_normalized` to leak.
-    return ok({ success: report.outcome !== 'rejected', ...report });
+    /**
+     * The call that wrote nothing is still a READ, and reads of other people's
+     * submissions are recorded here — the same doctrine behind the VIEW audits
+     * on list_form_responses and form_response_get.
+     *
+     * A dry run answers, for every address the caller supplies, "is this person
+     * already on the form, and in what state" — with the existing row's id. That
+     * is per-address membership in an applicant list, obtainable in one call for
+     * two hundred addresses, and it would otherwise leave no trace at all. A
+     * commit that created nothing (every address already present) discloses
+     * exactly the same thing, and the service deliberately writes no CREATE row
+     * for it, so this is the only record it gets.
+     *
+     * Counts and ids ONLY — never the addresses themselves. The audit log is not
+     * the place to make a second copy of the list.
+     *
+     * A `rejected` outcome is not audited: it returns before any database
+     * lookup, so it reveals nothing about who is on the form.
+     */
+    const dryRun = report.outcome === 'dry_run';
+    if (dryRun || (report.outcome === 'committed' && report.counts.created === 0)) {
+      await writeAudit(ctx, {
+        resource_type: FORMS_RESOURCE,
+        resource_id: form.id,
+        action: 'VIEW',
+        data: {
+          tool: 'forms.responses.create',
+          via: VIA_MCP,
+          mcp_tool: 'form_response_create',
+          form_slug: form.slug,
+          dry_run: dryRun,
+          counts: report.counts,
+        },
+      });
+    }
+
+    // Built key by key, like every other payload in this file, and NOT spread
+    // from the report. The service's return value is a DTO today, but "it is
+    // safe to spread because of what it currently contains" is exactly the
+    // assumption this module's allow-list rule exists to refuse: a debugging
+    // field added to the service's row — a normalized address, a trace id —
+    // would otherwise ship to clients the moment it was added, with nothing
+    // here changing to say so.
+    return ok({
+      success: report.outcome !== 'rejected',
+      outcome: report.outcome,
+      revision_id: report.revision_id,
+      counts: {
+        would_create: report.counts.would_create,
+        created: report.counts.created,
+        duplicate: report.counts.duplicate,
+        invalid: report.counts.invalid,
+      },
+      rows: report.rows.map(row => ({
+        input_index: row.input_index,
+        email: row.email,
+        disposition: row.disposition,
+        ...(row.response_id !== undefined ? { response_id: row.response_id } : {}),
+        ...(row.existing_state !== undefined ? { existing_state: row.existing_state } : {}),
+        ...(row.issues
+          ? {
+              issues: row.issues.map(issue => ({
+                code: issue.code,
+                field_id: issue.field_id,
+                label: issue.label,
+                path: issue.path,
+                message: issue.message,
+              })),
+            }
+          : {}),
+      })),
+    });
   },
 };
 

--- a/apps/mcp/src/tools/forms.ts
+++ b/apps/mcp/src/tools/forms.ts
@@ -2,7 +2,8 @@
  * Forms tools — the MCP face of the Classmoji Forms surface.
  *
  * list_forms / form_get / form_create / form_update / form_publish /
- * form_delete / list_form_responses / form_response_get / form_response_update.
+ * form_delete / list_form_responses / form_response_get / form_response_create /
+ * form_response_update.
  *
  * ROUTE-DERIVED TIER: the web surface is the forms subtree in apps/pages, gated
  * by `assertFormAdmin` (apps/pages/app/utils/formAuth.server.ts), which composes
@@ -102,6 +103,21 @@ const FORM_RULE_CODES: ReadonlySet<string> = new Set([
   'FORM_SLUG_RESERVED',
   'FORM_SLUG_UNAVAILABLE',
   'FORM_ROSTER_TOO_LARGE',
+  // …and the rules `formResponse.service` owns, reached by form_response_create.
+  // Same treatment for the same reason: each is a documented refusal a caller can
+  // act on — republish and retry (STALE), raise the cap (CAP_REACHED), publish the
+  // form (NOT_OPEN) — and its service message names the specific numbers. Kept as
+  // literals rather than imported symbols, exactly like the form-service codes
+  // above, so this file never pulls a module that opens a Prisma client.
+  'FORM_NOT_OPEN',
+  'FORM_CLOSED',
+  'FORM_CAP_REACHED',
+  'FORM_REVISION_STALE',
+  'FORM_ACCESS_MISMATCH',
+  'FORM_ALREADY_SUBMITTED',
+  'FORM_BATCH_INVALID',
+  'FORM_ANSWERS_INVALID',
+  'FORM_ANSWERS_TOO_LARGE',
 ]);
 
 /**
@@ -187,6 +203,8 @@ interface ResponseRow {
   revision_id: string;
   answers: unknown;
   resolved_context: unknown;
+  /** The staff user who typed this row in; null when the respondent filled it. */
+  added_by?: string | null;
   /** Present on the service row and deliberately never echoed. */
   draft_token?: string | null;
   email_normalized?: string;
@@ -268,6 +286,12 @@ function responseSummary(row: ResponseRow) {
     staff_status: row.staff_status ?? null,
     staff_note: row.staff_note ?? null,
     revision_id: row.revision_id,
+    // Who wrote the row, when it was not the respondent. Null is the ordinary
+    // case — somebody filled the form themselves — and a user id means staff
+    // typed it in with form_response_create. A reader comparing two responses
+    // has no other way to tell testimony from data entry: `revision_id` says
+    // "what the person saw", which for a staff-added row is not true of anyone.
+    added_by: row.added_by ?? null,
     answers: (row.answers ?? {}) as Record<string, unknown>,
     resolved_context: ClassmojiService.formTeam.withoutTargetEmails(row.resolved_context ?? null),
   };
@@ -964,6 +988,208 @@ export const formResponseGetTool: ToolDefinition<FormResponseGetArgs> = {
       definition,
       response: responseSummary(row),
     });
+  },
+};
+
+// ─── form_response_create ───────────────────────────────────────────────────
+
+/**
+ * Rows one call may carry.
+ *
+ * The literal, not the import: `CREATE_RESPONSES_MAX` is exported by
+ * `formResponse.service` but not re-exported by the `@classmoji/services`
+ * barrel, and reaching it through `ClassmojiService.formResponse` at module
+ * scope would make this schema depend on a service namespace being present
+ * before any handler runs. The service asserts the same bound itself and throws
+ * FORM_BATCH_INVALID, so the two cannot silently disagree in the dangerous
+ * direction — this one only ever refuses earlier.
+ */
+const CREATE_RESPONSES_MAX = 200;
+
+/** 2 MB across the whole batch; the contract's own per-response limit is 256 KiB. */
+const CREATE_RESPONSES_MAX_BYTES = 2 * 1024 * 1024;
+
+/**
+ * The report `formResponse.createResponses` returns, mirrored locally.
+ *
+ * Declared here rather than imported for the same reason `FormRow` and
+ * `ResponseRow` are: the barrel exports `ClassmojiService`, not the service
+ * modules' types. It is an allow-listed DTO the service builds field by field —
+ * it carries no `draft_token`, no `email_normalized` and no service row — which
+ * is why this is the one payload in this file returned whole.
+ */
+interface CreateResponsesReport {
+  outcome: 'dry_run' | 'committed' | 'rejected';
+  revision_id: string;
+  counts: { would_create: number; created: number; duplicate: number; invalid: number };
+  rows: Array<{
+    input_index: number;
+    email: string;
+    disposition: 'would_create' | 'created' | 'duplicate' | 'invalid';
+    response_id?: string;
+    existing_state?: string;
+    issues?: Array<{
+      code: string;
+      field_id?: string;
+      label?: string;
+      path: string;
+      message: string;
+    }>;
+  }>;
+}
+
+interface FormResponseCreateArgs {
+  classroom: string;
+  form_id: string;
+  revision_id?: string;
+  responses: Array<{
+    email: string;
+    name?: string;
+    answers: unknown;
+    submitted_at?: string;
+    staff_status?: string;
+    staff_note?: string;
+  }>;
+  dry_run?: boolean;
+}
+
+export const formResponseCreateTool: ToolDefinition<FormResponseCreateArgs> = {
+  name: 'form_response_create',
+  // destructive false: nothing is ever overwritten — an existing row for the same
+  // email is reported, not replaced. idempotent true: the same batch twice creates
+  // nothing the second time. openWorld false: no mail, nothing leaves the DB.
+  annotations: { destructive: false, idempotent: true, openWorld: false },
+  title: 'Add responses to a form',
+  description:
+    'Creates one or many responses on a PUBLIC form, exactly as if each respondent had filled it ' +
+    'in themselves — how a list of people who signed up somewhere else becomes rows on the form. ' +
+    'Staff only (owner or teacher); requires a Pro subscription. It is not an importer and knows ' +
+    'nothing about where the rows came from.\n' +
+    'ANSWERS ARE VALIDATED BY THE FILL PAGE’S OWN CONTRACT: keyed by field id, options by id, ' +
+    'required fields required, no coercion — "7" where a number belongs is a mistake, not a value ' +
+    'to fix up. Read the field and option ids from form_get. A row lacking a required answer is ' +
+    'the caller’s to supply, or make the field optional with form_update and form_publish first.\n' +
+    'NO EMAIL OF ANY KIND IS SENT and no magic link is minted: nobody is contacted.\n' +
+    'NEVER OVERWRITES. An address already on the form comes back as `duplicate` with the existing ' +
+    'row’s id and state, untouched; two rows in one call sharing an address are both refused. ALL ' +
+    'OR NOTHING on validation — one invalid row rejects the whole batch, writes nothing, and ' +
+    'reports every row.\n' +
+    'Respects response_cap: a batch that does not fit fails naming the cap, what is already taken ' +
+    'and the overflow — raise it with form_update. Allowed on OPEN and on CLOSED forms (adding to ' +
+    'a closed waitlist is the ordinary case); refused on a DRAFT form and on CLASSROOM-access ' +
+    'forms.\n' +
+    'RUN IT WITH dry_run: true FIRST — that validates every row, checks duplicates and the cap, ' +
+    'and writes nothing. Every created row records the acting staff user as `added_by`, so a ' +
+    'staff-typed row is never mistaken for the respondent’s own testimony.',
+  scope: 'write',
+  roles: FORMS_STAFF,
+  inputSchema: {
+    classroom: classroomArg,
+    form_id: formIdArg,
+    revision_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe(
+        'From form_get. When given, the form must still be on this revision or the call fails ' +
+          'with FORM_REVISION_STALE. Pass it on a commit that follows a dry run.'
+      ),
+    responses: z
+      .array(
+        z.object({
+          email: z
+            .string()
+            .email()
+            .describe('Respondent email; the identity key. One response per email per form.'),
+          name: z.string().min(1).max(200).optional(),
+          answers: z
+            .unknown()
+            .describe(
+              'Keyed by field id from form_get, contract-shaped: real numbers, real booleans, ' +
+                'option ids not labels. Validated exactly as the fill page validates.'
+            ),
+          submitted_at: z
+            .string()
+            .datetime()
+            .optional()
+            .describe(
+              'ISO 8601. Orders the responses list. Defaults to now. Future timestamps are ' +
+                'rejected.'
+            ),
+          staff_status: z.string().max(200).optional(),
+          staff_note: z.string().max(5000).optional(),
+        })
+      )
+      .min(1)
+      .max(CREATE_RESPONSES_MAX)
+      .describe('One to 200 responses. A single response is a batch of one.'),
+    dry_run: z
+      .boolean()
+      .optional()
+      .describe('Validate every row, check duplicates and the cap, write nothing. Run this first.'),
+  },
+  handler: async (args, ctx) => {
+    await assertFormsSurfaceEnabled(ctx);
+
+    // The aggregate cap. The raw zod shape the registry hands the SDK cannot
+    // carry a cross-field rule, so it is applied in-handler (the same place
+    // staff_add applies its OWNER-only confirm rule) — and before the form is
+    // read, so an oversized payload costs one string measurement, not a query.
+    if (JSON.stringify(args.responses).length > CREATE_RESPONSES_MAX_BYTES) {
+      throw new ToolError('invalid_params', 'Payload exceeds 2 MB');
+    }
+
+    // S1 first: `formResponse.service` carries no authorization by documented
+    // design, so the form id it is handed has to be one this classroom owns.
+    const form = await loadFormInClassroom(args.form_id, ctx);
+    const classroom = requireClassroomCtx(ctx);
+
+    // Field by field, in the service's own vocabulary — no caller argument is
+    // ever forwarded as an object. `addedBy` and the audit's actor come from
+    // the authorized context, never from input.
+    const report = (await withFormRules(() =>
+      ClassmojiService.formResponse.createResponses({
+        formId: form.id,
+        revisionId: args.revision_id,
+        responses: args.responses.map(row => ({
+          email: row.email,
+          name: row.name ?? null,
+          answers: row.answers,
+          submittedAt: row.submitted_at ?? null,
+          staffStatus: row.staff_status ?? null,
+          staffNote: row.staff_note ?? null,
+        })),
+        dryRun: args.dry_run ?? false,
+        addedBy: ctx.viewer.userId,
+        // The audit row is written INSIDE the service's transaction — up to two
+        // hundred rows commit with their audit or not at all — so this tool
+        // does NOT call writeAudit. A dry run and a rejected batch audit
+        // nothing, matching the sibling tools, which record no row when nothing
+        // changed. The names are still the web's `forms.*` vocabulary, tagged
+        // `via: 'mcp'`, exactly as every other tool here.
+        ...(args.dry_run
+          ? {}
+          : {
+              audit: {
+                user_id: ctx.viewer.userId,
+                classroom_id: classroom.classroomId,
+                role: classroom.role,
+                data: {
+                  tool: 'forms.responses.create',
+                  via: VIA_MCP,
+                  mcp_tool: 'form_response_create',
+                  form_slug: form.slug,
+                },
+              },
+            }),
+      })
+    )) as CreateResponsesReport;
+
+    // Returned whole, which no other payload in this file is: the report is
+    // already an allow-listed DTO the service assembles field by field — ids,
+    // dispositions, counts and issues — with no service row spread into it, so
+    // there is no `draft_token` or `email_normalized` to leak.
+    return ok({ success: report.outcome !== 'rejected', ...report });
   },
 };
 

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -70,6 +70,7 @@ import {
   formDeleteTool,
   listFormResponsesTool,
   formResponseGetTool,
+  formResponseCreateTool,
   formResponseUpdateTool,
 } from './forms.ts';
 import {
@@ -213,7 +214,9 @@ export function registerAllTools(): void {
   // requireClassroomStaff; each tool also re-checks Pro tier in-handler). The
   // response tools read applicant PII, so both of them write an audit VIEW row
   // the way the web responses loader does; form_delete cascades to every
-  // response and is confirm-gated.
+  // response and is confirm-gated. form_response_create writes responses on the
+  // respondents' behalf — no mail, never overwrites, and it audits inside the
+  // service transaction that writes the rows rather than after it.
   registerToolDefinition(listFormsTool);
   registerToolDefinition(formGetTool);
   registerToolDefinition(formCreateTool);
@@ -222,5 +225,6 @@ export function registerAllTools(): void {
   registerToolDefinition(formDeleteTool);
   registerToolDefinition(listFormResponsesTool);
   registerToolDefinition(formResponseGetTool);
+  registerToolDefinition(formResponseCreateTool);
   registerToolDefinition(formResponseUpdateTool);
 }

--- a/apps/pages/app/forms/admin/responses.tsx
+++ b/apps/pages/app/forms/admin/responses.tsx
@@ -1076,6 +1076,22 @@ function ResponseTableRow({
               {chip.label}
             </span>
           ) : null}
+          {/* SOMEBODY ELSE TYPED THIS IN.
+              A staff-added row reads exactly like a submission otherwise, and
+              the difference matters: one is what a person said, the other is
+              what a member of staff entered on their behalf. No new column —
+              the table already fights for width — so it rides in the Name cell,
+              which is where a reader is already looking to decide whose record
+              this is. */}
+          {row.addedBy ? (
+            <span
+              title="A member of staff created this record; the person did not fill the form in."
+              data-testid={`forms-added-by-chip-${row.id}`}
+              className="max-w-40 truncate rounded-full bg-gray-200 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+            >
+              Added by {row.addedByName ?? 'staff'}
+            </span>
+          ) : null}
           {/* WE NEVER REACHED THEM, ON THE ROW.
               An Unverified chip says somebody did not finish; this says we were
               never able to reach them, which is the difference between a person
@@ -1210,6 +1226,14 @@ function ResponseDrawer({
             <dt className="text-gray-500 dark:text-gray-400">State</dt>
             <dd className="text-gray-800 dark:text-gray-100">
               {chip ? `${chip.label} (${row.submissionState})` : row.submissionState}
+            </dd>
+            {/* ALWAYS shown, em dash and all. The row that says nobody added it
+                is the row that teaches a reader the distinction exists — hide
+                it on the common case and "Added by" only ever appears as a
+                surprise, on the rows where it is least welcome. */}
+            <dt className="text-gray-500 dark:text-gray-400">Added by</dt>
+            <dd data-testid="forms-response-added-by" className="text-gray-800 dark:text-gray-100">
+              {row.addedBy ? (row.addedByName ?? row.addedBy) : '—'}
             </dd>
             {/* Only for a row that is genuinely going. A labelled one is exempt
                 from the sweep, so offering it a date would be a false promise

--- a/apps/pages/app/forms/admin/responsesCsv.server.ts
+++ b/apps/pages/app/forms/admin/responsesCsv.server.ts
@@ -49,11 +49,22 @@ export interface ExportableResponse {
   submission_state: string;
   staff_status: string | null;
   staff_note: string | null;
+  /** The staff user who created the row; null when the respondent did. */
+  added_by?: string | null;
+  /** That user's display name, when it resolved. Falls back to the id. */
+  added_by_name?: string | null;
   answers: Record<string, unknown>;
   resolved_context: unknown;
 }
 
-/** Identity + metadata + triage, ahead of every answer column. */
+/**
+ * Identity + metadata + triage, ahead of every answer column.
+ *
+ * "Added by" sits LAST of the lead columns, immediately before the answers.
+ * Appending rather than inserting keeps every column an instructor's existing
+ * sheet, filter or import already points at exactly where it was; an empty cell
+ * is the ordinary case and means the person filled the form in themselves.
+ */
 const LEAD_HEADERS = [
   'Name',
   'Email',
@@ -62,6 +73,7 @@ const LEAD_HEADERS = [
   'Submission state',
   'Staff status',
   'Staff note',
+  'Added by',
 ];
 
 const leadCells = (response: ExportableResponse) => [
@@ -72,6 +84,9 @@ const leadCells = (response: ExportableResponse) => [
   response.submission_state,
   response.staff_status ?? '',
   response.staff_note ?? '',
+  // The name when we have one, the id when we do not (a deleted account still
+  // wrote the row), empty when nobody added it.
+  response.added_by ? (response.added_by_name ?? response.added_by) : '',
 ];
 
 /** Fields that contribute a column: everything that collects an answer. */

--- a/apps/pages/app/forms/admin/responsesData.server.ts
+++ b/apps/pages/app/forms/admin/responsesData.server.ts
@@ -47,6 +47,22 @@ export interface ResponseRow {
   staffNote: string | null;
   /** The revision this response was filled against — the drawer renders it. */
   revisionId: string;
+  /**
+   * The staff user who created this row on the respondent's behalf. Null means
+   * the respondent submitted it themselves.
+   *
+   * On the surface because a staff-typed record and a respondent's own words
+   * are not the same kind of evidence, and nothing else on the row separates
+   * them: `revision_id` is documented as "what the person actually saw", which
+   * for a staff-added row is not true.
+   */
+  addedBy: string | null;
+  /**
+   * That staff user's display name, resolved once per load. Null when nobody
+   * added the row, and null when the account no longer resolves to a name — the
+   * table and the CSV each fall back rather than printing a bare uuid.
+   */
+  addedByName: string | null;
   answers: Record<string, unknown>;
   resolvedContext: unknown;
   /**
@@ -140,30 +156,61 @@ export async function requireFormForResponses(
   };
 }
 
+/**
+ * Names for the staff accounts that added rows on somebody's behalf.
+ *
+ * ONE query for the distinct ids on the page, not one per row: a batch import
+ * is the whole reason `added_by` exists, so a form can easily carry two hundred
+ * rows added by the same person. A user whose account has since been deleted
+ * simply is not in the map, and the row falls back to its id.
+ */
+async function addedByNames(ids: Array<string | null>): Promise<Map<string, string>> {
+  const distinct = [...new Set(ids.filter((id): id is string => Boolean(id)))];
+  if (distinct.length === 0) return new Map();
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: distinct } },
+    select: { id: true, name: true, login: true, email: true },
+  });
+
+  return new Map(
+    users.map(user => [user.id, user.name || user.login || user.email || user.id] as const)
+  );
+}
+
 /** Every response to the form, FIFO, serialized for the client. */
 export async function loadResponseRows(formId: string): Promise<ResponseRow[]> {
   const rows = await ClassmojiService.formResponse.listByFormId(formId);
-  return rows.map(toResponseRow);
+  const names = await addedByNames(rows.map(row => row.added_by));
+  return rows.map(row => toResponseRow(row, names));
 }
 
-export function toResponseRow(row: {
-  id: string;
-  name: string | null;
-  email: string;
-  user_id: string | null;
-  submitted_at: Date;
-  verified_at: Date | null;
-  created_at?: Date;
-  updated_at: Date;
-  submission_state: string;
-  staff_status: string | null;
-  staff_note: string | null;
-  revision_id: string;
-  answers: unknown;
-  resolved_context: unknown;
-  /** The newest send's delivery outcome, when the caller selected it. */
-  tokens?: Array<{ delivery_state: string | null; delivery_detail: string | null }>;
-}): ResponseRow {
+export function toResponseRow(
+  row: {
+    id: string;
+    name: string | null;
+    email: string;
+    user_id: string | null;
+    submitted_at: Date;
+    verified_at: Date | null;
+    created_at?: Date;
+    updated_at: Date;
+    submission_state: string;
+    staff_status: string | null;
+    staff_note: string | null;
+    revision_id: string;
+    answers: unknown;
+    resolved_context: unknown;
+    /** The staff user who typed this row in; null when the respondent did. */
+    added_by?: string | null;
+    /** The newest send's delivery outcome, when the caller selected it. */
+    tokens?: Array<{ delivery_state: string | null; delivery_detail: string | null }>;
+  },
+  /** id → display name, from `addedByNames`. Empty is fine: every row falls back. */
+  names: Map<string, string> = new Map()
+): ResponseRow {
+  const addedBy = row.added_by ?? null;
+
   return {
     id: row.id,
     name: row.name,
@@ -180,6 +227,8 @@ export function toResponseRow(row: {
     staffStatus: row.staff_status,
     staffNote: row.staff_note,
     revisionId: row.revision_id,
+    addedBy,
+    addedByName: addedBy ? (names.get(addedBy) ?? null) : null,
     answers: (row.answers ?? {}) as Record<string, unknown>,
     resolvedContext: row.resolved_context ?? null,
     /**

--- a/apps/pages/app/forms/admin/responsesData.server.ts
+++ b/apps/pages/app/forms/admin/responsesData.server.ts
@@ -58,9 +58,15 @@ export interface ResponseRow {
    */
   addedBy: string | null;
   /**
-   * That staff user's display name, resolved once per load. Null when nobody
-   * added the row, and null when the account no longer resolves to a name — the
-   * table and the CSV each fall back rather than printing a bare uuid.
+   * That staff user's display name — `name || login`, resolved once per load,
+   * and never their email address: this is shown to every other member of the
+   * teaching team and written into an exported CSV.
+   *
+   * Null when nobody added the row, when the account is gone, and when it
+   * simply carries neither a name nor a login. Each surface answers a null its
+   * own way: the chip says "Added by staff" because a uuid tells a reader
+   * scanning a table nothing, while the drawer and the CSV print the id, where
+   * an identifier you can look up beats no attribution at all.
    */
   addedByName: string | null;
   answers: Record<string, unknown>;
@@ -163,19 +169,26 @@ export async function requireFormForResponses(
  * is the whole reason `added_by` exists, so a form can easily carry two hundred
  * rows added by the same person. A user whose account has since been deleted
  * simply is not in the map, and the row falls back to its id.
+ *
+ * NAME OR LOGIN, AND THEN NOTHING — email is not in the chain and is not even
+ * selected. This string is rendered to every other member of the teaching team
+ * on the responses page and written into an exported CSV, and a colleague's
+ * address is not ours to publish just because their profile happens to be
+ * blank. Every other display-name fallback in the platform stops in the same
+ * place (`classroomForm.server.ts`, `form.service.ts`, `formTeamResolver.ts`),
+ * and a null is already handled everywhere this lands: the chip reads "Added by
+ * staff", the drawer and the CSV each print the id.
  */
-async function addedByNames(ids: Array<string | null>): Promise<Map<string, string>> {
+async function addedByNames(ids: Array<string | null>): Promise<Map<string, string | null>> {
   const distinct = [...new Set(ids.filter((id): id is string => Boolean(id)))];
   if (distinct.length === 0) return new Map();
 
   const users = await prisma.user.findMany({
     where: { id: { in: distinct } },
-    select: { id: true, name: true, login: true, email: true },
+    select: { id: true, name: true, login: true },
   });
 
-  return new Map(
-    users.map(user => [user.id, user.name || user.login || user.email || user.id] as const)
-  );
+  return new Map(users.map(user => [user.id, user.name || user.login || null] as const));
 }
 
 /** Every response to the form, FIFO, serialized for the client. */
@@ -206,8 +219,11 @@ export function toResponseRow(
     /** The newest send's delivery outcome, when the caller selected it. */
     tokens?: Array<{ delivery_state: string | null; delivery_detail: string | null }>;
   },
-  /** id → display name, from `addedByNames`. Empty is fine: every row falls back. */
-  names: Map<string, string> = new Map()
+  /**
+   * id → display name, from `addedByNames`. Empty is fine, and so is a null
+   * value: every row falls back on its own.
+   */
+  names: Map<string, string | null> = new Map()
 ): ResponseRow {
   const addedBy = row.added_by ?? null;
 

--- a/apps/pages/app/forms/admin/responsesExport.ts
+++ b/apps/pages/app/forms/admin/responsesExport.ts
@@ -81,6 +81,8 @@ export const action = async ({
     submission_state: row.submissionState,
     staff_status: row.staffStatus,
     staff_note: row.staffNote,
+    added_by: row.addedBy,
+    added_by_name: row.addedByName,
     answers: row.answers,
     resolved_context: row.resolvedContext,
   }));

--- a/apps/pages/app/forms/fill/verify.tsx
+++ b/apps/pages/app/forms/fill/verify.tsx
@@ -35,7 +35,8 @@ import { themeFor, type CanvasTheme } from './publicForm.server.ts';
  * "Edit answers" mounts the SAME renderer the fill page uses, prefilled, and
  * resubmits with the token — `confirmSubmission` replaces the answers inside
  * the transaction that consumes it. A response that was already verified keeps
- * its original `verified_at`, so editing never costs a FIFO waitlist place.
+ * its original `verified_at`, and its place in a FIFO waitlist is `submitted_at`,
+ * which an edit does not move either.
  *
  * ── Cache ──────────────────────────────────────────────────────────────────
  * `no-store`, because this page serves one person's answers to a bearer-token

--- a/apps/pages/tests/unit/forms-responses-csv.spec.ts
+++ b/apps/pages/tests/unit/forms-responses-csv.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from '@playwright/test';
+import type { FormField } from '@classmoji/services/form-contract';
+
+import {
+  buildWideCsv,
+  type ExportableResponse,
+} from '../../app/forms/admin/responsesCsv.server.ts';
+
+/**
+ * The WIDE export's lead columns, pinned.
+ *
+ * ── Why this is a unit test ────────────────────────────────────────────────
+ * The wide sheet is a CONTRACT with a file an instructor already has open. Its
+ * lead columns are the ones a saved filter, a VLOOKUP, or a Notion import maps
+ * by position, so the cost of moving one is paid silently, months later, by
+ * somebody whose sheet now reads the staff note as the submission state. "Added
+ * by" was appended LAST for exactly that reason, and nothing in the type system
+ * says so — `LEAD_HEADERS` is a private array, and a well-meaning alphabetise or
+ * an "identity columns belong together" tidy would reorder it without a single
+ * red mark. This spec is the mark.
+ *
+ * The second thing pinned here is the two-row header's PADDING. The group row
+ * exists only when a matrix is present, and it is padded with one empty cell per
+ * lead column before the matrix label is pushed. Adding a lead column without
+ * adding to the padding — which is what happens if the padding is ever written
+ * as a literal count rather than derived from the header list — slides every
+ * group label one column left of the block it names, and the sheet still opens
+ * fine. Nobody notices until they read it.
+ *
+ * An end-to-end export test cannot see either property: it downloads one form's
+ * CSV and confirms the bytes look like a CSV.
+ */
+
+let seq = 0;
+const field = (patch: Record<string, unknown>): FormField =>
+  ({
+    id: `dddddddd-dddd-4ddd-8ddd-dddddddddd${String(++seq).padStart(2, '0')}`,
+    required: false,
+    ...patch,
+  }) as unknown as FormField;
+
+/** The lead columns, in the order the sheet promises them. */
+const LEAD = [
+  'Name',
+  'Email',
+  'Submitted at',
+  'Verified at',
+  'Submission state',
+  'Staff status',
+  'Staff note',
+  'Added by',
+];
+
+/** Where "Added by" sits, and therefore where the answers start. */
+const ADDED_BY = LEAD.indexOf('Added by');
+
+const response = (patch: Partial<ExportableResponse> = {}): ExportableResponse => ({
+  id: 'response-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.edu',
+  submitted_at: '2026-09-10T12:00:00.000Z',
+  verified_at: null,
+  submission_state: 'submitted',
+  staff_status: null,
+  staff_note: null,
+  answers: {},
+  resolved_context: null,
+  ...patch,
+});
+
+/**
+ * The CSV back into cells.
+ *
+ * A naive split is only safe while no cell needs quoting, so that is asserted
+ * rather than assumed — a fixture that grew a comma would otherwise shift every
+ * index in this file and the failure would read as a column-order regression.
+ */
+const cells = (csv: string): string[][] => {
+  expect(csv).not.toContain('"');
+  return csv.split('\r\n').map(line => line.split(','));
+};
+
+test.describe('buildWideCsv — lead columns', () => {
+  test('the header is the eight lead columns, in order, then the answers', () => {
+    const fields = [
+      field({ type: 'banner', text: 'FIFO, no guarantees.', tone: 'info' }),
+      field({ type: 'short_text', label: 'Full name', required: true }),
+      field({ type: 'long_text', label: 'Why this class?' }),
+    ];
+
+    const [header] = cells(buildWideCsv(fields, [response()]));
+
+    // Stated in full rather than as "starts with": the point of the assertion is
+    // that "Added by" is the LAST lead column, which a prefix check would miss.
+    expect(header).toEqual([...LEAD, 'Full name', 'Why this class?']);
+  });
+
+  test('a form with no matrix emits ONE header row', () => {
+    const fields = [field({ type: 'short_text', label: 'Full name' })];
+    const rows = cells(buildWideCsv(fields, [response()]));
+
+    expect(rows).toHaveLength(2); // header + the one response
+    expect(rows[0][0]).toBe('Name');
+  });
+});
+
+test.describe('buildWideCsv — the Added by cell', () => {
+  const fields = [field({ type: 'short_text', label: 'Full name' })];
+  const addedByCell = (patch: Partial<ExportableResponse>) =>
+    cells(buildWideCsv(fields, [response(patch)]))[1][ADDED_BY];
+
+  test('a resolved staff name is what the cell says', () => {
+    expect(
+      addedByCell({ added_by: 'user-grace', added_by_name: 'Grace Hopper' })
+    ).toBe('Grace Hopper');
+  });
+
+  test('an unresolved adder falls back to the id, not to a blank', () => {
+    // A deleted account — or one whose profile carries neither name nor login —
+    // still wrote the row. An empty cell here would say the respondent filled
+    // the form in themselves, which is the one thing it must never say.
+    expect(addedByCell({ added_by: 'user-ghost', added_by_name: null })).toBe('user-ghost');
+    expect(addedByCell({ added_by: 'user-ghost' })).toBe('user-ghost');
+  });
+
+  test('nobody added it — the ordinary case — is empty', () => {
+    expect(addedByCell({ added_by: null })).toBe('');
+    expect(addedByCell({})).toBe('');
+  });
+
+  test('a name is never invented from a null adder', () => {
+    // added_by_name without added_by is incoherent input; the cell keys on the
+    // id, so a stale name cannot leak into a respondent-filled row.
+    expect(addedByCell({ added_by: null, added_by_name: 'Grace Hopper' })).toBe('');
+  });
+});
+
+test.describe('buildWideCsv — the two-row header a matrix forces', () => {
+  const matrix = () =>
+    field({
+      type: 'matrix',
+      label: 'Rate each topic',
+      matrix: {
+        rows: [
+          { id: 'row-recursion', label: 'Recursion' },
+          { id: 'row-pointers', label: 'Pointers' },
+        ],
+        columns: [
+          { id: 'col-shaky', label: 'Shaky' },
+          { id: 'col-solid', label: 'Solid' },
+        ],
+      },
+    });
+
+  test('the group row is padded to the FULL lead-column count', () => {
+    const grid = matrix();
+    const rows = cells(buildWideCsv([grid], [response()]));
+    const [groupRow, headerRow] = rows;
+
+    expect(rows).toHaveLength(3); // group + header + the one response
+
+    // Every lead column gets an empty group cell — eight of them, including the
+    // one "Added by" added. Off by one and the label names the wrong block.
+    expect(groupRow.slice(0, LEAD.length)).toEqual(LEAD.map(() => ''));
+
+    // The label lands over the matrix's FIRST row column, and only that one.
+    expect(groupRow[ADDED_BY + 1]).toBe('Rate each topic');
+    expect(groupRow[ADDED_BY + 2]).toBe('');
+    expect(groupRow).toHaveLength(LEAD.length + 2);
+
+    // The sub-row names each matrix row, starting in the same column.
+    expect(headerRow.slice(0, LEAD.length)).toEqual(LEAD);
+    expect(headerRow[ADDED_BY + 1]).toBe('Recursion');
+    expect(headerRow[ADDED_BY + 2]).toBe('Pointers');
+  });
+
+  test('the data cells line up under the sub-row they belong to', () => {
+    const grid = matrix();
+    const rows = cells(
+      buildWideCsv(
+        [grid],
+        [
+          response({
+            added_by: 'user-grace',
+            added_by_name: 'Grace Hopper',
+            answers: { [grid.id]: { 'row-recursion': 'col-solid', 'row-pointers': 'col-shaky' } },
+          }),
+        ]
+      )
+    );
+    const body = rows[2];
+
+    // The whole point of the padding: the answer under "Recursion" is the
+    // Recursion answer, with the lead columns still holding their own values.
+    expect(body[ADDED_BY]).toBe('Grace Hopper');
+    expect(body[ADDED_BY + 1]).toBe('Solid');
+    expect(body[ADDED_BY + 2]).toBe('Shaky');
+    expect(body).toHaveLength(LEAD.length + 2);
+  });
+});

--- a/apps/site/src/content/docs/docs/instructors/mcp-server.mdx
+++ b/apps/site/src/content/docs/docs/instructors/mcp-server.mdx
@@ -101,8 +101,8 @@ For any other MCP client: point it at `https://mcp.classmoji.io/mcp`. A spec-com
 
 Once connected, the assistant has two kinds of capabilities, each limited to your role in each classroom:
 
-- **Read** — your classrooms, roster, teams, assignment containers and submissions, the grading queue, leaderboard, regrade requests, calendar, pages, modules, quizzes, and your token ledger.
-- **Act** — add and remove emoji grades, assign graders, resolve regrade requests, update assignments, create and publish modules, create and edit pages, manage calendar events, and grant tokens.
+- **Read** — your classrooms, roster, teams, assignment containers and submissions, the grading queue, leaderboard, regrade requests, calendar, pages, modules, quizzes, forms and their responses, and your token ledger.
+- **Act** — add and remove emoji grades, assign graders, resolve regrade requests, update assignments, create and publish modules, create and edit pages, manage calendar events, and grant tokens. You can also create and publish forms, label responses as you work through them, and add responses you collected elsewhere — a spreadsheet, a previous term's list — as if the person had filled the form in.
 
 Staff-only surfaces (rosters, grading, the leaderboard) require the corresponding teaching-team or owner role, exactly as in the web app; students connecting the same server get only their own view.
 

--- a/packages/database/migrations/20260910130000_form_response_added_by/migration.sql
+++ b/packages/database/migrations/20260910130000_form_response_added_by/migration.sql
@@ -1,0 +1,23 @@
+-- Who typed this response in, when it was not the respondent.
+--
+-- Every row in form_responses got there because a person filled the form in.
+-- `createResponses` adds a staff-side path, and without a column saying so a
+-- row staff typed is indistinguishable from one somebody submitted: it is
+-- SUBMITTED, it carries a verified_at, and it points at a revision documented
+-- as "what the person actually saw". All three are set on purpose — the cap
+-- counts exactly those rows, and a staff-added person has to count — so none of
+-- them is available to carry the distinction.
+--
+-- NULL means the respondent submitted it themselves, which is true of every row
+-- that already exists, so there is no backfill and nothing to repair.
+--
+-- SET NULL rather than CASCADE on delete: a staff account leaving the platform
+-- must not take the responses they entered with it. The row survives; only the
+-- attribution is lost, which is the same trade user_id already makes.
+ALTER TABLE "form_responses" ADD COLUMN "added_by" TEXT;
+
+-- CreateIndex
+CREATE INDEX "form_responses_added_by_idx" ON "form_responses"("added_by");
+
+-- AddForeignKey
+ALTER TABLE "form_responses" ADD CONSTRAINT "form_responses_added_by_fkey" FOREIGN KEY ("added_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -139,8 +139,9 @@ enum FormStatus {
 
 /// PENDING_VERIFICATION is the public path's holding state: the answers are
 /// stored but count for nothing until the magic link is clicked. DRAFT is the
-/// server-side autosave row for identified fillers. Only SUBMITTED rows with a
-/// verified_at count toward the response cap and the FIFO ordering.
+/// server-side autosave row for identified fillers. The response cap counts
+/// SUBMITTED rows carrying a verified_at, and nothing else; FIFO order is a
+/// separate question, answered by `submitted_at` (see `listByFormId`).
 enum SubmissionState {
   DRAFT
   PENDING_VERIFICATION
@@ -323,7 +324,9 @@ model User {
   oauth_access_tokens           OauthAccessToken[]
   oauth_consents                OauthConsent[]
   forms_created                 Form[]
-  form_responses                FormResponse[]
+  form_responses                FormResponse[]            @relation("FormResponseRespondent")
+  /// Rows this user typed in on somebody else's behalf — see FormResponse.added_by.
+  form_responses_added          FormResponse[]            @relation("FormResponseAddedBy")
 
   @@unique([provider, provider_id])
   @@index([provider, login])
@@ -1672,6 +1675,17 @@ model FormResponse {
   /// fills. SetNull so a deleted account leaves the response (and its
   /// resolved_context name snapshot) intact.
   user_id          String?
+  /// The staff user who created this row on the respondent's behalf, via
+  /// formResponse.createResponses. Null means the respondent submitted it
+  /// themselves. SetNull so a departed staff account leaves the row intact.
+  ///
+  /// It is what keeps a staff-typed row from reading as respondent testimony.
+  /// `revision_id` is documented as "what the person actually saw", which is
+  /// not true of a row nobody filled in, and `verified_at` means a mailbox was
+  /// proven, which is not true either — both are set on a staff-added row
+  /// because the cap and the queue count exactly those. This column is how a
+  /// reader tells the two apart.
+  added_by         String?
   /// As typed, for display. `email_normalized` (lower/trim) is the identity key
   /// the partial unique index enforces.
   email            String
@@ -1687,8 +1701,11 @@ model FormResponse {
   resolved_context Json?
 
   submission_state SubmissionState @default(PENDING_VERIFICATION)
-  /// Magic-link confirmation time. Set once and preserved across later edits —
-  /// the cap and the FIFO ordering count from the FIRST verification.
+  /// Magic-link confirmation time. Set once and preserved across later edits.
+  /// The cap counts SUBMITTED rows that carry one; FIFO order is `submitted_at`
+  /// (see `listByFormId`), NOT this column — a staff-added row is verified at
+  /// the moment it is written and can still be filed at the time it was
+  /// actually received.
   verified_at      DateTime?
   /// Opaque cookie value keying an anonymous server-side partial (only when the
   /// form's save_partials is on). Kept until somebody deletes it — there is no
@@ -1707,7 +1724,11 @@ model FormResponse {
 
   form     Form             @relation(fields: [form_id], references: [id], onDelete: Cascade)
   revision FormRevision     @relation(fields: [revision_id], references: [id], onDelete: Cascade)
-  user     User?            @relation(fields: [user_id], references: [id], onDelete: SetNull)
+  // Two relations to User, so both are NAMED: `user` is the respondent (a
+  // classroom fill's session identity), `adder` is the staff member who typed
+  // the row in. Unnamed, Prisma cannot tell which back-relation is which.
+  user     User?            @relation("FormResponseRespondent", fields: [user_id], references: [id], onDelete: SetNull)
+  adder    User?            @relation("FormResponseAddedBy", fields: [added_by], references: [id], onDelete: SetNull)
   tokens   FormMagicToken[]
 
   // Identity uniqueness is per access mode and cannot be expressed in Prisma —
@@ -1715,6 +1736,7 @@ model FormResponse {
   //   (form_id, user_id)          WHERE user_id IS NOT NULL
   //   (form_id, email_normalized) WHERE user_id IS NULL
   @@index([form_id, submitted_at])
+  @@index([added_by])
   @@map("form_responses")
 }
 

--- a/packages/services/src/classmoji/__tests__/forms.createResponses.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/forms.createResponses.integration.test.ts
@@ -1,0 +1,678 @@
+/**
+ * `formResponse.createResponses` against a REAL Postgres.
+ *
+ * The interesting parts of this function are all things a fake Prisma would
+ * agree with whatever it was told: the form row lock, the partial unique index
+ * on (form_id, email_normalized), batch cap arithmetic against a live count,
+ * and an audit row that must land inside the same transaction as two hundred
+ * responses or not at all. So it runs against the devport database.
+ *
+ * SAFETY: every fixture is namespaced with a fresh uuid and torn down in
+ * afterAll by deleting the git organization (which cascades classroom → forms →
+ * revisions → responses → tokens, and audit logs with the classroom). Nothing
+ * is truncated and no pre-existing row is touched.
+ *
+ * Skipped unless DATABASE_URL names a LOCAL, non-shared database — the same
+ * guard forms.integration.test.ts uses, for the same reason.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+import getPrisma from '@classmoji/database';
+import * as formService from '../form.service.ts';
+import * as responseService from '../formResponse.service.ts';
+
+const DATABASE_URL = process.env.DATABASE_URL ?? '';
+const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(DATABASE_URL);
+/** A devport database (`classmoji_<feature>`) is fine; the shared dev one is not. */
+const isSharedDevDb = /\/classmoji(\?|$)/.test(DATABASE_URL);
+const RUN = Boolean(DATABASE_URL) && isLocal && !isSharedDevDb;
+
+/** The error `code` a rejected promise carries, or undefined. */
+const codeOf = async (promise: Promise<unknown>): Promise<string | undefined> => {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as { code?: string }).code;
+  }
+  return undefined;
+};
+
+const tokenOf = ({ rawToken }: { rawToken: string | null }): string => {
+  if (!rawToken) throw new Error('expected a freshly minted link, got a reused one');
+  return rawToken;
+};
+
+const NAME_FIELD = { type: 'short_text', label: 'Full Name', required: true } as const;
+const NOTE_FIELD = { type: 'long_text', label: 'Anything else?' } as const;
+
+describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
+  const suite = randomUUID().slice(0, 8);
+  let classroomId: string;
+  let orgId: string;
+  let ownerId: string;
+
+  const prisma = getPrisma();
+
+  /** An address nobody else in the suite will collide with. */
+  const addr = (label: string) => `create-${suite}-${label}@example.test`;
+
+  const makeForm = async ({
+    access = 'PUBLIC' as const,
+    fields = [NAME_FIELD, NOTE_FIELD] as unknown,
+    ...rest
+  }: {
+    access?: 'PUBLIC' | 'CLASSROOM';
+    fields?: unknown;
+    response_cap?: number | null;
+    allow_multiple?: boolean;
+    closes_at?: Date | null;
+  } = {}) => {
+    const form = await formService.create({
+      classroomId,
+      title: `Create ${suite} ${randomUUID().slice(0, 8)}`,
+      access,
+      createdBy: ownerId,
+      fields,
+    });
+    if (Object.keys(rest).length > 0) await formService.update(form.id, rest);
+    return form;
+  };
+
+  /** A published form, the revision its fill page renders, and its field ids. */
+  const makeOpenForm = async (options: Parameters<typeof makeForm>[0] = {}) => {
+    const form = await makeForm(options);
+    const { revision } = await formService.publish(form.id);
+    const fields = formService.fieldsOf(revision.fields);
+    return { formId: form.id, revisionId: revision.id, nameId: fields[0].id };
+  };
+
+  /** The answer set a valid row carries. */
+  const answersFor = (nameId: string, name: string) => ({ [nameId]: name });
+
+  /** Every response row on a form, oldest first. */
+  const rowsOf = (formId: string) =>
+    prisma.formResponse.findMany({ where: { form_id: formId }, orderBy: { submitted_at: 'asc' } });
+
+  /** Put a real, verified, respondent-submitted response on a form. */
+  const publicSubmit = async (formId: string, revisionId: string, email: string, name: string) => {
+    const begun = await responseService.beginPublicSubmission({
+      formId,
+      revisionId,
+      email,
+      name,
+      answers: answersFor(await nameFieldOf(revisionId), name),
+    });
+    await responseService.confirmSubmission(tokenOf(begun));
+    return begun.responseId;
+  };
+
+  /** Leave an unverified PENDING_VERIFICATION row behind, and nothing else. */
+  const publicBegin = async (formId: string, revisionId: string, email: string, name: string) => {
+    const begun = await responseService.beginPublicSubmission({
+      formId,
+      revisionId,
+      email,
+      name,
+      answers: answersFor(await nameFieldOf(revisionId), name),
+    });
+    return begun.responseId;
+  };
+
+  const nameFieldOf = async (revisionId: string) => {
+    const revision = await prisma.formRevision.findUniqueOrThrow({ where: { id: revisionId } });
+    return formService.fieldsOf(revision.fields)[0].id;
+  };
+
+  beforeAll(async () => {
+    const org = await prisma.gitOrganization.create({
+      data: {
+        provider: 'GITHUB',
+        provider_id: `createtest-${suite}`,
+        login: `createtest-org-${suite}`,
+      },
+    });
+    orgId = org.id;
+
+    const classroom = await prisma.classroom.create({
+      data: {
+        slug: `createtest-${suite}`,
+        git_org_id: orgId,
+        name: `Create Test ${suite}`,
+        content_namespace: `createtest-${suite}`,
+        content_repo: `content-createtest-${suite}`,
+      },
+    });
+    classroomId = classroom.id;
+
+    const owner = await prisma.user.create({
+      data: {
+        login: `createtest-${suite}-owner`,
+        email: `createtest-${suite}-owner@example.test`,
+        name: `Create Test owner`,
+      },
+    });
+    ownerId = owner.id;
+  });
+
+  afterAll(async () => {
+    if (orgId) await prisma.gitOrganization.delete({ where: { id: orgId } }).catch(() => {});
+    await prisma.user
+      .deleteMany({ where: { login: { startsWith: `createtest-${suite}-` } } })
+      .catch(() => {});
+  });
+
+  // ── The happy path ───────────────────────────────────────────────────────
+
+  it('writes verified SUBMITTED rows, attributed, with no magic token anywhere', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const when = [
+      new Date('2026-03-01T10:00:00.000Z'),
+      new Date('2026-03-02T10:00:00.000Z'),
+      new Date('2026-03-03T10:00:00.000Z'),
+    ];
+
+    const before = new Date();
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: ['a', 'b', 'c'].map((label, index) => ({
+        email: addr(`happy-${label}`),
+        name: `Person ${label}`,
+        answers: answersFor(nameId, `Person ${label}`),
+        submittedAt: when[index],
+      })),
+    });
+
+    expect(report.outcome).toBe('committed');
+    expect(report.revision_id).toBe(revisionId);
+    expect(report.counts).toEqual({ would_create: 0, created: 3, duplicate: 0, invalid: 0 });
+    expect(report.rows.map(row => row.disposition)).toEqual(['created', 'created', 'created']);
+
+    const rows = await rowsOf(formId);
+    expect(rows).toHaveLength(3);
+    for (const [index, row] of rows.entries()) {
+      expect(row.submission_state).toBe('SUBMITTED');
+      expect(row.verified_at).not.toBeNull();
+      // NEVER backdated, whatever submitted_at says.
+      expect(row.verified_at?.getTime() ?? 0).toBeGreaterThanOrEqual(before.getTime());
+      expect(row.submitted_at.toISOString()).toBe(when[index].toISOString());
+      expect(row.added_by).toBe(ownerId);
+      expect(row.user_id).toBeNull();
+      expect(row.draft_token).toBeNull();
+      expect(row.resolved_context).toBeNull();
+      expect(row.revision_id).toBe(revisionId);
+    }
+
+    // The whole reason this is not a mode of beginPublicSubmission.
+    const tokens = await prisma.formMagicToken.count({
+      where: { response_id: { in: rows.map(row => row.id) } },
+    });
+    expect(tokens).toBe(0);
+  });
+
+  it('names every id it created, and each one is really there', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [
+        { email: addr('ids-a'), answers: answersFor(nameId, 'A') },
+        { email: addr('ids-b'), answers: answersFor(nameId, 'B') },
+      ],
+    });
+
+    const ids = report.rows.map(row => row.response_id);
+    expect(ids.every(Boolean)).toBe(true);
+    const found = await prisma.formResponse.findMany({
+      where: { id: { in: ids as string[] } },
+      select: { id: true, email: true },
+    });
+    expect(found).toHaveLength(2);
+    expect(new Set(found.map(row => row.id))).toEqual(new Set(ids));
+  });
+
+  it('defaults submitted_at to now when the caller supplies none', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const before = new Date();
+    await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [{ email: addr('nodate'), answers: answersFor(nameId, 'No Date') }],
+    });
+    const [row] = await rowsOf(formId);
+    expect(row.submitted_at.getTime()).toBeGreaterThanOrEqual(before.getTime());
+  });
+
+  // ── Duplicates ───────────────────────────────────────────────────────────
+
+  it('reports an existing SUBMITTED row as a duplicate and leaves its answers alone', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const email = addr('dup-submitted');
+    const existingId = await publicSubmit(formId, revisionId, email, 'Original Answer');
+    const before = await prisma.formResponse.findUniqueOrThrow({ where: { id: existingId } });
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [
+        { email: email.toUpperCase(), answers: answersFor(nameId, 'Staff Overwrite Attempt') },
+        { email: addr('dup-submitted-other'), answers: answersFor(nameId, 'Fresh') },
+      ],
+    });
+
+    expect(report.outcome).toBe('committed');
+    expect(report.counts).toEqual({ would_create: 0, created: 1, duplicate: 1, invalid: 0 });
+    expect(report.rows[0]).toMatchObject({
+      input_index: 0,
+      disposition: 'duplicate',
+      response_id: existingId,
+      existing_state: 'SUBMITTED',
+    });
+    expect(report.rows[1].disposition).toBe('created');
+
+    const after = await prisma.formResponse.findUniqueOrThrow({ where: { id: existingId } });
+    expect(after.answers).toEqual(before.answers);
+    expect(after.name).toBe(before.name);
+    expect(after.added_by).toBeNull();
+    expect(await rowsOf(formId)).toHaveLength(2);
+  });
+
+  it('reports a PENDING_VERIFICATION row as one, and does not promote it', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const email = addr('dup-pending');
+    const existingId = await publicBegin(formId, revisionId, email, 'Half Way');
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [{ email, answers: answersFor(nameId, 'Staff Version') }],
+    });
+
+    expect(report.counts).toEqual({ would_create: 0, created: 0, duplicate: 1, invalid: 0 });
+    expect(report.rows[0]).toMatchObject({
+      disposition: 'duplicate',
+      response_id: existingId,
+      existing_state: 'PENDING_VERIFICATION',
+    });
+
+    const after = await prisma.formResponse.findUniqueOrThrow({ where: { id: existingId } });
+    expect(after.submission_state).toBe('PENDING_VERIFICATION');
+    expect(after.name).toBe('Half Way');
+    expect(after.added_by).toBeNull();
+  });
+
+  it('refuses BOTH rows when one call carries the same address twice', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const email = addr('twice');
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [
+        { email, answers: answersFor(nameId, 'First') },
+        { email: ` ${email.toUpperCase()} `, answers: answersFor(nameId, 'Second') },
+        { email: addr('twice-other'), answers: answersFor(nameId, 'Other') },
+      ],
+    });
+
+    expect(report.rows[0].disposition).toBe('duplicate');
+    expect(report.rows[1].disposition).toBe('duplicate');
+    expect(report.rows[0].issues?.[0]).toMatchObject({
+      code: 'duplicate_in_input',
+      path: 'email',
+    });
+    expect(report.rows[1].issues?.[0]?.code).toBe('duplicate_in_input');
+    // No first-wins rule: neither is written, and neither claims a row id.
+    expect(report.rows[0].response_id).toBeUndefined();
+    expect(report.rows[0].existing_state).toBeUndefined();
+
+    const rows = await rowsOf(formId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email_normalized).toBe(addr('twice-other'));
+  });
+
+  // ── All or nothing ───────────────────────────────────────────────────────
+
+  it('rejects the whole batch for one invalid row, and writes nothing', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [
+        { email: addr('reject-a'), answers: answersFor(nameId, 'Fine') },
+        // The required field has no answer — the fill page's own rule.
+        { email: addr('reject-b'), answers: {} },
+        { email: addr('reject-c'), answers: answersFor(nameId, 'Also fine') },
+      ],
+    });
+
+    expect(report.outcome).toBe('rejected');
+    expect(report.counts).toEqual({ would_create: 2, created: 0, duplicate: 0, invalid: 1 });
+    expect(await rowsOf(formId)).toHaveLength(0);
+
+    const issue = report.rows[1].issues?.[0];
+    expect(issue?.field_id).toBe(nameId);
+    expect(issue?.label).toBe('Full Name');
+    expect(issue?.path).toBe(nameId);
+    expect(issue?.code).toBeTruthy();
+    expect(issue?.message).toBeTruthy();
+  });
+
+  it('marks a malformed address invalid', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [{ email: 'not an address', answers: answersFor(nameId, 'X') }],
+    });
+    expect(report.outcome).toBe('rejected');
+    expect(report.rows[0].issues?.[0]).toMatchObject({ code: 'invalid_email', path: 'email' });
+    expect(await rowsOf(formId)).toHaveLength(0);
+  });
+
+  it('marks a submitted_at in the future invalid', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [
+        { email: addr('past'), answers: answersFor(nameId, 'Past'), submittedAt: new Date(0) },
+        {
+          email: addr('future'),
+          answers: answersFor(nameId, 'Future'),
+          submittedAt: new Date(Date.now() + 60_000),
+        },
+      ],
+    });
+
+    expect(report.outcome).toBe('rejected');
+    expect(report.rows[0].disposition).toBe('would_create');
+    expect(report.rows[1].disposition).toBe('invalid');
+    expect(report.rows[1].issues?.[0]).toMatchObject({
+      code: 'future_timestamp',
+      path: 'submitted_at',
+    });
+    expect(await rowsOf(formId)).toHaveLength(0);
+  });
+
+  // ── Dry run ──────────────────────────────────────────────────────────────
+
+  it('counts a dry run without writing anything', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const email = addr('dry-existing');
+    await publicSubmit(formId, revisionId, email, 'Already Here');
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      dryRun: true,
+      responses: [
+        { email: addr('dry-a'), answers: answersFor(nameId, 'A') },
+        { email: addr('dry-b'), answers: answersFor(nameId, 'B') },
+        { email, answers: answersFor(nameId, 'Dup') },
+      ],
+    });
+
+    expect(report.outcome).toBe('dry_run');
+    expect(report.counts).toEqual({ would_create: 2, created: 0, duplicate: 1, invalid: 0 });
+    expect(report.rows[2].existing_state).toBe('SUBMITTED');
+    expect(report.rows.every(row => row.disposition !== 'created')).toBe(true);
+    // Only the row the public path made.
+    expect(await rowsOf(formId)).toHaveLength(1);
+  });
+
+  // ── The cap ──────────────────────────────────────────────────────────────
+
+  it('does batch arithmetic against the cap, and writes nothing when it overflows', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm({ response_cap: 3 });
+    await publicSubmit(formId, revisionId, addr('cap-1'), 'One');
+    await publicSubmit(formId, revisionId, addr('cap-2'), 'Two');
+
+    const twoRows = [
+      { email: addr('cap-3'), answers: answersFor(nameId, 'Three') },
+      { email: addr('cap-4'), answers: answersFor(nameId, 'Four') },
+    ];
+
+    expect(
+      await codeOf(
+        responseService.createResponses({
+          formId,
+          revisionId,
+          addedBy: ownerId,
+          responses: twoRows,
+        })
+      )
+    ).toBe(responseService.FORM_CAP_REACHED);
+    expect(await rowsOf(formId)).toHaveLength(2);
+
+    // A dry run is refused on exactly the same terms — a rehearsal that says
+    // "fine" and a commit that says "full" would be worse than no rehearsal.
+    expect(
+      await codeOf(
+        responseService.createResponses({
+          formId,
+          revisionId,
+          addedBy: ownerId,
+          dryRun: true,
+          responses: twoRows,
+        })
+      )
+    ).toBe(responseService.FORM_CAP_REACHED);
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [twoRows[0]],
+    });
+    expect(report.outcome).toBe('committed');
+    expect(await rowsOf(formId)).toHaveLength(3);
+  });
+
+  // ── Guards ───────────────────────────────────────────────────────────────
+
+  it('refuses a revision that is not the form’s current one', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    await formService.publish(formId); // revision 2 supersedes it
+
+    expect(
+      await codeOf(
+        responseService.createResponses({
+          formId,
+          revisionId,
+          addedBy: ownerId,
+          responses: [{ email: addr('stale'), answers: answersFor(nameId, 'Stale') }],
+        })
+      )
+    ).toBe(responseService.FORM_REVISION_STALE);
+    expect(await rowsOf(formId)).toHaveLength(0);
+  });
+
+  it('refuses a CLASSROOM form', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm({ access: 'CLASSROOM' });
+    expect(
+      await codeOf(
+        responseService.createResponses({
+          formId,
+          revisionId,
+          addedBy: ownerId,
+          responses: [{ email: addr('classroom'), answers: answersFor(nameId, 'Nope') }],
+        })
+      )
+    ).toBe(responseService.FORM_ACCESS_MISMATCH);
+  });
+
+  it('refuses a form that was never published', async () => {
+    const form = await makeForm();
+    expect(
+      await codeOf(
+        responseService.createResponses({
+          formId: form.id,
+          addedBy: ownerId,
+          responses: [{ email: addr('draft'), answers: {} }],
+        })
+      )
+    ).toBe(responseService.FORM_NOT_OPEN);
+  });
+
+  it('accepts a CLOSED form — adding to a closed waitlist is the ordinary case', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    await formService.close(formId);
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [{ email: addr('closed'), answers: answersFor(nameId, 'Late') }],
+    });
+    expect(report.outcome).toBe('committed');
+    expect(await rowsOf(formId)).toHaveLength(1);
+  });
+
+  it('refuses an empty batch and one over the ceiling', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    expect(
+      await codeOf(
+        responseService.createResponses({ formId, revisionId, addedBy: ownerId, responses: [] })
+      )
+    ).toBe(responseService.FORM_BATCH_INVALID);
+
+    const tooMany = Array.from({ length: responseService.CREATE_RESPONSES_MAX + 1 }, (_, i) => ({
+      email: addr(`bulk-${i}`),
+      answers: answersFor(nameId, `Bulk ${i}`),
+    }));
+    expect(
+      await codeOf(
+        responseService.createResponses({
+          formId,
+          revisionId,
+          addedBy: ownerId,
+          responses: tooMany,
+        })
+      )
+    ).toBe(responseService.FORM_BATCH_INVALID);
+  });
+
+  // ── Audit ────────────────────────────────────────────────────────────────
+
+  describe('the audit row', () => {
+    const auditsFor = (formId: string) =>
+      prisma.auditLog.count({ where: { classroom_id: classroomId, resource_id: formId } });
+
+    const descriptor = () => ({
+      user_id: ownerId,
+      classroom_id: classroomId,
+      role: 'OWNER' as const,
+      data: { tool: 'form_response_create' },
+    });
+
+    it('writes exactly one row on a commit, carrying the ids and counts', async () => {
+      const { formId, revisionId, nameId } = await makeOpenForm();
+      const report = await responseService.createResponses({
+        formId,
+        revisionId,
+        addedBy: ownerId,
+        audit: descriptor(),
+        responses: [
+          { email: addr('audit-a'), answers: answersFor(nameId, 'A') },
+          { email: addr('audit-b'), answers: answersFor(nameId, 'B') },
+        ],
+      });
+
+      expect(await auditsFor(formId)).toBe(1);
+      const row = await prisma.auditLog.findFirstOrThrow({
+        where: { classroom_id: classroomId, resource_id: formId },
+      });
+      expect(row.action).toBe('CREATE');
+      expect(row.resource_type).toBe('FORMS');
+      expect(row.user_id).toBe(ownerId);
+      const payload = row.data as Record<string, unknown>;
+      expect(payload.tool).toBe('form_response_create');
+      expect(payload.revision_id).toBe(revisionId);
+      expect(payload.counts).toMatchObject({ created: 2 });
+      expect(payload.created_ids).toEqual(report.rows.map(r => r.response_id));
+    });
+
+    it('writes none on a dry run', async () => {
+      const { formId, revisionId, nameId } = await makeOpenForm();
+      await responseService.createResponses({
+        formId,
+        revisionId,
+        addedBy: ownerId,
+        dryRun: true,
+        audit: descriptor(),
+        responses: [{ email: addr('audit-dry'), answers: answersFor(nameId, 'Dry') }],
+      });
+      expect(await auditsFor(formId)).toBe(0);
+    });
+
+    it('writes none on a rejected batch', async () => {
+      const { formId, revisionId, nameId } = await makeOpenForm();
+      const report = await responseService.createResponses({
+        formId,
+        revisionId,
+        addedBy: ownerId,
+        audit: descriptor(),
+        responses: [
+          { email: addr('audit-rej-a'), answers: answersFor(nameId, 'A') },
+          { email: addr('audit-rej-b'), answers: {} },
+        ],
+      });
+      expect(report.outcome).toBe('rejected');
+      expect(await auditsFor(formId)).toBe(0);
+    });
+  });
+
+  // ── What the staff list sees ─────────────────────────────────────────────
+
+  it('files created rows into the FIFO order by their supplied submitted_at', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    // A real submission lands NOW, between the two backdated rows below.
+    const middleId = await publicSubmit(formId, revisionId, addr('order-mid'), 'Middle');
+    await prisma.formResponse.update({
+      where: { id: middleId },
+      data: { submitted_at: new Date('2026-02-15T12:00:00.000Z') },
+    });
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      responses: [
+        {
+          email: addr('order-late'),
+          answers: answersFor(nameId, 'Late'),
+          submittedAt: new Date('2026-03-15T12:00:00.000Z'),
+        },
+        {
+          email: addr('order-early'),
+          answers: answersFor(nameId, 'Early'),
+          submittedAt: new Date('2026-01-15T12:00:00.000Z'),
+        },
+      ],
+    });
+    expect(report.outcome).toBe('committed');
+
+    const listed = await responseService.listByFormId(formId);
+    expect(listed.map(row => row.email)).toEqual([
+      addr('order-early'),
+      addr('order-mid'),
+      addr('order-late'),
+    ]);
+    // And the staff select carries the attribution the list column reads.
+    expect(listed.map(row => row.added_by)).toEqual([ownerId, null, ownerId]);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/forms.createResponses.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/forms.createResponses.integration.test.ts
@@ -58,6 +58,17 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
   /** An address nobody else in the suite will collide with. */
   const addr = (label: string) => `create-${suite}-${label}@example.test`;
 
+  /**
+   * The audit descriptor every call now carries — `audit` is a REQUIRED
+   * parameter, so there is no such thing as an unaudited batch to test.
+   */
+  const descriptor = () => ({
+    user_id: ownerId,
+    classroom_id: classroomId,
+    role: 'OWNER' as const,
+    data: { tool: 'form_response_create' },
+  });
+
   const makeForm = async ({
     access = 'PUBLIC' as const,
     fields = [NAME_FIELD, NOTE_FIELD] as unknown,
@@ -68,6 +79,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
     response_cap?: number | null;
     allow_multiple?: boolean;
     closes_at?: Date | null;
+    save_partials?: boolean;
   } = {}) => {
     const form = await formService.create({
       classroomId,
@@ -178,6 +190,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: ['a', 'b', 'c'].map((label, index) => ({
         email: addr(`happy-${label}`),
         name: `Person ${label}`,
@@ -219,6 +232,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [
         { email: addr('ids-a'), answers: answersFor(nameId, 'A') },
         { email: addr('ids-b'), answers: answersFor(nameId, 'B') },
@@ -242,6 +256,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [{ email: addr('nodate'), answers: answersFor(nameId, 'No Date') }],
     });
     const [row] = await rowsOf(formId);
@@ -260,6 +275,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [
         { email: email.toUpperCase(), answers: answersFor(nameId, 'Staff Overwrite Attempt') },
         { email: addr('dup-submitted-other'), answers: answersFor(nameId, 'Fresh') },
@@ -292,6 +308,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [{ email, answers: answersFor(nameId, 'Staff Version') }],
     });
 
@@ -308,7 +325,46 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
     expect(after.added_by).toBeNull();
   });
 
-  it('refuses BOTH rows when one call carries the same address twice', async () => {
+  it('reports an anonymous DRAFT row as a duplicate and leaves it a draft', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm({ save_partials: true });
+    const email = addr('dup-draft');
+    const draft = await responseService.upsertDraft({
+      formId,
+      revisionId,
+      draftToken: randomUUID(),
+      email,
+      name: 'Half Typed',
+      answers: answersFor(nameId, 'Half Typed'),
+    });
+    expect(draft.submission_state).toBe('DRAFT');
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      audit: descriptor(),
+      responses: [{ email: email.toUpperCase(), answers: answersFor(nameId, 'Staff Version') }],
+    });
+
+    expect(report.counts).toEqual({ would_create: 0, created: 0, duplicate: 1, invalid: 0 });
+    expect(report.rows[0]).toMatchObject({
+      disposition: 'duplicate',
+      response_id: draft.id,
+      existing_state: 'DRAFT',
+    });
+
+    // A DRAFT is somebody's half-finished typing, not a submission — and it is
+    // certainly not staff's to overwrite on the way past.
+    const after = await prisma.formResponse.findUniqueOrThrow({ where: { id: draft.id } });
+    expect(after.submission_state).toBe('DRAFT');
+    expect(after.name).toBe('Half Typed');
+    expect(after.answers).toEqual(answersFor(nameId, 'Half Typed'));
+    expect(after.added_by).toBeNull();
+    expect(after.draft_token).not.toBeNull();
+    expect(await rowsOf(formId)).toHaveLength(1);
+  });
+
+  it('marks BOTH rows invalid when one call carries the same address twice', async () => {
     const { formId, revisionId, nameId } = await makeOpenForm();
     const email = addr('twice');
 
@@ -316,6 +372,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [
         { email, answers: answersFor(nameId, 'First') },
         { email: ` ${email.toUpperCase()} `, answers: answersFor(nameId, 'Second') },
@@ -323,8 +380,13 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       ],
     });
 
-    expect(report.rows[0].disposition).toBe('duplicate');
-    expect(report.rows[1].disposition).toBe('duplicate');
+    // The caller's own list disagrees with itself — a data error like any
+    // other, so the whole batch is rejected and NOTHING is written, not even
+    // the third row that was fine.
+    expect(report.outcome).toBe('rejected');
+    expect(report.counts).toEqual({ would_create: 1, created: 0, duplicate: 0, invalid: 2 });
+    expect(report.rows[0].disposition).toBe('invalid');
+    expect(report.rows[1].disposition).toBe('invalid');
     expect(report.rows[0].issues?.[0]).toMatchObject({
       code: 'duplicate_in_input',
       path: 'email',
@@ -334,9 +396,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
     expect(report.rows[0].response_id).toBeUndefined();
     expect(report.rows[0].existing_state).toBeUndefined();
 
-    const rows = await rowsOf(formId);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].email_normalized).toBe(addr('twice-other'));
+    expect(await rowsOf(formId)).toHaveLength(0);
   });
 
   // ── All or nothing ───────────────────────────────────────────────────────
@@ -348,6 +408,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [
         { email: addr('reject-a'), answers: answersFor(nameId, 'Fine') },
         // The required field has no answer — the fill page's own rule.
@@ -368,12 +429,46 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
     expect(issue?.message).toBeTruthy();
   });
 
+  it('names the offending key when the answers carry a field id the form has not', async () => {
+    const { formId, revisionId, nameId } = await makeOpenForm();
+    const stale = randomUUID();
+
+    const report = await responseService.createResponses({
+      formId,
+      revisionId,
+      addedBy: ownerId,
+      audit: descriptor(),
+      responses: [
+        {
+          email: addr('unknown-key'),
+          answers: { ...answersFor(nameId, 'Fine'), [stale]: 'from an older revision' },
+        },
+      ],
+    });
+
+    expect(report.outcome).toBe('rejected');
+    // ONE issue per refused key, each naming the key — not a single issue with
+    // an empty path, which is what zod's `unrecognized_keys` would give.
+    const issues = report.rows[0].issues ?? [];
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: 'unrecognized_keys',
+      field_id: stale,
+      path: stale,
+    });
+    expect(issues[0]?.label).toBeUndefined();
+    expect(issues[0]?.message).toContain(stale);
+    expect(issues[0]?.message).toContain('form_get');
+    expect(await rowsOf(formId)).toHaveLength(0);
+  });
+
   it('marks a malformed address invalid', async () => {
     const { formId, revisionId, nameId } = await makeOpenForm();
     const report = await responseService.createResponses({
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [{ email: 'not an address', answers: answersFor(nameId, 'X') }],
     });
     expect(report.outcome).toBe('rejected');
@@ -387,6 +482,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [
         { email: addr('past'), answers: answersFor(nameId, 'Past'), submittedAt: new Date(0) },
         {
@@ -418,6 +514,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       dryRun: true,
       responses: [
         { email: addr('dry-a'), answers: answersFor(nameId, 'A') },
@@ -452,6 +549,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
           formId,
           revisionId,
           addedBy: ownerId,
+          audit: descriptor(),
           responses: twoRows,
         })
       )
@@ -466,6 +564,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
           formId,
           revisionId,
           addedBy: ownerId,
+          audit: descriptor(),
           dryRun: true,
           responses: twoRows,
         })
@@ -476,6 +575,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [twoRows[0]],
     });
     expect(report.outcome).toBe('committed');
@@ -494,6 +594,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
           formId,
           revisionId,
           addedBy: ownerId,
+          audit: descriptor(),
           responses: [{ email: addr('stale'), answers: answersFor(nameId, 'Stale') }],
         })
       )
@@ -509,6 +610,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
           formId,
           revisionId,
           addedBy: ownerId,
+          audit: descriptor(),
           responses: [{ email: addr('classroom'), answers: answersFor(nameId, 'Nope') }],
         })
       )
@@ -522,6 +624,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
         responseService.createResponses({
           formId: form.id,
           addedBy: ownerId,
+          audit: descriptor(),
           responses: [{ email: addr('draft'), answers: {} }],
         })
       )
@@ -536,6 +639,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [{ email: addr('closed'), answers: answersFor(nameId, 'Late') }],
     });
     expect(report.outcome).toBe('committed');
@@ -546,7 +650,13 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
     const { formId, revisionId, nameId } = await makeOpenForm();
     expect(
       await codeOf(
-        responseService.createResponses({ formId, revisionId, addedBy: ownerId, responses: [] })
+        responseService.createResponses({
+          formId,
+          revisionId,
+          addedBy: ownerId,
+          audit: descriptor(),
+          responses: [],
+        })
       )
     ).toBe(responseService.FORM_BATCH_INVALID);
 
@@ -560,6 +670,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
           formId,
           revisionId,
           addedBy: ownerId,
+          audit: descriptor(),
           responses: tooMany,
         })
       )
@@ -571,13 +682,6 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
   describe('the audit row', () => {
     const auditsFor = (formId: string) =>
       prisma.auditLog.count({ where: { classroom_id: classroomId, resource_id: formId } });
-
-    const descriptor = () => ({
-      user_id: ownerId,
-      classroom_id: classroomId,
-      role: 'OWNER' as const,
-      data: { tool: 'form_response_create' },
-    });
 
     it('writes exactly one row on a commit, carrying the ids and counts', async () => {
       const { formId, revisionId, nameId } = await makeOpenForm();
@@ -612,10 +716,30 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
         formId,
         revisionId,
         addedBy: ownerId,
-        dryRun: true,
         audit: descriptor(),
+        dryRun: true,
         responses: [{ email: addr('audit-dry'), answers: answersFor(nameId, 'Dry') }],
       });
+      expect(await auditsFor(formId)).toBe(0);
+    });
+
+    it('writes none on a commit that created nothing — a no-op is not a mutation', async () => {
+      const { formId, revisionId, nameId } = await makeOpenForm();
+      const email = addr('audit-noop');
+      await publicSubmit(formId, revisionId, email, 'Already Here');
+
+      const report = await responseService.createResponses({
+        formId,
+        revisionId,
+        addedBy: ownerId,
+        audit: descriptor(),
+        responses: [{ email, answers: answersFor(nameId, 'Staff Version') }],
+      });
+
+      expect(report.outcome).toBe('committed');
+      expect(report.counts).toEqual({ would_create: 0, created: 0, duplicate: 1, invalid: 0 });
+      // The transaction committed, but it wrote no response — so no CREATE row
+      // may claim it did. (The MCP tool records that case as the VIEW it was.)
       expect(await auditsFor(formId)).toBe(0);
     });
 
@@ -651,6 +775,7 @@ describe.skipIf(!RUN)('formResponse.createResponses (integration)', () => {
       formId,
       revisionId,
       addedBy: ownerId,
+      audit: descriptor(),
       responses: [
         {
           email: addr('order-late'),

--- a/packages/services/src/classmoji/formResponse.service.ts
+++ b/packages/services/src/classmoji/formResponse.service.ts
@@ -1,11 +1,15 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import getPrisma from '@classmoji/database';
 import {
   answersByteSize,
+  flattenFields,
   parseAnswers,
   requiresResolvedContext,
+  FIELD_TYPE_REGISTRY,
+  FORM_ANSWERS_INVALID,
   FORM_ANSWERS_TOO_LARGE,
   FORM_LIMITS,
+  type FormField,
   type ResolvedTargetRef,
 } from './formContract.ts';
 import {
@@ -18,7 +22,8 @@ import {
 } from './formTeamResolver.ts';
 import { escapeVars, pagesUrl } from '../emails/escape.ts';
 import { fieldsOf } from './form.service.ts';
-import type { Prisma, SubmissionState } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import type { Role, SubmissionState } from '@prisma/client';
 
 /**
  * Form Response Service
@@ -86,6 +91,15 @@ export const FORM_NOT_SUBMITTED_YET = 'FORM_NOT_SUBMITTED_YET';
  * send is an optimisation and never a requirement.
  */
 export const MAGIC_LINK_NOT_BOUND = 'MAGIC_LINK_NOT_BOUND';
+
+/**
+ * A staff-side batch that is empty or bigger than `CREATE_RESPONSES_MAX`.
+ *
+ * Not a form rule and not something a respondent can cause — it is a caller
+ * that built the wrong request, and it says so rather than borrowing a code
+ * that means something about the form.
+ */
+export const FORM_BATCH_INVALID = 'FORM_BATCH_INVALID';
 
 export const MAGIC_LINK_INVALID = 'MAGIC_LINK_INVALID';
 export const MAGIC_LINK_EXPIRED = 'MAGIC_LINK_EXPIRED';
@@ -1583,6 +1597,517 @@ export async function submitClassroom({
   });
 }
 
+// ─── Staff-created responses ────────────────────────────────────────────────
+
+/**
+ * Rows one `createResponses` call may carry.
+ *
+ * Two hundred, matching `roster_add_student`. The ceiling is about the
+ * transaction, not the arithmetic: every writer to this form — including every
+ * public submitter — waits behind the form's row lock while the batch inserts.
+ */
+export const CREATE_RESPONSES_MAX = 200;
+
+/** One row a caller wants written, before anything has looked at it. */
+export interface CreateResponseInput {
+  email: string;
+  name?: string | null;
+  /**
+   * Keyed by field uuid, exactly as the fill page posts them. Validated by the
+   * form contract and never coerced: `'7'` where a number belongs is a mistake,
+   * not a value to fix up.
+   */
+  answers: unknown;
+  /**
+   * When the response was actually received. Defaults to now, and is never
+   * accepted in the future. This is the FIFO position — see `listByFormId`.
+   */
+  submittedAt?: Date | string | null;
+  staffStatus?: string | null;
+  staffNote?: string | null;
+}
+
+/**
+ * One reason a row was refused, addressed at the field it is about.
+ *
+ * `field_id` AND `label`, because neither alone is enough: labels collide
+ * ("Name" twice on a long form) and a uuid that matches no field has no label
+ * at all. `path` is the zod path, which reaches inside a matrix or a group.
+ */
+export interface CreateResponseIssue {
+  code: string;
+  field_id?: string;
+  label?: string;
+  path: string;
+  message: string;
+}
+
+export type CreateResponseDisposition = 'would_create' | 'created' | 'duplicate' | 'invalid';
+
+export interface CreateResponseRow {
+  input_index: number;
+  email: string;
+  disposition: CreateResponseDisposition;
+  /** The EXISTING row's id on a duplicate; the NEW row's id on a created one. */
+  response_id?: string;
+  /** The state of the row already holding this address. Duplicates only. */
+  existing_state?: SubmissionState;
+  issues?: CreateResponseIssue[];
+}
+
+export interface CreateResponsesReport {
+  outcome: 'dry_run' | 'committed' | 'rejected';
+  /** The revision the answers were validated against, and that every row points at. */
+  revision_id: string;
+  counts: { would_create: number; created: number; duplicate: number; invalid: number };
+  rows: CreateResponseRow[];
+}
+
+/**
+ * The audit row to write, if the caller wants one — INSIDE the transaction.
+ *
+ * Every sibling tool audits after its write, and one row after one write is a
+ * fair trade. This writes up to two hundred, and a commit followed by a crashed
+ * audit would leave a form full of responses nobody can account for, plus a
+ * retry that reports every one of them as a duplicate. So it commits with them
+ * or not at all, which is why this takes a descriptor rather than calling
+ * `audit.service` (that one holds its own connection and its own dedup read).
+ */
+export interface CreateResponsesAudit {
+  user_id: string;
+  classroom_id: string;
+  role: Role;
+  /** Merged into the audit payload beneath the ids and counts written here. */
+  data?: Record<string, unknown>;
+}
+
+/** Enough to catch a pasted name or a missing @; the contract owns the rest. */
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const trimToNull = (value: string | null | undefined): string | null =>
+  value === null || value === undefined ? null : value.trim() || null;
+
+/** The field's label, when it has one a person would recognise. */
+const labelOf = (field: FormField): string | undefined =>
+  typeof field.label === 'string' ? field.label : undefined;
+
+/** The zod-issue shape `parseAnswers` attaches, without importing zod here. */
+interface ThrownIssue {
+  code?: string;
+  path?: Array<string | number>;
+  message?: string;
+}
+
+/** Everything one input row needs, carried beside the row it will report as. */
+interface PreparedRow {
+  report: CreateResponseRow;
+  emailNormalized: string;
+  emailTrimmed: string;
+  name: string | null;
+  answers?: Record<string, unknown>;
+  submittedAt?: Date;
+  staffStatus: string | null;
+  staffNote: string | null;
+}
+
+const countRows = (rows: CreateResponseRow[]) => ({
+  would_create: rows.filter(row => row.disposition === 'would_create').length,
+  created: rows.filter(row => row.disposition === 'created').length,
+  duplicate: rows.filter(row => row.disposition === 'duplicate').length,
+  invalid: rows.filter(row => row.disposition === 'invalid').length,
+});
+
+/**
+ * Write one or many responses on the respondents' behalf.
+ *
+ * ── What this is, and what it deliberately is not ──────────────────────────
+ * A form could only ever be FILLED. Every row in `form_responses` is there
+ * because a person typed it into the fill page, and staff holding a list of
+ * people who signed up somewhere else had no way to record them. This is that
+ * way, and it is not an importer: it knows nothing about where the rows came
+ * from and does nothing special for any of them.
+ *
+ * The answers are validated by exactly the contract the fill page runs —
+ * `parseAnswers`, strict, keyed by field uuid, options by id, no coercion.
+ * Required means required. A caller holding rows that lack a required answer
+ * supplies one or makes the field optional first; there is no lenient flag.
+ *
+ * ── No mail, no tokens ─────────────────────────────────────────────────────
+ * This never touches `mintLinkFor`, `composeLinkEmail` or `findLiveLink`, and
+ * returns no `emails`, which is the whole reason it is a sibling of
+ * `beginPublicSubmission` rather than a mode of it: token minting is welded
+ * into that path, and a staff data-entry pass must not mail two hundred people.
+ *
+ * ── `verified_at` is now, and never backdated ──────────────────────────────
+ * A staff-added row has to count toward the cap, and the cap counts SUBMITTED
+ * rows carrying a `verified_at`. Backdating it would claim a mailbox
+ * confirmation that never happened, on a date it did not happen. `submitted_at`
+ * — the FIFO position — is the caller's to set, which is where a real signup
+ * date belongs. Known side effect: a non-null `verified_at` suppresses the
+ * courtesy early link, so somebody staff added who later types their own
+ * address into the open form gets no pre-submit mail. They can still submit and
+ * receive one.
+ *
+ * `added_by` is what keeps all of this honest — see the column's own comment.
+ *
+ * ── Never overwrites ───────────────────────────────────────────────────────
+ * An address already on the form is reported as a duplicate with the existing
+ * row's id and state, and that row is left exactly as it was. A DRAFT or an
+ * unverified placeholder is NOT a submission, so reporting one as "already
+ * present" is a statement about what is there, not a claim that the person is
+ * covered. Two rows in one call sharing an address are both refused; there is
+ * no first-wins rule to guess wrong about.
+ *
+ * ── All or nothing ─────────────────────────────────────────────────────────
+ * One invalid row rejects the batch, reports every row, and writes nothing —
+ * `outcome: 'rejected'`, returned rather than thrown, because the report is the
+ * useful part.
+ *
+ * PUBLIC forms only. The email-uniqueness index is scoped `WHERE user_id IS
+ * NULL`, so a staff-added row on a CLASSROOM form would not collide with the
+ * same human's later signed-in submission — two rows for one person. That also
+ * excludes roster- and teammate-sourced field types for free, and both are
+ * asserted against the registry rather than special-cased by name.
+ *
+ * @throws FORM_NOT_FOUND, FORM_ACCESS_MISMATCH, FORM_NOT_OPEN,
+ *   FORM_BATCH_INVALID, FORM_REVISION_STALE, FORM_CAP_REACHED.
+ */
+export async function createResponses({
+  formId,
+  revisionId,
+  responses,
+  dryRun = false,
+  addedBy,
+  audit,
+}: {
+  formId: string;
+  /**
+   * Pin the revision. Asserted equal to the form's current one under the lock,
+   * so a dry run and the commit that follows it cannot straddle a republish
+   * that changed what the answers mean. Omitted means "the current one", which
+   * is reported back.
+   */
+  revisionId?: string;
+  responses: CreateResponseInput[];
+  dryRun?: boolean;
+  /** The staff user doing the typing. Written to `added_by` on every row. */
+  addedBy?: string | null;
+  audit?: CreateResponsesAudit;
+}): Promise<CreateResponsesReport> {
+  // ── Pre-flight, outside every lock ────────────────────────────────────────
+  const form = await getPrisma().form.findUnique({
+    where: { id: formId },
+    select: { id: true, access: true, status: true, current_revision_id: true },
+  });
+  if (!form) throw serviceError(FORM_NOT_FOUND, `Form ${formId} not found`);
+
+  if (form.access !== 'PUBLIC') {
+    throw serviceError(
+      FORM_ACCESS_MISMATCH,
+      `This form is ${form.access} — responses can only be created on a PUBLIC form.`
+    );
+  }
+  // OPEN and CLOSED are both fine: adding to a closed waitlist is the ordinary
+  // case, and the alternative — reopen, add, close — briefly exposes a live
+  // form. `assertAccepting` is deliberately NOT called. A form that was never
+  // published has no revision to validate against and nothing to add to.
+  if (form.status === 'DRAFT' || !form.current_revision_id) {
+    throw serviceError(FORM_NOT_OPEN, 'This form has not been published yet.');
+  }
+
+  if (responses.length < 1 || responses.length > CREATE_RESPONSES_MAX) {
+    throw serviceError(
+      FORM_BATCH_INVALID,
+      `A batch carries between 1 and ${CREATE_RESPONSES_MAX} responses (got ${responses.length}).`
+    );
+  }
+
+  const targetRevisionId = revisionId ?? form.current_revision_id;
+  const revision = await getPrisma().formRevision.findUnique({
+    where: { id: targetRevisionId },
+  });
+  if (!revision || revision.form_id !== formId) {
+    throw serviceError(FORM_REVISION_STALE, 'Unknown form revision.');
+  }
+  const fields = fieldsOf(revision.fields);
+
+  // Asserted, not assumed — the same backstop `confirmSubmission` keeps. Both
+  // of these are impossible on a PUBLIC form today (the contract refuses
+  // classroom-only types at save), and if that ever stops being true this fails
+  // loudly here instead of throwing FORM_REPEAT_CONTEXT_MISSING out of zod or,
+  // worse, writing a row against a schema nobody could have filled in.
+  if (requiresResolvedContext(fields)) {
+    throw serviceError(
+      FORM_ACCESS_MISMATCH,
+      'This form has per-respondent fields — its responses cannot be created on somebody else’s behalf.'
+    );
+  }
+  const classroomOnly = [
+    ...new Set(
+      flattenFields(fields)
+        .filter(field => FIELD_TYPE_REGISTRY[field.type]?.classroomOnly)
+        .map(field => field.type)
+    ),
+  ];
+  if (classroomOnly.length > 0) {
+    throw serviceError(
+      FORM_ACCESS_MISMATCH,
+      `Field type(s) ${classroomOnly.join(', ')} require Classroom access — responses to them cannot be created this way.`
+    );
+  }
+
+  // ── Every row validated before a lock is taken ────────────────────────────
+  const labels = new Map(flattenFields(fields).map(field => [field.id, labelOf(field)]));
+  const now = new Date();
+
+  const prepared: PreparedRow[] = responses.map((input, index) => {
+    const emailTrimmed = typeof input.email === 'string' ? input.email.trim() : '';
+    const row: PreparedRow = {
+      report: { input_index: index, email: emailTrimmed, disposition: 'would_create' },
+      emailNormalized: normalizeEmail(emailTrimmed),
+      emailTrimmed,
+      name: trimToNull(input.name),
+      staffStatus: trimToNull(input.staffStatus),
+      staffNote: trimToNull(input.staffNote),
+    };
+    const issues: CreateResponseIssue[] = [];
+
+    if (!EMAIL_SHAPE.test(emailTrimmed)) {
+      issues.push({
+        code: 'invalid_email',
+        path: 'email',
+        message: 'Not an email address.',
+      });
+    }
+
+    if (input.submittedAt !== undefined && input.submittedAt !== null) {
+      const at =
+        input.submittedAt instanceof Date ? input.submittedAt : new Date(input.submittedAt);
+      if (Number.isNaN(at.getTime())) {
+        issues.push({
+          code: 'invalid_datetime',
+          path: 'submitted_at',
+          message: 'Not a date.',
+        });
+      } else if (at.getTime() > now.getTime()) {
+        // Ties are fine; the future is not. `submitted_at` is the queue
+        // position, and a row dated tomorrow claims a place nobody held.
+        issues.push({
+          code: 'future_timestamp',
+          path: 'submitted_at',
+          message: 'A response cannot be received in the future.',
+        });
+      } else {
+        row.submittedAt = at;
+      }
+    }
+
+    try {
+      row.answers = parseAnswers(fields, input.answers);
+    } catch (error) {
+      const thrown = error as { code?: string; message?: string; issues?: ThrownIssue[] };
+      if (thrown.issues && thrown.issues.length > 0) {
+        for (const issue of thrown.issues) {
+          const first = issue.path?.[0];
+          const fieldId = typeof first === 'string' && labels.has(first) ? first : undefined;
+          const label = fieldId ? labels.get(fieldId) : undefined;
+          issues.push({
+            code: issue.code ?? FORM_ANSWERS_INVALID,
+            ...(fieldId ? { field_id: fieldId } : {}),
+            ...(label ? { label } : {}),
+            path: (issue.path ?? []).join('.'),
+            message: issue.message ?? 'Invalid.',
+          });
+        }
+      } else {
+        // FORM_ANSWERS_TOO_LARGE and anything else the contract raises without
+        // zod issues behind it — reported about the answer set as a whole.
+        issues.push({
+          code: thrown.code ?? FORM_ANSWERS_INVALID,
+          path: 'answers',
+          message: thrown.message ?? 'Invalid answers.',
+        });
+      }
+    }
+
+    if (issues.length > 0) {
+      row.report.disposition = 'invalid';
+      row.report.issues = issues;
+    }
+    return row;
+  });
+
+  // Two rows in one call for the same person. BOTH are refused: picking a
+  // winner would silently drop the other one's answers, and the caller is the
+  // only one who knows which is right.
+  const seen = new Map<string, number>();
+  for (const row of prepared) {
+    if (!row.emailNormalized) continue;
+    seen.set(row.emailNormalized, (seen.get(row.emailNormalized) ?? 0) + 1);
+  }
+  for (const row of prepared) {
+    if (row.report.disposition !== 'would_create') continue;
+    if ((seen.get(row.emailNormalized) ?? 0) < 2) continue;
+    row.report.disposition = 'duplicate';
+    row.report.issues = [
+      {
+        code: 'duplicate_in_input',
+        path: 'email',
+        message: 'This address appears more than once in the batch.',
+      },
+    ];
+  }
+
+  const reportRows = prepared.map(row => row.report);
+  const report = (outcome: CreateResponsesReport['outcome']): CreateResponsesReport => ({
+    outcome,
+    revision_id: targetRevisionId,
+    counts: countRows(reportRows),
+    rows: reportRows,
+  });
+
+  // One bad row rejects the batch. Returned, not thrown: the caller needs the
+  // per-row detail to fix its input, and an exception carries none of it.
+  // `would_create` here means "passed validation" — nothing was ever compared
+  // against the database, because nothing was written.
+  if (prepared.some(row => row.report.disposition === 'invalid')) {
+    return report('rejected');
+  }
+
+  return getPrisma().$transaction(
+    async tx => {
+      const locked = await lockForm(tx, formId);
+
+      // Re-checked under the lock, which is what actually makes any of it safe.
+      // `access` is not in the lock's SELECT and is frozen once a form leaves
+      // DRAFT, so it is read here beside it rather than raced for.
+      const live = await tx.form.findUniqueOrThrow({
+        where: { id: formId },
+        select: { access: true },
+      });
+      if (live.access !== 'PUBLIC') {
+        throw serviceError(
+          FORM_ACCESS_MISMATCH,
+          `This form is ${live.access} — responses can only be created on a PUBLIC form.`
+        );
+      }
+      if (locked.status === 'DRAFT' || !locked.current_revision_id) {
+        throw serviceError(FORM_NOT_OPEN, 'This form has not been published yet.');
+      }
+      // Covers both callers: one that pinned a revision, and one that took the
+      // current revision at pre-flight and would otherwise write answers
+      // validated against a definition a republish has since replaced.
+      assertRevisionCurrent(locked, targetRevisionId);
+
+      const pending = prepared.filter(row => row.report.disposition === 'would_create');
+
+      // ONE read for the whole batch. Select-then-insert is safe only because
+      // of the row lock above: every writer for this form is serialized, so the
+      // read cannot go stale before the insert. Catching P2002 and carrying on
+      // would be wrong inside a transaction anyway — Postgres 25P02 aborts it.
+      const existing = await tx.formResponse.findMany({
+        where: {
+          form_id: formId,
+          user_id: null,
+          email_normalized: { in: [...new Set(pending.map(row => row.emailNormalized))] },
+        },
+        select: { id: true, email_normalized: true, submission_state: true },
+      });
+      const held = new Map(existing.map(row => [row.email_normalized, row]));
+      for (const row of pending) {
+        const hit = held.get(row.emailNormalized);
+        if (!hit) continue;
+        row.report.disposition = 'duplicate';
+        row.report.response_id = hit.id;
+        row.report.existing_state = hit.submission_state;
+      }
+
+      const toCreate = prepared.filter(row => row.report.disposition === 'would_create');
+
+      // ONE count for the cap, and the arithmetic a batch needs:
+      // `assertCapAvailable` proves room for a single row and would admit two
+      // hundred into the last free slot.
+      if (locked.response_cap !== null && toCreate.length > 0) {
+        const occupied = await tx.formResponse.count({
+          where: { form_id: formId, submission_state: 'SUBMITTED', verified_at: { not: null } },
+        });
+        if (occupied + toCreate.length > locked.response_cap) {
+          const over = occupied + toCreate.length - locked.response_cap;
+          throw serviceError(
+            FORM_CAP_REACHED,
+            `This form's limit is ${locked.response_cap} responses; ${occupied} are taken and this batch adds ${toCreate.length}, which is ${over} over. Raise the cap or send fewer rows.`
+          );
+        }
+      }
+
+      // A dry run has now done every check a commit does — including the cap,
+      // which throws here exactly as it would on the real call — and written
+      // nothing.
+      if (dryRun) return report('dry_run');
+
+      if (toCreate.length > 0) {
+        const data: Prisma.FormResponseCreateManyInput[] = toCreate.map(row => {
+          // Minted here rather than by the database so the report can NAME the
+          // row it just made. No id is ever reported for a row that did not
+          // commit: this whole block is inside the transaction.
+          const id = randomUUID();
+          row.report.response_id = id;
+          row.report.disposition = 'created';
+          return {
+            id,
+            form_id: formId,
+            revision_id: targetRevisionId,
+            user_id: null,
+            email: row.emailTrimmed,
+            email_normalized: row.emailNormalized,
+            name: row.name,
+            answers: row.answers as Prisma.InputJsonValue,
+            submission_state: 'SUBMITTED',
+            submitted_at: row.submittedAt ?? now,
+            // Now, never the row's own timestamp — see the note above.
+            verified_at: now,
+            added_by: addedBy ?? null,
+            staff_status: row.staffStatus,
+            staff_note: row.staffNote,
+            // Neither belongs to a row nobody filled in: there is no browser
+            // holding a partial, and no teammate resolution behind it.
+            draft_token: null,
+            resolved_context: Prisma.DbNull,
+          };
+        });
+        await tx.formResponse.createMany({ data });
+      }
+
+      const committed = report('committed');
+
+      if (audit) {
+        await tx.auditLog.create({
+          data: {
+            user_id: audit.user_id,
+            classroom_id: audit.classroom_id,
+            role: audit.role,
+            action: 'CREATE',
+            resource_type: 'FORMS',
+            resource_id: formId,
+            data: {
+              ...(audit.data ?? {}),
+              form_id: formId,
+              revision_id: targetRevisionId,
+              counts: committed.counts,
+              created_ids: toCreate.map(row => row.report.response_id).filter(Boolean),
+            } as Prisma.InputJsonValue,
+          },
+        });
+      }
+
+      return committed;
+    },
+    // Generous enough for two hundred rows plus the audit; Prisma's default is
+    // five seconds, and every public submitter is queued behind this lock.
+    { timeout: 30_000 }
+  );
+}
+
 // ─── Drafts (server-side autosave) ──────────────────────────────────────────
 
 /**
@@ -1817,6 +2342,15 @@ const RESPONSE_SELECT = {
   resolved_context: true,
   submission_state: true,
   verified_at: true,
+  /**
+   * Who typed this row in, when it was not the respondent — STAFF ONLY, and
+   * read by every surface that shows a response list (the responses page, the
+   * MCP tool, the CSV export). Null means the person submitted it themselves.
+   *
+   * Deliberately absent from SELF_SELECT: a filler looking at their own record
+   * has no business knowing which staff account touched it.
+   */
+  added_by: true,
   staff_status: true,
   staff_note: true,
   submitted_at: true,

--- a/packages/services/src/classmoji/formResponse.service.ts
+++ b/packages/services/src/classmoji/formResponse.service.ts
@@ -2,10 +2,10 @@ import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import getPrisma from '@classmoji/database';
 import {
   answersByteSize,
+  assertFieldsAllowedForAccess,
   flattenFields,
   parseAnswers,
   requiresResolvedContext,
-  FIELD_TYPE_REGISTRY,
   FORM_ANSWERS_INVALID,
   FORM_ANSWERS_TOO_LARGE,
   FORM_LIMITS,
@@ -1134,8 +1134,8 @@ export const isAddressPlaceholder = (response: {
  *
  * Two details that are easy to get wrong:
  *  - `verified_at` is set only the FIRST time. A later edit via a fresh link
- *    keeps the original timestamp, so editing an answer never costs the filler
- *    their place in a FIFO waitlist.
+ *    keeps the original timestamp. (The FIFO place itself is `submitted_at`,
+ *    which an edit does not move either — see `listByFormId`.)
  *  - the cap is checked only on that first transition. An already-verified
  *    response editing itself must not be bounced by a cap it is already inside.
  *
@@ -1642,6 +1642,15 @@ export interface CreateResponseIssue {
   message: string;
 }
 
+/**
+ * What happened to one row.
+ *
+ * `duplicate` is a statement about the DATABASE — an address already on the
+ * form, reported with the existing row's id and state, untouched. A batch may
+ * commit with duplicates in it. Two rows in one CALL sharing an address are
+ * `invalid` instead, carrying a `duplicate_in_input` issue: that is caller
+ * data disagreeing with itself, and it rejects the whole batch.
+ */
 export type CreateResponseDisposition = 'would_create' | 'created' | 'duplicate' | 'invalid';
 
 export interface CreateResponseRow {
@@ -1696,6 +1705,8 @@ interface ThrownIssue {
   code?: string;
   path?: Array<string | number>;
   message?: string;
+  /** `unrecognized_keys` only: the keys the strict object refused. */
+  keys?: string[];
 }
 
 /** Everything one input row needs, carried beside the row it will report as. */
@@ -1755,13 +1766,22 @@ const countRows = (rows: CreateResponseRow[]) => ({
  * row's id and state, and that row is left exactly as it was. A DRAFT or an
  * unverified placeholder is NOT a submission, so reporting one as "already
  * present" is a statement about what is there, not a claim that the person is
- * covered. Two rows in one call sharing an address are both refused; there is
- * no first-wins rule to guess wrong about.
+ * covered. Two rows in ONE call sharing an address are a different thing: that
+ * is the caller's own list contradicting itself, so BOTH are `invalid` and the
+ * batch is rejected like any other caller data error. There is no first-wins
+ * rule to guess wrong about.
  *
  * ── All or nothing ─────────────────────────────────────────────────────────
  * One invalid row rejects the batch, reports every row, and writes nothing —
  * `outcome: 'rejected'`, returned rather than thrown, because the report is the
  * useful part.
+ *
+ * ── `addedBy` and `audit` are REQUIRED ─────────────────────────────────────
+ * Neither is a convenience a future caller may skip. `added_by` is the only
+ * thing distinguishing a staff-typed row from the respondent's own testimony,
+ * and the audit descriptor is the only record that the batch happened at all.
+ * Making them arguments rather than defaults is what forces the next caller to
+ * answer "who is doing this, and where is it written down?".
  *
  * PUBLIC forms only. The email-uniqueness index is scoped `WHERE user_id IS
  * NULL`, so a staff-added row on a CLASSROOM form would not collide with the
@@ -1769,8 +1789,8 @@ const countRows = (rows: CreateResponseRow[]) => ({
  * excludes roster- and teammate-sourced field types for free, and both are
  * asserted against the registry rather than special-cased by name.
  *
- * @throws FORM_NOT_FOUND, FORM_ACCESS_MISMATCH, FORM_NOT_OPEN,
- *   FORM_BATCH_INVALID, FORM_REVISION_STALE, FORM_CAP_REACHED.
+ * @throws FORM_NOT_FOUND, FORM_ACCESS_MISMATCH, FORM_FIELD_ACCESS_VIOLATION,
+ *   FORM_NOT_OPEN, FORM_BATCH_INVALID, FORM_REVISION_STALE, FORM_CAP_REACHED.
  */
 export async function createResponses({
   formId,
@@ -1790,9 +1810,16 @@ export async function createResponses({
   revisionId?: string;
   responses: CreateResponseInput[];
   dryRun?: boolean;
-  /** The staff user doing the typing. Written to `added_by` on every row. */
-  addedBy?: string | null;
-  audit?: CreateResponsesAudit;
+  /**
+   * The staff user doing the typing. Written to `added_by` on every row.
+   * REQUIRED: attribution is the honesty guarantee, not an option.
+   */
+  addedBy: string;
+  /**
+   * REQUIRED, for the same reason. The row is written inside the transaction,
+   * and only when the batch actually created something.
+   */
+  audit: CreateResponsesAudit;
 }): Promise<CreateResponsesReport> {
   // ── Pre-flight, outside every lock ────────────────────────────────────────
   const form = await getPrisma().form.findUnique({
@@ -1842,19 +1869,10 @@ export async function createResponses({
       'This form has per-respondent fields — its responses cannot be created on somebody else’s behalf.'
     );
   }
-  const classroomOnly = [
-    ...new Set(
-      flattenFields(fields)
-        .filter(field => FIELD_TYPE_REGISTRY[field.type]?.classroomOnly)
-        .map(field => field.type)
-    ),
-  ];
-  if (classroomOnly.length > 0) {
-    throw serviceError(
-      FORM_ACCESS_MISMATCH,
-      `Field type(s) ${classroomOnly.join(', ')} require Classroom access — responses to them cannot be created this way.`
-    );
-  }
+  // The contract's own save-time rule, run again here rather than re-implemented
+  // — one definition of "classroom-only", in the module that owns the registry.
+  // Throws FORM_FIELD_ACCESS_VIOLATION.
+  assertFieldsAllowedForAccess(fields, 'PUBLIC');
 
   // ── Every row validated before a lock is taken ────────────────────────────
   const labels = new Map(flattenFields(fields).map(field => [field.id, labelOf(field)]));
@@ -1908,6 +1926,23 @@ export async function createResponses({
       const thrown = error as { code?: string; message?: string; issues?: ThrownIssue[] };
       if (thrown.issues && thrown.issues.length > 0) {
         for (const issue of thrown.issues) {
+          // A wrong or stale field uuid. Zod reports this ONCE for the whole
+          // object with an empty path and the offending keys in `keys`, which
+          // would otherwise reach the caller as `path: ''` naming nothing —
+          // useless for the one mistake most likely to produce it. One issue
+          // per key, each naming the key it is about.
+          if (issue.code === 'unrecognized_keys') {
+            for (const key of issue.keys ?? []) {
+              issues.push({
+                code: 'unrecognized_keys',
+                field_id: key,
+                label: undefined,
+                path: key,
+                message: `No field ${key} on this form — field ids come from form_get.`,
+              });
+            }
+            continue;
+          }
           const first = issue.path?.[0];
           const fieldId = typeof first === 'string' && labels.has(first) ? first : undefined;
           const label = fieldId ? labels.get(fieldId) : undefined;
@@ -1937,19 +1972,24 @@ export async function createResponses({
     return row;
   });
 
-  // Two rows in one call for the same person. BOTH are refused: picking a
-  // winner would silently drop the other one's answers, and the caller is the
-  // only one who knows which is right.
+  // Two rows in one call for the same person. This is not a "duplicate" in the
+  // sense the report otherwise uses that word — nothing in the database is
+  // being reported back — it is the caller's own list contradicting itself, so
+  // every row that shares an address is INVALID and the batch is rejected on
+  // the ordinary all-or-nothing rule. Picking a winner would silently drop the
+  // other one's answers, and the caller is the only one who knows which is
+  // right. Counted over every row whatever else is wrong with it: a row that
+  // already failed validation still names an address the batch repeats.
   const seen = new Map<string, number>();
   for (const row of prepared) {
     if (!row.emailNormalized) continue;
     seen.set(row.emailNormalized, (seen.get(row.emailNormalized) ?? 0) + 1);
   }
   for (const row of prepared) {
-    if (row.report.disposition !== 'would_create') continue;
     if ((seen.get(row.emailNormalized) ?? 0) < 2) continue;
-    row.report.disposition = 'duplicate';
+    row.report.disposition = 'invalid';
     row.report.issues = [
+      ...(row.report.issues ?? []),
       {
         code: 'duplicate_in_input',
         path: 'email',
@@ -1996,8 +2036,15 @@ export async function createResponses({
       }
       // Covers both callers: one that pinned a revision, and one that took the
       // current revision at pre-flight and would otherwise write answers
-      // validated against a definition a republish has since replaced.
-      assertRevisionCurrent(locked, targetRevisionId);
+      // validated against a definition a republish has since replaced. Not
+      // `assertRevisionCurrent` — its message tells a filler to reload the page
+      // they are looking at, and nobody on this path is looking at a page.
+      if (locked.current_revision_id !== targetRevisionId) {
+        throw serviceError(
+          FORM_REVISION_STALE,
+          `The form is now on revision ${locked.current_revision_id}; re-read it with form_get and pass revision_id.`
+        );
+      }
 
       const pending = prepared.filter(row => row.report.disposition === 'would_create');
 
@@ -2066,7 +2113,7 @@ export async function createResponses({
             submitted_at: row.submittedAt ?? now,
             // Now, never the row's own timestamp — see the note above.
             verified_at: now,
-            added_by: addedBy ?? null,
+            added_by: addedBy,
             staff_status: row.staffStatus,
             staff_note: row.staffNote,
             // Neither belongs to a row nobody filled in: there is no browser
@@ -2080,7 +2127,12 @@ export async function createResponses({
 
       const committed = report('committed');
 
-      if (audit) {
+      // Only when something was actually written. A batch that committed and
+      // created nothing — every address already on the form — mutated nothing,
+      // and a CREATE row claiming otherwise would be a lie in the one place
+      // that has to be literal. The caller audits that case as the read it
+      // really was (see the tool's VIEW row).
+      if (committed.counts.created > 0) {
         await tx.auditLog.create({
           data: {
             user_id: audit.user_id,
@@ -2104,7 +2156,10 @@ export async function createResponses({
     },
     // Generous enough for two hundred rows plus the audit; Prisma's default is
     // five seconds, and every public submitter is queued behind this lock.
-    { timeout: 30_000 }
+    // `maxWait` is the wait for a POOL CONNECTION, before any of that starts:
+    // the 2 s default can fail a batch under pool pressure without it ever
+    // reaching the database.
+    { timeout: 30_000, maxWait: 10_000 }
   );
 }
 


### PR DESCRIPTION
## What

A new MCP tool, `form_response_create`, that adds one or many responses to a PUBLIC form as if the respondent had filled it in, plus the service function behind it and an `added_by` column so a staff-created row says so.

Forms could only be filled, never seeded. Every response in the database got there because a person typed it into the fill page. Staff had no way to add a record, so any course arriving from a spreadsheet or a previous term's list started empty.

## How it behaves

- **Same validation as the fill page.** Answers are keyed by field id (from `form_get`), contract-shaped, no coercion. Required fields are required. A wrong field id comes back as a structured issue naming the key.
- **No mail, no magic link.** The service never touches the token or mail path and returns no `emails` field.
- **Never overwrites.** An address that already has a response on the form is reported as a duplicate with its existing id and state. The same address twice in one call rejects the batch.
- **All or nothing.** Any invalid row rejects the batch and reports every row. Nothing is written until every row passes.
- **`dry_run` first.** Validates, checks duplicates and the cap, writes nothing.
- **Cap respected for the whole batch**, under the form's row lock; overflow hard-fails naming the cap, occupancy and overflow.
- **OPEN and CLOSED forms accepted; DRAFT and CLASSROOM-access forms refused.** Classroom forms are a later feature (the email-uniqueness index is scoped to anonymous rows, so a staff-added row would not collide with the same person's later classroom submission).
- **Every created row is stamped `verified_at = now`** (never backdated) and `added_by = the staff user`. `submitted_at` is the caller's value, which is what orders the list.
- **Audit:** a CREATE row inside the transaction when rows were created; a VIEW row for dry runs and no-op commits (counts only, never addresses); nothing for a rejected batch, which returns before any database read.

The transaction is one lock, one `findMany`, one `count`, one `createMany`, one audit insert, with an explicit timeout and `maxWait`.

## Also in this PR

- `FormResponse.added_by` (nullable, FK to `User`, `SetNull`), surfaced as an "Added by" chip and drawer row in the responses list, in `form_response_get` / `list_form_responses`, and as the last lead column of the wide CSV. The display name stops at `name || login`, never email.
- Fastify `bodyLimit` raised to 4 MiB on the MCP server so the tool's own 2 MB payload cap is the one that fires, as a readable tool error rather than a raw 413.
- The schema comments that said the cap and queue order "count from the first verification" now say what the code does: the cap counts verified SUBMITTED rows, and FIFO order is `submitted_at`.
- The MCP docs page mentions forms for the first time.

## Verification

- Services: 97 integration tests green against a real Postgres, including: no `FormMagicToken` row is ever created; cap arithmetic on commit and dry run; duplicate against SUBMITTED / PENDING_VERIFICATION / DRAFT rows; all-or-nothing; backdated `submitted_at` honored and ordered; revision assert; audit row present on create, absent on dry run, rejected, and no-op.
- MCP: 584 tests green (71 in the forms file), including the four hand-maintained tool lists, S1 cross-classroom refusal with identical messages, the Pro gate, byte-measured payload cap, audit vocabulary, and every reachable rule code.
- Pages: unit spec pins the CSV column position, cell fallbacks, and matrix two-row header padding; `pages` build succeeds.
- End to end against a local dev MCP server through the real registry and database: 22/22 (tools/list, honest annotations, create + publish a form, rejected batch with structured issues, dry run writes nothing, commit, idempotent re-run reports duplicates, list order by `submitted_at`, `added_by` present, no `draft_token` / `email_normalized` leaked, stale revision refused, cap overflow refused with numbers, closed form accepted, unknown form scoped not-found).
- Typecheck clean in services, mcp, pages, admin, slides.

## Review

Three plan-versus-code reviewers (service, tool + adversarial, surfaces + coverage) and a codex critique of the design. Every medium finding was fixed in the last commit; the low ones that guard callers that do not exist were left out on purpose.

## Migration

One additive migration (`20260910130000_form_response_added_by`), applied by the webapp release command before the MCP deploy runs.

## Not in this PR

- Classroom-access forms (email → member resolution).
- A "mail me my existing response" path for closed or full forms.
- An undo tool; rows can be removed one at a time in the web responses view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUe1wgdneE2UsbgDDrjjgW
