### PR TITLE
fix(repos): resolve a template with no owner instead of cloning undefined

### DIFF
--- a/packages/services/src/classmoji/repository.service.ts
+++ b/packages/services/src/classmoji/repository.service.ts
@@ -1,5 +1,5 @@
 import getPrisma from '@classmoji/database';
-import { titleToIdentifier } from '@classmoji/utils';
+import { titleToIdentifier, resolveTemplateRef } from '@classmoji/utils';
 import type { AssignmentType, Prisma } from '@prisma/client';
 import * as notificationService from './notification.service.ts';
 
@@ -33,7 +33,8 @@ interface RepositoryFormValues {
   branch?: string | null;
 }
 
-interface RepositoryAssignmentUpdateInput extends Prisma.AssignmentUncheckedCreateWithoutRepositoryInput {
+interface RepositoryAssignmentUpdateInput
+  extends Prisma.AssignmentUncheckedCreateWithoutRepositoryInput {
   id?: string;
   title: string;
   linkedPageIds?: string[];
@@ -308,11 +309,18 @@ export const createFromForm = async (values: RepositoryFormValues) => {
 
   const classroom = await getPrisma().classroom.findUnique({
     where: { slug: classroomSlug },
+    include: { git_organization: { select: { login: true } } },
   });
 
   if (!classroom) {
     throw new Error('Classroom not found');
   }
+
+  // Store the template fully qualified. A bare name is a legitimate thing to
+  // type when the template sits in the classroom's own org, but it only reads
+  // as one here — every consumer downstream splits on `/`.
+  const templateRef = resolveTemplateRef(template, classroom.git_organization?.login);
+  const qualifiedTemplate = templateRef ? `${templateRef.owner}/${templateRef.repo}` : template;
 
   // Generate slug from title (set once, never updated)
   const slug = titleToIdentifier(title);
@@ -322,7 +330,7 @@ export const createFromForm = async (values: RepositoryFormValues) => {
       title,
       slug,
       type,
-      template,
+      template: qualifiedTemplate,
       weight: Number(weight ?? 100),
       classroom_id: classroom.id,
       ...(tag && { tag_id: tag }),
@@ -538,7 +546,9 @@ export const setPublished = async (id: string, isPublished: boolean, classroomId
         recipientUserIds: studentIds,
         resourceType: 'repository',
         resourceId: mod.id,
-        title: isPublished ? `Repository published: ${mod.title}` : `Repository unpublished: ${mod.title}`,
+        title: isPublished
+          ? `Repository published: ${mod.title}`
+          : `Repository unpublished: ${mod.title}`,
       });
     });
   }

--- a/packages/tasks/src/workflows/__tests__/gitRepo.provisionOnly.test.ts
+++ b/packages/tasks/src/workflows/__tests__/gitRepo.provisionOnly.test.ts
@@ -66,6 +66,19 @@ vi.mock('@classmoji/services', () => ({
 
 vi.mock('@classmoji/utils', () => ({
   titleToIdentifier: (title: string) => title.toLowerCase().replace(/\s+/g, '-'),
+  // The real resolver: the task's template handling is part of what these
+  // fixtures exercise, so a stub would pin the stub.
+  resolveTemplateRef: (
+    template: string | null | undefined,
+    orgLogin: string | null | undefined
+  ) => {
+    const trimmed = (template ?? '').trim().replace(/^\/+|\/+$/g, '');
+    if (!trimmed) return null;
+    const [first, second] = trimmed.split('/');
+    if (second) return { owner: first, repo: second };
+    const owner = (orgLogin ?? '').trim();
+    return owner ? { owner, repo: first } : null;
+  },
 }));
 
 vi.mock('../gitRepoAssignment.ts', () => ({

--- a/packages/tasks/src/workflows/gitRepo.ts
+++ b/packages/tasks/src/workflows/gitRepo.ts
@@ -9,7 +9,7 @@ import {
   getGitProvider,
   ensureClassroomTeam,
 } from '@classmoji/services';
-import { titleToIdentifier } from '@classmoji/utils';
+import { titleToIdentifier, resolveTemplateRef } from '@classmoji/utils';
 import { createGithubRepositoryAssignmentTask } from './gitRepoAssignment.ts';
 import { updateRepository, type UpdateRepositoryPayload } from '../helpers/updateRepository.ts';
 import { createRepository, type CreateRepositoryPayload } from '../helpers/createRepository.ts';
@@ -159,7 +159,18 @@ export const createRepositoriesTask = task({
       throw new Error(`Unable to load repository or classroom for ${org}/${assignmentTitle}`);
     }
 
-    const [templateOwner, templateRepo] = repository.template.split('/');
+    // A template stored without an owner belongs to the classroom's own org,
+    // which is where templates live. Splitting blindly used to leave the repo
+    // half undefined and fail once per student on a URL that named no field.
+    const templateRef = resolveTemplateRef(repository.template, classroom.git_organization.login);
+    if (!templateRef) {
+      throw new Error(
+        `Assignment "${repository.title}" has no usable template repository ` +
+          `(template is "${repository.template ?? ''}"). Set it to owner/repo, ` +
+          `or to a repository in ${classroom.git_organization.login}.`
+      );
+    }
+    const { owner: templateOwner, repo: templateRepo } = templateRef;
     const students: StudentRecord[] = await ClassmojiService.classroomMembership.findUsersByRole(
       classroom.id,
       'STUDENT'

--- a/packages/utils/src/__tests__/resolveTemplateRef.test.ts
+++ b/packages/utils/src/__tests__/resolveTemplateRef.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTemplateRef } from '../repoNames.ts';
+
+const ORG = 'itmo-kotlin-android-tech-26-27';
+
+describe('resolveTemplateRef', () => {
+  it('qualifies a bare name with the classroom org', () => {
+    // The ITMO case: the template existed, the owner was simply never typed,
+    // and 15 students got github.com/kotlin-quiz-app-task-1/undefined.git.
+    expect(resolveTemplateRef('kotlin-quiz-app-task-1', ORG)).toEqual({
+      owner: ORG,
+      repo: 'kotlin-quiz-app-task-1',
+    });
+  });
+
+  it('leaves an already qualified reference alone', () => {
+    expect(resolveTemplateRef('ichrak-cspp-test/TPX', ORG)).toEqual({
+      owner: 'ichrak-cspp-test',
+      repo: 'TPX',
+    });
+  });
+
+  it('trims whitespace and stray slashes', () => {
+    expect(resolveTemplateRef('  /starter/  ', ORG)).toEqual({ owner: ORG, repo: 'starter' });
+    expect(resolveTemplateRef(' owner/repo ', ORG)).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns null when there is nothing usable, rather than a broken half', () => {
+    expect(resolveTemplateRef('', ORG)).toBeNull();
+    expect(resolveTemplateRef('   ', ORG)).toBeNull();
+    expect(resolveTemplateRef(null, ORG)).toBeNull();
+    expect(resolveTemplateRef(undefined, ORG)).toBeNull();
+  });
+
+  it('returns null for a bare name with no org to qualify it', () => {
+    expect(resolveTemplateRef('starter', null)).toBeNull();
+    expect(resolveTemplateRef('starter', '')).toBeNull();
+  });
+});

--- a/packages/utils/src/repoNames.ts
+++ b/packages/utils/src/repoNames.ts
@@ -101,3 +101,29 @@ export function suggestContentNamespace({
   }
   return slug;
 }
+
+/**
+ * Resolve a template repository reference to `owner/repo`.
+ *
+ * A bare name is what an instructor types when the template lives in their own
+ * classroom org, which is where templates almost always live. Splitting it on
+ * `/` regardless left the repo half undefined and produced clone URLs like
+ * `github.com/kotlin-quiz-app-task-1/undefined.git`, which failed once per
+ * student with nothing in the message pointing at the template field.
+ *
+ * Returns null when there is nothing usable, so callers can say which field is
+ * wrong instead of building a URL out of it.
+ */
+export function resolveTemplateRef(
+  template: string | null | undefined,
+  orgLogin: string | null | undefined
+): { owner: string; repo: string } | null {
+  const trimmed = (template ?? '').trim().replace(/^\/+|\/+$/g, '');
+  if (!trimmed) return null;
+
+  const [first, second] = trimmed.split('/');
+  if (second) return { owner: first!, repo: second };
+
+  const owner = (orgLogin ?? '').trim();
+  return owner ? { owner, repo: first! } : null;
+}


### PR DESCRIPTION
Fifteen `gh-create_git_repo` runs failed in production over two days, one per student in `itmo-kotlin-26-27`, cloning from:

```
github.com/kotlin-quiz-app-task-1/undefined.git
```

## Cause

The instructor entered the template as `kotlin-quiz-app-task-1`. That is a **real template repository** — `itmo-kotlin-android-tech-26-27/kotlin-quiz-app-task-1`, public, `is_template: true` — sitting in their own classroom org. They simply never typed the owner.

`gitRepo.ts:162` did `repository.template.split('/')`, which put the whole string in the owner half and left the repo half `undefined`. Every other template row in the database is `owner/repo`; this was the only bare one.

The worse part is the diagnosis: it failed once per student with a URL, and nothing in the message mentioned the template field, the assignment, or the org. Two days of failures pointed at nothing.

## Changes

- **`resolveTemplateRef`** (`packages/utils/src/repoNames.ts`) — a bare name resolves against the classroom's org, which is where templates live and what the instructor meant. Returns `null` when there is nothing usable, so callers can name the bad field instead of building a URL out of it.
- **The task** uses it, and when it returns null throws an error naming the assignment, the value and the org.
- **`createFromForm`** qualifies the template on save, so the database stops accepting bare names.

Existing rows are handled at run time by the task, which is what matters for anything already in flight.

## Not covered, deliberately

A well-formed template pointing at a repository that no longer exists still fails, with GitHub's own message. That is the second failure in the same batch (`ichrak-cspp-test/tp3-pilote-groupe-template`, 404 to both the app installation and a user token) and it is correct behaviour for a deleted template.

## Production data

The ITMO row has already been repaired by hand to the fully qualified value, so those students are unblocked by a re-run rather than by this deploy.

## Tests

5 new for the resolver: bare name qualified, qualified reference untouched, whitespace and stray slashes trimmed, null for empty input, null for a bare name with no org. The task's existing `provisionOnly` suite passes, with its `@classmoji/utils` mock taught about the new export.

`processSafety` has 5 pre-existing failures in `packages/utils` — identical with this branch stashed.

## Test steps

1. Create an assignment with a template typed as a bare repo name that exists in the classroom org, publish it, confirm repos are created from that template.
2. Create one with a bare name that does **not** exist: the run fails with a message naming the assignment and the org, not a URL.
3. Check the saved row: the template is stored fully qualified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152e3TdpwbtvjYktXUPSufk