### PR TITLE
chore(db): rename user_survey_responses to survey_responses

### DIFF
--- a/apps/webapp/app/routes/test-login/route.tsx
+++ b/apps/webapp/app/routes/test-login/route.tsx
@@ -149,7 +149,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
     // Pre-record a skip for every survey question so the picker's one-off
     // prompt (a blocking overlay) never appears in front of a Playwright spec.
-    await getPrisma().userSurveyResponse.createMany({
+    await getPrisma().surveyResponse.createMany({
       data: SURVEY_QUESTIONS.map(q => ({
         user_id: user.id,
         question_key: q.key,

--- a/packages/database/migrations/20260912030000_rename_survey_responses/migration.sql
+++ b/packages/database/migrations/20260912030000_rename_survey_responses/migration.sql
@@ -1,0 +1,11 @@
+-- Rename user_survey_responses -> survey_responses. Constraints and indexes are
+-- renamed too so they match what Prisma generates for the new model name.
+ALTER TABLE "user_survey_responses" RENAME TO "survey_responses";
+
+ALTER TABLE "survey_responses" RENAME CONSTRAINT "user_survey_responses_pkey" TO "survey_responses_pkey";
+
+ALTER TABLE "survey_responses" RENAME CONSTRAINT "user_survey_responses_user_id_fkey" TO "survey_responses_user_id_fkey";
+
+ALTER INDEX "user_survey_responses_question_key_answer_idx" RENAME TO "survey_responses_question_key_answer_idx";
+
+ALTER INDEX "user_survey_responses_user_id_question_key_key" RENAME TO "survey_responses_user_id_question_key_key";

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -327,7 +327,7 @@ model User {
   form_responses                FormResponse[]            @relation("FormResponseRespondent")
   /// Rows this user typed in on somebody else's behalf — see FormResponse.added_by.
   form_responses_added          FormResponse[]            @relation("FormResponseAddedBy")
-  survey_responses              UserSurveyResponse[]
+  survey_responses              SurveyResponse[]
 
   @@unique([provider, provider_id])
   @@index([provider, login])
@@ -1568,7 +1568,7 @@ model NotificationPreference {
 /// question is a new `question_key`, not a migration. One answer per user per
 /// question; a skip is recorded too (answer = "skipped") so the prompt does not
 /// come back every login.
-model UserSurveyResponse {
+model SurveyResponse {
   id           String   @id @default(uuid())
   user_id      String
   question_key String
@@ -1586,7 +1586,7 @@ model UserSurveyResponse {
 
   @@unique([user_id, question_key])
   @@index([question_key, answer])
-  @@map("user_survey_responses")
+  @@map("survey_responses")
 }
 
 model ProcessedWebhookEvent {

--- a/packages/services/src/classmoji/__tests__/survey.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/survey.service.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for userSurvey.service — the one-off product questions asked on
+ * Unit tests for survey.service — the one-off product questions asked on
  * the classroom picker. Prisma is mocked; the tests pin the role signal that
  * `context` records, the audience filter, the catalog validation on write,
  * and that a skip is stored like any other answer (so the prompt stays gone).
@@ -14,14 +14,14 @@ const responseUpsert = vi.fn();
 vi.mock('@classmoji/database', () => ({
   default: () => ({
     classroomMembership: { findMany: (...a: unknown[]) => membershipFindMany(...a) },
-    userSurveyResponse: {
+    surveyResponse: {
       findMany: (...a: unknown[]) => responseFindMany(...a),
       upsert: (...a: unknown[]) => responseUpsert(...a),
     },
   }),
 }));
 
-const survey = await import('../userSurvey.service.ts');
+const survey = await import('../survey.service.ts');
 
 beforeEach(() => {
   membershipFindMany.mockReset();

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -34,7 +34,7 @@ import * as gitRepoService from './gitRepo.service.ts';
 import * as subscriptionService from './subscription.service.ts';
 import * as entitlementService from './entitlement.service.ts';
 import * as instructorAudienceService from './instructorAudience.service.ts';
-import * as userSurveyService from './userSurvey.service.ts';
+import * as surveyService from './survey.service.ts';
 export { ClassroomSettingsEntitlementError } from './classroom.service.ts';
 // Installation repair: the refusal every caller has to tell apart from "not
 // installed", plus the shapes its results come back in.
@@ -119,7 +119,7 @@ const ClassmojiService = {
   subscription: subscriptionService,
   entitlement: entitlementService,
   instructorAudience: instructorAudienceService,
-  userSurvey: userSurveyService,
+  survey: surveyService,
   teamMembership: teamMembershipService,
   team: teamService,
   teamAdmin: teamAdminService,

--- a/packages/services/src/classmoji/survey.service.ts
+++ b/packages/services/src/classmoji/survey.service.ts
@@ -43,7 +43,7 @@ export const deriveSurveyContext = async (userId: string): Promise<SurveyContext
 export const pendingQuestions = async (userId: string): Promise<SurveyQuestion[]> => {
   if (SURVEY_QUESTIONS.length === 0) return [];
 
-  const answered = await getPrisma().userSurveyResponse.findMany({
+  const answered = await getPrisma().surveyResponse.findMany({
     where: { user_id: userId },
     select: { question_key: true },
   });
@@ -88,7 +88,7 @@ export const recordAnswer = async ({ userId, questionKey, answer, detail }: Reco
   const keptDetail = option?.detailPrompt && trimmed ? trimmed.slice(0, DETAIL_MAX) : null;
   const context = await deriveSurveyContext(userId);
 
-  return getPrisma().userSurveyResponse.upsert({
+  return getPrisma().surveyResponse.upsert({
     where: { user_id_question_key: { user_id: userId, question_key: questionKey } },
     create: {
       user_id: userId,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -184,7 +184,7 @@ export {
   deriveSurveyContext,
   SurveyValidationError,
   type SurveyContext,
-} from './classmoji/userSurvey.service.ts';
+} from './classmoji/survey.service.ts';
 
 // Fly certificate automation for class-site custom domains. Every method throws
 // a typed FlyCertError when the credentials are absent, so importing this in a

--- a/packages/utils/src/surveyQuestions.ts
+++ b/packages/utils/src/surveyQuestions.ts
@@ -1,6 +1,6 @@
 /**
  * Product questions the webapp asks a signed-in user once, on the classroom
- * picker. Answers are stored in `user_survey_responses`; this file is the only
+ * picker. Answers are stored in `survey_responses`; this file is the only
  * definition of what gets asked, so adding a question is a new entry here, not
  * a migration. Plain data, safe to import on the client.
  */


### PR DESCRIPTION
## What

Follow-up to #348. `UserSurveyResponse` / `user_survey_responses` becomes `SurveyResponse` / `survey_responses`.

- Migration renames the table plus its pkey, fkey, and both indexes so names match what Prisma generates for the new model (no drift; existing rows carry over).
- Service follows: `userSurvey.service.ts` → `survey.service.ts`, `ClassmojiService.survey`. Public exports (`pendingSurveyQuestions`, `recordSurveyAnswer`) are unchanged.

## Test steps

1. `npm run db:deploy` → applies `20260912030000_rename_survey_responses`
2. `npm run test --workspace packages/services` → 13 survey tests pass
3. Picker prompt still works; answers land in `survey_responses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dee6yiWgUquraHqWpG3wS7