### PR TITLE
feat(webapp): ask how people heard about Classmoji

### DIFF
--- a/apps/webapp/app/components/features/onboarding/OnboardingTour.tsx
+++ b/apps/webapp/app/components/features/onboarding/OnboardingTour.tsx
@@ -25,6 +25,7 @@ import { Tour, Button } from 'antd';
 import type { TourProps } from 'antd';
 import { useUser } from '~/hooks';
 import useStore from '~/store';
+import { useSurveyPending } from '~/components/features/survey';
 import type { TourPhase } from '~/types';
 
 /** Target a landing `data-onboarding` element; null -> antd renders centered. */
@@ -143,6 +144,9 @@ export function OnboardingTour() {
   // active across /select-organization and /settings.
   const onAccountRoute = onLanding || location.pathname.startsWith('/settings');
   const active = tourPhase === 'landing' && onAccountRoute;
+  // The picker's one-off survey prompt goes first; the auto-start below waits
+  // until the loader stops sending questions, then fires on that re-render.
+  const surveyPending = useSurveyPending();
 
   // Initialize the landing tour exactly once on mount, two ways in (in order):
   //  - Resume: a landing tour was already running and you refreshed — pick it back
@@ -155,6 +159,9 @@ export function OnboardingTour() {
   useEffect(() => {
     if (initRef.current) return;
     if (!user || !onLanding || tourPhase !== 'idle') return;
+    // Two modals on top of each other looks broken; let the survey finish first.
+    // initRef stays unset, so this re-runs once the loader drops the question.
+    if (surveyPending) return;
     initRef.current = true;
 
     let saved: { phase?: TourPhase; step?: number } | null = null;
@@ -173,7 +180,16 @@ export function OnboardingTour() {
       startFullTour();
       fetcher.submit(null, { method: 'POST', action: '/api/onboarding/complete' });
     }
-  }, [user, onLanding, tourPhase, startFullTour, setTourPhase, setTourStep, fetcher]);
+  }, [
+    user,
+    onLanding,
+    tourPhase,
+    surveyPending,
+    startFullTour,
+    setTourPhase,
+    setTourStep,
+    fetcher,
+  ]);
 
   // Each step lives on a specific account route; navigate there when it opens.
   useEffect(() => {

--- a/apps/webapp/app/components/features/survey/SurveyPrompt.tsx
+++ b/apps/webapp/app/components/features/survey/SurveyPrompt.tsx
@@ -1,0 +1,175 @@
+/**
+ * One-question dialog shown on the classroom picker to anyone who has not yet
+ * answered it. Asks the first pending question; both "Continue" and "Skip"
+ * POST to /api/survey/answer, which is what makes the prompt go away (the
+ * loader revalidates and stops sending the question). With several pending
+ * questions the dialog re-renders for the next one after each revalidation.
+ *
+ * An option with a detailPrompt reveals a free-text field under it. Hand-rolled
+ * on the design tokens (same approach as the landing screen and the page peek
+ * drawer) rather than antd, so it matches the picker it sits on.
+ */
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useFetcher } from 'react-router';
+import { Button } from '@classmoji/ui-components';
+import { SURVEY_SKIPPED, type SurveyQuestion } from '@classmoji/utils';
+
+interface SurveyPromptProps {
+  questions: SurveyQuestion[];
+}
+
+export function SurveyPrompt({ questions }: SurveyPromptProps) {
+  const question = questions[0];
+  const fetcher = useFetcher();
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [detail, setDetail] = useState('');
+  // Null until mounted so server and first client render agree (no portal in SSR).
+  const [mounted, setMounted] = useState(false);
+  const [entered, setEntered] = useState(false);
+
+  // A different question means fresh inputs.
+  useEffect(() => {
+    setAnswer(null);
+    setDetail('');
+  }, [question?.key]);
+
+  // Mount, then fade in on the next frame.
+  useEffect(() => {
+    setMounted(true);
+    const id = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  if (!question || !mounted) return null;
+
+  const busy = fetcher.state !== 'idle';
+  const picked = question.options.find(o => o.value === answer) ?? null;
+  const canContinue = picked != null && !busy;
+
+  const submit = (value: string) => {
+    fetcher.submit(
+      { question_key: question.key, answer: value, detail: picked?.detailPrompt ? detail : null },
+      { method: 'POST', action: '/api/survey/answer', encType: 'application/json' }
+    );
+  };
+
+  const pick = (value: string) => {
+    if (value !== answer) setDetail('');
+    setAnswer(value);
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[1100] flex items-center justify-center p-4">
+      <div
+        aria-hidden
+        className={`absolute inset-0 bg-gray-900/35 transition-opacity duration-200 motion-reduce:transition-none dark:bg-black/60 ${
+          entered ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="survey-prompt-title"
+        className={`card relative w-full max-w-[460px] max-h-[calc(100vh-2rem)] overflow-y-auto p-6 transition-all duration-200 ease-out motion-reduce:transition-none ${
+          entered ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+        }`}
+      >
+        <h2 id="survey-prompt-title" className="text-lg font-semibold text-ink-0 m-0">
+          {question.prompt}
+        </h2>
+        <p className="text-sm text-ink-3 mt-1 mb-5">
+          One quick question so we know what is working. You will not be asked again.
+        </p>
+
+        <div
+          role="radiogroup"
+          aria-labelledby="survey-prompt-title"
+          className="flex flex-col gap-2"
+        >
+          {question.options.map(opt => {
+            const selected = answer === opt.value;
+            return (
+              <div key={opt.value}>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  disabled={busy}
+                  onClick={() => pick(opt.value)}
+                  className={`w-full flex items-center gap-3 text-left rounded-xl border px-3.5 py-2.5 text-sm font-medium transition-colors cursor-pointer disabled:cursor-default ${
+                    selected
+                      ? 'border-accent bg-accent-soft text-accent-ink'
+                      : 'border-line bg-bg-0 text-ink-1 hover:bg-bg-1 hover:border-line-strong'
+                  }`}
+                >
+                  <span aria-hidden className="text-base leading-none">
+                    {opt.emoji}
+                  </span>
+                  {opt.label}
+                </button>
+                {selected && opt.detailPrompt && (
+                  <div className="mt-2 ml-4 pl-3 border-l-2 border-accent-soft-2">
+                    {opt.detailSuggestions && (
+                      <div className="flex flex-wrap gap-1.5 mb-2">
+                        {opt.detailSuggestions.map(s => {
+                          const on = detail === s;
+                          return (
+                            <button
+                              key={s}
+                              type="button"
+                              aria-pressed={on}
+                              disabled={busy}
+                              onClick={() => setDetail(on ? '' : s)}
+                              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer disabled:cursor-default ${
+                                on
+                                  ? 'border-accent bg-accent text-white'
+                                  : 'border-line bg-bg-0 text-ink-1 hover:bg-bg-1 hover:border-line-strong'
+                              }`}
+                            >
+                              {s}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                    <input
+                      type="text"
+                      autoFocus={!opt.detailSuggestions}
+                      maxLength={200}
+                      placeholder={opt.detailSuggestions ? 'Or somewhere else…' : opt.detailPrompt}
+                      value={detail}
+                      onChange={e => setDetail(e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && canContinue) submit(opt.value);
+                      }}
+                      className="w-full rounded-xl border border-line bg-bg-0 px-3.5 py-2 text-sm text-ink-0 placeholder:text-ink-4 outline-none focus:border-accent"
+                    />
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex items-center justify-between mt-6">
+          <Button variant="ghost" disabled={busy} onClick={() => submit(SURVEY_SKIPPED)}>
+            Skip
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!canContinue}
+            className="disabled:opacity-50 disabled:cursor-default"
+            onClick={() => canContinue && submit(picked.value)}
+          >
+            {busy ? 'Saving…' : 'Continue'}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default SurveyPrompt;

--- a/apps/webapp/app/components/features/survey/index.ts
+++ b/apps/webapp/app/components/features/survey/index.ts
@@ -1,0 +1,2 @@
+export { SurveyPrompt } from './SurveyPrompt';
+export { useSurveyPending } from './useSurveyPending';

--- a/apps/webapp/app/components/features/survey/useSurveyPending.ts
+++ b/apps/webapp/app/components/features/survey/useSurveyPending.ts
@@ -1,0 +1,15 @@
+import { useMatches } from 'react-router';
+import type { SurveyQuestion } from '@classmoji/utils';
+
+/**
+ * Whether any matched route's loader is currently holding unanswered survey
+ * questions (exposed as `surveyQuestions` in its data). Read off route data
+ * rather than the store so it is right on the very first render — the
+ * onboarding tour uses it to hold off auto-starting until the prompt is done.
+ */
+export const useSurveyPending = (): boolean =>
+  useMatches().some(m => {
+    const questions = (m.data as { surveyQuestions?: SurveyQuestion[] } | undefined)
+      ?.surveyQuestions;
+    return Array.isArray(questions) && questions.length > 0;
+  });

--- a/apps/webapp/app/routes/_user.select-organization/route.tsx
+++ b/apps/webapp/app/routes/_user.select-organization/route.tsx
@@ -15,6 +15,7 @@ import {
   ensureClassroomTeam,
   notificationService,
   provisionExampleClassroom,
+  pendingSurveyQuestions,
 } from '@classmoji/services';
 import { ActionTypes, roleSettings } from '~/constants';
 import useStore from '~/store';
@@ -28,6 +29,7 @@ import {
   type LandingRole,
 } from '~/components/features/landing';
 import type { NotificationRole } from '~/components/features/notifications';
+import { SurveyPrompt } from '~/components/features/survey';
 
 interface SelectOrganizationMembership extends MembershipWithOrganization {
   has_accepted_invite: boolean;
@@ -126,7 +128,21 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
       }
     }
 
-    const { items, unreadCount } = await notificationService.getForBell(typedUser.id);
+    // Runs after the invite claim above so a freshly-claimed student membership
+    // counts toward the audience filter. Never asked during impersonation: a
+    // platform admin must not answer on the user's behalf.
+    const impersonating = !!(
+      authData.session as { session?: { impersonatedBy?: string | null } } | undefined
+    )?.session?.impersonatedBy;
+    const [{ items, unreadCount }, surveyQuestions] = await Promise.all([
+      notificationService.getForBell(typedUser.id),
+      impersonating
+        ? []
+        : pendingSurveyQuestions(typedUser.id).catch(error => {
+            console.error('Failed to load survey questions:', error);
+            return [];
+          }),
+    ]);
     const notifications = items.map(n => ({
       id: n.id,
       type: n.type,
@@ -155,6 +171,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
       notifications,
       unreadCount,
       membershipRoles,
+      surveyQuestions,
     };
   } else {
     return redirect('/registration');
@@ -252,7 +269,7 @@ function buildLandingClasses(memberships: SelectOrganizationMembership[]): Landi
 // ───────── component ─────────
 
 const SelectOrganization = ({ loaderData }: Route.ComponentProps) => {
-  const { memberships, notifications, unreadCount, membershipRoles } = loaderData;
+  const { memberships, notifications, unreadCount, membershipRoles, surveyQuestions } = loaderData;
   const { user } = useUser();
   const { classroom, setClassroom, startFullTour } = useStore();
   const { fetcher, notify } = useGlobalFetcher();
@@ -335,6 +352,9 @@ const SelectOrganization = ({ loaderData }: Route.ComponentProps) => {
 
   return (
     <>
+      {/* Asked once per user, before the first-sign-in tour (which waits on it). */}
+      {surveyQuestions.length > 0 && <SurveyPrompt questions={surveyQuestions} />}
+
       <Modal
         open={visible}
         onOk={() => acceptInvite(pendingClassroom ?? classroom)}

--- a/apps/webapp/app/routes/api.survey.answer/route.ts
+++ b/apps/webapp/app/routes/api.survey.answer/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Record the current user's answer to one survey question.
+ *
+ * POST /api/survey/answer   { question_key, answer, detail? }
+ *
+ * `answer` is an option value from the question's catalog entry, or "skipped"
+ * when the user dismissed the prompt. Either way a row is written, which is
+ * what stops the prompt from coming back on the next login. The role context
+ * stored with the answer is derived server-side from memberships.
+ *
+ * Auth: any signed-in user — scoped to their own row only.
+ */
+
+import { requireAuth } from '@classmoji/auth/server';
+import { recordSurveyAnswer, SurveyValidationError } from '@classmoji/services';
+import type { Route } from './+types/route';
+
+interface AnswerBody {
+  question_key?: unknown;
+  answer?: unknown;
+  detail?: unknown;
+}
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const { userId } = await requireAuth(request);
+
+  let body: AnswerBody;
+  try {
+    body = (await request.json()) as AnswerBody;
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { question_key, answer, detail } = body;
+  if (typeof question_key !== 'string' || typeof answer !== 'string') {
+    return Response.json({ error: 'question_key and answer are required' }, { status: 400 });
+  }
+  if (detail != null && typeof detail !== 'string') {
+    return Response.json({ error: 'detail must be a string' }, { status: 400 });
+  }
+
+  try {
+    await recordSurveyAnswer({ userId, questionKey: question_key, answer, detail });
+  } catch (error) {
+    if (error instanceof SurveyValidationError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
+
+  return Response.json({ ok: true });
+};

--- a/apps/webapp/app/routes/test-login/route.tsx
+++ b/apps/webapp/app/routes/test-login/route.tsx
@@ -3,6 +3,7 @@ import type { Route } from './+types/route';
 import { COOKIE_DOMAIN } from '@classmoji/auth/secret';
 import { GitHubProvider } from '@classmoji/services';
 import getPrisma from '@classmoji/database';
+import { SURVEY_QUESTIONS, SURVEY_SKIPPED } from '@classmoji/utils';
 
 /**
  * Role configuration for test login.
@@ -145,6 +146,18 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     });
 
     console.log(`[test-login] Created session for ${user.login} (role=${role})`);
+
+    // Pre-record a skip for every survey question so the picker's one-off
+    // prompt (a blocking overlay) never appears in front of a Playwright spec.
+    await getPrisma().userSurveyResponse.createMany({
+      data: SURVEY_QUESTIONS.map(q => ({
+        user_id: user.id,
+        question_key: q.key,
+        answer: SURVEY_SKIPPED,
+        context: 'unknown',
+      })),
+      skipDuplicates: true,
+    });
 
     // Find the user's classroom membership matching the requested role
     // This allows us to redirect directly to the dashboard, bypassing /select-organization

--- a/packages/database/migrations/20260911120000_user_survey_responses/migration.sql
+++ b/packages/database/migrations/20260911120000_user_survey_responses/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "user_survey_responses" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "question_key" TEXT NOT NULL,
+    "answer" TEXT NOT NULL,
+    "detail" TEXT,
+    "context" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_survey_responses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_survey_responses_question_key_answer_idx" ON "user_survey_responses"("question_key", "answer");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_survey_responses_user_id_question_key_key" ON "user_survey_responses"("user_id", "question_key");
+
+-- AddForeignKey
+ALTER TABLE "user_survey_responses" ADD CONSTRAINT "user_survey_responses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -327,6 +327,7 @@ model User {
   form_responses                FormResponse[]            @relation("FormResponseRespondent")
   /// Rows this user typed in on somebody else's behalf — see FormResponse.added_by.
   form_responses_added          FormResponse[]            @relation("FormResponseAddedBy")
+  survey_responses              UserSurveyResponse[]
 
   @@unique([provider, provider_id])
   @@index([provider, login])
@@ -1559,6 +1560,33 @@ model NotificationPreference {
   user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@map("notification_preferences")
+}
+
+/// One user's answer to a product question asked in the webapp, such as
+/// "how did you hear about Classmoji?". The questions themselves live in code
+/// (apps/webapp survey config); this table only holds answers, so asking a new
+/// question is a new `question_key`, not a migration. One answer per user per
+/// question; a skip is recorded too (answer = "skipped") so the prompt does not
+/// come back every login.
+model UserSurveyResponse {
+  id           String   @id @default(uuid())
+  user_id      String
+  question_key String
+  /// One of the question's option values, or "skipped".
+  answer       String
+  /// Free text that accompanies an "other" answer.
+  detail       String?
+  /// Role signal at answer time: "instructor" | "student" | "unknown". Kept on
+  /// the row so segmenting later does not depend on reconstructing membership
+  /// history.
+  context      String
+  created_at   DateTime @default(now())
+
+  user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, question_key])
+  @@index([question_key, answer])
+  @@map("user_survey_responses")
 }
 
 model ProcessedWebhookEvent {

--- a/packages/services/src/classmoji/__tests__/userSurvey.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/userSurvey.service.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for userSurvey.service — the one-off product questions asked on
+ * the classroom picker. Prisma is mocked; the tests pin the role signal that
+ * `context` records, the audience filter, the catalog validation on write,
+ * and that a skip is stored like any other answer (so the prompt stays gone).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const membershipFindMany = vi.fn();
+const responseFindMany = vi.fn();
+const responseUpsert = vi.fn();
+
+vi.mock('@classmoji/database', () => ({
+  default: () => ({
+    classroomMembership: { findMany: (...a: unknown[]) => membershipFindMany(...a) },
+    userSurveyResponse: {
+      findMany: (...a: unknown[]) => responseFindMany(...a),
+      upsert: (...a: unknown[]) => responseUpsert(...a),
+    },
+  }),
+}));
+
+const survey = await import('../userSurvey.service.ts');
+
+beforeEach(() => {
+  membershipFindMany.mockReset();
+  responseFindMany.mockReset();
+  responseUpsert.mockReset();
+  responseUpsert.mockImplementation(async (args: { create: unknown }) => args.create);
+});
+
+describe('deriveSurveyContext', () => {
+  it('excludes the example classroom everyone owns', async () => {
+    membershipFindMany.mockResolvedValue([]);
+    await survey.deriveSurveyContext('u1');
+    expect(membershipFindMany.mock.calls[0][0].where).toEqual({
+      user_id: 'u1',
+      classroom: { is_example: false },
+    });
+  });
+
+  it('is unknown with no real memberships', async () => {
+    membershipFindMany.mockResolvedValue([]);
+    expect(await survey.deriveSurveyContext('u1')).toBe('unknown');
+  });
+
+  it('is student when every membership is a student one', async () => {
+    membershipFindMany.mockResolvedValue([{ role: 'STUDENT' }, { role: 'STUDENT' }]);
+    expect(await survey.deriveSurveyContext('u1')).toBe('student');
+  });
+
+  it('lets any staff role win over a student enrollment', async () => {
+    membershipFindMany.mockResolvedValue([{ role: 'STUDENT' }, { role: 'ASSISTANT' }]);
+    expect(await survey.deriveSurveyContext('u1')).toBe('instructor');
+  });
+});
+
+describe('pendingQuestions', () => {
+  it('returns the catalog question when nothing is answered', async () => {
+    responseFindMany.mockResolvedValue([]);
+    const pending = await survey.pendingQuestions('u1');
+    expect(pending.map(q => q.key)).toEqual(['referral_source']);
+  });
+
+  it('treats a skip as answered', async () => {
+    responseFindMany.mockResolvedValue([{ question_key: 'referral_source' }]);
+    expect(await survey.pendingQuestions('u1')).toEqual([]);
+  });
+
+  it('shuffles options per user, keeps the catch-all last, and is stable for a user', async () => {
+    responseFindMany.mockResolvedValue([]);
+    const [a1] = await survey.pendingQuestions('user-a');
+    const [a2] = await survey.pendingQuestions('user-a');
+    const [b] = await survey.pendingQuestions('user-b');
+
+    const values = (q: { options: { value: string }[] }) => q.options.map(o => o.value);
+    expect(values(a1)).toEqual(values(a2));
+    expect(values(a1)).not.toEqual(values(b));
+    expect(values(a1).at(-1)).toBe('other');
+    expect(values(b).at(-1)).toBe('other');
+    expect([...values(a1)].sort()).toEqual([...values(b)].sort());
+  });
+
+  it('does not look up memberships when no open question targets a role', async () => {
+    responseFindMany.mockResolvedValue([]);
+    await survey.pendingQuestions('u1');
+    expect(membershipFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordAnswer', () => {
+  it('rejects a question that is not in the catalog', async () => {
+    await expect(
+      survey.recordAnswer({ userId: 'u1', questionKey: 'nope', answer: 'x' })
+    ).rejects.toBeInstanceOf(survey.SurveyValidationError);
+    expect(responseUpsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an answer the question did not offer', async () => {
+    await expect(
+      survey.recordAnswer({ userId: 'u1', questionKey: 'referral_source', answer: 'tiktok' })
+    ).rejects.toBeInstanceOf(survey.SurveyValidationError);
+    expect(responseUpsert).not.toHaveBeenCalled();
+  });
+
+  it('stores a valid answer with the derived context, keyed per user and question', async () => {
+    membershipFindMany.mockResolvedValue([{ role: 'OWNER' }]);
+    await survey.recordAnswer({ userId: 'u1', questionKey: 'referral_source', answer: 'github' });
+
+    const args = responseUpsert.mock.calls[0][0];
+    expect(args.where).toEqual({
+      user_id_question_key: { user_id: 'u1', question_key: 'referral_source' },
+    });
+    expect(args.create).toEqual({
+      user_id: 'u1',
+      question_key: 'referral_source',
+      answer: 'github',
+      detail: null,
+      context: 'instructor',
+    });
+    expect(args.update).toEqual({ answer: 'github', detail: null, context: 'instructor' });
+  });
+
+  it('keeps detail only for an option that asks for it', async () => {
+    membershipFindMany.mockResolvedValue([]);
+    await survey.recordAnswer({
+      userId: 'u1',
+      questionKey: 'referral_source',
+      answer: 'conference',
+      detail: '  SIGCSE  ',
+    });
+    expect(responseUpsert.mock.calls[0][0].create.detail).toBe('SIGCSE');
+
+    await survey.recordAnswer({
+      userId: 'u1',
+      questionKey: 'referral_source',
+      answer: 'social',
+      detail: 'Reddit',
+    });
+    expect(responseUpsert.mock.calls[1][0].create.detail).toBe('Reddit');
+
+    await survey.recordAnswer({
+      userId: 'u1',
+      questionKey: 'referral_source',
+      answer: 'search',
+      detail: 'should be dropped',
+    });
+    expect(responseUpsert.mock.calls[2][0].create.detail).toBeNull();
+  });
+
+  it('records a skip as a row so the prompt does not return', async () => {
+    membershipFindMany.mockResolvedValue([{ role: 'STUDENT' }]);
+    await survey.recordAnswer({
+      userId: 'u1',
+      questionKey: 'referral_source',
+      answer: 'skipped',
+      detail: 'ignored',
+    });
+    expect(responseUpsert.mock.calls[0][0].create).toMatchObject({
+      answer: 'skipped',
+      detail: null,
+      context: 'student',
+    });
+  });
+});

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -34,6 +34,7 @@ import * as gitRepoService from './gitRepo.service.ts';
 import * as subscriptionService from './subscription.service.ts';
 import * as entitlementService from './entitlement.service.ts';
 import * as instructorAudienceService from './instructorAudience.service.ts';
+import * as userSurveyService from './userSurvey.service.ts';
 export { ClassroomSettingsEntitlementError } from './classroom.service.ts';
 // Installation repair: the refusal every caller has to tell apart from "not
 // installed", plus the shapes its results come back in.
@@ -118,6 +119,7 @@ const ClassmojiService = {
   subscription: subscriptionService,
   entitlement: entitlementService,
   instructorAudience: instructorAudienceService,
+  userSurvey: userSurveyService,
   teamMembership: teamMembershipService,
   team: teamService,
   teamAdmin: teamAdminService,

--- a/packages/services/src/classmoji/userSurvey.service.ts
+++ b/packages/services/src/classmoji/userSurvey.service.ts
@@ -1,0 +1,102 @@
+import getPrisma from '@classmoji/database';
+import {
+  SURVEY_QUESTIONS,
+  SURVEY_SKIPPED,
+  findSurveyOption,
+  getSurveyQuestion,
+  randomizeSurveyOptions,
+  type SurveyQuestion,
+} from '@classmoji/utils';
+
+export type SurveyContext = 'instructor' | 'student' | 'unknown';
+
+const DETAIL_MAX = 500;
+
+export class SurveyValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SurveyValidationError';
+  }
+}
+
+/**
+ * Role signal for a user, read off their memberships on real classrooms. Any
+ * staff membership wins over student: a TA who is also enrolled somewhere found
+ * the product the way an instructor did. The example classroom is excluded
+ * because everyone who signs in owns one.
+ */
+export const deriveSurveyContext = async (userId: string): Promise<SurveyContext> => {
+  const memberships = await getPrisma().classroomMembership.findMany({
+    where: { user_id: userId, classroom: { is_example: false } },
+    select: { role: true },
+  });
+  if (memberships.some(m => m.role !== 'STUDENT')) return 'instructor';
+  if (memberships.length > 0) return 'student';
+  return 'unknown';
+};
+
+/**
+ * Questions to put in front of this user now: in the catalog, aimed at their
+ * audience, and without a stored answer (a skip counts as an answer, so a
+ * dismissed prompt stays dismissed).
+ */
+export const pendingQuestions = async (userId: string): Promise<SurveyQuestion[]> => {
+  if (SURVEY_QUESTIONS.length === 0) return [];
+
+  const answered = await getPrisma().userSurveyResponse.findMany({
+    where: { user_id: userId },
+    select: { question_key: true },
+  });
+  const done = new Set(answered.map(a => a.question_key));
+  const open = SURVEY_QUESTIONS.filter(q => !done.has(q.key));
+  if (open.length === 0) return [];
+
+  // Only pay for the membership lookup when a question actually targets a role.
+  const context = open.some(q => q.audience !== 'all')
+    ? await deriveSurveyContext(userId)
+    : 'unknown';
+  return open
+    .filter(q => q.audience === 'all' || context === 'unknown' || q.audience === context)
+    .map(q => randomizeSurveyOptions(q, userId));
+};
+
+interface RecordAnswerInput {
+  userId: string;
+  questionKey: string;
+  /** An option value from the question, or SURVEY_SKIPPED. */
+  answer: string;
+  detail?: string | null;
+}
+
+/**
+ * Store (or overwrite) one answer. The answer is checked against the catalog
+ * so the table never holds values the question did not offer; `detail` is only
+ * kept for an option that asks for it. `context` is derived here, not taken
+ * from the client.
+ */
+export const recordAnswer = async ({ userId, questionKey, answer, detail }: RecordAnswerInput) => {
+  const question = getSurveyQuestion(questionKey);
+  if (!question) throw new SurveyValidationError(`Unknown survey question: ${questionKey}`);
+
+  const skipped = answer === SURVEY_SKIPPED;
+  const option = skipped ? undefined : findSurveyOption(question, answer);
+  if (!skipped && !option) {
+    throw new SurveyValidationError(`Unknown answer for ${questionKey}: ${answer}`);
+  }
+
+  const trimmed = (detail ?? '').trim();
+  const keptDetail = option?.detailPrompt && trimmed ? trimmed.slice(0, DETAIL_MAX) : null;
+  const context = await deriveSurveyContext(userId);
+
+  return getPrisma().userSurveyResponse.upsert({
+    where: { user_id_question_key: { user_id: userId, question_key: questionKey } },
+    create: {
+      user_id: userId,
+      question_key: questionKey,
+      answer,
+      detail: keptDetail,
+      context,
+    },
+    update: { answer, detail: keptDetail, context },
+  });
+};

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -176,6 +176,16 @@ export {
   type InstructorContact,
 } from './classmoji/instructorAudience.service.ts';
 
+// One-off product questions asked on the classroom picker. The catalog itself
+// is in @classmoji/utils so the client can render it.
+export {
+  pendingQuestions as pendingSurveyQuestions,
+  recordAnswer as recordSurveyAnswer,
+  deriveSurveyContext,
+  SurveyValidationError,
+  type SurveyContext,
+} from './classmoji/userSurvey.service.ts';
+
 // Fly certificate automation for class-site custom domains. Every method throws
 // a typed FlyCertError when the credentials are absent, so importing this in a
 // deployment that has none is safe.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,3 +29,4 @@ export * from './processSafety.ts';
 export * from './roomStateStore.ts';
 export * from './blockAssetRefs.ts';
 export * from './naturalSort.ts';
+export * from './surveyQuestions.ts';

--- a/packages/utils/src/surveyQuestions.ts
+++ b/packages/utils/src/surveyQuestions.ts
@@ -1,0 +1,112 @@
+/**
+ * Product questions the webapp asks a signed-in user once, on the classroom
+ * picker. Answers are stored in `user_survey_responses`; this file is the only
+ * definition of what gets asked, so adding a question is a new entry here, not
+ * a migration. Plain data, safe to import on the client.
+ */
+
+export type SurveyAudience = 'all' | 'instructor' | 'student';
+
+export interface SurveyOption {
+  /** Stored as the row's `answer` when this is the picked leaf. */
+  value: string;
+  label: string;
+  emoji: string;
+  /** Placeholder for a free-text field shown once this option is picked. */
+  detailPrompt?: string;
+  /** One-tap answers for that field, shown as chips above it. */
+  detailSuggestions?: string[];
+  /** Keep this option at the bottom when the rest are shuffled (the catch-all). */
+  pinLast?: boolean;
+}
+
+export interface SurveyQuestion {
+  /** Stable id stored on the response row. Never rename once answers exist. */
+  key: string;
+  prompt: string;
+  options: SurveyOption[];
+  /** Who gets asked. `instructor`/`student` use the same role signal the
+   *  response's `context` column records; `unknown` users are asked either way. */
+  audience: SurveyAudience;
+}
+
+/** Answer recorded when the user dismisses the prompt without choosing. */
+export const SURVEY_SKIPPED = 'skipped';
+
+export const SURVEY_QUESTIONS: SurveyQuestion[] = [
+  {
+    key: 'referral_source',
+    prompt: 'How did you hear about Classmoji?',
+    audience: 'all',
+    options: [
+      { value: 'colleague', emoji: '🗣️', label: 'A colleague or friend' },
+      { value: 'instructor', emoji: '🎓', label: 'My instructor or a course' },
+      {
+        value: 'conference',
+        emoji: '🎤',
+        label: 'A conference, workshop, or talk',
+        detailPrompt: 'Which one? (SIGCSE, CCSC, a campus event…)',
+      },
+      { value: 'search', emoji: '🔍', label: 'Web search' },
+      { value: 'ai', emoji: '🤖', label: 'ChatGPT, Claude, or another AI assistant' },
+      { value: 'github', emoji: '🐙', label: 'Github' },
+      {
+        value: 'social',
+        emoji: '📱',
+        label: 'Social media',
+        detailPrompt: 'Which platform?',
+        detailSuggestions: ['Reddit', 'LinkedIn'],
+      },
+      { value: 'publication', emoji: '📰', label: 'A newsletter, blog post, or podcast' },
+      {
+        value: 'other',
+        emoji: '✨',
+        label: 'Somewhere else',
+        detailPrompt: 'Where?',
+        pinLast: true,
+      },
+    ],
+  },
+];
+
+export const getSurveyQuestion = (key: string): SurveyQuestion | undefined =>
+  SURVEY_QUESTIONS.find(q => q.key === key);
+
+export const findSurveyOption = (
+  question: SurveyQuestion,
+  value: string
+): SurveyOption | undefined => question.options.find(o => o.value === value);
+
+// FNV-1a, then mulberry32: enough to turn "user id + question key" into a
+// stable shuffle. Not for anything that needs real randomness.
+const hashSeed = (input: string): number => {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+};
+
+const seededRandom = (seed: number) => () => {
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+/**
+ * The question with its options in a per-seed order, so the first slot is not
+ * always the same choice (top options get over-picked). Pinned options keep
+ * their place at the end. Same seed, same order, so a user's list does not
+ * reshuffle between renders.
+ */
+export const randomizeSurveyOptions = (question: SurveyQuestion, seed: string): SurveyQuestion => {
+  const rand = seededRandom(hashSeed(`${seed}:${question.key}`));
+  const shuffled = question.options.filter(o => !o.pinLast);
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return { ...question, options: [...shuffled, ...question.options.filter(o => o.pinLast)] };
+};


### PR DESCRIPTION
## What

A one-question prompt on the classroom picker: "How did you hear about Classmoji?" Shown to any signed-in user (new or existing) who has not answered it yet. Skip is recorded so it never comes back.

## How it works

- **Storage**: new `user_survey_responses` table, one row per user per question. Columns: `question_key`, `answer` (option value or `skipped`), `detail` (free text, only for options that ask), `context` (`instructor` / `student` / `unknown`, derived from memberships at answer time, never from the client).
- **Catalog**: questions live in code at `packages/utils/src/surveyQuestions.ts`. A new question is a catalog entry, not a migration. Supports `audience` (all / instructor / student), per-option follow-up text, quick-pick chips, and a pinned catch-all.
- **Order**: options are shuffled per user (seeded from user id) so position bias averages out; "Somewhere else" stays last.
- **Tour**: the first-sign-in onboarding tour waits for the prompt so two modals never stack.
- **Guards**: suppressed under impersonation (an admin never answers for a user); `test-login` pre-records a skip so Playwright specs never meet the overlay.
- **API**: `POST /api/survey/answer`, auth'd to the caller's own row, validates the answer against the catalog.

## Reading the data

```sql
SELECT answer, context, count(*)
FROM user_survey_responses
WHERE question_key = 'referral_source'
GROUP BY 1, 2 ORDER BY 3 DESC;
```

## Test steps

1. `npm run db:deploy` (new migration)
2. Sign in, land on `/select-organization`, see the prompt
3. Pick Social media → Reddit / LinkedIn chips appear; pick Conference → text field appears
4. Continue or Skip → prompt gone, row in `user_survey_responses`
5. Reload → not asked again
6. `npm run test --workspace packages/services` → 13 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dee6yiWgUquraHqWpG3wS7