### PR TITLE
fix(survey): stop asking students how they heard about Classmoji

### DIFF
--- a/packages/services/src/classmoji/__tests__/survey.service.test.ts
+++ b/packages/services/src/classmoji/__tests__/survey.service.test.ts
@@ -59,6 +59,7 @@ describe('deriveSurveyContext', () => {
 describe('pendingQuestions', () => {
   it('returns the catalog question when nothing is answered', async () => {
     responseFindMany.mockResolvedValue([]);
+    membershipFindMany.mockResolvedValue([]);
     const pending = await survey.pendingQuestions('u1');
     expect(pending.map(q => q.key)).toEqual(['referral_source']);
   });
@@ -70,6 +71,7 @@ describe('pendingQuestions', () => {
 
   it('shuffles options per user, keeps the catch-all last, and is stable for a user', async () => {
     responseFindMany.mockResolvedValue([]);
+    membershipFindMany.mockResolvedValue([]);
     const [a1] = await survey.pendingQuestions('user-a');
     const [a2] = await survey.pendingQuestions('user-a');
     const [b] = await survey.pendingQuestions('user-b');
@@ -82,10 +84,17 @@ describe('pendingQuestions', () => {
     expect([...values(a1)].sort()).toEqual([...values(b)].sort());
   });
 
-  it('does not look up memberships when no open question targets a role', async () => {
+  it('skips students for an instructor-audience question but still asks unknowns', async () => {
     responseFindMany.mockResolvedValue([]);
-    await survey.pendingQuestions('u1');
-    expect(membershipFindMany).not.toHaveBeenCalled();
+
+    membershipFindMany.mockResolvedValue([{ role: 'STUDENT' }]);
+    expect(await survey.pendingQuestions('u1')).toEqual([]);
+
+    membershipFindMany.mockResolvedValue([]);
+    expect((await survey.pendingQuestions('u1')).map(q => q.key)).toEqual(['referral_source']);
+
+    membershipFindMany.mockResolvedValue([{ role: 'OWNER' }]);
+    expect((await survey.pendingQuestions('u1')).map(q => q.key)).toEqual(['referral_source']);
   });
 });
 

--- a/packages/utils/src/surveyQuestions.ts
+++ b/packages/utils/src/surveyQuestions.ts
@@ -37,7 +37,9 @@ export const SURVEY_QUESTIONS: SurveyQuestion[] = [
   {
     key: 'referral_source',
     prompt: 'How did you hear about Classmoji?',
-    audience: 'all',
+    // Students overwhelmingly skip this (they are here because their instructor
+    // said so), so only people who are not yet a student anywhere get asked.
+    audience: 'instructor',
     options: [
       { value: 'colleague', emoji: '🗣️', label: 'A colleague or friend' },
       { value: 'instructor', emoji: '🎓', label: 'My instructor or a course' },


### PR DESCRIPTION
## What

First day of prod data on the referral prompt: 12 of 13 students skipped, and the one who answered said "my instructor". The question is now `audience: 'instructor'`, so:

- anyone whose memberships are all `STUDENT` is not asked
- fresh sign-ups with no classroom yet (`unknown`) still are
- anyone with a staff role still is

No schema change. Existing student rows stay; filter `context = 'student'` out when reading.

## Test steps

1. `npm run test --workspace packages/services` → 13 survey tests pass (new case covers student / unknown / owner)
2. Sign in as a student-only account → no prompt on the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dee6yiWgUquraHqWpG3wS7