### PR TITLE
Documentation search: index the docs site and serve it through the content tools

### DIFF
--- a/apps/mcp/src/tools/__tests__/contentSearch.test.ts
+++ b/apps/mcp/src/tools/__tests__/contentSearch.test.ts
@@ -27,9 +27,15 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Prisma } from '@prisma/client';
-import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ToolError } from '../../mcp/errors.ts';
-import { toolAnnotations, type ToolContext, type ToolDefinition } from '../../mcp/registry.ts';
+import {
+  buildMcpServer,
+  registerToolDefinition,
+  toolAnnotations,
+  type ToolContext,
+  type ToolDefinition,
+} from '../../mcp/registry.ts';
 
 const mocks = vi.hoisted(() => ({
   embedTexts: vi.fn(),
@@ -63,8 +69,16 @@ vi.mock('@classmoji/services', async () => {
   const real = await vi.importActual<
     typeof import('../../../../../packages/services/src/classmoji/contentSearch.service.ts')
   >('../../../../../packages/services/src/classmoji/contentSearch.service.ts');
+  // The REAL docs read service too, for the same reason: what these tests are
+  // about is that the tool forwards to the right corpus and shapes the result,
+  // and a hand-written `searchDocs` stub would agree with a handler that built
+  // a nonsense statement.
+  const docs = await vi.importActual<
+    typeof import('../../../../../packages/services/src/classmoji/docsSearch.service.ts')
+  >('../../../../../packages/services/src/classmoji/docsSearch.service.ts');
   return {
     ...real,
+    ...docs,
     ClassmojiService: {
       contentDelivery: {
         fetchContentText: (...args: unknown[]) => mocks.fetchContentText(...args),
@@ -721,5 +735,463 @@ describe('content_get', () => {
       0
     );
     expect(mocks.fetchContentText).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TWO CORPORA BEHIND THE SAME THREE TOOLS
+//
+// The failure this block exists for is not "docs search does not work" — it is
+// the two lanes LEAKING into each other. A `scope: 'docs'` call that reaches
+// `searchContent` answers a platform question out of one classroom's material;
+// a default call that reaches `searchDocs` answers a course question out of the
+// product manual. Both are confident, plausible and wrong.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Which raw statement a stubbed answer belongs to, keyed by a SQL fragment. */
+type RawAnswers = Array<[fragment: string, rows: unknown[]]>;
+
+/** Install a raw handler that dispatches on the statement's own text. */
+const answerRawBy = (answers: RawAnswers): void => {
+  setPrismaRaw((parts: unknown[]) => {
+    rawStatements.push(parts);
+    const sql = (parts as string[]).join(' ');
+    for (const [fragment, rows] of answers) if (sql.includes(fragment)) return rows;
+    return [];
+  });
+};
+
+const DOCS_ROW = {
+  slug: 'docs/instructors/roster',
+  chunkIx: 0,
+  title: 'Manage your roster',
+  description: 'How to add students and teaching staff',
+  section: 'instructors',
+  snippet: 'Go to the Teaching Staff tab and click New staff member.',
+  score: 0.91,
+};
+
+const COURSE_ROW = {
+  docKind: 'page' as const,
+  docId: PAGE_ID,
+  chunkIx: 0,
+  title: 'Course Policies',
+  snippet: 'Late work is accepted for 48 hours.',
+  score: 0.8,
+  isDraft: null,
+};
+
+/** Every raw statement issued, as one string, for "did it touch that table". */
+const allSql = (): string => rawStatements.map(parts => (parts as string[]).join(' ')).join('\n');
+
+describe('scope selects the corpus, and the two never leak into each other', () => {
+  it('defaults to the COURSE corpus and never touches docs_index', async () => {
+    answerRawBy([['content_index', [COURSE_ROW]]]);
+
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'late work' },
+      STUDENT
+    );
+
+    expect(payload.count).toBe(1);
+    expect((payload.hits as Array<Record<string, unknown>>)[0].kind).toBe('page');
+    expect(allSql()).toContain('content_index');
+    expect(allSql()).not.toContain('docs_index');
+  });
+
+  it("scope: 'docs' reads docs_index and never touches content_index", async () => {
+    answerRawBy([['docs_index', [DOCS_ROW]]]);
+
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'where do I add a TA', scope: 'docs' },
+      STUDENT
+    );
+
+    expect(payload.count).toBe(1);
+    expect(allSql()).toContain('docs_index');
+    expect(allSql()).not.toContain('content_index');
+  });
+
+  it("shapes a docs hit as kind 'doc' with the slug as id and a real url", async () => {
+    answerRawBy([['docs_index', [DOCS_ROW]]]);
+
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'where do I add a TA', scope: 'docs' },
+      STUDENT
+    );
+
+    const [hit] = payload.hits as Array<Record<string, unknown>>;
+    expect(hit.kind).toBe('doc');
+    expect(hit.id).toBe('docs/instructors/roster');
+    expect(hit.title).toBe('Manage your roster');
+    expect(hit.section).toBe('instructors');
+    // The id and the link are the same string by construction, so a citation
+    // and the chip under it cannot disagree.
+    expect(hit.url).toBe('https://classmoji.io/docs/instructors/roster');
+    expect(hit.snippet).toContain('Teaching Staff');
+    // No course-only fields leak across.
+    expect(Object.keys(hit)).not.toContain('isDraft');
+    expect(Object.keys(hit)).not.toContain('source_path');
+  });
+
+  it("scope: 'docs' still embeds the query exactly as the course lane does", async () => {
+    answerRawBy([['docs_index', [DOCS_ROW]]]);
+    await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'how do tokens work', scope: 'docs' },
+      STUDENT
+    );
+    expect(mocks.embedTexts).toHaveBeenCalledWith(['how do tokens work']);
+  });
+
+  it('reports an embedding failure on the DOCS lane with the same marker', async () => {
+    // Not a docs-specific message: "retrieval is down" is the same fact in both
+    // corpora, and a second vocabulary for it is a second thing to get wrong.
+    mocks.isWorkersAiConfigured.mockReturnValue(false);
+
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'anything', scope: 'docs' },
+      STUDENT
+    );
+
+    expect(payload.unavailable).toBe('embedding_not_configured');
+    expect(String(payload.message)).toMatch(/not an empty result set/i);
+    expect(allSql()).not.toContain('docs_index');
+  });
+
+  it("scope: 'docs' lists from docs_index, default lists from the course records", async () => {
+    answerRawBy([['docs_index', [{ ...DOCS_ROW, updatedAt: new Date('2026-09-12T00:00:00Z') }]]]);
+    const docs = await call(contentListTool, { classroom: 'o/c', scope: 'docs' }, STUDENT);
+    expect((docs.items as Array<Record<string, unknown>>)[0].kind).toBe('doc');
+    expect((docs.items as Array<Record<string, unknown>>)[0].url).toBe(
+      'https://classmoji.io/docs/instructors/roster'
+    );
+
+    rawStatements = [];
+    answerRawBy([['pages', []]]);
+    await call(contentListTool, { classroom: 'o/c' }, STUDENT);
+    expect(allSql()).not.toContain('docs_index');
+  });
+});
+
+describe('kind and scope: docs are refused together, never silently reconciled', () => {
+  it.each([['page'], ['slide'], ['file']] as const)(
+    "refuses kind '%s' with scope: 'docs'",
+    async kind => {
+      const refusal = await refusalOf(() =>
+        call(
+          contentSearchTool,
+          { classroom: 'o/c', query: 'anything', scope: 'docs', kind },
+          STUDENT
+        )
+      );
+      expect(refusal.error).toBe('invalid_params');
+      expect(refusal.message).toMatch(/has no meaning for scope: 'docs'/);
+    }
+  );
+
+  it('refuses the pair on content_list too', async () => {
+    const refusal = await refusalOf(() =>
+      call(contentListTool, { classroom: 'o/c', scope: 'docs', kind: 'page' }, STUDENT)
+    );
+    expect(refusal.error).toBe('invalid_params');
+  });
+
+  it('refuses BEFORE running anything, so no statement is issued', async () => {
+    await refusalOf(() =>
+      call(
+        contentSearchTool,
+        { classroom: 'o/c', query: 'anything', scope: 'docs', kind: 'page' },
+        STUDENT
+      )
+    );
+    expect(mocks.embedTexts).not.toHaveBeenCalled();
+    expect(rawStatements).toHaveLength(0);
+  });
+
+  it('still accepts kind on the COURSE lane', async () => {
+    answerRawBy([['content_index', [COURSE_ROW]]]);
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'late work', kind: 'page' },
+      STUDENT
+    );
+    expect(payload.count).toBe(1);
+  });
+});
+
+describe('an unbuilt docs index is an UNAVAILABLE, not an empty result', () => {
+  it('carries the marker and a message that does not claim no search was run', async () => {
+    answerRawBy([
+      ['docs_index di', []],
+      ['NOT EXISTS', [{ empty: true }]],
+    ]);
+
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'anything', scope: 'docs' },
+      STUDENT
+    );
+
+    expect(payload.unavailable).toBe('docs_index_empty');
+    expect(payload.hits).toEqual([]);
+    expect(String(payload.message)).toMatch(/has not been built on this deployment/);
+    expect(String(payload.message)).toMatch(/not an empty result set/i);
+    // A search WAS run on this branch. Saying otherwise is simply false, and it
+    // is the sentence the course lane uses for a DIFFERENT state.
+    expect(String(payload.message)).not.toMatch(/no search was run/);
+  });
+
+  it('is never an error — the caller can still answer around it', async () => {
+    answerRawBy([
+      ['docs_index di', []],
+      ['NOT EXISTS', [{ empty: true }]],
+    ]);
+    await expect(
+      contentSearchTool.handler({ classroom: 'o/c', query: 'anything', scope: 'docs' }, STUDENT)
+    ).resolves.toBeDefined();
+  });
+
+  it('reports a genuinely empty ANSWER as empty when the index is populated', async () => {
+    answerRawBy([
+      ['docs_index di', []],
+      ['NOT EXISTS', [{ empty: false }]],
+    ]);
+
+    const payload = await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'quantum tunnelling', scope: 'docs' },
+      STUDENT
+    );
+
+    expect(payload.count).toBe(0);
+    expect(payload.unavailable).toBeUndefined();
+    expect(payload.message).toBeUndefined();
+  });
+
+  it('does NOT ask whether the index is empty when there are hits', async () => {
+    // One statement, not two: the emptiness probe exists only to explain an
+    // absence, and running it on every successful search is a query per call
+    // for an answer nobody reads.
+    answerRawBy([['docs_index', [DOCS_ROW]]]);
+
+    await call(contentSearchTool, { classroom: 'o/c', query: 'roster', scope: 'docs' }, STUDENT);
+
+    expect(allSql()).not.toContain('NOT EXISTS');
+  });
+
+  it('marks an empty docs LISTING the same way', async () => {
+    answerRawBy([
+      ['docs_index di', []],
+      ['NOT EXISTS', [{ empty: true }]],
+    ]);
+    const payload = await call(contentListTool, { classroom: 'o/c', scope: 'docs' }, STUDENT);
+    expect(payload.unavailable).toBe('docs_index_empty');
+    expect(payload.items).toEqual([]);
+  });
+});
+
+describe('content_get with kind: doc', () => {
+  it('returns the page text, its canonical url, and no course-only fields', async () => {
+    answerRawBy([
+      [
+        'docs_index di',
+        [
+          {
+            slug: 'docs/instructors/roster',
+            title: 'Manage your roster',
+            description: 'How to add students',
+            section: 'instructors',
+            text: 'Go to the Teaching Staff tab and click New staff member.',
+            chunkCount: 1,
+            updatedAt: new Date('2026-09-12T00:00:00Z'),
+          },
+        ],
+      ],
+    ]);
+
+    const payload = await call(
+      contentGetTool,
+      { classroom: 'o/c', kind: 'doc', id: 'docs/instructors/roster' },
+      STUDENT
+    );
+
+    expect(payload.kind).toBe('doc');
+    expect(payload.id).toBe('docs/instructors/roster');
+    expect(payload.url).toBe('https://classmoji.io/docs/instructors/roster');
+    expect(String(payload.text)).toContain('Teaching Staff');
+    expect(Object.keys(payload)).not.toContain('source_path');
+    expect(Object.keys(payload)).not.toContain('isDraft');
+  });
+
+  it('refuses a missing page distinctly, because docs are public', async () => {
+    answerRawBy([['docs_index di', []]]);
+
+    const refusal = await refusalOf(() =>
+      call(contentGetTool, { classroom: 'o/c', kind: 'doc', id: 'docs/nope' }, STUDENT)
+    );
+
+    expect(refusal.error).toBe('not_found');
+    // NOT the uniform `scopedNotFound('Content')` wording. That one is uniform
+    // to stop a student enumerating drafts by watching which ids answer
+    // differently; documentation is global and public, so there is nothing to
+    // enumerate.
+    expect(refusal.message).toBe('Documentation page not found');
+    expect(refusal.message).not.toMatch(/in this classroom/);
+  });
+
+  it('never falls back to a live fetch for a doc', async () => {
+    answerRawBy([['docs_index di', []]]);
+    await refusalOf(() =>
+      call(contentGetTool, { classroom: 'o/c', kind: 'doc', id: 'docs/nope' }, STUDENT)
+    );
+    // The course lane reads the content repo when its index lags. Documentation
+    // exists ONLY in the index, so a fallback would be an on-demand fetch of a
+    // caller-supplied path from github.com.
+    expect(mocks.fetchContentText).not.toHaveBeenCalled();
+    // Keyed (model, method) — the stub's own signature. A single dotted string
+    // silently matches nothing, which is a passing assertion about nothing.
+    expect(prismaCallsFor('page', 'findFirst')).toHaveLength(0);
+    expect(prismaCallsFor('slide', 'findFirst')).toHaveLength(0);
+  });
+});
+
+describe('the instrumentation line carries the corpus, and still never the query', () => {
+  it("logs scope 'docs' and the doc ids, not the text asked for", async () => {
+    answerRawBy([['docs_index', [DOCS_ROW]]]);
+
+    await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'where do I add a teaching assistant', scope: 'docs' },
+      STUDENT
+    );
+
+    const line = searchLog();
+    expect(line.scope).toBe('docs');
+    expect(line.result_count).toBe(1);
+    expect(line.results).toEqual(['doc:docs/instructors/roster']);
+    expect(line.query_chars).toBe('where do I add a teaching assistant'.length);
+    // The whole point of logging a LENGTH: what a student typed is not kept.
+    expect(loggedLines.join('\n')).not.toContain('teaching assistant');
+  });
+
+  it("logs scope 'course' by default, with the course ids", async () => {
+    answerRawBy([['content_index', [COURSE_ROW]]]);
+    await call(contentSearchTool, { classroom: 'o/c', query: 'late work' }, STUDENT);
+
+    const line = searchLog();
+    expect(line.scope).toBe('course');
+    expect(line.results).toEqual([`page:${PAGE_ID}`]);
+  });
+
+  it('logs the marker when the docs index is unbuilt', async () => {
+    answerRawBy([
+      ['docs_index di', []],
+      ['NOT EXISTS', [{ empty: true }]],
+    ]);
+    await call(contentSearchTool, { classroom: 'o/c', query: 'anything', scope: 'docs' }, STUDENT);
+
+    const line = searchLog();
+    expect(line.scope).toBe('docs');
+    expect(line.unavailable).toBe('docs_index_empty');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE SCHEMAS AS A CLIENT ACTUALLY SEES THEM
+//
+// Everything above reads `contentSearchTool.inputSchema` — the object this file
+// exports. That is not what a model is handed. The registry converts the zod
+// raw shape to JSON Schema and publishes it over `tools/list`, and the SDK
+// validates every call against the converted copy. A zod shape that is correct
+// in TypeScript and unconvertible, or a tool the registry declines to register
+// at all, looks perfect to every assertion above and is invisible to a client.
+//
+// So this block registers the three REAL definitions and drives a REAL
+// McpServer over the SDK's in-memory transport, the same way registry.test.ts
+// does.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('the schemas the registry publishes', () => {
+  let listed: Array<{ name: string; description?: string; inputSchema: Record<string, unknown> }>;
+
+  beforeAll(async () => {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js');
+
+    for (const tool of [contentSearchTool, contentListTool, contentGetTool]) {
+      registerToolDefinition(tool as unknown as ToolDefinition<never>);
+    }
+
+    const server = buildMcpServer({
+      userId: 'schema-viewer',
+      clientId: 'schema-test',
+      scopes: new Set(['read']),
+    } as never);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'schema-test', version: '0.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    listed = (await client.listTools()).tools as typeof listed;
+  });
+
+  const toolNamed = (name: string) => {
+    const tool = listed.find(entry => entry.name === name);
+    expect(tool, `${name} must be registered`).toBeDefined();
+    return tool as (typeof listed)[number];
+  };
+
+  const propertiesOf = (name: string): Record<string, { enum?: string[] }> =>
+    (toolNamed(name).inputSchema.properties ?? {}) as Record<string, { enum?: string[] }>;
+
+  it('registers all three, so a schema that will not convert fails here', () => {
+    expect(listed.map(entry => entry.name)).toEqual(
+      expect.arrayContaining(['content_search', 'content_list', 'content_get'])
+    );
+  });
+
+  it('publishes the two corpus values on search and list', () => {
+    for (const name of ['content_search', 'content_list']) {
+      expect(propertiesOf(name).scope?.enum).toEqual(['course', 'docs']);
+    }
+  });
+
+  it("keeps `kind` on search and list at the three COURSE kinds — no 'doc'", () => {
+    // Widening the shared `kindArg` would make `kind: 'doc'` a legal FILTER on
+    // search and list, where it means nothing, and would carry the same
+    // widening into the live fallback.
+    for (const name of ['content_search', 'content_list']) {
+      expect(propertiesOf(name).kind?.enum).toEqual(['page', 'slide', 'file']);
+    }
+  });
+
+  it("gives content_get its own four-value kind, including 'doc'", () => {
+    expect(propertiesOf('content_get').kind?.enum).toEqual(['page', 'slide', 'file', 'doc']);
+  });
+
+  it('does NOT offer a scope argument on content_get', () => {
+    // `kind` already selects the corpus there; a second, redundant selector is
+    // a second thing for a model to get inconsistent with itself.
+    expect(propertiesOf('content_get').scope).toBeUndefined();
+  });
+
+  it('describes both corpora in every description, so the choice is not a guess', () => {
+    for (const name of ['content_search', 'content_list']) {
+      const description = String(toolNamed(name).description);
+      expect(description).toMatch(/classmoji\.io/);
+      expect(description).toMatch(/scope: 'docs'/);
+      expect(description).toMatch(/this classroom/i);
+    }
+    expect(String(toolNamed('content_get').description)).toMatch(/kind: 'doc'/);
+  });
+
+  it('still says an `unavailable` field is not an absence of material', () => {
+    expect(String(toolNamed('content_search').description)).toMatch(
+      /NOT the same as "nothing found"/
+    );
   });
 });

--- a/apps/mcp/src/tools/__tests__/contentSearch.test.ts
+++ b/apps/mcp/src/tools/__tests__/contentSearch.test.ts
@@ -92,6 +92,8 @@ const { prismaCalls, prismaCallsFor, resetPrismaStub, setPrismaRaw, setPrismaRow
   await import('../../__tests__/prismaSchemaStub.ts');
 const { EMBEDDING_DIMENSIONS, WorkersAiError } =
   await import('../../../../../packages/services/src/helpers/workersAi.ts');
+const { MAX_LIST_LIMIT, MAX_SEARCH_LIMIT } =
+  await import('../../../../../packages/services/src/classmoji/contentSearch.service.ts');
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -861,6 +863,65 @@ describe('scope selects the corpus, and the two never leak into each other', () 
     expect(payload.unavailable).toBe('embedding_not_configured');
     expect(String(payload.message)).toMatch(/not an empty result set/i);
     expect(allSql()).not.toContain('docs_index');
+  });
+
+  it('bounds BOTH scopes at the number the service actually clamps to', async () => {
+    // `content_search` and `content_list` each have ONE `limit` field covering
+    // both corpora, so each schema can name exactly one ceiling — the course
+    // one. The docs read service used to declare its own copy of every bound at
+    // the same five values and export them to nobody, which made "the schema
+    // refuses where the service clamps" true only by coincidence: editing the
+    // docs copy would have moved the clamp and left the refusal behind, with no
+    // test anywhere to notice. There is now ONE constant per bound.
+    const bound = (tool: typeof contentSearchTool | typeof contentListTool, value: unknown) =>
+      (
+        tool.inputSchema as unknown as Record<
+          string,
+          { safeParse(v: unknown): { success: boolean } }
+        >
+      ).limit.safeParse(value).success;
+
+    expect(bound(contentSearchTool, MAX_SEARCH_LIMIT)).toBe(true);
+    expect(bound(contentSearchTool, MAX_SEARCH_LIMIT + 1)).toBe(false);
+    expect(bound(contentListTool, MAX_LIST_LIMIT)).toBe(true);
+    expect(bound(contentListTool, MAX_LIST_LIMIT + 1)).toBe(false);
+
+    // And the ceiling the schema accepts reaches the docs statement UNCLAMPED,
+    // which is what makes the two thresholds the same number rather than two
+    // numbers that happen to agree.
+    answerRawBy([['docs_index', [DOCS_ROW]]]);
+    await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'how do tokens work', scope: 'docs', limit: MAX_SEARCH_LIMIT },
+      STUDENT
+    );
+    expect(paramsOf(lastStatement())).toContain(MAX_SEARCH_LIMIT);
+
+    rawStatements = [];
+    answerRawBy([['content_index', [COURSE_ROW]]]);
+    await call(
+      contentSearchTool,
+      { classroom: 'o/c', query: 'late work', limit: MAX_SEARCH_LIMIT },
+      STUDENT
+    );
+    expect(paramsOf(lastStatement())).toContain(MAX_SEARCH_LIMIT);
+  });
+
+  it('leaves the docs service no second copy of a bound to drift from', () => {
+    // The negative space of the test above. A `MAX_DOCS_SEARCH_LIMIT` declared
+    // here again would compile, pass every other test, and silently reopen the
+    // gap the moment somebody changed its value.
+    const source = readFileSync(
+      path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '../../../../../packages/services/src/classmoji/docsSearch.service.ts'
+      ),
+      'utf8'
+    );
+    const declarations = source.match(/^export const [A-Z_]+/gm) ?? [];
+    // One export, and it is the search floor — not a bound the tool schema has
+    // to mirror.
+    expect(declarations).toEqual(['export const DOCS_SEARCH_MIN_CHARS']);
   });
 
   it("scope: 'docs' lists from docs_index, default lists from the course records", async () => {

--- a/apps/mcp/src/tools/contentSearch.ts
+++ b/apps/mcp/src/tools/contentSearch.ts
@@ -1,9 +1,28 @@
 /**
- * Course-content read tools — `content_search`, `content_list`, `content_get`.
+ * Content read tools — `content_search`, `content_list`, `content_get`.
  *
  * The retrieval surface Ask Moji answers out of (plan §5.7, P2-7). Three read
- * tools over one classroom's pages, slide decks and `bot-context/` notes: find
- * by meaning, enumerate, read one in full.
+ * tools: find by meaning, enumerate, read one in full.
+ *
+ * ── TWO CORPORA BEHIND THE SAME THREE TOOLS ────────────────────────────────
+ * `scope: 'course'` (the default) is this classroom's pages, slide decks and
+ * `bot-context/` notes — per classroom, permission-filtered, drafts included
+ * for staff. `scope: 'docs'` is the Classmoji PRODUCT DOCUMENTATION at
+ * classmoji.io: fleet-wide, public, identical for every caller, and answering
+ * "how does this platform work" rather than "what does this course require".
+ *
+ * They are one tool rather than six because the model's decision is which
+ * corpus to ask, not which tool to call — and because a second set of tools is
+ * a second set of descriptions to keep in step. They are two code paths rather
+ * than one table because everything below the surface differs: one has a
+ * visibility predicate and a live fallback, the other has neither and could not
+ * safely have either.
+ *
+ * NOTE that this input `scope` and each tool's `scope: 'read'` are unrelated.
+ * The latter is the OAuth scope a bearer token must carry. Nothing about
+ * `scope: 'docs'` widens who may call anything: all three tools stay
+ * `roles: MEMBER` against the supplied classroom, so documentation is global
+ * BEHIND a membership rather than anonymously readable.
  *
  * ── ONE PREDICATE, AND IT IS NOT HERE (decision D6) ────────────────────────
  * Nothing in this file decides who may see what. Every handler resolves the
@@ -28,9 +47,12 @@
  * ── What a caller gets back ────────────────────────────────────────────────
  * Only the SANITIZED extracted text the indexer stored (or, in the one fallback
  * below, the same extractor run live) — never raw repo bytes, never a deck's
- * speaker notes, never `pageLink`/`navGrid` labels. That sanitization is the
- * extractor's job (`@classmoji/services/content/extract`); this file's job is
- * to never route around it. Note the divergence from `page_content_get`
+ * speaker notes, never `pageLink`/`navGrid` labels, and for documentation never
+ * the `.mdx` source. That sanitization is the extractor's job
+ * (`@classmoji/services/content/extract`); this file's job is to never route
+ * around it — which is also why `scope: 'docs'` has NO live fallback: a
+ * fallback there would mean fetching a caller-supplied path from github.com on
+ * demand. Note the divergence from `page_content_get`
  * (`pageContent.ts`), which still reads GitHub through `ContentService` with no
  * such filtering — out of scope for this lane, flagged in the PR.
  *
@@ -47,17 +69,25 @@ import getPrisma from '@classmoji/database';
 import {
   ClassmojiService,
   ContentNotFoundError,
+  DocsNotFoundError,
   contentVisibility,
+  docsIndexIsEmpty,
   getContentText,
+  getDocText,
   listContent,
+  listDocs,
   searchContent,
+  searchDocs,
   MAX_SEARCH_LIMIT,
   DEFAULT_LIST_LIMIT,
   MAX_LIST_LIMIT,
   type ContentDocKind,
   type ContentListEntry,
   type ContentSearchHit,
+  type DocsListEntry,
+  type DocsSearchHit,
 } from '@classmoji/services';
+import { docsUrl } from '@classmoji/utils';
 import { WorkersAiError, embedTexts, isWorkersAiConfigured } from '@classmoji/services/workers-ai';
 import { ToolError } from '../mcp/errors.ts';
 import type { ToolContext, ToolDefinition } from '../mcp/registry.ts';
@@ -73,6 +103,79 @@ const kindArg = z
   .describe("Document kind: 'page', 'slide' (a deck), or 'file' (a bot-context/ note)");
 
 /**
+ * WHICH CORPUS to read. Not a permission.
+ *
+ * `scope: 'read'` on each tool below is the OAuth scope the bearer token must
+ * carry; this `scope` argument names one of two bodies of text. They share a
+ * word and nothing else, and conflating them is how a widening here would get
+ * read as a widening there. Membership in the supplied `classroom` is still
+ * required for both — what is global is the corpus, not the door.
+ *
+ *   'course' (default) — this classroom's pages, decks and bot-context notes.
+ *                        Per classroom, permission-filtered, may include drafts.
+ *   'docs'             — the Classmoji product documentation at classmoji.io.
+ *                        Fleet-wide, public, identical for every caller.
+ */
+const scopeArg = z
+  .enum(['course', 'docs'])
+  .describe(
+    "Which body of text to read: 'course' (default) for this classroom's own material, " +
+      "or 'docs' for the Classmoji product documentation at classmoji.io"
+  );
+
+type ContentScope = 'course' | 'docs';
+
+/**
+ * `content_get`'s kind union, kept SEPARATE from {@link kindArg}.
+ *
+ * Widening the shared `kindArg` to include `'doc'` would silently broaden
+ * `content_search` and `content_list` — both of which take `kind` as a FILTER
+ * over course content — and with them the live-fallback's assumption that every
+ * kind it is handed has a `pages`/`slides` row or is a repo path. A `'doc'`
+ * reaching that code is a `findFirst` on a slug. Two unions is two lines; one
+ * union is a silent broadening of three tools to fix one.
+ */
+const getKindArg = z
+  .enum(['page', 'slide', 'file', 'doc'])
+  .describe(
+    "Document kind: 'page', 'slide' (a deck), 'file' (a bot-context/ note), or " +
+      "'doc' (a Classmoji documentation page, from a scope: 'docs' search)"
+  );
+
+type ContentGetKind = ContentDocKind | 'doc';
+
+/**
+ * `kind` filters course content. It cannot filter documentation, which has no
+ * kinds — so the pair is refused rather than one of them quietly ignored.
+ *
+ * SILENTLY DROPPING AN ARGUMENT IS HOW A MODEL CONCLUDES A FILTER WAS APPLIED.
+ * Asked for "slides about tokens" and handed documentation pages with the
+ * `kind` ignored, it reports them as slides.
+ */
+function assertScopeAndKind(scope: ContentScope, kind: ContentDocKind | undefined): void {
+  if (scope === 'docs' && kind !== undefined) {
+    throw new ToolError(
+      'invalid_params',
+      "`kind` filters course content and has no meaning for scope: 'docs' — " +
+        'the documentation has no kinds. Drop `kind`, or drop `scope`.'
+    );
+  }
+}
+
+/**
+ * The marker a zero-hit documentation answer carries when the index was never
+ * built on this deployment.
+ *
+ * NOT "no search was run" — a search WAS run, against an empty table, and a
+ * message that says otherwise is simply false. What the caller needs to know is
+ * that the absence is an absence of INDEX, not of documentation.
+ */
+const DOCS_INDEX_EMPTY = 'docs_index_empty';
+const DOCS_INDEX_EMPTY_MESSAGE =
+  'The documentation index has not been built on this deployment — there is nothing to search ' +
+  'yet. This is not an empty result set.';
+
+/**
  * ONE refusal for every way `content_get` can fail to produce a document: no
  * such id, another classroom's id, an id this viewer may not see, and an id
  * with nothing readable behind it. Distinguishing them would turn the tool into
@@ -86,6 +189,7 @@ const contentNotFound = (): ToolError => scopedNotFound('Content');
 interface ContentSearchArgs {
   classroom: string;
   query: string;
+  scope?: ContentScope;
   kind?: ContentDocKind;
   limit?: number;
 }
@@ -98,7 +202,19 @@ interface ContentSearchArgs {
  * empty list. A model that cannot tell them apart will confidently report the
  * second when the truth is the first.
  */
-export type SearchUnavailable = 'embedding_not_configured' | 'embedding_failed';
+export type SearchUnavailable =
+  | 'embedding_not_configured'
+  | 'embedding_failed'
+  /**
+   * The documentation index is empty ON THIS DEPLOYMENT. Distinct from the two
+   * above: the embedding worked and the query ran — there is simply nothing in
+   * the table yet, because the backfill has not been run here. Reported as
+   * `unavailable` rather than as an empty result for the same reason as the
+   * others: "the docs do not cover that" and "documentation search has not been
+   * switched on" are different answers, and a model handed the same empty list
+   * for both will confidently give the first.
+   */
+  | 'docs_index_empty';
 
 type EmbeddedQuery = { ok: true; vector: number[] } | { ok: false; unavailable: SearchUnavailable };
 
@@ -154,6 +270,40 @@ function presentHit(hit: ContentSearchHit) {
   };
 }
 
+/** A documentation hit as the model sees it. */
+function presentDocsHit(hit: DocsSearchHit) {
+  return {
+    // `kind: 'doc'` is what content_get takes back, and what the prompt keys
+    // the `platform_docs` reference type off.
+    kind: 'doc' as const,
+    // The SLUG is the id. It is also the URL path, which is why there is no
+    // separate mapping and no way for the citation and the link to disagree.
+    id: hit.slug,
+    title: hit.title,
+    ...(hit.section ? { section: hit.section } : {}),
+    ...(hit.description ? { description: hit.description } : {}),
+    url: docsUrl(hit.slug),
+    chunk: hit.chunkIx,
+    snippet: hit.snippet,
+    score: Math.round(hit.score * 1e4) / 1e4,
+  };
+}
+
+/** A documentation listing row. */
+function presentDocsEntry(entry: DocsListEntry) {
+  return {
+    kind: 'doc' as const,
+    id: entry.slug,
+    title: entry.title,
+    ...(entry.section ? { section: entry.section } : {}),
+    ...(entry.description ? { description: entry.description } : {}),
+    url: entry.url,
+    updated_at: new Date(entry.updatedAt).toISOString(),
+    /** Listing reads the index, so anything listed is searchable. */
+    indexed: true,
+  };
+}
+
 /**
  * The retrieval-quality log line (plan §5.6, "instrumentation, from day one").
  *
@@ -164,21 +314,35 @@ function presentHit(hit: ContentSearchHit) {
 function logContentSearch(entry: {
   classroomId: string;
   role: string;
+  scope: ContentScope;
   queryChars: number;
   kind?: ContentDocKind;
   limit?: number;
-  hits: ContentSearchHit[];
+  /**
+   * ALREADY NORMALIZED to `{ kind, id }`, not `ContentSearchHit[]`.
+   *
+   * The two corpora return different row shapes (`docKind`/`docId` against
+   * `slug`), and a logger that took one of them would either need a second
+   * overload or would quietly log `undefined:undefined` for the other. The
+   * caller has the hit in hand and knows which it is; normalizing there is one
+   * line and cannot be wrong for half the calls.
+   */
+  hits: Array<{ kind: string; id: string }>;
   unavailable: SearchUnavailable | null;
 }): void {
   console.log(
     `[mcp] content_search ${JSON.stringify({
       classroom_id: entry.classroomId,
       role: entry.role,
+      // Which corpus was searched — the one dimension retrieval quality now has
+      // to be read along, since a docs miss and a course miss have different
+      // fixes.
+      scope: entry.scope,
       query_chars: entry.queryChars,
       kind: entry.kind ?? null,
       limit: entry.limit ?? null,
       result_count: entry.hits.length,
-      results: entry.hits.map(hit => `${hit.docKind}:${hit.docId}`),
+      results: entry.hits.map(hit => `${hit.kind}:${hit.id}`),
       unavailable: entry.unavailable,
     })}`
   );
@@ -186,14 +350,21 @@ function logContentSearch(entry: {
 
 export const contentSearchTool: ToolDefinition<ContentSearchArgs> = {
   name: 'content_search',
-  title: 'Search course content',
+  title: 'Search course content and Classmoji docs',
   description:
-    "Semantic search over this classroom's pages, slide decks and bot-context notes. Returns " +
-    'document ids, titles and snippets ranked by meaning rather than keywords — ask the question ' +
-    'the way a student would. Staff also reach unpublished material; students reach published ' +
-    'material only. Use content_get to read a result in full. If the response carries an ' +
-    '`unavailable` field, search itself could not run — that is NOT the same as "nothing found", ' +
-    'and it must not be reported to the user as an absence of course material.',
+    'Semantic search over one of two bodies of text, chosen with `scope`. ' +
+    "`scope: 'course'` (the default) searches THIS classroom's pages, slide decks and " +
+    'bot-context notes: staff also reach unpublished material, students reach published ' +
+    'material only. ' +
+    "`scope: 'docs'` searches the Classmoji PRODUCT DOCUMENTATION at classmoji.io — how the " +
+    'platform works, the same for every classroom — and returns `kind: "doc"` hits whose `id` is ' +
+    'the page slug and whose `url` is a real link you may cite. Use it for "how does X work in ' +
+    'Classmoji", and `course` for anything about this particular course. ' +
+    'Results are ranked by meaning rather than keywords, so ask the question the way a person ' +
+    'would. Read a result in full with content_get before answering from it. If the response ' +
+    'carries an `unavailable` field, search itself could not run or the index is not built — ' +
+    'that is NOT the same as "nothing found", and it must not be reported to the user as an ' +
+    'absence of material.',
   scope: 'read',
   roles: MEMBER,
   inputSchema: {
@@ -203,6 +374,7 @@ export const contentSearchTool: ToolDefinition<ContentSearchArgs> = {
       .min(2)
       .max(500)
       .describe('What to look for, in plain language (a question works well)'),
+    scope: scopeArg.optional(),
     kind: kindArg.optional(),
     limit: z
       .number()
@@ -214,18 +386,31 @@ export const contentSearchTool: ToolDefinition<ContentSearchArgs> = {
   },
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
+    const scope: ContentScope = args.scope ?? 'course';
+    assertScopeAndKind(scope, args.kind);
 
-    const embedded = await embedQuery(args.query);
-    if (!embedded.ok) {
+    const log = (
+      hits: Array<{ kind: string; id: string }>,
+      unavailable: SearchUnavailable | null
+    ): void =>
       logContentSearch({
         classroomId: classroom.classroomId,
         role: classroom.role,
+        scope,
         queryChars: args.query.length,
         kind: args.kind,
         limit: args.limit,
-        hits: [],
-        unavailable: embedded.unavailable,
+        hits,
+        unavailable,
       });
+
+    // ONE embedding path for both corpora: the same client, the same refusal
+    // classes, the same `embedding_*` markers. A docs search that failed to
+    // embed has to be as distinguishable from an empty one as a course search
+    // is, and a second code path here would be a second place to forget that.
+    const embedded = await embedQuery(args.query);
+    if (!embedded.ok) {
+      log([], embedded.unavailable);
       return ok({
         count: 0,
         hits: [],
@@ -237,6 +422,31 @@ export const contentSearchTool: ToolDefinition<ContentSearchArgs> = {
       });
     }
 
+    if (scope === 'docs') {
+      const hits = await searchDocs({
+        queryVector: embedded.vector,
+        ...(args.limit ? { limit: args.limit } : {}),
+      });
+
+      // Zero hits over a corpus that exists means the documentation genuinely
+      // does not cover it. Zero hits over a corpus that was never built means
+      // something else entirely, and only the index can tell them apart — so
+      // it is asked ONLY when there is an absence to explain.
+      if (hits.length === 0 && (await docsIndexIsEmpty())) {
+        log([], DOCS_INDEX_EMPTY);
+        return ok({
+          count: 0,
+          hits: [],
+          unavailable: DOCS_INDEX_EMPTY,
+          message: DOCS_INDEX_EMPTY_MESSAGE,
+        });
+      }
+
+      const presented = hits.map(presentDocsHit);
+      log(presented, null);
+      return ok({ count: presented.length, hits: presented });
+    }
+
     const hits = await searchContent({
       classroomId: classroom.classroomId,
       role: classroom.role,
@@ -245,15 +455,10 @@ export const contentSearchTool: ToolDefinition<ContentSearchArgs> = {
       ...(args.limit ? { limit: args.limit } : {}),
     });
 
-    logContentSearch({
-      classroomId: classroom.classroomId,
-      role: classroom.role,
-      queryChars: args.query.length,
-      kind: args.kind,
-      limit: args.limit,
-      hits,
-      unavailable: null,
-    });
+    log(
+      hits.map(hit => ({ kind: hit.docKind, id: hit.docId })),
+      null
+    );
 
     return ok({ count: hits.length, hits: hits.map(presentHit) });
   },
@@ -263,6 +468,7 @@ export const contentSearchTool: ToolDefinition<ContentSearchArgs> = {
 
 interface ContentListArgs {
   classroom: string;
+  scope?: ContentScope;
   kind?: ContentDocKind;
   limit?: number;
   offset?: number;
@@ -290,20 +496,27 @@ function presentEntry(entry: ContentListEntry) {
 
 export const contentListTool: ToolDefinition<ContentListArgs> = {
   name: 'content_list',
-  title: 'List course content',
+  title: 'List course content and Classmoji docs',
   description:
-    'Enumerates every page, slide deck and bot-context note in this classroom that the caller may ' +
-    'see, whether or not it has been indexed for search. Staff also see unpublished material. ' +
-    'Each row reports `indexed`: false means content_search cannot reach that document yet, ' +
-    'though content_get still can. Use this to find a document by name when a search comes back ' +
-    `empty. The listing is paged: at most \`limit\` rows come back (default ${LIST_DEFAULT_LIMIT}, ` +
-    `max ${LIST_MAX_LIMIT}) in a stable order. If \`truncated\` is true this is NOT the whole ` +
-    'catalogue — call again with `offset` set to the returned `next_offset` to continue, and do ' +
-    'not tell the user a document is absent on the strength of one page.',
+    'Enumerates one of two bodies of text, chosen with `scope`. ' +
+    "`scope: 'course'` (the default) lists every page, slide deck and bot-context note in THIS " +
+    'classroom the caller may see, whether or not it has been indexed for search; staff also ' +
+    'see unpublished material, and each row reports `indexed` — false means content_search ' +
+    'cannot reach that document yet, though content_get still can. ' +
+    '`scope: \'docs\'` lists the Classmoji product documentation at classmoji.io as `kind: "doc"` ' +
+    'rows with a real `url`; documentation exists only in the index, so a row that is listed is ' +
+    'a row search can reach, and an empty listing with an `unavailable` marker means the index ' +
+    'has not been built here rather than that there are no docs. ' +
+    'Use this to find something by name when a search comes back empty. The listing is paged: ' +
+    `at most \`limit\` rows come back (default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}) in a ` +
+    'stable order. If `truncated` is true this is NOT the whole catalogue — call again with ' +
+    '`offset` set to the returned `next_offset` to continue, and do not tell the user something ' +
+    'is absent on the strength of one page.',
   scope: 'read',
   roles: MEMBER,
   inputSchema: {
     classroom: classroomArg,
+    scope: scopeArg.optional(),
     kind: kindArg.optional(),
     limit: z
       .number()
@@ -321,6 +534,36 @@ export const contentListTool: ToolDefinition<ContentListArgs> = {
   },
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
+    const scope: ContentScope = args.scope ?? 'course';
+    assertScopeAndKind(scope, args.kind);
+
+    if (scope === 'docs') {
+      const page = await listDocs({
+        ...(args.limit ? { limit: args.limit } : {}),
+        ...(args.offset ? { offset: args.offset } : {}),
+      });
+
+      // The same distinction search draws, drawn here too: an empty catalogue
+      // and a catalogue that was never built are different facts, and a model
+      // handed a bare `[]` for both will report the first.
+      if (page.items.length === 0 && (await docsIndexIsEmpty())) {
+        return ok({
+          count: 0,
+          items: [],
+          truncated: false,
+          unavailable: DOCS_INDEX_EMPTY,
+          message: DOCS_INDEX_EMPTY_MESSAGE,
+        });
+      }
+
+      return ok({
+        count: page.items.length,
+        items: page.items.map(presentDocsEntry),
+        truncated: page.truncated,
+        ...(page.nextOffset !== null ? { next_offset: page.nextOffset } : {}),
+      });
+    }
+
     const page = await listContent({
       classroomId: classroom.classroomId,
       role: classroom.role,
@@ -342,7 +585,7 @@ export const contentListTool: ToolDefinition<ContentListArgs> = {
 
 interface ContentGetArgs {
   classroom: string;
-  kind: ContentDocKind;
+  kind: ContentGetKind;
   id: string;
 }
 
@@ -475,25 +718,63 @@ async function readLiveDocument(
 
 export const contentGetTool: ToolDefinition<ContentGetArgs> = {
   name: 'content_get',
-  title: 'Read course content',
+  title: 'Read course content or a Classmoji doc',
   description:
-    'Returns the full plain text of one page, slide deck or bot-context note — the same text ' +
-    'content_search ranks, so ids from a search result can be passed straight in. Use it after ' +
-    'content_search or content_list to read a document a snippet only hinted at. Deck speaker ' +
-    'notes are never included.',
+    'Returns the full plain text of one document — the same text content_search ranks, so an ' +
+    'id and kind from a search or listing result can be passed straight back in. ' +
+    "For `kind: 'page' | 'slide' | 'file'` that is this classroom's own material (deck speaker " +
+    'notes are never included). ' +
+    "For `kind: 'doc'` it is a Classmoji product documentation page from classmoji.io: pass the " +
+    'page slug as `id`, and the response carries the canonical `url` you may cite. ' +
+    'Use it after content_search or content_list to read a document a snippet only hinted at.',
   scope: 'read',
   roles: MEMBER,
   inputSchema: {
     classroom: classroomArg,
-    kind: kindArg,
+    kind: getKindArg,
     id: z
       .string()
       .min(1)
       .max(400)
-      .describe("Document id from content_search or content_list (a repo path for kind 'file')"),
+      .describe(
+        "Document id from content_search or content_list (a repo path for kind 'file', a page " +
+          "slug such as 'docs/instructors/roster' for kind 'doc')"
+      ),
   },
   handler: async (args, ctx) => {
     const classroom = requireClassroomCtx(ctx);
+
+    if (args.kind === 'doc') {
+      try {
+        const document = await getDocText(args.id);
+        return ok({
+          kind: 'doc',
+          id: document.slug,
+          title: document.title,
+          ...(document.description ? { description: document.description } : {}),
+          ...(document.section ? { section: document.section } : {}),
+          url: document.url,
+          indexed: true,
+          chunk_count: document.chunkCount,
+          text: document.text,
+        });
+      } catch (error) {
+        if (!(error instanceof DocsNotFoundError)) throw error;
+        // Deliberately NOT `scopedNotFound('Content')`. That refusal is uniform
+        // on purpose, because distinguishing "no such id" from "another
+        // classroom's id" would turn course lookups into a probe a student
+        // could enumerate drafts with. Documentation is public and global:
+        // there is nothing to enumerate and no boundary to defend, so the
+        // refusal can say what actually happened.
+        //
+        // There is also NO LIVE FALLBACK here. The course lane falls back to
+        // reading the content repo because its index can legitimately lag a
+        // page somebody just saved. Documentation only exists in the index, so
+        // a fallback would mean fetching an arbitrary caller-supplied path from
+        // github.com on demand.
+        throw new ToolError('not_found', 'Documentation page not found');
+      }
+    }
 
     try {
       const document = await getContentText({

--- a/apps/mcp/tests/phase2-content.integration.test.ts
+++ b/apps/mcp/tests/phase2-content.integration.test.ts
@@ -118,6 +118,10 @@ const stubEmbedding = (text: string): number[] => {
   if (lowered.includes('capstone') || lowered.includes('final project')) return basis(1); // draft
   if (lowered.includes('recursion')) return basis(2); // the deck
   if (lowered.includes('office hours')) return basis(3); // the bot-context note
+  // The DOCUMENTATION fixture. Deliberately a basis no course fixture carries,
+  // so a corpus leak in either direction shows up as a hit that should not
+  // exist rather than as a reordering.
+  if (lowered.includes('teaching assistant') || lowered.includes('add a ta')) return basis(5);
   return basis(4); // orthogonal to the entire fixture corpus
 };
 
@@ -204,6 +208,19 @@ const FOREIGN_SLUG = `p27-${ns}-b`;
 const CLASS_REF = `${ORG_LOGIN}/${CLASS_SLUG}`;
 const FOREIGN_REF = `${ORG_LOGIN}/${FOREIGN_SLUG}`;
 const FILE_DOC_ID = 'bot-context/office-hours.md';
+/**
+ * The documentation fixture.
+ *
+ * `docs_index` is GLOBAL — there is no classroom to hang it off and no cascade
+ * to clean it up — so the slug is namespaced with this run's uuid and teardown
+ * deletes exactly that prefix. Nothing pre-existing is read or written, and a
+ * developer's real docs rows (which this database may well hold) are left
+ * alone: they sit at distance 1 from the stub's basis vector while the fixture
+ * sits at 0, so they cannot change what the top hit is.
+ */
+const DOCS_SLUG = `docs/p27-${ns}/roster`;
+/** An identifier that must survive the extractor AND the round trip. */
+const DOCS_CODE_SENTINEL = 'AI_AGENT_SHARED_SECRET';
 const BOGUS_ID = '00000000-0000-4000-8000-00000000dead';
 
 const LOGINS = {
@@ -251,6 +268,32 @@ const insertIndexRow = async (args: {
       ${ids.classroom}, ${args.docKind}, ${args.docId}, 0, 1,
       ${args.sourcePath}, ${`sha-${ns}`}, 1, ${'@cf/qwen/qwen3-embedding-0.6b'},
       ${args.title}, ${args.text}, ${Prisma.sql`${toVectorLiteral(args.vector)}::vector`}
+    )`;
+};
+
+/**
+ * One documentation row.
+ *
+ * `docs_index` has no classroom column, no FK and no visibility columns — that
+ * is the point of the second corpus — so this writes a GLOBAL row and teardown
+ * removes it by its namespaced slug prefix.
+ */
+const insertDocsRow = async (args: {
+  slug: string;
+  title: string;
+  description: string;
+  section: string;
+  text: string;
+  vector: number[];
+}): Promise<void> => {
+  await getPrisma().$executeRaw`
+    INSERT INTO docs_index (
+      slug, chunk_ix, chunk_count, title, description, section, text,
+      source_sha, extract_version, embed_model, embedding
+    ) VALUES (
+      ${args.slug}, 0, 1, ${args.title}, ${args.description}, ${args.section}, ${args.text},
+      ${`sha-${ns}`}, 1, ${'@cf/qwen/qwen3-embedding-0.6b'},
+      ${Prisma.sql`${toVectorLiteral(args.vector)}::vector`}
     )`;
 };
 
@@ -370,6 +413,17 @@ beforeAll(async () => {
     vector: basis(3),
     sourcePath: FILE_DOC_ID,
   });
+
+  await insertDocsRow({
+    slug: DOCS_SLUG,
+    title: `Manage your roster ${ns}`,
+    description: 'How to add students and teaching staff to your classroom',
+    section: 'instructors',
+    text:
+      'Go to the Teaching Staff tab and click New staff member. Pick the role, enter their ' +
+      `Github username, and confirm. Set ${DOCS_CODE_SENTINEL} to enable AI features.`,
+    vector: basis(5),
+  });
 });
 
 afterAll(async () => {
@@ -381,6 +435,10 @@ afterAll(async () => {
   await deleteMintedTokens();
   if (ids.org) await prisma.gitOrganization.delete({ where: { id: ids.org } });
   await prisma.user.deleteMany({ where: { login: { in: Object.values(LOGINS) } } });
+  // `docs_index` is global and cascades from nothing, so it is deleted by this
+  // run's own slug prefix. A bare `DELETE FROM docs_index` would take a
+  // developer's real 25 documentation rows with it.
+  await prisma.$executeRaw`DELETE FROM docs_index WHERE slug LIKE ${`docs/p27-${ns}/%`}`;
 });
 
 /** Mint one read token per fixture identity against the running server. */
@@ -702,6 +760,114 @@ describe.skipIf(!RUN)('content_search — end to end against a stubbed embedder'
     expect(outcome.payload.unavailable).toBeUndefined();
     expect(outcome.payload.count).toBe(0);
     expect(outcome.payload.hits).toEqual([]);
+  });
+
+  // ── scope: 'docs' — the SECOND corpus, end to end ─────────────────────────
+
+  const searchDocsAs = (token: string, query: string) =>
+    callTool(token, 'content_search', { classroom: CLASS_REF, query, scope: 'docs', limit: 20 });
+
+  it('answers a documentation question for a STUDENT with a real, non-empty result', async () => {
+    const outcome = await searchDocsAs(tokens.student, 'where do I add a teaching assistant?');
+
+    expect(outcome.isError).toBe(false);
+    expect(outcome.payload.unavailable).toBeUndefined();
+    // NON-EMPTY, asserted on its own. "the two roles agree" is satisfied by two
+    // empty lists and by two identical errors, so agreement alone proves
+    // nothing about retrieval having worked.
+    expect(Number(outcome.payload.count)).toBeGreaterThan(0);
+    expect(idsIn(outcome, 'hits')[0]).toBe(DOCS_SLUG);
+
+    const hit = rowById(outcome, 'hits', DOCS_SLUG, 'the docs fixture must be the top hit');
+    expect(hit.kind).toBe('doc');
+    expect(hit.section).toBe('instructors');
+    expect(hit.url).toBe(`https://classmoji.io/${DOCS_SLUG}`);
+  });
+
+  it('gives a TEACHER exactly the same documentation, non-empty', async () => {
+    // Documentation is public and fleet-wide: unlike course content there is no
+    // role tier here at all, and that has to be shown on a result set that
+    // actually contains something.
+    const student = await searchDocsAs(tokens.student, 'where do I add a teaching assistant?');
+    const teacher = await searchDocsAs(tokens.teacher, 'where do I add a teaching assistant?');
+
+    expect(Number(student.payload.count)).toBeGreaterThan(0);
+    expect(Number(teacher.payload.count)).toBeGreaterThan(0);
+    expect(idsIn(teacher, 'hits')).toEqual(idsIn(student, 'hits'));
+    expect(idsIn(teacher, 'hits')).toContain(DOCS_SLUG);
+  });
+
+  it('keeps the two corpora apart in BOTH directions', async () => {
+    // A docs search must not reach this classroom's pages…
+    const docs = await searchDocsAs(tokens.teacher, 'where do I add a teaching assistant?');
+    const docsPayload = JSON.stringify(docs.payload);
+    expect(docsPayload).not.toContain(ids.publishedPage);
+    expect(docsPayload).not.toContain(ids.draftPage);
+    expect(docsPayload).not.toContain(FILE_DOC_ID);
+
+    // …and a course search must not reach the documentation.
+    const course = await callTool(tokens.teacher, 'content_search', {
+      classroom: CLASS_REF,
+      query: 'where do I add a teaching assistant?',
+      limit: 20,
+    });
+    expect(JSON.stringify(course.payload)).not.toContain(DOCS_SLUG);
+    expect(JSON.stringify(course.payload)).not.toContain(DOCS_CODE_SENTINEL);
+  });
+
+  it('reads a documentation page in full through content_get, code identifiers intact', async () => {
+    const outcome = await callTool(tokens.student, 'content_get', {
+      classroom: CLASS_REF,
+      kind: 'doc',
+      id: DOCS_SLUG,
+    });
+
+    expect(outcome.isError).toBe(false);
+    expect(outcome.payload.kind).toBe('doc');
+    expect(outcome.payload.id).toBe(DOCS_SLUG);
+    expect(outcome.payload.url).toBe(`https://classmoji.io/${DOCS_SLUG}`);
+    expect(String(outcome.payload.text)).toContain('New staff member');
+    // The whole extractor contract, checked at the far end of the pipe: an
+    // underscored identifier still reads as itself after indexing, storage and
+    // retrieval.
+    expect(String(outcome.payload.text)).toContain(DOCS_CODE_SENTINEL);
+  });
+
+  it('lists the documentation under scope: docs, with real URLs', async () => {
+    const outcome = await callTool(tokens.student, 'content_list', {
+      classroom: CLASS_REF,
+      scope: 'docs',
+      limit: 200,
+    });
+
+    expect(outcome.isError).toBe(false);
+    expect(idsIn(outcome, 'items')).toContain(DOCS_SLUG);
+    const row = rowById(outcome, 'items', DOCS_SLUG, 'the docs fixture must be listed');
+    expect(row.kind).toBe('doc');
+    expect(row.url).toBe(`https://classmoji.io/${DOCS_SLUG}`);
+  });
+
+  it("refuses `kind` together with scope: 'docs' rather than ignoring one", async () => {
+    const outcome = await callTool(tokens.student, 'content_search', {
+      classroom: CLASS_REF,
+      query: 'where do I add a teaching assistant?',
+      scope: 'docs',
+      kind: 'page',
+    });
+
+    expect(outcome.isError).toBe(true);
+    expect(JSON.stringify(outcome.payload)).toMatch(/invalid_params/);
+  });
+
+  it('refuses a NON-MEMBER a documentation search, exactly as it refuses a course one', async () => {
+    // Global corpus, not a global door. Membership in the supplied classroom is
+    // still what gets you in.
+    const outcome = await callTool(tokens.outsider, 'content_search', {
+      classroom: CLASS_REF,
+      query: 'where do I add a teaching assistant?',
+      scope: 'docs',
+    });
+    expectForbidden(outcome, "content_search scope:'docs' as a non-member", 'NOT_A_MEMBER');
   });
 
   it("still refuses a non-member with 'forbidden/NOT_A_MEMBER' before embedding anything", async () => {

--- a/apps/mcp/tests/phase2-content.integration.test.ts
+++ b/apps/mcp/tests/phase2-content.integration.test.ts
@@ -419,9 +419,18 @@ beforeAll(async () => {
     title: `Manage your roster ${ns}`,
     description: 'How to add students and teaching staff to your classroom',
     section: 'instructors',
+    // Long enough to clear `DOCS_SEARCH_MIN_CHARS`. `searchDocs` drops any
+    // chunk under 400 characters, which is what keeps the corpus's two
+    // section-index pages — a heading and a list of links — out of the results;
+    // a two-sentence fixture is indistinguishable from one of those.
     text:
       'Go to the Teaching Staff tab and click New staff member. Pick the role, enter their ' +
-      `Github username, and confirm. Set ${DOCS_CODE_SENTINEL} to enable AI features.`,
+      `Github username, and confirm. Set ${DOCS_CODE_SENTINEL} to enable AI features. ` +
+      'Roles add up rather than replace: granting someone a second role in the same class ' +
+      'leaves the first one alone, and they appear once per role they hold. Removing someone ' +
+      'takes away that one role and nothing else. An assistant grades the work assigned to ' +
+      'them and helps run the class; a teacher can do everything an owner can except delete ' +
+      'the classroom itself.',
     vector: basis(5),
   });
 });

--- a/apps/webapp/app/components/features/syllabus-bot/ContentReferenceChips.tsx
+++ b/apps/webapp/app/components/features/syllabus-bot/ContentReferenceChips.tsx
@@ -1,0 +1,82 @@
+import { IconBook, IconFile, IconFileText, IconHelp } from '@tabler/icons-react';
+import { buildContentReferenceUrl } from '~/utils/contentReferenceUrl';
+
+export interface ContentReference {
+  referenceType: string;
+  contentPath: string;
+  displayText: string;
+  [key: string]: unknown;
+}
+
+interface ContentReferenceChipsProps {
+  references: ContentReference[];
+  classroomSlug: string;
+  slidesUrl: string;
+  pagesUrl: string;
+}
+
+const iconFor = (type: string) => {
+  switch (type) {
+    case 'page':
+      return <IconFileText size={13} />;
+    case 'slides':
+      return <IconBook size={13} />;
+    case 'platform_docs':
+      return <IconHelp size={13} />;
+    default:
+      return <IconFile size={13} />;
+  }
+};
+
+/**
+ * The citation chips under an assistant answer.
+ *
+ * Lifted out of `SyllabusBotChat` so the ONE rule that matters here can be
+ * asserted against rendered markup rather than against a regex over the chat
+ * component's source. It is presentational and stateless: what it draws depends
+ * only on its props.
+ *
+ * ── A REFERENCE WITH NO URL IS A LABEL, NOT A LINK ─────────────────────────
+ * `buildContentReferenceUrl` returns null when it cannot build a link — an
+ * unknown reference type, a malformed docs slug, a page whose app URL was never
+ * passed in. This used to render `href={url || '#'}`, which is a clickable dead
+ * link: focusable, announced as a link, styled exactly like a working chip, and
+ * it navigates the page to itself.
+ *
+ * So the null case is a `<span>`. Same class, so it looks identical in both
+ * themes (the chip's colours come from panel-level CSS variables); no `href`,
+ * no `tabIndex` and no `role`, so it is not in the tab order and nothing about
+ * it says "activate me".
+ */
+export default function ContentReferenceChips({
+  references,
+  classroomSlug,
+  slidesUrl,
+  pagesUrl,
+}: ContentReferenceChipsProps) {
+  if (!references || references.length === 0) return null;
+
+  return (
+    <div className="askmoji-refs">
+      {references.map((ref, idx) => {
+        const url = buildContentReferenceUrl(ref, classroomSlug, slidesUrl, pagesUrl);
+
+        if (!url) {
+          return (
+            <span key={idx} className="askmoji-ref">
+              {iconFor(ref.referenceType)}
+              {ref.displayText}
+            </span>
+          );
+        }
+
+        return (
+          <a key={idx} href={url} target="_blank" rel="noopener noreferrer" className="askmoji-ref">
+            {iconFor(ref.referenceType)}
+            {ref.displayText}
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/webapp/app/components/features/syllabus-bot/SyllabusBotChat.tsx
+++ b/apps/webapp/app/components/features/syllabus-bot/SyllabusBotChat.tsx
@@ -174,10 +174,14 @@ const SyllabusBotChat = ({
 
   const getReferenceIcon = (type: string) => {
     switch (type) {
-      case 'page': return <IconFileText size={13} />;
-      case 'slides': return <IconBook size={13} />;
-      case 'platform_docs': return <IconHelp size={13} />;
-      default: return <IconFile size={13} />;
+      case 'page':
+        return <IconFileText size={13} />;
+      case 'slides':
+        return <IconBook size={13} />;
+      case 'platform_docs':
+        return <IconHelp size={13} />;
+      default:
+        return <IconFile size={13} />;
     }
   };
 
@@ -191,7 +195,9 @@ const SyllabusBotChat = ({
       <div className="askmoji-body" onClick={() => inputRef.current?.focus()}>
         {/* Course header */}
         <div className="askmoji-course-name">{courseName}</div>
-        <div className="askmoji-course-sub">Ask about assignments, deadlines, tokens, or the syllabus.</div>
+        <div className="askmoji-course-sub">
+          Ask about assignments, deadlines, tokens, or the syllabus.
+        </div>
 
         {/* Hints (empty state) */}
         {!hasUserMessages && suggestedQuestions.length > 0 && (
@@ -215,7 +221,7 @@ const SyllabusBotChat = ({
         )}
 
         {/* Messages */}
-        {visibleMessages.map((msg) => (
+        {visibleMessages.map(msg => (
           <div key={msg.id}>
             {msg.role === 'user' ? (
               <div className="askmoji-msg askmoji-msg--user">
@@ -228,7 +234,7 @@ const SyllabusBotChat = ({
                 isLatest={msg.id === lastAssistantId && !revealedIds.has(msg.id)}
                 onRevealDone={() => markRevealed(msg.id)}
               >
-                {(text) => (
+                {text => (
                   <div className="askmoji-msg askmoji-msg--moji">
                     <ReactMarkdown
                       rehypePlugins={[rehypeHighlight]}
@@ -241,7 +247,9 @@ const SyllabusBotChat = ({
                           !href || href.startsWith('content://') || href === '#' ? (
                             <span>{children}</span>
                           ) : (
-                            <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
+                            <a href={href} target="_blank" rel="noopener noreferrer">
+                              {children}
+                            </a>
                           ),
                         ul: ({ children }) => <ul>{children}</ul>,
                         ol: ({ children }) => <ol>{children}</ol>,
@@ -255,12 +263,32 @@ const SyllabusBotChat = ({
                     {revealedIds.has(msg.id) && msg.references && msg.references.length > 0 && (
                       <div className="askmoji-refs">
                         {msg.references.map((ref, idx) => {
-                          const url = buildContentReferenceUrl(ref, classroomSlug, slidesUrl, pagesUrl);
+                          const url = buildContentReferenceUrl(
+                            ref,
+                            classroomSlug,
+                            slidesUrl,
+                            pagesUrl
+                          );
+                          // A null url used to render `href={url || '#'}`, which
+                          // is a CLICKABLE DEAD LINK: focusable, styled exactly
+                          // like a working chip, and it navigates the page to
+                          // itself. A reference we cannot link to is a label, so
+                          // render a span -- same class, so it looks identical in
+                          // both themes, and no tabindex, so it is not reachable
+                          // by keyboard as something actionable.
+                          if (!url) {
+                            return (
+                              <span key={idx} className="askmoji-ref">
+                                {getReferenceIcon(ref.referenceType)}
+                                {ref.displayText}
+                              </span>
+                            );
+                          }
                           return (
                             <a
                               key={idx}
-                              href={url || '#'}
-                              target={url ? '_blank' : undefined}
+                              href={url}
+                              target="_blank"
                               rel="noopener noreferrer"
                               className="askmoji-ref"
                             >

--- a/apps/webapp/app/components/features/syllabus-bot/SyllabusBotChat.tsx
+++ b/apps/webapp/app/components/features/syllabus-bot/SyllabusBotChat.tsx
@@ -1,8 +1,9 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
-import { IconChevronRight, IconFileText, IconBook, IconHelp, IconFile } from '@tabler/icons-react';
+import { IconChevronRight } from '@tabler/icons-react';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
-import { buildContentReferenceUrl, normalizeAssistantText } from '~/utils/contentReferenceUrl';
+import { normalizeAssistantText } from '~/utils/contentReferenceUrl';
+import ContentReferenceChips from './ContentReferenceChips';
 
 interface ChatMessage {
   id: string;
@@ -172,19 +173,6 @@ const SyllabusBotChat = ({
     });
   }, []);
 
-  const getReferenceIcon = (type: string) => {
-    switch (type) {
-      case 'page':
-        return <IconFileText size={13} />;
-      case 'slides':
-        return <IconBook size={13} />;
-      case 'platform_docs':
-        return <IconHelp size={13} />;
-      default:
-        return <IconFile size={13} />;
-    }
-  };
-
   const hasUserMessages = messages.some(m => m.role === 'user');
   const visibleMessages = messages.filter(m => !(m.id === 'welcome' && !hasUserMessages));
   const lastAssistantId = [...visibleMessages].reverse().find(m => m.role === 'assistant')?.id;
@@ -260,44 +248,13 @@ const SyllabusBotChat = ({
                     </ReactMarkdown>
 
                     {/* Content references -- only show after fully revealed */}
-                    {revealedIds.has(msg.id) && msg.references && msg.references.length > 0 && (
-                      <div className="askmoji-refs">
-                        {msg.references.map((ref, idx) => {
-                          const url = buildContentReferenceUrl(
-                            ref,
-                            classroomSlug,
-                            slidesUrl,
-                            pagesUrl
-                          );
-                          // A null url used to render `href={url || '#'}`, which
-                          // is a CLICKABLE DEAD LINK: focusable, styled exactly
-                          // like a working chip, and it navigates the page to
-                          // itself. A reference we cannot link to is a label, so
-                          // render a span -- same class, so it looks identical in
-                          // both themes, and no tabindex, so it is not reachable
-                          // by keyboard as something actionable.
-                          if (!url) {
-                            return (
-                              <span key={idx} className="askmoji-ref">
-                                {getReferenceIcon(ref.referenceType)}
-                                {ref.displayText}
-                              </span>
-                            );
-                          }
-                          return (
-                            <a
-                              key={idx}
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="askmoji-ref"
-                            >
-                              {getReferenceIcon(ref.referenceType)}
-                              {ref.displayText}
-                            </a>
-                          );
-                        })}
-                      </div>
+                    {revealedIds.has(msg.id) && (
+                      <ContentReferenceChips
+                        references={msg.references ?? []}
+                        classroomSlug={classroomSlug}
+                        slidesUrl={slidesUrl}
+                        pagesUrl={pagesUrl}
+                      />
                     )}
                   </div>
                 )}

--- a/apps/webapp/app/components/features/syllabus-bot/__tests__/ContentReferenceChips.test.tsx
+++ b/apps/webapp/app/components/features/syllabus-bot/__tests__/ContentReferenceChips.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The citation chips, asserted against RENDERED MARKUP.
+ *
+ * These used to be regexes over `SyllabusBotChat.tsx` — a test that the source
+ * contains `if (!url)` and a `<span>`, which is not a test that a null-URL
+ * reference renders as one. A regex passes on a branch that is never reached,
+ * on a component that throws before it draws, and on a `<span>` that somebody
+ * later gave an `onClick`.
+ *
+ * `renderToStaticMarkup` needs no DOM and no new dependency — `react-dom` is
+ * already one — so this runs in the ordinary node-environment unit suite.
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import ContentReferenceChips, { type ContentReference } from '../ContentReferenceChips';
+
+const SLUG = 'cs52';
+const SLIDES = 'https://slides.example';
+const PAGES = 'https://pages.example';
+
+const render = (references: ContentReference[]): string =>
+  renderToStaticMarkup(
+    <ContentReferenceChips
+      references={references}
+      classroomSlug={SLUG}
+      slidesUrl={SLIDES}
+      pagesUrl={PAGES}
+    />
+  );
+
+/** A docs reference that builds a URL, and one that cannot. */
+const LINKED: ContentReference = {
+  referenceType: 'platform_docs',
+  contentPath: 'docs/instructors/roster',
+  displayText: 'Manage your roster',
+};
+const UNLINKABLE: ContentReference = {
+  referenceType: 'platform_docs',
+  // A bare name from the old `/docs/{name}` scheme: `buildContentReferenceUrl`
+  // returns null for it rather than guessing a slug.
+  contentPath: 'quizzes',
+  displayText: 'Quizzes',
+};
+
+describe('a reference the widget cannot link to renders as TEXT, not a dead link', () => {
+  it('gives the null-URL reference a span with no href and no tab stop', () => {
+    const html = render([UNLINKABLE]);
+
+    expect(html).toContain('<span class="askmoji-ref"');
+    expect(html).toContain('Quizzes');
+    // The three ways a dead chip used to pretend to be a link.
+    expect(html).not.toContain('<a ');
+    expect(html).not.toContain('href');
+    expect(html).not.toContain('tabindex');
+    expect(html).not.toContain('role=');
+  });
+
+  it('never emits href="#" — the fallback that navigated the page to itself', () => {
+    expect(render([UNLINKABLE])).not.toContain('#');
+  });
+
+  it('gives the linked reference a real href, opened in a new tab safely', () => {
+    const html = render([LINKED]);
+
+    expect(html).toContain('href="https://classmoji.io/docs/instructors/roster"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain('Manage your roster');
+  });
+
+  it('draws both in ONE list, with the SAME chip class, so they look identical', () => {
+    // The visual claim the span branch rests on: a reader must not be able to
+    // tell a label from a link by its styling, only by whether it responds.
+    // The chip's colours come from panel-level CSS variables, so one class is
+    // correct in light and dark alike.
+    const html = render([LINKED, UNLINKABLE]);
+
+    expect(html.match(/class="askmoji-ref"/g) ?? []).toHaveLength(2);
+    expect(html).toMatch(/<a [^>]*class="askmoji-ref"/);
+    expect(html).toMatch(/<span class="askmoji-ref"/);
+    expect(html.indexOf('Manage your roster')).toBeLessThan(html.indexOf('Quizzes'));
+  });
+
+  it('renders each reference type with its own icon, and an unknown one with the fallback', () => {
+    // The icon is the only thing that distinguishes a page citation from a docs
+    // one at a glance, and an unknown type must still draw something rather
+    // than a hole.
+    const svgs = (html: string) => (html.match(/<svg/g) ?? []).length;
+    expect(svgs(render([{ ...LINKED, referenceType: 'page', contentPath: 'p1' }]))).toBe(1);
+    expect(svgs(render([{ ...LINKED, referenceType: 'slides', contentPath: 'd1' }]))).toBe(1);
+    expect(svgs(render([LINKED]))).toBe(1);
+    expect(svgs(render([{ ...LINKED, referenceType: 'mystery' }]))).toBe(1);
+  });
+
+  it('draws nothing at all when there are no references', () => {
+    // Not an empty `askmoji-refs` div: that reserves margin under an answer
+    // that cited nothing.
+    expect(render([])).toBe('');
+  });
+});

--- a/apps/webapp/app/utils/__tests__/contentReferenceUrl.test.ts
+++ b/apps/webapp/app/utils/__tests__/contentReferenceUrl.test.ts
@@ -17,13 +17,135 @@ describe('buildContentReferenceUrl', () => {
 
   it('still builds slide links from slidesUrl', () => {
     expect(
-      buildContentReferenceUrl({ referenceType: 'slides', contentPath: 'd1' }, 'cs52', 'https://slides.example')
+      buildContentReferenceUrl(
+        { referenceType: 'slides', contentPath: 'd1' },
+        'cs52',
+        'https://slides.example'
+      )
     ).toBe('https://slides.example/d1');
   });
 
   it('never reads process.env — this module runs in the browser', () => {
     const source = readFileSync(new URL('../contentReferenceUrl.ts', import.meta.url), 'utf8');
     expect(source).not.toMatch(/process\.env\./);
+  });
+});
+
+describe('platform_docs references', () => {
+  const docsRef = (contentPath: string) => ({
+    referenceType: 'platform_docs',
+    contentPath,
+    displayText: 'Manage your roster',
+  });
+
+  it('builds the canonical absolute URL from a doc slug', () => {
+    // NOT `/docs/${contentPath}`, which is what this used to do: the origin is
+    // the marketing site rather than the app, and a full slug produced
+    // `/docs/docs/instructors/roster`.
+    expect(buildContentReferenceUrl(docsRef('docs/instructors/roster'), 'cs52')).toBe(
+      'https://classmoji.io/docs/instructors/roster'
+    );
+  });
+
+  it.each([
+    ['docs', 'https://classmoji.io/docs'],
+    ['docs/instructors', 'https://classmoji.io/docs/instructors'],
+    [
+      'docs/open-source/local-development',
+      'https://classmoji.io/docs/open-source/local-development',
+    ],
+  ])('%s → %s', (slug, url) => {
+    expect(buildContentReferenceUrl(docsRef(slug), 'cs52')).toBe(url);
+  });
+
+  it('never guesses the origin from the page it is rendered on', () => {
+    // The widget runs inside the app, so a relative `/docs/...` would resolve
+    // against app.classmoji.io, where the documentation is not served.
+    const url = buildContentReferenceUrl(docsRef('docs/instructors/roster'), 'cs52');
+    expect(url?.startsWith('https://classmoji.io/')).toBe(true);
+  });
+
+  it.each([
+    ['quizzes', 'a bare doc name from the old /docs/{name} scheme'],
+    ['assignments', 'another bare name'],
+    ['docs/../admin', 'traversal'],
+    ['/docs/instructors/roster', 'an absolute path — a slug carries no leading slash'],
+    ['https://evil.example/docs', 'an absolute URL'],
+    ['', 'empty'],
+  ])('renders NO link for %s (%s)', slug => {
+    expect(buildContentReferenceUrl(docsRef(slug), 'cs52')).toBeNull();
+  });
+
+  it('needs no env var and no init payload, unlike page and slide links', () => {
+    // The docs origin is one public host for the whole fleet, so it is a
+    // constant rather than something plumbed through the widget's init payload
+    // — which is why this works with both URL arguments absent.
+    expect(buildContentReferenceUrl(docsRef('docs/instructors/roster'), 'cs52', null, null)).toBe(
+      'https://classmoji.io/docs/instructors/roster'
+    );
+  });
+});
+
+describe('a reference the widget cannot link to renders as TEXT, not a dead link', () => {
+  /**
+   * The component's CODE, with `//` comment lines removed.
+   *
+   * The comments explain the dead-link bug by quoting it, so an assertion that
+   * the file no longer contains `href={url || '#'}` would fail on the sentence
+   * saying it used to.
+   */
+  const chat = () =>
+    readFileSync(
+      new URL('../../components/features/syllabus-bot/SyllabusBotChat.tsx', import.meta.url),
+      'utf8'
+    )
+      .split('\n')
+      .filter(line => !/^\s*\/\//.test(line))
+      .join('\n');
+
+  it('no longer falls back to href="#"', () => {
+    // `href={url || '#'}` is a clickable dead link: focusable, styled exactly
+    // like a working chip, and it navigates the page to itself.
+    const source = chat();
+    expect(source).not.toMatch(/href=\{url \|\| '#'\}/);
+    expect(source).not.toMatch(/href="#"/);
+  });
+
+  it('renders a span for a null url, with the same chip class', () => {
+    const source = chat();
+    // Same class, so the two look identical — and the chip's colours come from
+    // panel-level CSS variables, so it is correct in light and dark without a
+    // second rule.
+    expect(source).toMatch(/if \(!url\) \{[\s\S]{0,200}<span key=\{idx\} className="askmoji-ref">/);
+  });
+
+  it('does not make that span keyboard-focusable or announce it as a link', () => {
+    // A <span> with no tabindex is not in the tab order at all, which is the
+    // whole point: it is a label, and nothing about it should say "activate me".
+    const source = chat();
+    const start = source.indexOf('if (!url)');
+    expect(start).toBeGreaterThan(-1);
+    const branch = source.slice(start, source.indexOf('}', source.indexOf('</span>', start)));
+    expect(branch).toContain('<span');
+    expect(branch).not.toMatch(/tabIndex/);
+    expect(branch).not.toMatch(/role=/);
+    expect(branch).not.toMatch(/onClick/);
+    expect(branch).not.toMatch(/href/);
+  });
+
+  it('keeps target=_blank only on the branch that HAS a url', () => {
+    const source = chat();
+    expect(source).not.toMatch(/target=\{url \? '_blank' : undefined\}/);
+    expect(source).toMatch(/href=\{url\}\s*\n\s*target="_blank"/);
+  });
+
+  it('the chip class is themed by variables the panel redefines in dark mode', () => {
+    const css = readFileSync(
+      new URL('../../components/features/syllabus-bot/styles.css', import.meta.url),
+      'utf8'
+    );
+    expect(css).toMatch(/\.askmoji-ref \{[\s\S]*?var\(--am-ref-bg\)/);
+    expect(css).toMatch(/\.dark \.askmoji-panel/);
   });
 });
 
@@ -37,9 +159,9 @@ describe('normalizeAssistantText', () => {
   });
 
   it('collapses [page:Title] to the title', () => {
-    expect(normalizeAssistantText('According to the [page:Course Schedule], Exam 2 is on Oct 22.')).toBe(
-      'According to the Course Schedule, Exam 2 is on Oct 22.'
-    );
+    expect(
+      normalizeAssistantText('According to the [page:Course Schedule], Exam 2 is on Oct 22.')
+    ).toBe('According to the Course Schedule, Exam 2 is on Oct 22.');
   });
 
   it('leaves ordinary markdown alone', () => {

--- a/apps/webapp/app/utils/__tests__/contentReferenceUrl.test.ts
+++ b/apps/webapp/app/utils/__tests__/contentReferenceUrl.test.ts
@@ -86,59 +86,20 @@ describe('platform_docs references', () => {
   });
 });
 
-describe('a reference the widget cannot link to renders as TEXT, not a dead link', () => {
+describe('the chip the widget draws for a reference', () => {
   /**
-   * The component's CODE, with `//` comment lines removed.
+   * WHAT THIS BLOCK NO LONGER DOES.
    *
-   * The comments explain the dead-link bug by quoting it, so an assertion that
-   * the file no longer contains `href={url || '#'}` would fail on the sentence
-   * saying it used to.
+   * It used to grep `SyllabusBotChat.tsx` for `if (!url)` and a `<span>`, which
+   * is a test that the source contains a branch — not a test that a null-URL
+   * reference renders as a label. That markup now lives in
+   * `ContentReferenceChips`, and
+   * `components/features/syllabus-bot/__tests__/ContentReferenceChips.test.tsx`
+   * asserts it against the HTML React actually produces.
+   *
+   * What is left here is the one claim the render test cannot make: the chip's
+   * single class has to be correct in BOTH themes, which is a CSS fact.
    */
-  const chat = () =>
-    readFileSync(
-      new URL('../../components/features/syllabus-bot/SyllabusBotChat.tsx', import.meta.url),
-      'utf8'
-    )
-      .split('\n')
-      .filter(line => !/^\s*\/\//.test(line))
-      .join('\n');
-
-  it('no longer falls back to href="#"', () => {
-    // `href={url || '#'}` is a clickable dead link: focusable, styled exactly
-    // like a working chip, and it navigates the page to itself.
-    const source = chat();
-    expect(source).not.toMatch(/href=\{url \|\| '#'\}/);
-    expect(source).not.toMatch(/href="#"/);
-  });
-
-  it('renders a span for a null url, with the same chip class', () => {
-    const source = chat();
-    // Same class, so the two look identical — and the chip's colours come from
-    // panel-level CSS variables, so it is correct in light and dark without a
-    // second rule.
-    expect(source).toMatch(/if \(!url\) \{[\s\S]{0,200}<span key=\{idx\} className="askmoji-ref">/);
-  });
-
-  it('does not make that span keyboard-focusable or announce it as a link', () => {
-    // A <span> with no tabindex is not in the tab order at all, which is the
-    // whole point: it is a label, and nothing about it should say "activate me".
-    const source = chat();
-    const start = source.indexOf('if (!url)');
-    expect(start).toBeGreaterThan(-1);
-    const branch = source.slice(start, source.indexOf('}', source.indexOf('</span>', start)));
-    expect(branch).toContain('<span');
-    expect(branch).not.toMatch(/tabIndex/);
-    expect(branch).not.toMatch(/role=/);
-    expect(branch).not.toMatch(/onClick/);
-    expect(branch).not.toMatch(/href/);
-  });
-
-  it('keeps target=_blank only on the branch that HAS a url', () => {
-    const source = chat();
-    expect(source).not.toMatch(/target=\{url \? '_blank' : undefined\}/);
-    expect(source).toMatch(/href=\{url\}\s*\n\s*target="_blank"/);
-  });
-
   it('the chip class is themed by variables the panel redefines in dark mode', () => {
     const css = readFileSync(
       new URL('../../components/features/syllabus-bot/styles.css', import.meta.url),

--- a/apps/webapp/app/utils/contentReferenceUrl.ts
+++ b/apps/webapp/app/utils/contentReferenceUrl.ts
@@ -7,8 +7,13 @@
  * Routes supported:
  * - {pagesUrl}/{classroomSlug}/{pageId} - External pages app URL
  * - {slidesUrl}/{slideId} - External slides URL
- * - /docs/{contentPath} - Platform documentation
+ * - https://classmoji.io/{slug} - Platform documentation
+ *
+ * A null return means NO LINK, and every caller must render text rather than a
+ * link when it gets one. Returning a best-effort URL instead would hand a user
+ * a confident chip that goes nowhere, which is worse than prose.
  */
+import { docsUrl } from '@classmoji/utils';
 
 /**
  * Build a URL for a content reference
@@ -62,8 +67,23 @@ export function buildContentReferenceUrl(
     }
 
     case 'platform_docs': {
-      // contentPath is a doc identifier like "quizzes", "assignments", "getting-started"
-      return `/docs/${contentPath}`;
+      // `contentPath` is the SLUG of a `kind: 'doc'` search hit — the page's
+      // path under classmoji.io, e.g. `docs/instructors/roster`.
+      //
+      // This used to build `/docs/${contentPath}`, which was wrong twice over:
+      // the origin is the marketing site and not the app, and with a full slug
+      // it produced `/docs/docs/instructors/roster`. `docsUrl` comes from
+      // `@classmoji/utils` — the SAME function the MCP uses for a hit's `url` —
+      // so the link the model cites and the chip the user clicks cannot
+      // disagree.
+      //
+      // It returns null for a malformed slug. That is a SHAPE guard, not an
+      // existence check: it blocks traversal and absolute paths, but
+      // `docs/instructors/made-up-feature` passes, and so does the
+      // `/docs/docs/instructors` typo the corpus itself contains. Only the
+      // index knows what exists, and a slug that came from a search hit already
+      // does.
+      return docsUrl(contentPath);
     }
 
     // Deprecated: Keep for backwards compatibility with old references
@@ -80,28 +100,6 @@ export function buildContentReferenceUrl(
       console.warn('[contentReferenceUrl] Unknown reference type:', referenceType);
       return null;
   }
-}
-
-/**
- * Render a content reference as a markdown link
- *
- * @param {Object} reference - Content reference from syllabus bot
- * @param {string} classroomSlug - Classroom slug for URL routing
- * @param {string|null} slidesUrl - External slides URL
- * @returns {string} - Markdown link or plain text
- */
-export function renderContentReferenceMarkdown(
-  reference: ContentReferenceInput,
-  classroomSlug: string,
-  slidesUrl: string | null = null
-) {
-  const url = buildContentReferenceUrl(reference, classroomSlug, slidesUrl);
-
-  if (!url) {
-    return reference.displayText || reference.contentPath;
-  }
-
-  return `[${reference.displayText}](${url})`;
 }
 
 /**

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -1,14 +1,26 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 /**
  * Vitest config for webapp unit tests.
  *
- * Picks up *.test.ts under app/, leaving the Playwright suites under tests/
- * (which use *.spec.ts) untouched.
+ * Picks up *.test.ts and *.test.tsx under app/, leaving the Playwright suites
+ * under tests/ (which use *.spec.ts) untouched.
+ *
+ * `.tsx` is included so a presentational component can be asserted against the
+ * markup it actually renders (`react-dom/server`, already a dependency) rather
+ * than against a regex over its source. `environment: 'node'` is enough for
+ * that: `renderToStaticMarkup` needs no DOM, and nothing here mounts or clicks.
+ *
+ * The `~` alias mirrors `tsconfig.json`'s `paths`, so a component under test
+ * resolves its imports the same way the app does.
  */
 export default defineConfig({
+  resolve: {
+    alias: { '~': fileURLToPath(new URL('./app', import.meta.url)) },
+  },
   test: {
-    include: ['app/**/__tests__/**/*.test.ts', 'app/**/*.test.ts'],
+    include: ['app/**/__tests__/**/*.test.ts?(x)', 'app/**/*.test.ts?(x)'],
     environment: 'node',
   },
 });

--- a/packages/database/migrations/20260912123220_docs_index/migration.sql
+++ b/packages/database/migrations/20260912123220_docs_index/migration.sql
@@ -1,0 +1,79 @@
+-- Semantic index over the PRODUCT DOCUMENTATION: one row and one vector per
+-- chunk of a `classmoji.io/docs` page.
+--
+-- CREATE EXTENSION is the first statement for the same reason it is in
+-- `20260910225742_content_index`: the column type `vector(1024)` does not parse
+-- until pgvector exists, and Prisma's shadow database replays this file from
+-- empty. IF NOT EXISTS makes it a no-op wherever it already ran — including on
+-- a database that already carries `content_index`.
+--
+-- ── WHY A SECOND TABLE RATHER THAN A FOURTH doc_kind ────────────────────────
+-- `content_index` is per classroom: every row carries `classroom_id`, every
+-- statement filters on it, the FK cascades when a classroom is deleted, and the
+-- read path joins `pages`/`slides` to apply a draft/publish visibility rule.
+-- Documentation has none of that. It is one fleet-wide public website, so a row
+-- here belongs to nobody, is visible to everybody, and outlives every classroom.
+-- Putting it in `content_index` would mean a row that has to OPT OUT of the
+-- tenancy filter those statements are built around — the one thing that file's
+-- header says must never happen. Separate table, separate statements, no
+-- classroom column to forget.
+--
+-- ── slug IS the identity AND the URL ────────────────────────────────────────
+-- `docs/instructors/roster` is both the primary key and the path under
+-- https://classmoji.io/. It is derived from the repo path under
+-- `apps/site/src/content/docs` minus `.mdx` and minus a trailing `/index`, so
+-- the id a search hit returns is also the link the chat widget renders. No
+-- second mapping table, and no way for the two to disagree.
+--
+-- ── NO INDEX AT ALL, AND THE REASON IS NOT content_index's REASON ───────────
+-- There is no HNSW/IVFFlat index and no secondary B-tree. The justification is
+-- CORPUS SIZE ALONE: the documentation is 25 pages, so an exact
+-- `ORDER BY embedding <=> $1` is a sequential pass over a couple of dozen rows
+-- and is already the cheapest correct plan.
+--
+-- This is DELIBERATELY NOT the argument `content_index` makes. That table skips
+-- an approximate index because an approximate scan returns candidates BEFORE
+-- the per-classroom permission filter runs, so a filtered-away candidate is a
+-- lost result. That reasoning is specific to filtering, and there is no filter
+-- here — so it must not be copied across as though it were. If this corpus ever
+-- grows by an order of magnitude, add an index on the size argument, and do not
+-- inherit a justification that never applied.
+--
+-- ── Freshness, and why chunking survives a 25-page corpus ───────────────────
+-- The freshness triple is the same as `content_index`'s —
+-- (source_sha, extract_version, embed_model) — and the same `isFresh` function
+-- reads it. `source_sha` is the git blob sha of the `.mdx`.
+--
+-- Every page fits in one chunk today: the largest is 7,976 characters against a
+-- 24,576-character budget. `chunk_ix`/`chunk_count` are kept anyway because
+-- (a) that budget is env-overridable DOWNWARD
+-- (CLOUDFLARE_WORKERS_AI_EMBED_MAX_TOKENS), (b) `chunk_count` is what lets
+-- `isFresh` tell a complete document from a write that died halfway, and
+-- (c) the composite primary key is what makes the upsert idempotent. A
+-- one-row-per-page variant would be MORE code, not less.
+--
+-- `embedding` is nullable twice over: Prisma requires `Unsupported()` fields to
+-- be optional, and a row may legitimately exist before its embedding call
+-- succeeded. Every read filters `embedding IS NOT NULL` so a half-written row
+-- cannot sort first by accident.
+--
+-- The table is a CACHE over a public git repo. Losing it costs a re-index, not
+-- content; the reconcile rebuilds it from `main`.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE "docs_index" (
+    "slug" TEXT NOT NULL,
+    "chunk_ix" INTEGER NOT NULL DEFAULT 0,
+    "chunk_count" INTEGER NOT NULL DEFAULT 1,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "section" TEXT,
+    "text" TEXT NOT NULL,
+    "source_sha" TEXT NOT NULL,
+    "extract_version" INTEGER NOT NULL,
+    "embed_model" TEXT NOT NULL,
+    "embedding" vector(1024),
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "docs_index_pkey" PRIMARY KEY ("slug","chunk_ix")
+);

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -1942,3 +1942,68 @@ model ContentIndex {
   @@index([classroom_id, source_path])
   @@map("content_index")
 }
+
+/// Semantic index over the PRODUCT DOCUMENTATION — `classmoji.io/docs`, the
+/// `.mdx` files under `apps/site/src/content/docs` in the public monorepo.
+///
+/// A SECOND, CLASSROOM-INDEPENDENT CORPUS. `ContentIndex` above is per
+/// classroom and cascades with it; this table has no `classroom_id`, no FK and
+/// no visibility columns, because the documentation is one fleet-wide public
+/// website. That difference is the whole reason it is a separate table rather
+/// than a fourth `doc_kind`: a global row in a per-classroom table would have
+/// to opt out of every tenancy filter the search statements are built around.
+///
+/// `slug` IS the identity and IS the URL path: `docs/instructors/roster`
+/// renders at `https://classmoji.io/docs/instructors/roster`. Derived from the
+/// repo path minus `.mdx` and a trailing `/index`, so the id a search hit hands
+/// back is also the link the widget shows.
+///
+/// Freshness is the same triple as `content_index` —
+/// (source_sha, extract_version, embed_model) — and `isFresh` is literally the
+/// same function. `source_sha` is the git blob sha of the `.mdx` at index time.
+///
+/// Chunking is kept for the same three reasons it exists next door, even though
+/// every page fits in one chunk today (the largest is 7,976 characters against
+/// a 24,576-character budget that is itself env-overridable DOWNWARD):
+/// `chunk_count` is what lets `isFresh` spot a half-written document, the
+/// composite PK makes the upsert idempotent, and a page past the cap would
+/// otherwise be refused and silently never index.
+model DocsIndex {
+  /// The URL path under classmoji.io, e.g. `docs/instructors/roster`. No
+  /// leading slash, no `.mdx`, no trailing `/index`.
+  slug            String
+  /// 0 for a whole-document row; otherwise this chunk's ordinal in reading
+  /// order. Part of the primary key.
+  chunk_ix        Int                          @default(0)
+  /// How many chunks this page produced (1 when it fit in one call). Stamped on
+  /// every chunk so a partial write reads as stale rather than as complete.
+  chunk_count     Int                          @default(1)
+  /// Frontmatter `title`. Required — a page without one is refused by the
+  /// extractor rather than indexed under a guess.
+  title           String
+  /// Frontmatter `description`. Optional in principle; present on all 25 today.
+  description     String?
+  /// The top-level docs section, or null for a page directly under the root:
+  /// `instructors`, `students`, `self-hosting`, `open-source`, `introduction`.
+  section         String?
+  /// The extracted plain text of this row — the whole page when `chunk_count`
+  /// is 1, otherwise just this chunk.
+  text            String
+  /// git blob sha of the `.mdx` the text came from.
+  source_sha      String
+  /// Version of the MDX extractor that produced `text`. Bumping it re-indexes
+  /// every page on the next run, which is the recovery path for an extractor
+  /// bug.
+  extract_version Int
+  /// The Workers AI model id the vector came from. A mismatch re-indexes:
+  /// vectors from two models are not comparable.
+  embed_model     String
+  /// Workers AI @cf/qwen/qwen3-embedding-0.6b, 1024 dimensions. Nullable
+  /// because Prisma requires `Unsupported` fields to be optional, and because a
+  /// row can be written before the embedding call succeeds.
+  embedding       Unsupported("vector(1024)")?
+  updated_at      DateTime                     @default(now()) @updatedAt
+
+  @@id([slug, chunk_ix])
+  @@map("docs_index")
+}

--- a/packages/services/src/classmoji/__tests__/docsIndex.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/docsIndex.integration.test.ts
@@ -1,0 +1,323 @@
+/**
+ * The docs indexer's SQL, against a real Postgres.
+ *
+ * ── Why this exists beside `docsIndex.test.ts` ─────────────────────────────
+ * That file drives every branch over a recording Prisma, which agrees with
+ * whatever statement it is handed. It can prove a statement was or was not
+ * ISSUED; it cannot prove one is correct. Three things here are only true if
+ * real SQL says so:
+ *
+ *   - `embedding` is an `Unsupported("vector(1024)")` column. Prisma Client
+ *     cannot see it, so every read and write is raw, and the only proof that
+ *     the `'[…]'::vector` parameter, the two-column `ON CONFLICT` target and
+ *     the 1,024-dimension width line up is a row landing in pgvector;
+ *   - `updated_at` has `@updatedAt`, which is a Prisma CLIENT feature a raw
+ *     upsert goes straight past. Only a real UPDATE shows the column moved;
+ *   - the SHRINK-TAIL delete, the SWEEP and transactional ROLLBACK are SQL.
+ *
+ * ── The database ───────────────────────────────────────────────────────────
+ * A disposable one, created from the migrations and dropped afterwards — see
+ * `helpers/docsTestDatabase.ts` for why namespacing cannot work for a global
+ * table. It is created BEFORE `@classmoji/database` is imported, because that
+ * module builds its client from `DATABASE_URL` at import time.
+ *
+ * Opted in with `DOCS_INDEX_INTEGRATION=1`, and when opted in it FAILS rather
+ * than skipping if the database is unreachable.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDocsTestDatabase,
+  docsDbOptedIn,
+  type DisposableDatabase,
+} from './helpers/docsTestDatabase.ts';
+
+const RUN = docsDbOptedIn();
+
+// Created at module scope, on purpose: `@classmoji/database` constructs its
+// singleton the moment it is imported, so the URL has to be in place first.
+let database: DisposableDatabase | null = null;
+if (RUN) {
+  database = await createDocsTestDatabase();
+  process.env.DATABASE_URL = database.url;
+}
+
+const embedTextsMock = vi.fn();
+vi.mock('../../helpers/workersAi.ts', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../helpers/workersAi.ts')>();
+  return {
+    ...actual,
+    isWorkersAiConfigured: () => true,
+    embedTexts: (...args: unknown[]) => embedTextsMock(...args),
+  };
+});
+
+const getPrisma = (await import('@classmoji/database')).default;
+const { DOCS_EXTRACT_VERSION, reconcileDocsIndex } = await import('../docsIndex.service.ts');
+const { EMBEDDING_MODEL, EMBEDDING_DIMENSIONS } = await import('../../helpers/workersAi.ts');
+
+afterAll(async () => {
+  if (!RUN) return;
+  await getPrisma().$disconnect();
+  await database?.drop();
+});
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const COMMIT = 'a'.repeat(40);
+const shaFor = (seed: string): string =>
+  seed
+    .padEnd(40, '0')
+    .replace(/[^0-9a-f]/g, '1')
+    .slice(0, 40);
+
+const blob = (path: string, seed: string) => ({ path, type: 'blob', sha: shaFor(seed) });
+
+const mdx = (title: string, body: string): string =>
+  `---\ntitle: ${title}\ndescription: Fixture page\n---\n\n${body}\n`;
+
+const reader = (entries: ReturnType<typeof blob>[], bodies: Record<string, string>) => ({
+  head: async () => COMMIT,
+  tree: async () => ({ entries: entries as never, truncated: false }),
+  body: async (_commit: string, relPath: string) => bodies[relPath] ?? null,
+});
+
+const unitVector = (seed: number): number[] =>
+  Array.from({ length: EMBEDDING_DIMENSIONS }, (_, i) =>
+    i === seed % EMBEDDING_DIMENSIONS ? 1 : 0
+  );
+
+interface Row {
+  slug: string;
+  chunk_ix: number;
+  chunk_count: number;
+  title: string;
+  description: string | null;
+  section: string | null;
+  text: string;
+  source_sha: string;
+  extract_version: number;
+  embed_model: string;
+  embedding_null: boolean;
+  updated_at: Date;
+}
+
+/**
+ * Set (or unset) an env var and hand back a restore.
+ *
+ * `process.env.X = undefined` assigns the STRING "undefined", which is a
+ * different bug every time: here it left the embed cap unparseable for every
+ * test that ran after the one that lowered it.
+ */
+function withEnv(name: string, value: string): () => void {
+  const previous = process.env[name];
+  process.env[name] = value;
+  return () => {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  };
+}
+
+const rows = async (): Promise<Row[]> =>
+  getPrisma().$queryRaw<Row[]>`
+    SELECT slug, chunk_ix, chunk_count, title, description, section, text,
+           source_sha, extract_version, embed_model,
+           (embedding IS NULL) AS embedding_null, updated_at
+    FROM docs_index ORDER BY slug, chunk_ix`;
+
+beforeEach(async () => {
+  if (!RUN) return;
+  await getPrisma().$executeRaw`DELETE FROM docs_index`;
+  embedTextsMock.mockReset();
+  embedTextsMock.mockImplementation(async (texts: string[]) => ({
+    ok: true,
+    vectors: texts.map((_, index) => unitVector(index + 1)),
+  }));
+});
+
+describe.skipIf(!RUN)('docsIndex writes (real Postgres)', () => {
+  it('lands a row with a real vector, the frontmatter and the derived section', async () => {
+    const report = await reconcileDocsIndex({
+      reader: reader([blob('docs/instructors/roster.mdx', 'abc')], {
+        'docs/instructors/roster.mdx': mdx('Manage your roster', 'Go to the Students tab.'),
+      }),
+    });
+
+    expect(report.error).toBeUndefined();
+    expect(report.indexed).toBe(1);
+
+    const [row] = await rows();
+    expect(row.slug).toBe('docs/instructors/roster');
+    expect(row.chunk_ix).toBe(0);
+    expect(row.chunk_count).toBe(1);
+    expect(row.title).toBe('Manage your roster');
+    expect(row.description).toBe('Fixture page');
+    expect(row.section).toBe('instructors');
+    expect(row.text).toContain('Go to the Students tab.');
+    expect(row.source_sha).toBe(shaFor('abc'));
+    expect(row.extract_version).toBe(DOCS_EXTRACT_VERSION);
+    expect(row.embed_model).toBe(EMBEDDING_MODEL);
+    // The whole point of a real database: pgvector accepted the literal at the
+    // declared width.
+    expect(row.embedding_null).toBe(false);
+    const [{ dims }] = await getPrisma().$queryRaw<Array<{ dims: number }>>`
+      SELECT vector_dims(embedding) AS dims FROM docs_index WHERE slug = 'docs/instructors/roster'`;
+    expect(dims).toBe(EMBEDDING_DIMENSIONS);
+  });
+
+  it('leaves section NULL for a page directly under the docs root', async () => {
+    await reconcileDocsIndex({
+      reader: reader([blob('docs/index.mdx', 'bbb')], {
+        'docs/index.mdx': mdx('Welcome', 'Some prose.'),
+      }),
+    });
+    const [row] = await rows();
+    expect(row.slug).toBe('docs');
+    expect(row.section).toBeNull();
+  });
+
+  it('UPDATES in place on a re-index, and moves updated_at by hand', async () => {
+    const first = reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', 'First body.') });
+    await reconcileDocsIndex({ reader: first });
+    const [before] = await rows();
+
+    await new Promise(resolve => setTimeout(resolve, 25));
+
+    const second = reader([blob('docs/a.mdx', 'bbb')], { 'docs/a.mdx': mdx('A', 'Second body.') });
+    const report = await reconcileDocsIndex({ reader: second });
+
+    expect(report.indexed).toBe(1);
+    const after = await rows();
+    // One row, not two: the ON CONFLICT target is the real primary key.
+    expect(after).toHaveLength(1);
+    expect(after[0].text).toContain('Second body.');
+    expect(after[0].source_sha).toBe(shaFor('bbb'));
+    // `@updatedAt` is a Prisma Client feature and a raw upsert goes past it, so
+    // the statement sets the column itself. Only a real UPDATE proves it moved.
+    expect(after[0].updated_at.getTime()).toBeGreaterThan(before.updated_at.getTime());
+  });
+
+  it('DELETES the tail a shrinking document leaves behind', async () => {
+    // Force two chunks, then one, by driving the chunker's budget down.
+    const restoreCap = withEnv('CLOUDFLARE_WORKERS_AI_EMBED_MAX_TOKENS', '30');
+
+    const long = `${'First paragraph is reasonably long here. '.repeat(3)}\n\n${'Second paragraph is also reasonably long. '.repeat(3)}`;
+    await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', long) }),
+    });
+    const chunked = await rows();
+    expect(chunked.length).toBeGreaterThan(1);
+
+    restoreCap();
+
+    await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'bbb')], { 'docs/a.mdx': mdx('A', 'Now short.') }),
+    });
+
+    const after = await rows();
+    // Chunk 1 of the previous version is a perfectly good row with a perfectly
+    // good vector, and it would go on answering out of text this page no longer
+    // has.
+    expect(after).toHaveLength(1);
+    expect(after[0].chunk_ix).toBe(0);
+    expect(after[0].chunk_count).toBe(1);
+    expect(after[0].text).toContain('Now short.');
+  });
+
+  it('ROLLS BACK the whole page when a chunk write fails', async () => {
+    const restoreCap = withEnv('CLOUDFLARE_WORKERS_AI_EMBED_MAX_TOKENS', '30');
+    const long = `${'First paragraph is reasonably long here. '.repeat(3)}\n\n${'Second paragraph is also reasonably long. '.repeat(3)}`;
+
+    // A vector of the wrong width: pgvector refuses the second INSERT, inside
+    // the transaction that already wrote the first.
+    embedTextsMock.mockImplementation(async (texts: string[]) => ({
+      ok: true,
+      vectors: texts.map((_, index) => (index === 0 ? unitVector(1) : new Array(16).fill(0.5))),
+    }));
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const report = await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', long) }),
+    });
+    warn.mockRestore();
+    restoreCap();
+
+    expect(report.failed).toBe(1);
+    // NOT a half-written document. Chunk 0 with a `chunk_count` of 2 and no
+    // chunk 1 reads as stale to `isFresh`, but it is also a document the search
+    // can already reach with half its text.
+    expect(await rows()).toHaveLength(0);
+  });
+
+  it('SWEEPS a page that has left the tree, and only that page', async () => {
+    await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa'), blob('docs/b.mdx', 'bbb')], {
+        'docs/a.mdx': mdx('A', 'Body A.'),
+        'docs/b.mdx': mdx('B', 'Body B.'),
+      }),
+    });
+    expect((await rows()).map(row => row.slug)).toEqual(['docs/a', 'docs/b']);
+
+    const report = await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', 'Body A.') }),
+    });
+
+    expect(report.deleted).toBe(1);
+    expect((await rows()).map(row => row.slug)).toEqual(['docs/a']);
+  });
+
+  it('does NOT sweep when the tree could not be trusted', async () => {
+    await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', 'Body A.') }),
+    });
+    expect(await rows()).toHaveLength(1);
+
+    // The failure this guard exists for: `slug <> ALL('{}'::text[])` matches
+    // every row, so a truncated or empty tree taken at face value empties the
+    // corpus. Against a real database, that is the difference between one row
+    // and none.
+    const truncated = {
+      head: async () => COMMIT,
+      tree: async () => ({ entries: [] as never, truncated: true }),
+      body: async () => null,
+    };
+    const report = await reconcileDocsIndex({ reader: truncated });
+
+    expect(report.halted).toBe('tree_invalid');
+    expect(await rows()).toHaveLength(1);
+  });
+
+  it('is idempotent: a second run indexes nothing and deletes nothing', async () => {
+    const same = () => reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', 'Body A.') });
+
+    await reconcileDocsIndex({ reader: same() });
+    const first = await rows();
+
+    const report = await reconcileDocsIndex({ reader: same() });
+
+    expect(report.indexed).toBe(0);
+    expect(report.byReason.fresh).toBe(1);
+    expect(report.deleted).toBe(0);
+    // Freshness is read out of the real row, so this is the proof that the
+    // stamp written and the stamp compared are the same three values.
+    expect(await rows()).toEqual(first);
+  });
+
+  it('finishes a half-written document rather than calling it fresh', async () => {
+    await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', 'Body A.') }),
+    });
+    // Simulate the write that died between chunks: the stored row claims there
+    // are two, and only one is there.
+    await getPrisma().$executeRaw`UPDATE docs_index SET chunk_count = 2 WHERE slug = 'docs/a'`;
+
+    const report = await reconcileDocsIndex({
+      reader: reader([blob('docs/a.mdx', 'aaa')], { 'docs/a.mdx': mdx('A', 'Body A.') }),
+    });
+
+    expect(report.indexed).toBe(1);
+    const after = await rows();
+    expect(after).toHaveLength(1);
+    expect(after[0].chunk_count).toBe(1);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/docsIndex.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/docsIndex.integration.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../helpers/workersAi.ts', async importOriginal => {
 
 const getPrisma = (await import('@classmoji/database')).default;
 const { DOCS_EXTRACT_VERSION, reconcileDocsIndex } = await import('../docsIndex.service.ts');
+const { DOCS_SEARCH_MIN_CHARS } = await import('../docsSearch.service.ts');
 const { EMBEDDING_MODEL, EMBEDDING_DIMENSIONS } = await import('../../helpers/workersAi.ts');
 
 afterAll(async () => {
@@ -301,6 +302,76 @@ describe.skipIf(!RUN)('docsIndex writes (real Postgres)', () => {
     // Freshness is read out of the real row, so this is the proof that the
     // stamp written and the stamp compared are the same three values.
     expect(await rows()).toEqual(first);
+  });
+
+  it('NAMES every page too short for search to reach, and only those', async () => {
+    // `searchDocs` filters chunks below `DOCS_SEARCH_MIN_CHARS`, which is how
+    // the two section-index pages stop crowding out the pages that answer. The
+    // cost is that a page which gets short by accident stops being findable
+    // with nothing anywhere saying so — so the reconcile names them.
+    const long = 'Tokens buy a student extra hours on a deadline. '.repeat(20);
+    const short = 'Roster. Grading. Tokens.';
+    expect(long.length).toBeGreaterThan(DOCS_SEARCH_MIN_CHARS);
+
+    const report = await reconcileDocsIndex({
+      reader: reader(
+        [blob('docs/instructors/index.mdx', 'aaa'), blob('docs/instructors/tokens.mdx', 'bbb')],
+        {
+          'docs/instructors/index.mdx': mdx('For instructors', short),
+          'docs/instructors/tokens.mdx': mdx('Add tokens', long),
+        }
+      ),
+    });
+
+    expect(report.indexed).toBe(2);
+    expect(report.belowSearchMin).toEqual(['docs/instructors']);
+  });
+
+  it('reads belowSearchMin from the TABLE, so a fully FRESH run still reports it', async () => {
+    // The trap: computing it from the chunks a run happened to build gives an
+    // empty list on every steady-state night, because a fresh page is never
+    // re-chunked. Those are exactly the runs somebody would be reading.
+    const same = () =>
+      reader([blob('docs/instructors/index.mdx', 'aaa')], {
+        'docs/instructors/index.mdx': mdx('For instructors', 'Roster. Grading.'),
+      });
+
+    const first = await reconcileDocsIndex({ reader: same() });
+    expect(first.indexed).toBe(1);
+    expect(first.belowSearchMin).toEqual(['docs/instructors']);
+
+    const second = await reconcileDocsIndex({ reader: same() });
+    expect(second.indexed).toBe(0);
+    expect(second.byReason.fresh).toBe(1);
+    expect(second.belowSearchMin).toEqual(['docs/instructors']);
+  });
+
+  it('does not name a page that has ONE long chunk among short ones', async () => {
+    // The filter is per CHUNK, so a page is only unsearchable when every chunk
+    // it has is below the line. `min(length(text))` here would report a page
+    // search can reach perfectly well, and the signal would be noise within a
+    // week.
+    // 200 tokens x 3 chars = a 600-character chunk budget, so a 590-character
+    // paragraph and an eleven-character tail land in different chunks.
+    const restore = withEnv('CLOUDFLARE_WORKERS_AI_EMBED_MAX_TOKENS', '200');
+    try {
+      const long = 'Tokens buy a student extra hours on a deadline. '.repeat(13).slice(0, 590);
+      const report = await reconcileDocsIndex({
+        reader: reader([blob('docs/a.mdx', 'aaa')], {
+          'docs/a.mdx': mdx('A', `${long}\n\nShort tail.`),
+        }),
+      });
+      expect(report.indexed).toBe(1);
+      const stored = await rows();
+      expect(stored.length).toBeGreaterThan(1);
+      expect(Math.min(...stored.map(row => row.text.length))).toBeLessThan(DOCS_SEARCH_MIN_CHARS);
+      expect(Math.max(...stored.map(row => row.text.length))).toBeGreaterThan(
+        DOCS_SEARCH_MIN_CHARS
+      );
+      expect(report.belowSearchMin).toEqual([]);
+    } finally {
+      restore();
+    }
   });
 
   it('finishes a half-written document rather than calling it fresh', async () => {

--- a/packages/services/src/classmoji/__tests__/docsIndex.test.ts
+++ b/packages/services/src/classmoji/__tests__/docsIndex.test.ts
@@ -1,0 +1,811 @@
+/**
+ * The docs reconcile, over a stubbed `DocsReader` and a recording Prisma.
+ *
+ * WHAT THIS FILE IS FOR
+ * ---------------------
+ * The reconcile's dangerous half is not "did it index a page" — it is what it
+ * does when the world answers wrongly. HTTP 200 with `truncated: true` is a
+ * 200. An empty tree is a 200. And the sweep is
+ * `DELETE … WHERE slug <> ALL($1)`, which on an empty array matches EVERY row.
+ * So most of what is below is about refusals: the tree shapes that must end the
+ * run with zero writes and zero deletes, and the per-page failures that must
+ * leave the last good rows alone.
+ *
+ * WHAT IS NOT PROVEN HERE, DELIBERATELY
+ * -------------------------------------
+ * A recording Prisma agrees with whatever SQL it is handed, so nothing in this
+ * file can show that a statement is CORRECT — only that it was or was not
+ * issued. Rollback, the shrink-tail delete and the sweep's semantics are pinned
+ * against a real Postgres in `docsIndex.integration.test.ts`, which runs on a
+ * disposable database built from the migrations.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── A recording Prisma ─────────────────────────────────────────────────────
+
+interface RecordedCall {
+  kind: 'queryRaw' | 'executeRaw';
+  sql: string;
+  params: unknown[];
+}
+
+const calls: RecordedCall[] = [];
+/** Rows the next `$queryRaw` should answer with, keyed by a fragment of the SQL. */
+let storedRows: Record<string, unknown[]> = {};
+let lockGranted = true;
+
+const sqlOf = (strings: TemplateStringsArray | { strings?: string[] }): string =>
+  Array.isArray(strings) ? strings.join('?') : String(strings);
+
+const record = (kind: RecordedCall['kind'], strings: TemplateStringsArray, params: unknown[]) => {
+  const sql = sqlOf(strings);
+  calls.push({ kind, sql, params });
+  return sql;
+};
+
+const prismaStub = {
+  $queryRaw: vi.fn((strings: TemplateStringsArray, ...params: unknown[]) => {
+    const sql = record('queryRaw', strings, params);
+    if (sql.includes('pg_try_advisory_lock')) {
+      return Promise.resolve([{ locked: lockGranted }]);
+    }
+    if (sql.includes('pg_advisory_unlock')) return Promise.resolve([{ unlocked: true }]);
+    if (sql.includes('FROM docs_index')) {
+      const slug = String(params[0]);
+      return Promise.resolve(storedRows[slug] ?? []);
+    }
+    return Promise.resolve([]);
+  }),
+  $executeRaw: vi.fn((strings: TemplateStringsArray, ...params: unknown[]) => {
+    record('executeRaw', strings, params);
+    return Promise.resolve(0);
+  }),
+  $transaction: vi.fn(async (run: (tx: unknown) => Promise<unknown>) => run(prismaStub)),
+};
+
+vi.mock('@classmoji/database', () => ({
+  default: () => prismaStub,
+  getPrisma: () => prismaStub,
+}));
+
+/**
+ * The lock's OWN connection.
+ *
+ * `pg_try_advisory_lock` is session-scoped and the shared client is a pool, so
+ * the service opens one dedicated `PrismaClient` for the lock and closes it
+ * when the run ends. These stubs stand in for that session, and count how many
+ * were opened and disconnected — which is how "the lock did not ride the pool"
+ * is asserted rather than assumed.
+ */
+const lockSessions: Array<{ disconnected: boolean }> = [];
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: class {
+    readonly handle = { disconnected: false };
+    constructor() {
+      lockSessions.push(this.handle);
+    }
+    $queryRaw(strings: TemplateStringsArray, ...params: unknown[]) {
+      const sql = record('queryRaw', strings, params);
+      if (sql.includes('pg_try_advisory_lock')) return Promise.resolve([{ locked: lockGranted }]);
+      return Promise.resolve([{ unlocked: true }]);
+    }
+    $disconnect() {
+      this.handle.disconnected = true;
+      return Promise.resolve();
+    }
+  },
+}));
+
+const embedTextsMock = vi.fn();
+const isConfiguredMock = vi.fn(() => true);
+
+vi.mock('../../helpers/workersAi.ts', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../helpers/workersAi.ts')>();
+  return {
+    ...actual,
+    isWorkersAiConfigured: () => isConfiguredMock(),
+    embedTexts: (...args: unknown[]) => embedTextsMock(...args),
+  };
+});
+
+const {
+  createGitHubDocsReader,
+  DOCS_EXTRACT_VERSION,
+  DOCS_INDEX_LOCK_KEY,
+  DocsBodyError,
+  reconcileDocsIndex,
+  sectionForPath,
+  slugForPath,
+} = await import('../docsIndex.service.ts');
+const { EMBEDDING_MODEL, EMBEDDING_DIMENSIONS } = await import('../../helpers/workersAi.ts');
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+/** The 25 real paths, relative to `apps/site/src/content/docs`. */
+const REAL_PATHS = [
+  'docs/index.mdx',
+  'docs/video-tutorials.mdx',
+  'docs/instructors/autograding.mdx',
+  'docs/instructors/class-sites.mdx',
+  'docs/instructors/create-classroom.mdx',
+  'docs/instructors/custom-domains.mdx',
+  'docs/instructors/grading.mdx',
+  'docs/instructors/import-github-classroom.mdx',
+  'docs/instructors/index.mdx',
+  'docs/instructors/mcp-server.mdx',
+  'docs/instructors/modules-and-assignments.mdx',
+  'docs/instructors/modules.mdx',
+  'docs/instructors/pages.mdx',
+  'docs/instructors/roster.mdx',
+  'docs/instructors/tokens.mdx',
+  'docs/introduction/fundamentals.mdx',
+  'docs/introduction/getting-started.mdx',
+  'docs/open-source/local-development/index.mdx',
+  'docs/self-hosting/docker.mdx',
+  'docs/self-hosting/environment-variables.mdx',
+  'docs/students/index.mdx',
+  'docs/students/join-a-classroom.mdx',
+  'docs/students/submit-assignments.mdx',
+  'docs/students/use-tokens.mdx',
+  'docs/students/view-grades.mdx',
+] as const;
+
+const COMMIT = 'c'.repeat(40);
+const shaFor = (path: string): string =>
+  path
+    .split('')
+    .reduce((acc, ch) => (acc * 31 + ch.charCodeAt(0)) % 0xffffffff, 7)
+    .toString(16)
+    .padStart(40, '0')
+    .slice(0, 40);
+
+const blob = (path: string, sha = shaFor(path)) => ({ path, type: 'blob', sha });
+
+const mdxFor = (title: string, body = 'Some prose about the thing.'): string =>
+  `---\ntitle: ${title}\ndescription: A page\n---\n\n${body}\n`;
+
+interface StubOptions {
+  entries?: unknown[];
+  truncated?: boolean;
+  headThrows?: boolean;
+  treeThrows?: boolean;
+  bodies?: Record<string, string | null | Error>;
+}
+
+const bodyCalls: string[] = [];
+
+function stubReader(options: StubOptions = {}) {
+  return {
+    head: async () => {
+      if (options.headThrows) throw new Error('head unavailable');
+      return COMMIT;
+    },
+    tree: async () => {
+      if (options.treeThrows) throw new Error('tree unavailable');
+      return {
+        entries: (options.entries ?? REAL_PATHS.map(path => blob(path))) as never,
+        truncated: options.truncated ?? false,
+      };
+    },
+    body: async (_commit: string, relPath: string) => {
+      bodyCalls.push(relPath);
+      const configured = options.bodies?.[relPath];
+      if (configured instanceof Error) throw configured;
+      if (configured === null) return null;
+      return configured ?? mdxFor(`Page ${relPath}`);
+    },
+  };
+}
+
+/** A stored row that looks exactly as fresh as the tree says it should. */
+const freshRows = (path: string, chunkCount = 1) =>
+  Array.from({ length: chunkCount }, (_, chunk_ix) => ({
+    chunk_ix,
+    chunk_count: chunkCount,
+    source_sha: shaFor(path),
+    extract_version: DOCS_EXTRACT_VERSION,
+    embed_model: EMBEDDING_MODEL,
+    embedding_null: false,
+  }));
+
+const vector = (): number[] => Array.from({ length: EMBEDDING_DIMENSIONS }, () => 0.1);
+
+const inserts = () => calls.filter(call => call.sql.includes('INSERT INTO docs_index'));
+const sweeps = () => calls.filter(call => call.sql.includes('slug <> ALL'));
+const shrinkDeletes = () => calls.filter(call => call.sql.includes('chunk_ix >='));
+
+beforeEach(() => {
+  calls.length = 0;
+  bodyCalls.length = 0;
+  lockSessions.length = 0;
+  storedRows = {};
+  lockGranted = true;
+  isConfiguredMock.mockReturnValue(true);
+  embedTextsMock.mockReset();
+  embedTextsMock.mockImplementation(async (texts: string[]) => ({
+    ok: true,
+    vectors: texts.map(() => vector()),
+  }));
+  prismaStub.$queryRaw.mockClear();
+  prismaStub.$executeRaw.mockClear();
+});
+
+// ─── Slugs ──────────────────────────────────────────────────────────────────
+
+describe('the slug IS the URL path', () => {
+  it.each([
+    ['docs/index.mdx', 'docs', null],
+    ['docs/video-tutorials.mdx', 'docs/video-tutorials', null],
+    ['docs/instructors/roster.mdx', 'docs/instructors/roster', 'instructors'],
+    ['docs/instructors/index.mdx', 'docs/instructors', 'instructors'],
+    ['docs/students/view-grades.mdx', 'docs/students/view-grades', 'students'],
+    ['docs/self-hosting/docker.mdx', 'docs/self-hosting/docker', 'self-hosting'],
+    [
+      'docs/open-source/local-development/index.mdx',
+      'docs/open-source/local-development',
+      'open-source',
+    ],
+    ['docs/introduction/fundamentals.mdx', 'docs/introduction/fundamentals', 'introduction'],
+  ])('%s → %s (section %s)', (path, slug, section) => {
+    expect(slugForPath(path)).toBe(slug);
+    expect(sectionForPath(path)).toBe(section);
+  });
+
+  it('produces 25 distinct slugs for the 25 real paths', () => {
+    const slugs = REAL_PATHS.map(slugForPath);
+    expect(new Set(slugs).size).toBe(25);
+    // The two most easily confused: a directory index and a sibling page.
+    expect(slugs).toContain('docs/instructors');
+    expect(slugs).toContain('docs/instructors/roster');
+  });
+});
+
+// ─── Freshness ──────────────────────────────────────────────────────────────
+
+describe('an unchanged corpus costs nothing', () => {
+  it('fetches NO bodies when every sha already matches', async () => {
+    for (const path of REAL_PATHS) storedRows[slugForPath(path)] = freshRows(path);
+
+    const report = await reconcileDocsIndex({ reader: stubReader() });
+
+    expect(report.error).toBeUndefined();
+    expect(report.halted).toBeUndefined();
+    expect(report.eligible).toBe(25);
+    expect(report.indexed).toBe(0);
+    expect(report.skipped).toBe(25);
+    expect(report.byReason.fresh).toBe(25);
+    // The whole point of reading the sha out of the tree: an unchanged page
+    // never has its body fetched, so a nightly run is two REST calls.
+    expect(bodyCalls).toHaveLength(0);
+    expect(embedTextsMock).not.toHaveBeenCalled();
+    expect(inserts()).toHaveLength(0);
+  });
+
+  it('re-indexes exactly the one page whose sha moved', async () => {
+    for (const path of REAL_PATHS) storedRows[slugForPath(path)] = freshRows(path);
+    storedRows['docs/instructors/roster'] = freshRows('docs/instructors/roster').map(row => ({
+      ...row,
+      source_sha: 'd'.repeat(40),
+    }));
+
+    const report = await reconcileDocsIndex({ reader: stubReader() });
+
+    expect(report.indexed).toBe(1);
+    expect(report.skipped).toBe(24);
+    expect(bodyCalls).toEqual(['docs/instructors/roster.mdx']);
+    expect(embedTextsMock).toHaveBeenCalledTimes(1);
+    expect(report.bySlug.find(row => row.slug === 'docs/instructors/roster')).toMatchObject({
+      outcome: 'indexed',
+      chunks: 1,
+    });
+  });
+
+  it('re-indexes EVERYTHING when the extractor version moves, shas unchanged', async () => {
+    // The recovery path for an extractor bug: bump the constant, and the next
+    // run rebuilds the corpus without anybody touching a sha.
+    for (const path of REAL_PATHS) {
+      storedRows[slugForPath(path)] = freshRows(path).map(row => ({
+        ...row,
+        extract_version: DOCS_EXTRACT_VERSION - 1,
+      }));
+    }
+
+    const report = await reconcileDocsIndex({ reader: stubReader() });
+
+    expect(report.indexed).toBe(25);
+    expect(report.skipped).toBe(0);
+    expect(bodyCalls).toHaveLength(25);
+  });
+
+  it('re-indexes when the embedding model moves', async () => {
+    for (const path of REAL_PATHS) {
+      storedRows[slugForPath(path)] = freshRows(path).map(row => ({
+        ...row,
+        embed_model: '@cf/some/other-model',
+      }));
+    }
+    const report = await reconcileDocsIndex({ reader: stubReader() });
+    expect(report.indexed).toBe(25);
+  });
+});
+
+// ─── Tree validation: the branches that must not delete ─────────────────────
+
+describe('a tree it cannot trust ends the run with NO writes and NO deletes', () => {
+  const expectRefused = (report: Awaited<ReturnType<typeof reconcileDocsIndex>>, why: string) => {
+    expect(report.halted).toBe('tree_invalid');
+    expect(report.error).toBe(why);
+    expect(report.indexed).toBe(0);
+    expect(inserts()).toHaveLength(0);
+    // THE assertion. `slug <> ALL('{}'::text[])` matches every row, so a sweep
+    // issued on a tree we could not validate empties the corpus.
+    expect(sweeps()).toHaveLength(0);
+    expect(shrinkDeletes()).toHaveLength(0);
+  };
+
+  it('refuses a TRUNCATED tree — which arrives as an HTTP 200', async () => {
+    const report = await reconcileDocsIndex({ reader: stubReader({ truncated: true }) });
+    expectRefused(report, 'tree_truncated');
+  });
+
+  it('treats a missing `truncated` field as truncated, not as complete', async () => {
+    const reader = stubReader();
+    reader.tree = async () => ({
+      entries: REAL_PATHS.map(p => blob(p)) as never,
+      truncated: undefined as never,
+    });
+    const report = await reconcileDocsIndex({ reader });
+    expectRefused(report, 'tree_truncated');
+  });
+
+  it('refuses an EMPTY tree rather than reading it as "delete everything"', async () => {
+    const report = await reconcileDocsIndex({ reader: stubReader({ entries: [] }) });
+    expectRefused(report, 'tree_empty');
+  });
+
+  it('refuses a tree with no .mdx in it at all', async () => {
+    const report = await reconcileDocsIndex({
+      reader: stubReader({
+        entries: [
+          blob('docs/img-students.png'),
+          { path: 'docs', type: 'tree', sha: shaFor('docs') },
+        ],
+      }),
+    });
+    expectRefused(report, 'tree_empty');
+  });
+
+  it('refuses two entries that normalize to the SAME slug', async () => {
+    // `docs/foo.mdx` and `docs/foo/index.mdx` are both `docs/foo`, and whichever
+    // wrote last would decide what that page says.
+    const report = await reconcileDocsIndex({
+      reader: stubReader({ entries: [blob('docs/foo.mdx'), blob('docs/foo/index.mdx')] }),
+    });
+    expectRefused(report, 'tree_duplicate_slug');
+  });
+
+  it('refuses an entry with a malformed sha', async () => {
+    const report = await reconcileDocsIndex({
+      reader: stubReader({ entries: [blob('docs/a.mdx', 'not-a-sha')] }),
+    });
+    expectRefused(report, 'tree_malformed');
+  });
+
+  it('refuses an entry that is not an object at all', async () => {
+    const report = await reconcileDocsIndex({ reader: stubReader({ entries: ['docs/a.mdx'] }) });
+    expectRefused(report, 'tree_malformed');
+  });
+
+  it('refuses a path that tries to escape the collection root', async () => {
+    for (const path of ['../../../etc/passwd.mdx', '/etc/passwd.mdx', 'docs/../../secret.mdx']) {
+      calls.length = 0;
+      const report = await reconcileDocsIndex({ reader: stubReader({ entries: [blob(path)] }) });
+      expectRefused(report, 'tree_unsafe_path');
+    }
+  });
+
+  it('ignores the .png files and directories beside the pages', async () => {
+    const report = await reconcileDocsIndex({
+      reader: stubReader({
+        entries: [
+          blob('docs/index.mdx'),
+          blob('docs/img-students.png'),
+          { path: 'docs/instructors', type: 'tree', sha: shaFor('docs/instructors') },
+        ],
+      }),
+    });
+    expect(report.halted).toBeUndefined();
+    expect(report.pages).toBe(3);
+    expect(report.eligible).toBe(1);
+  });
+});
+
+describe('a GitHub read that fails abandons the run whole', () => {
+  it('reports tree_unavailable and deletes nothing when head() throws', async () => {
+    const report = await reconcileDocsIndex({ reader: stubReader({ headThrows: true }) });
+    expect(report.halted).toBe('tree_unavailable');
+    expect(report.error).toContain('head unavailable');
+    expect(report.commit).toBeNull();
+    expect(sweeps()).toHaveLength(0);
+  });
+
+  it('reports tree_unavailable and deletes nothing when tree() throws', async () => {
+    const report = await reconcileDocsIndex({ reader: stubReader({ treeThrows: true }) });
+    expect(report.halted).toBe('tree_unavailable');
+    expect(sweeps()).toHaveLength(0);
+    expect(inserts()).toHaveLength(0);
+  });
+});
+
+// ─── Per-page failures keep the last good rows ──────────────────────────────
+
+describe('a page that fails keeps whatever it already had', () => {
+  const twoPages = [blob('docs/index.mdx'), blob('docs/instructors/roster.mdx')];
+
+  it('classifies a 404 body as http_404 and still indexes the others', async () => {
+    const report = await reconcileDocsIndex({
+      reader: stubReader({ entries: twoPages, bodies: { 'docs/instructors/roster.mdx': null } }),
+    });
+
+    expect(report.indexed).toBe(1);
+    expect(report.failed).toBe(1);
+    expect(report.byReason.http_404).toBe(1);
+    expect(report.bySlug.find(r => r.slug === 'docs/instructors/roster')).toMatchObject({
+      outcome: 'failed',
+      reason: 'http_404',
+    });
+    // No row for the failed page was written, and none was removed.
+    expect(inserts()).toHaveLength(1);
+    expect(shrinkDeletes()).toHaveLength(1);
+  });
+
+  it('classifies a rate-limited body read, and keeps going', async () => {
+    const report = await reconcileDocsIndex({
+      reader: stubReader({
+        entries: twoPages,
+        bodies: { 'docs/index.mdx': new DocsBodyError('rate_limited') },
+      }),
+    });
+    expect(report.byReason.rate_limited).toBe(1);
+    expect(report.indexed).toBe(1);
+  });
+
+  it('classifies a timeout', async () => {
+    const report = await reconcileDocsIndex({
+      reader: stubReader({
+        entries: twoPages,
+        bodies: { 'docs/index.mdx': new DocsBodyError('timeout') },
+      }),
+    });
+    expect(report.byReason.timeout).toBe(1);
+  });
+
+  it('writes NOTHING for a page the extractor refuses', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const report = await reconcileDocsIndex({
+      reader: stubReader({
+        entries: twoPages,
+        // No frontmatter: the extractor refuses, and the last good rows stay.
+        bodies: { 'docs/index.mdx': 'Just prose, no frontmatter.\n' },
+      }),
+    });
+    warn.mockRestore();
+
+    expect(report.byReason.extract).toBe(1);
+    expect(report.failed).toBe(1);
+    const written = inserts().map(call => call.params[0]);
+    expect(written).toEqual(['docs/instructors/roster']);
+    // Not even the shrink delete: a failed extract must not touch the page.
+    expect(shrinkDeletes().map(call => call.params[0])).toEqual(['docs/instructors/roster']);
+  });
+
+  it('counts an embedding refusal without writing a partial page', async () => {
+    embedTextsMock.mockResolvedValue({
+      ok: false,
+      reason: 'over_cap',
+      estimatedTokens: 1,
+      limit: 1,
+      index: 0,
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const report = await reconcileDocsIndex({ reader: stubReader({ entries: twoPages }) });
+    warn.mockRestore();
+
+    expect(report.failed).toBe(2);
+    expect(report.byReason.over_cap).toBe(2);
+    expect(inserts()).toHaveLength(0);
+  });
+});
+
+// ─── The sweep ──────────────────────────────────────────────────────────────
+
+describe('the sweep', () => {
+  it('runs once, last, with the run’s slugs as a BOUND array', async () => {
+    for (const path of REAL_PATHS) storedRows[slugForPath(path)] = freshRows(path);
+    await reconcileDocsIndex({ reader: stubReader() });
+
+    const sweep = sweeps();
+    expect(sweep).toHaveLength(1);
+    expect(sweep[0].sql).toContain('::text[]');
+    const bound = sweep[0].params[0] as string[];
+    expect(Array.isArray(bound)).toBe(true);
+    expect(bound).toHaveLength(25);
+    expect(bound).toContain('docs/instructors/roster');
+    // Last statement of the run: sweeping before the writes would delete a page
+    // that this very run is about to re-create.
+    expect(calls.at(-2)?.sql).toContain('slug <> ALL');
+  });
+});
+
+// ─── Serialization ──────────────────────────────────────────────────────────
+
+describe('serialization', () => {
+  it('does NOTHING at all when the advisory lock is already held', async () => {
+    lockGranted = false;
+    const reader = stubReader();
+    const headSpy = vi.spyOn(reader, 'head');
+
+    const report = await reconcileDocsIndex({ reader });
+
+    expect(report.halted).toBe('lock_held');
+    expect(report.commit).toBeNull();
+    // The lock is taken BEFORE the commit is resolved: taking it afterwards
+    // still lets two runs pin different commits and then serialize their
+    // sweeps, which is the interleaving that deletes a live page.
+    expect(headSpy).not.toHaveBeenCalled();
+    expect(inserts()).toHaveLength(0);
+    expect(sweeps()).toHaveLength(0);
+  });
+
+  it('takes and releases the lock on the key both callers use', async () => {
+    for (const path of REAL_PATHS) storedRows[slugForPath(path)] = freshRows(path);
+    await reconcileDocsIndex({ reader: stubReader() });
+
+    const take = calls.find(call => call.sql.includes('pg_try_advisory_lock'));
+    const release = calls.find(call => call.sql.includes('pg_advisory_unlock'));
+    expect(take?.params[0]).toBe(DOCS_INDEX_LOCK_KEY);
+    expect(release?.params[0]).toBe(DOCS_INDEX_LOCK_KEY);
+  });
+
+  it('releases the lock even when the run refuses the tree', async () => {
+    await reconcileDocsIndex({ reader: stubReader({ truncated: true }) });
+    expect(calls.some(call => call.sql.includes('pg_advisory_unlock'))).toBe(true);
+  });
+
+  it('holds the lock on its OWN connection, and closes it when the run ends', async () => {
+    // `pg_try_advisory_lock` is SESSION-scoped and the shared client is a POOL:
+    // a lock taken on one pooled connection and unlocked on another leaks, the
+    // unlock silently returns false, and every later run lands on a different
+    // connection and is refused with `lock_held`. The job then serializes
+    // against ITSELF and quietly stops indexing. One dedicated session is what
+    // makes the lock mean what it says.
+    for (const path of REAL_PATHS) storedRows[slugForPath(path)] = freshRows(path);
+    await reconcileDocsIndex({ reader: stubReader() });
+
+    expect(lockSessions).toHaveLength(1);
+    expect(lockSessions[0].disconnected).toBe(true);
+    // And the pooled client was never asked to take or release it.
+    expect(
+      prismaStub.$queryRaw.mock.calls.some(call =>
+        String(Array.isArray(call[0]) ? call[0].join('') : '').includes('advisory')
+      )
+    ).toBe(false);
+  });
+
+  it('closes the lock connection even when the lock was NOT granted', async () => {
+    lockGranted = false;
+    await reconcileDocsIndex({ reader: stubReader() });
+    expect(lockSessions).toHaveLength(1);
+    expect(lockSessions[0].disconnected).toBe(true);
+  });
+});
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+describe('an unconfigured deployment writes nothing and takes no lock', () => {
+  it('halts before any database work', async () => {
+    isConfiguredMock.mockReturnValue(false);
+    const reader = stubReader();
+    const headSpy = vi.spyOn(reader, 'head');
+
+    const report = await reconcileDocsIndex({ reader });
+
+    expect(report.halted).toBe('not_configured');
+    expect(report.error).toBeUndefined();
+    expect(calls).toHaveLength(0);
+    expect(headSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── The report ─────────────────────────────────────────────────────────────
+
+describe('the report is the readiness signal', () => {
+  it('names the commit everything was read at', async () => {
+    for (const path of REAL_PATHS) storedRows[slugForPath(path)] = freshRows(path);
+    const report = await reconcileDocsIndex({ reader: stubReader() });
+    expect(report.commit).toBe(COMMIT);
+  });
+
+  it('carries one row per eligible page, with its outcome', async () => {
+    const report = await reconcileDocsIndex({ reader: stubReader() });
+    expect(report.bySlug).toHaveLength(25);
+    expect(new Set(report.bySlug.map(row => row.slug)).size).toBe(25);
+    expect(report.indexed + report.skipped + report.failed).toBe(25);
+  });
+});
+
+// ─── isFresh, the shared rule ───────────────────────────────────────────────
+
+describe('isFresh rejects an EXTRA chunk, not just a missing one', () => {
+  it('is stale when a leftover tail sits beside a one-chunk document', async () => {
+    const { isFresh } = await import('../contentIndex.service.ts');
+    const stamp = { sourceSha: 'a'.repeat(40), extractVersion: 1, embedModel: 'm' };
+    const row = (chunk_ix: number) => ({
+      chunk_ix,
+      chunk_count: 1,
+      source_sha: stamp.sourceSha,
+      extract_version: 1,
+      embed_model: 'm',
+      embedding_null: false,
+    });
+
+    // Both rows declare `chunk_count: 1`, every index in 0..0 is present, and
+    // every stamp matches — yet chunk 1 is a stale leftover still answering
+    // out of the previous version's text.
+    expect(isFresh([row(0), row(1)], stamp)).toBe(false);
+    expect(isFresh([row(0)], stamp)).toBe(true);
+  });
+
+  it('is still stale for the cases it already caught', async () => {
+    const { isFresh } = await import('../contentIndex.service.ts');
+    const stamp = { sourceSha: 'a'.repeat(40), extractVersion: 1, embedModel: 'm' };
+    const base = {
+      chunk_count: 2,
+      source_sha: stamp.sourceSha,
+      extract_version: 1,
+      embed_model: 'm',
+      embedding_null: false,
+    };
+    expect(isFresh([], stamp)).toBe(false);
+    expect(isFresh([{ ...base, chunk_ix: 0 }], stamp)).toBe(false); // chunk 1 missing
+    expect(
+      isFresh(
+        [
+          { ...base, chunk_ix: 0 },
+          { ...base, chunk_ix: 1, embedding_null: true },
+        ],
+        stamp
+      )
+    ).toBe(false);
+    expect(
+      isFresh(
+        [
+          { ...base, chunk_ix: 0 },
+          { ...base, chunk_ix: 1 },
+        ],
+        stamp
+      )
+    ).toBe(true);
+  });
+});
+
+// ─── The GitHub reader ──────────────────────────────────────────────────────
+
+/**
+ * The default reader, against a STUBBED `fetch`.
+ *
+ * Never the network. These assertions are about what the reader does with an
+ * answer — a truncated tree, a 429 carrying a `Retry-After`, a 404 — and a test
+ * that depended on github.com being reachable would be a test that goes red for
+ * reasons that have nothing to do with this code.
+ */
+describe('createGitHubDocsReader', () => {
+  const realFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const jsonResponse = (body: unknown, init: ResponseInit = {}): Response =>
+    new Response(JSON.stringify(body), { status: 200, ...init });
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.useRealTimers();
+  });
+
+  it('resolves the head commit and pins everything else to it', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sha: COMMIT }));
+    const reader = createGitHubDocsReader();
+    await expect(reader.head()).resolves.toBe(COMMIT);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://api.github.com/repos/classmoji/classmoji/commits/main'
+    );
+  });
+
+  it('refuses a head response with no usable sha rather than inventing one', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sha: 'not-a-sha' }));
+    await expect(createGitHubDocsReader().head()).rejects.toThrow(/no sha/);
+  });
+
+  it('asks for the tree AT THE COMMIT, rooted at the docs directory', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ tree: [blob('docs/index.mdx')], truncated: false })
+    );
+    const result = await createGitHubDocsReader().tree(COMMIT);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain(`/git/trees/${COMMIT}:`);
+    expect(url).toContain(encodeURIComponent('apps/site/src/content/docs'));
+    expect(url).toContain('recursive=1');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('reports a tree whose `truncated` is anything but false AS truncated', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ tree: [] }));
+    await expect(createGitHubDocsReader().tree(COMMIT)).resolves.toMatchObject({
+      truncated: true,
+    });
+  });
+
+  it('reads a body from raw.githubusercontent AT THE COMMIT, never from a branch', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('body', { status: 200 }));
+    await createGitHubDocsReader().body(COMMIT, 'docs/instructors/roster.mdx');
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      `https://raw.githubusercontent.com/classmoji/classmoji/${COMMIT}/apps/site/src/content/docs/docs/instructors/roster.mdx`
+    );
+  });
+
+  it('turns a 404 body into null, which the reconcile counts as http_404', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 404 }));
+    await expect(createGitHubDocsReader().body(COMMIT, 'docs/gone.mdx')).resolves.toBeNull();
+    // ONE call: a 404 is an answer, not a fault, and retrying it wastes budget.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies a rate-limited body read so the report can name it', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 429, headers: { 'retry-after': '0' } }));
+    await expect(createGitHubDocsReader().body(COMMIT, 'docs/a.mdx')).rejects.toMatchObject({
+      reason: 'rate_limited',
+    });
+  });
+
+  it('HONOURS Retry-After rather than retrying straight away', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 429, headers: { 'retry-after': '5' } }))
+      .mockResolvedValueOnce(jsonResponse({ sha: COMMIT }));
+
+    const pending = createGitHubDocsReader().head();
+    // Let the first attempt settle, then check nothing has been retried yet.
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(pending).resolves.toBe(COMMIT);
+  });
+
+  it('gives up after a bounded number of attempts rather than looping', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(new Response('', { status: 500 }));
+
+    // The rejection handler is attached BEFORE the timers advance, so the
+    // rejection is never momentarily unhandled.
+    const pending = expect(createGitHubDocsReader().head()).rejects.toThrow(/HTTP 500/);
+    await vi.advanceTimersByTimeAsync(120_000);
+    await pending;
+    // `trigger.config.js` sets maxAttempts: 1, so these in-run retries are the
+    // only retries there are — and they must still terminate.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a non-retryable status', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 401 }));
+    await expect(createGitHubDocsReader().head()).rejects.toThrow(/HTTP 401/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/docsIndex.test.ts
+++ b/packages/services/src/classmoji/__tests__/docsIndex.test.ts
@@ -533,9 +533,22 @@ describe('the sweep', () => {
     expect(Array.isArray(bound)).toBe(true);
     expect(bound).toHaveLength(25);
     expect(bound).toContain('docs/instructors/roster');
-    // Last statement of the run: sweeping before the writes would delete a page
+    // LAST WRITE of the run: sweeping before the writes would delete a page
     // that this very run is about to re-create.
-    expect(calls.at(-2)?.sql).toContain('slug <> ALL');
+    //
+    // Asserted as "nothing after it writes", not as an offset from the end of
+    // `calls`. `calls.at(-2)` said the same thing right up until the run grew a
+    // read after the sweep (`belowSearchMin`), at which point it was an
+    // assertion about the advisory unlock and nobody would have known.
+    const sweepAt = calls.findIndex(call => call.sql.includes('slug <> ALL'));
+    expect(sweepAt).toBeGreaterThanOrEqual(0);
+    const after = calls.slice(sweepAt + 1).map(call => call.sql);
+    expect(after.some(sql => /INSERT INTO|DELETE FROM|UPDATE /.test(sql))).toBe(false);
+    // And what IS allowed to follow it: the short-page report, then the unlock.
+    expect(after.map(sql => sql.replace(/\s+/g, ' ').trim().slice(0, 24))).toEqual([
+      'SELECT slug FROM docs_in',
+      'SELECT pg_advisory_unloc',
+    ]);
   });
 });
 

--- a/packages/services/src/classmoji/__tests__/docsSearch.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/docsSearch.integration.test.ts
@@ -1,0 +1,447 @@
+/**
+ * The docs read statements, against a real Postgres.
+ *
+ * ── Why these CANNOT be unit tests ─────────────────────────────────────────
+ * Everything worth asserting about them is SQL semantics:
+ *
+ *   - `DISTINCT ON (slug)` picking each page's BEST chunk before the limit;
+ *   - pgvector's `<=>` actually ordering the way the statement claims;
+ *   - `string_agg(… ORDER BY chunk_ix)` reassembling a page in reading order;
+ *   - `NOT EXISTS (… WHERE embedding IS NOT NULL)` returning a boolean rather
+ *     than a row count;
+ *   - `limit + 1` / `truncated` / `nextOffset` paging over a total order.
+ *
+ * A fake Prisma agrees with all of those whatever the statement says.
+ *
+ * ── Why a DISPOSABLE database ──────────────────────────────────────────────
+ * `docs_index` is GLOBAL — no classroom column, so no namespace to hide
+ * fixtures behind. Ranking, pagination and "is the index empty" are all
+ * statements over the WHOLE table, and a developer's real docs rows would sit
+ * between the fixtures and change every answer. See `helpers/docsTestDatabase`.
+ *
+ * Opted in with `DOCS_INDEX_INTEGRATION=1`; when opted in it FAILS rather than
+ * skipping if the database is unreachable.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  createDocsTestDatabase,
+  docsDbOptedIn,
+  type DisposableDatabase,
+} from './helpers/docsTestDatabase.ts';
+
+const RUN = docsDbOptedIn();
+
+let database: DisposableDatabase | null = null;
+if (RUN) {
+  database = await createDocsTestDatabase();
+  process.env.DATABASE_URL = database.url;
+}
+
+const getPrisma = (await import('@classmoji/database')).default;
+const { toVectorLiteral } = await import('../contentSearch.service.ts');
+const { DocsNotFoundError, docsIndexIsEmpty, getDocText, listDocs, searchDocs } =
+  await import('../docsSearch.service.ts');
+const { EMBEDDING_DIMENSIONS } = await import('../../helpers/workersAi.ts');
+
+afterAll(async () => {
+  if (!RUN) return;
+  await getPrisma().$disconnect();
+  await database?.drop();
+});
+
+// ─── Deterministic vectors ──────────────────────────────────────────────────
+
+/**
+ * The i-th unit basis vector.
+ *
+ * Cosine distance from one basis vector to the same one is 0 and to any other
+ * is exactly 1, so the ranking a search returns is decided entirely by which
+ * basis vector each fixture carries — nothing depends on an embedding model's
+ * judgement, or on it being reachable.
+ */
+const basis = (index: number): number[] => {
+  const vector = new Array<number>(EMBEDDING_DIMENSIONS).fill(0);
+  vector[index] = 1;
+  return vector;
+};
+
+/**
+ * A vector between two bases, closer to `near` than a pure `far` basis is.
+ *
+ * Used for the "a LATER chunk is strictly better" case: an equal-distance later
+ * chunk would let a `DISTINCT ON` that simply took the first chunk pass.
+ */
+const between = (near: number, weight: number): number[] => {
+  const vector = new Array<number>(EMBEDDING_DIMENSIONS).fill(0);
+  vector[near] = weight;
+  vector[EMBEDDING_DIMENSIONS - 1] = Math.sqrt(1 - weight * weight);
+  return vector;
+};
+
+interface Seed {
+  slug: string;
+  chunkIx: number;
+  chunkCount: number;
+  title: string;
+  description?: string | null;
+  section?: string | null;
+  text: string;
+  vector: number[] | null;
+}
+
+const insert = async (seed: Seed): Promise<void> => {
+  const literal = seed.vector === null ? null : toVectorLiteral(seed.vector);
+  await getPrisma().$executeRaw`
+    INSERT INTO docs_index
+      (slug, chunk_ix, chunk_count, title, description, section, text,
+       source_sha, extract_version, embed_model, embedding, updated_at)
+    VALUES
+      (${seed.slug}, ${seed.chunkIx}::int, ${seed.chunkCount}::int, ${seed.title},
+       ${seed.description ?? null}, ${seed.section ?? null}, ${seed.text},
+       ${'a'.repeat(40)}, 1, ${'@cf/qwen/qwen3-embedding-0.6b'},
+       ${literal}::vector, NOW())`;
+};
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const ROSTER = 'docs/instructors/roster';
+const GRADING = 'docs/instructors/grading';
+const TOKENS = 'docs/students/use-tokens';
+const ROOT = 'docs';
+const NO_VECTOR = 'docs/self-hosting/docker';
+/**
+ * Long, and named so its TITLE sorts first in its section while its SLUG sorts
+ * last. Two contracts ride on that: the snippet is bounded rather than the
+ * whole chunk, and `listDocs` orders by title rather than inheriting the inner
+ * query's slug order.
+ */
+const LONG = 'docs/instructors/tokens';
+const LONG_TEXT = `Add tokens to a class. ${'Tokens buy a student extra hours on a deadline. '.repeat(40)}`;
+
+beforeAll(async () => {
+  if (!RUN) return;
+
+  await insert({
+    slug: ROSTER,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'Manage your roster',
+    description: 'How to add students and teaching staff',
+    section: 'instructors',
+    text: 'Go to the Teaching Staff tab and click New staff member.',
+    vector: basis(0),
+  });
+
+  // THREE chunks, and the BEST one is chunk 2 — strictly better than chunk 0,
+  // not merely equal. An equal-distance later chunk would let a statement that
+  // took the first chunk of each page pass by accident.
+  await insert({
+    slug: GRADING,
+    chunkIx: 0,
+    chunkCount: 3,
+    title: 'Grading',
+    section: 'instructors',
+    text: 'GRADING-CHUNK-ZERO emoji mappings.',
+    vector: between(1, 0.2),
+  });
+  await insert({
+    slug: GRADING,
+    chunkIx: 2,
+    chunkCount: 3,
+    title: 'Grading',
+    section: 'instructors',
+    text: 'GRADING-CHUNK-TWO releasing grades.',
+    vector: basis(1),
+  });
+  // Deliberately inserted OUT OF ORDER, after chunk 2, so `getDocText` has to
+  // do the ordering rather than inherit the insertion order.
+  await insert({
+    slug: GRADING,
+    chunkIx: 1,
+    chunkCount: 3,
+    title: 'Grading',
+    section: 'instructors',
+    text: 'GRADING-CHUNK-ONE grading an assignment.',
+    vector: between(1, 0.1),
+  });
+
+  await insert({
+    slug: TOKENS,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'Use tokens',
+    section: 'students',
+    text: 'Spend a token to extend a deadline.',
+    vector: basis(2),
+  });
+
+  await insert({
+    slug: ROOT,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'Welcome to Classmoji Docs',
+    section: null,
+    text: 'Classmoji is a Git-native platform for CS courses.',
+    vector: basis(3),
+  });
+
+  await insert({
+    slug: LONG,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'Add tokens to a class',
+    section: 'instructors',
+    text: LONG_TEXT,
+    vector: basis(6),
+  });
+
+  // A row with NO vector: written, but unsearchable.
+  await insert({
+    slug: NO_VECTOR,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'Docker',
+    section: 'self-hosting',
+    text: 'UNEMBEDDED-SENTINEL run it with docker compose.',
+    vector: null,
+  });
+});
+
+const slugsOf = (hits: Array<{ slug: string }>): string[] => hits.map(hit => hit.slug);
+
+describe.skipIf(!RUN)('searchDocs', () => {
+  it('ranks by cosine distance, nearest first', async () => {
+    const hits = await searchDocs({ queryVector: basis(0), limit: 20 });
+    expect(slugsOf(hits)[0]).toBe(ROSTER);
+    expect(hits[0].score).toBeCloseTo(1, 5);
+    expect(hits[0].title).toBe('Manage your roster');
+    expect(hits[0].section).toBe('instructors');
+    expect(hits[0].description).toBe('How to add students and teaching staff');
+  });
+
+  it('returns a page ONCE, on its BEST chunk — not its first', async () => {
+    const hits = await searchDocs({ queryVector: basis(1), limit: 20 });
+    const grading = hits.filter(hit => hit.slug === GRADING);
+
+    expect(grading).toHaveLength(1);
+    // Chunk 2 is strictly nearer than chunks 0 and 1, so a statement that
+    // collapsed to the first chunk would answer with the wrong text here.
+    expect(grading[0].chunkIx).toBe(2);
+    expect(grading[0].snippet).toContain('GRADING-CHUNK-TWO');
+    expect(slugsOf(hits)[0]).toBe(GRADING);
+  });
+
+  it('EXCLUDES a row with no vector, at a limit wide enough to have included it', async () => {
+    // The limit matters: at limit 5 a removed `embedding IS NOT NULL` filter
+    // could be masked by the cap. 20 is wider than the whole fixture corpus.
+    const hits = await searchDocs({ queryVector: basis(0), limit: 20 });
+    expect(slugsOf(hits)).not.toContain(NO_VECTOR);
+    expect(JSON.stringify(hits)).not.toContain('UNEMBEDDED-SENTINEL');
+    // Every embedded page came back, so the exclusion is the filter and not the
+    // limit.
+    expect(new Set(slugsOf(hits))).toEqual(new Set([ROSTER, GRADING, TOKENS, ROOT, LONG]));
+  });
+
+  it('de-dupes BEFORE the limit, so a chunked page cannot crowd the results out', async () => {
+    // Grading alone has three rows. A `LIMIT 3` applied before the collapse
+    // would return three copies of it and nothing else.
+    const hits = await searchDocs({ queryVector: basis(1), limit: 3 });
+    expect(hits).toHaveLength(3);
+    expect(new Set(slugsOf(hits)).size).toBe(3);
+    expect(slugsOf(hits)[0]).toBe(GRADING);
+  });
+
+  it('bounds the snippet rather than returning the whole chunk', async () => {
+    // The fixture is deliberately far longer than the budget: with a short one,
+    // `LEFT(text, 400)` and `text` are the same string and the cap is untested.
+    expect(LONG_TEXT.length).toBeGreaterThan(1000);
+    const hits = await searchDocs({ queryVector: basis(6), limit: 1 });
+    expect(hits[0].slug).toBe(LONG);
+    expect(hits[0].snippet).toHaveLength(400);
+    expect(hits[0].snippet).toBe(LONG_TEXT.slice(0, 400));
+    // And the whole page is still available through getDocText.
+    const document = await getDocText(LONG);
+    expect(document.text.length).toBeGreaterThan(1000);
+  });
+
+  it('clamps a silly limit instead of refusing', async () => {
+    await expect(searchDocs({ queryVector: basis(0), limit: 9999 })).resolves.toBeInstanceOf(Array);
+    const one = await searchDocs({ queryVector: basis(0), limit: 0 });
+    expect(one).toHaveLength(1);
+  });
+
+  it('refuses a query vector of the wrong width', async () => {
+    await expect(searchDocs({ queryVector: [1, 2, 3] })).rejects.toThrow(/1024 dimensions/);
+  });
+});
+
+describe.skipIf(!RUN)('listDocs', () => {
+  it('returns ONE row per page, never one per chunk', async () => {
+    const page = await listDocs();
+    const grading = page.items.filter(item => item.slug === GRADING);
+    expect(grading).toHaveLength(1);
+    expect(grading[0].title).toBe('Grading');
+  });
+
+  it('lists unembedded pages too — the index is where they exist', async () => {
+    const page = await listDocs();
+    expect(page.items.map(item => item.slug)).toContain(NO_VECTOR);
+  });
+
+  it('orders root pages first, then sections, titles alphabetically within', async () => {
+    const page = await listDocs();
+    expect(page.items[0].slug).toBe(ROOT);
+    expect(page.items[0].section).toBeNull();
+    const sections = page.items.map(item => item.section);
+    expect(sections).toEqual([
+      null,
+      'instructors',
+      'instructors',
+      'instructors',
+      'self-hosting',
+      'students',
+    ]);
+    // Alphabetical by LOWERCASED TITLE within a section — which for these three
+    // is deliberately the opposite of their slug order, so an ORDER BY that
+    // merely inherited the inner query's `ORDER BY slug` shows up here.
+    const instructors = page.items.filter(item => item.section === 'instructors');
+    expect(instructors.map(item => item.title)).toEqual([
+      'Add tokens to a class',
+      'Grading',
+      'Manage your roster',
+    ]);
+    expect(instructors.map(item => item.slug)).toEqual([LONG, GRADING, ROSTER]);
+  });
+
+  it('carries the canonical URL for every row', async () => {
+    const page = await listDocs();
+    const roster = page.items.find(item => item.slug === ROSTER);
+    expect(roster?.url).toBe('https://classmoji.io/docs/instructors/roster');
+  });
+
+  it('reports truncation and a next offset, and pages cleanly through', async () => {
+    const first = await listDocs({ limit: 2 });
+    expect(first.items).toHaveLength(2);
+    expect(first.truncated).toBe(true);
+    expect(first.nextOffset).toBe(2);
+
+    const second = await listDocs({ limit: 2, offset: first.nextOffset ?? 0 });
+    expect(second.items).toHaveLength(2);
+    expect(second.truncated).toBe(true);
+
+    const third = await listDocs({ limit: 2, offset: second.nextOffset ?? 0 });
+    expect(third.items).toHaveLength(2);
+    expect(third.truncated).toBe(false);
+    expect(third.nextOffset).toBeNull();
+
+    // No page repeated, none skipped: the ORDER BY is total.
+    const all = [...first.items, ...second.items, ...third.items].map(item => item.slug);
+    expect(new Set(all).size).toBe(all.length);
+    expect(all).toHaveLength(6);
+  });
+
+  it('COMPLETES on its OWN default, which is not the search default of 5', async () => {
+    // Called with NO arguments, the way a "what documentation is there?" caller
+    // calls it. Clamped to search's default of 5, this corpus would come back
+    // truncated — which reads to a model as "there is much more" rather than
+    // "that is all of it". The real corpus is 25 pages against a default of
+    // 100, for the same reason.
+    const page = await listDocs();
+    expect(page.items).toHaveLength(6);
+    expect(page.truncated).toBe(false);
+    expect(page.nextOffset).toBeNull();
+  });
+});
+
+describe.skipIf(!RUN)('getDocText', () => {
+  it('returns a single-chunk page whole', async () => {
+    const document = await getDocText(ROSTER);
+    expect(document.slug).toBe(ROSTER);
+    expect(document.title).toBe('Manage your roster');
+    expect(document.section).toBe('instructors');
+    expect(document.url).toBe('https://classmoji.io/docs/instructors/roster');
+    expect(document.chunkCount).toBe(1);
+    expect(document.text).toContain('New staff member');
+  });
+
+  it('reassembles a chunked page IN READING ORDER, whatever order it was written', async () => {
+    // The fixtures were inserted 0, 2, 1 on purpose: without the ORDER BY
+    // inside `string_agg`, Postgres may concatenate in scan order, and a model
+    // reading a shuffled document answers out of a paragraph that lost its
+    // context.
+    const document = await getDocText(GRADING);
+    expect(document.chunkCount).toBe(3);
+    const zero = document.text.indexOf('GRADING-CHUNK-ZERO');
+    const one = document.text.indexOf('GRADING-CHUNK-ONE');
+    const two = document.text.indexOf('GRADING-CHUNK-TWO');
+    expect(zero).toBeGreaterThanOrEqual(0);
+    expect(zero).toBeLessThan(one);
+    expect(one).toBeLessThan(two);
+  });
+
+  it('serves a page that has no vector — reading does not need one', async () => {
+    const document = await getDocText(NO_VECTOR);
+    expect(document.text).toContain('UNEMBEDDED-SENTINEL');
+  });
+
+  it('orders INSIDE the aggregate, not by relying on the plan', () => {
+    // Honest about what the behavioural test above can and cannot show. With
+    // seven rows and a primary key on (slug, chunk_ix), the planner happens to
+    // use an index scan, which already returns chunk order — so REMOVING the
+    // `ORDER BY` still passes today, and would start failing silently the day
+    // the corpus grows into a sequential or parallel plan. (Verified: on a
+    // plain seq scan, `string_agg` without an ORDER BY returns heap order.)
+    //
+    // The behavioural test catches a WRONG ordering (`DESC`); this catches a
+    // MISSING one.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(resolve(here, '..', 'docsSearch.service.ts'), 'utf8');
+    // Anchored on `string_agg(di.text` and confined to ONE line. `[^)]*` fails
+    // (the separator `chr(10) || chr(10)` carries its own parentheses) and
+    // `[\s\S]*?` fails too — it lets the `string_agg(` in the docblock above
+    // reach the `array_agg(… ORDER BY di.chunk_ix)` further down and match a
+    // statement that has no ordering at all.
+    expect(source).toMatch(/string_agg\(di\.text,[^\n]*ORDER BY di\.chunk_ix\)/);
+  });
+
+  it('throws DocsNotFoundError for a slug that is not there', async () => {
+    await expect(getDocText('docs/instructors/made-up')).rejects.toBeInstanceOf(DocsNotFoundError);
+    await expect(getDocText('')).rejects.toBeInstanceOf(DocsNotFoundError);
+  });
+});
+
+describe.skipIf(!RUN)('docsIndexIsEmpty', () => {
+  it('is false while embedded rows exist', async () => {
+    await expect(docsIndexIsEmpty()).resolves.toBe(false);
+  });
+
+  it('is TRUE when every row is unembedded — not merely when the table is empty', async () => {
+    // `count(*) = 0` would say false here, and the caller would tell a user
+    // "the docs say nothing about that" about a corpus search cannot reach.
+    await getPrisma().$executeRaw`UPDATE docs_index SET embedding = NULL`;
+    await expect(docsIndexIsEmpty()).resolves.toBe(true);
+
+    // And restore, so the ordering of these blocks does not matter.
+    await getPrisma().$executeRaw`
+      UPDATE docs_index SET embedding = ${toVectorLiteral(basis(5))}::vector
+      WHERE slug <> ${NO_VECTOR}`;
+    await expect(docsIndexIsEmpty()).resolves.toBe(false);
+  });
+
+  it('is TRUE on a genuinely empty table, and returns a BOOLEAN not a row count', async () => {
+    await getPrisma().$executeRaw`CREATE TEMP TABLE docs_backup AS SELECT * FROM docs_index`;
+    await getPrisma().$executeRaw`DELETE FROM docs_index`;
+
+    const answer = await docsIndexIsEmpty();
+    expect(typeof answer).toBe('boolean');
+    expect(answer).toBe(true);
+
+    await getPrisma().$executeRaw`INSERT INTO docs_index SELECT * FROM docs_backup`;
+    await getPrisma().$executeRaw`DROP TABLE docs_backup`;
+    await expect(docsIndexIsEmpty()).resolves.toBe(false);
+  });
+});

--- a/packages/services/src/classmoji/__tests__/docsSearch.integration.test.ts
+++ b/packages/services/src/classmoji/__tests__/docsSearch.integration.test.ts
@@ -43,8 +43,14 @@ if (RUN) {
 
 const getPrisma = (await import('@classmoji/database')).default;
 const { toVectorLiteral } = await import('../contentSearch.service.ts');
-const { DocsNotFoundError, docsIndexIsEmpty, getDocText, listDocs, searchDocs } =
-  await import('../docsSearch.service.ts');
+const {
+  DOCS_SEARCH_MIN_CHARS,
+  DocsNotFoundError,
+  docsIndexIsEmpty,
+  getDocText,
+  listDocs,
+  searchDocs,
+} = await import('../docsSearch.service.ts');
 const { EMBEDDING_DIMENSIONS } = await import('../../helpers/workersAi.ts');
 
 afterAll(async () => {
@@ -122,6 +128,34 @@ const NO_VECTOR = 'docs/self-hosting/docker';
 const LONG = 'docs/instructors/tokens';
 const LONG_TEXT = `Add tokens to a class. ${'Tokens buy a student extra hours on a deadline. '.repeat(40)}`;
 
+/**
+ * The NAVIGATION STUB and the page it stands in front of.
+ *
+ * `STUB` is the shape `DOCS_SEARCH_MIN_CHARS` exists for: a real corpus page
+ * (`docs/instructors` is 253 characters, `docs/students` 187) that is a heading
+ * and a list of link labels. It carries the same vector the query does, so it
+ * is STRICTLY nearer than anything else — which is exactly what happened
+ * against the live corpus, and why "the top hit" was a page of links.
+ * `DEADLINES` is the page that actually answers, one notch further away.
+ *
+ * Their lengths bracket the threshold on purpose: 200 and 600, either side of
+ * 400, mirroring the real gap between 253 and 537.
+ */
+const STUB = 'docs/instructors';
+const DEADLINES = 'docs/instructors/deadlines';
+const fill = (lead: string, length: number): string =>
+  `${lead} ${'Classmoji is a Git-native platform for CS courses. '.repeat(30)}`.slice(0, length);
+const STUB_TEXT = fill('For instructors. Roster. Grading. Tokens.', 200);
+const DEADLINES_TEXT = fill('Set a deadline on an assignment from the Assignments tab.', 600);
+
+/**
+ * A fixture body comfortably over the search floor, with its sentinel FIRST.
+ *
+ * First matters twice: `LEFT(text, SNIPPET_CHARS)` is the snippet, and the
+ * assertions below look for the sentinel in it.
+ */
+const body = (lead: string): string => fill(lead, 520);
+
 beforeAll(async () => {
   if (!RUN) return;
 
@@ -132,7 +166,7 @@ beforeAll(async () => {
     title: 'Manage your roster',
     description: 'How to add students and teaching staff',
     section: 'instructors',
-    text: 'Go to the Teaching Staff tab and click New staff member.',
+    text: body('Go to the Teaching Staff tab and click New staff member.'),
     vector: basis(0),
   });
 
@@ -145,7 +179,7 @@ beforeAll(async () => {
     chunkCount: 3,
     title: 'Grading',
     section: 'instructors',
-    text: 'GRADING-CHUNK-ZERO emoji mappings.',
+    text: body('GRADING-CHUNK-ZERO emoji mappings.'),
     vector: between(1, 0.2),
   });
   await insert({
@@ -154,7 +188,7 @@ beforeAll(async () => {
     chunkCount: 3,
     title: 'Grading',
     section: 'instructors',
-    text: 'GRADING-CHUNK-TWO releasing grades.',
+    text: body('GRADING-CHUNK-TWO releasing grades.'),
     vector: basis(1),
   });
   // Deliberately inserted OUT OF ORDER, after chunk 2, so `getDocText` has to
@@ -165,17 +199,35 @@ beforeAll(async () => {
     chunkCount: 3,
     title: 'Grading',
     section: 'instructors',
-    text: 'GRADING-CHUNK-ONE grading an assignment.',
+    text: body('GRADING-CHUNK-ONE grading an assignment.'),
     vector: between(1, 0.1),
   });
 
+  // TWO chunks at EXACTLY the same distance. This is the `chunk_ix` tiebreaker's
+  // fixture: with equal distances, `ORDER BY di.slug, distance` alone leaves
+  // which chunk survives `DISTINCT ON` to whatever order the sort happens to
+  // emit, and the page answers out of a paragraph nobody chose.
+  //
+  // Written in READING ORDER, which is not an arbitrary choice: `writePage`
+  // inserts `chunks.entries()` ascending, so this is the physical layout a real
+  // page has. Verified against this Postgres: with the `chunk_ix` key removed
+  // from the inner ORDER BY, this exact shape returns chunk 1.
   await insert({
     slug: TOKENS,
     chunkIx: 0,
-    chunkCount: 1,
+    chunkCount: 2,
     title: 'Use tokens',
     section: 'students',
-    text: 'Spend a token to extend a deadline.',
+    text: body('TOKENS-CHUNK-ZERO spend a token to extend a deadline.'),
+    vector: basis(2),
+  });
+  await insert({
+    slug: TOKENS,
+    chunkIx: 1,
+    chunkCount: 2,
+    title: 'Use tokens',
+    section: 'students',
+    text: body('TOKENS-CHUNK-ONE what happens when you run out.'),
     vector: basis(2),
   });
 
@@ -185,7 +237,7 @@ beforeAll(async () => {
     chunkCount: 1,
     title: 'Welcome to Classmoji Docs',
     section: null,
-    text: 'Classmoji is a Git-native platform for CS courses.',
+    text: body('Classmoji is a Git-native platform for CS courses.'),
     vector: basis(3),
   });
 
@@ -199,14 +251,37 @@ beforeAll(async () => {
     vector: basis(6),
   });
 
-  // A row with NO vector: written, but unsearchable.
+  // The navigation stub, and the page it stands in front of. The stub carries
+  // the query vector ITSELF, so it is nearer than anything else in the table.
+  await insert({
+    slug: STUB,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'For instructors',
+    section: 'instructors',
+    text: STUB_TEXT,
+    vector: basis(7),
+  });
+  await insert({
+    slug: DEADLINES,
+    chunkIx: 0,
+    chunkCount: 1,
+    title: 'Set a deadline',
+    section: 'instructors',
+    text: DEADLINES_TEXT,
+    vector: between(7, 0.9),
+  });
+
+  // A row with NO vector: written, but unsearchable. LONG ENOUGH to clear the
+  // search floor, so the only thing keeping it out of results is the missing
+  // embedding and not its length.
   await insert({
     slug: NO_VECTOR,
     chunkIx: 0,
     chunkCount: 1,
     title: 'Docker',
     section: 'self-hosting',
-    text: 'UNEMBEDDED-SENTINEL run it with docker compose.',
+    text: body('UNEMBEDDED-SENTINEL run it with docker compose.'),
     vector: null,
   });
 });
@@ -241,9 +316,11 @@ describe.skipIf(!RUN)('searchDocs', () => {
     const hits = await searchDocs({ queryVector: basis(0), limit: 20 });
     expect(slugsOf(hits)).not.toContain(NO_VECTOR);
     expect(JSON.stringify(hits)).not.toContain('UNEMBEDDED-SENTINEL');
-    // Every embedded page came back, so the exclusion is the filter and not the
-    // limit.
-    expect(new Set(slugsOf(hits))).toEqual(new Set([ROSTER, GRADING, TOKENS, ROOT, LONG]));
+    // Every embedded page long enough to be searchable came back, so the
+    // exclusion is the filter and not the limit.
+    expect(new Set(slugsOf(hits))).toEqual(
+      new Set([ROSTER, GRADING, TOKENS, ROOT, LONG, DEADLINES])
+    );
   });
 
   it('de-dupes BEFORE the limit, so a chunked page cannot crowd the results out', async () => {
@@ -277,6 +354,65 @@ describe.skipIf(!RUN)('searchDocs', () => {
   it('refuses a query vector of the wrong width', async () => {
     await expect(searchDocs({ queryVector: [1, 2, 3] })).rejects.toThrow(/1024 dimensions/);
   });
+
+  it('DROPS a page shorter than the search floor even when it ranks FIRST', async () => {
+    // The stub carries the query vector itself, so by distance alone it is the
+    // top hit and nothing else can displace it. This is the live failure: "where
+    // do I add a TA" ranked `docs/instructors` — a list of link labels — above
+    // the page that answers.
+    expect(STUB_TEXT.length).toBeLessThan(DOCS_SEARCH_MIN_CHARS);
+    expect(DEADLINES_TEXT.length).toBeGreaterThan(DOCS_SEARCH_MIN_CHARS);
+
+    const hits = await searchDocs({ queryVector: basis(7), limit: 20 });
+    expect(slugsOf(hits)).not.toContain(STUB);
+    // And the page behind it is what a caller gets instead — first, because the
+    // stub is no longer standing in front of it.
+    expect(slugsOf(hits)[0]).toBe(DEADLINES);
+  });
+
+  it('the stub really is the nearer page — the floor is what removed it', async () => {
+    // Without this the test above passes for a stub that simply ranked badly.
+    // Cosine distance to its own basis vector is 0; `between(7, 0.9)` is 0.1
+    // away, so the ordering is arithmetic rather than an embedding's opinion.
+    const stub = await getPrisma().$queryRaw<Array<{ distance: number }>>`
+      SELECT (embedding <=> ${toVectorLiteral(basis(7))}::vector) AS distance
+      FROM docs_index WHERE slug = ${STUB}`;
+    const answer = await getPrisma().$queryRaw<Array<{ distance: number }>>`
+      SELECT (embedding <=> ${toVectorLiteral(basis(7))}::vector) AS distance
+      FROM docs_index WHERE slug = ${DEADLINES}`;
+    expect(Number(stub[0].distance)).toBeLessThan(Number(answer[0].distance));
+  });
+
+  it('a short page is still LISTED and still READABLE — the floor is search only', async () => {
+    // The stub is navigation, not a secret. `content_list` must still show it
+    // and `content_get` must still serve it, because the prompt tells the model
+    // to follow a stub's labels to the page behind them — which it can only do
+    // if it can look one up by title.
+    const page = await listDocs();
+    expect(page.items.map(item => item.slug)).toContain(STUB);
+    expect(page.items.find(item => item.slug === STUB)?.title).toBe('For instructors');
+
+    const document = await getDocText(STUB);
+    expect(document.text).toBe(STUB_TEXT);
+    expect(document.title).toBe('For instructors');
+  });
+
+  it('breaks an EQUAL-distance tie on the lower chunk_ix', async () => {
+    // Both of `TOKENS`'s chunks carry the same vector, so distance cannot decide
+    // between them and `DISTINCT ON (slug)` keeps exactly one. Without
+    // `chunk_ix` closing the inner ORDER BY, which one survives is whatever the
+    // sort emitted first — and a page that answers out of its opening paragraph
+    // today answers out of its second tomorrow, with nothing in the diff to
+    // explain it. On this Postgres, removing that key makes this fixture return
+    // chunk 1.
+    const hits = await searchDocs({ queryVector: basis(2), limit: 20 });
+    const tokens = hits.filter(hit => hit.slug === TOKENS);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].chunkIx).toBe(0);
+    expect(tokens[0].snippet).toContain('TOKENS-CHUNK-ZERO');
+    expect(tokens[0].snippet).not.toContain('TOKENS-CHUNK-ONE');
+  });
 });
 
 describe.skipIf(!RUN)('listDocs', () => {
@@ -302,19 +438,23 @@ describe.skipIf(!RUN)('listDocs', () => {
       'instructors',
       'instructors',
       'instructors',
+      'instructors',
+      'instructors',
       'self-hosting',
       'students',
     ]);
-    // Alphabetical by LOWERCASED TITLE within a section — which for these three
-    // is deliberately the opposite of their slug order, so an ORDER BY that
-    // merely inherited the inner query's `ORDER BY slug` shows up here.
+    // Alphabetical by LOWERCASED TITLE within a section — which for the first
+    // three is deliberately the opposite of their slug order, so an ORDER BY
+    // that merely inherited the inner query's `ORDER BY slug` shows up here.
     const instructors = page.items.filter(item => item.section === 'instructors');
     expect(instructors.map(item => item.title)).toEqual([
       'Add tokens to a class',
+      'For instructors',
       'Grading',
       'Manage your roster',
+      'Set a deadline',
     ]);
-    expect(instructors.map(item => item.slug)).toEqual([LONG, GRADING, ROSTER]);
+    expect(instructors.map(item => item.slug)).toEqual([LONG, STUB, GRADING, ROSTER, DEADLINES]);
   });
 
   it('carries the canonical URL for every row', async () => {
@@ -329,19 +469,23 @@ describe.skipIf(!RUN)('listDocs', () => {
     expect(first.truncated).toBe(true);
     expect(first.nextOffset).toBe(2);
 
-    const second = await listDocs({ limit: 2, offset: first.nextOffset ?? 0 });
-    expect(second.items).toHaveLength(2);
-    expect(second.truncated).toBe(true);
+    // Walk the whole catalogue two at a time, following `nextOffset` the way a
+    // caller does, and stop only when the listing says it is complete.
+    const all: string[] = [...first.items.map(item => item.slug)];
+    let cursor = first.nextOffset;
+    let pages = 1;
+    while (cursor !== null) {
+      const next = await listDocs({ limit: 2, offset: cursor });
+      all.push(...next.items.map(item => item.slug));
+      cursor = next.nextOffset;
+      pages += 1;
+      expect(pages, 'paging did not terminate').toBeLessThan(20);
+    }
 
-    const third = await listDocs({ limit: 2, offset: second.nextOffset ?? 0 });
-    expect(third.items).toHaveLength(2);
-    expect(third.truncated).toBe(false);
-    expect(third.nextOffset).toBeNull();
-
+    expect(pages).toBe(4);
     // No page repeated, none skipped: the ORDER BY is total.
-    const all = [...first.items, ...second.items, ...third.items].map(item => item.slug);
     expect(new Set(all).size).toBe(all.length);
-    expect(all).toHaveLength(6);
+    expect(all).toHaveLength(8);
   });
 
   it('COMPLETES on its OWN default, which is not the search default of 5', async () => {
@@ -351,7 +495,7 @@ describe.skipIf(!RUN)('listDocs', () => {
     // "that is all of it". The real corpus is 25 pages against a default of
     // 100, for the same reason.
     const page = await listDocs();
-    expect(page.items).toHaveLength(6);
+    expect(page.items).toHaveLength(8);
     expect(page.truncated).toBe(false);
     expect(page.nextOffset).toBeNull();
   });

--- a/packages/services/src/classmoji/__tests__/helpers/docsTestDatabase.ts
+++ b/packages/services/src/classmoji/__tests__/helpers/docsTestDatabase.ts
@@ -1,0 +1,142 @@
+/**
+ * A DISPOSABLE Postgres database, built from the migrations, for the docs suites.
+ *
+ * ── Why `docs_index` cannot use the house pattern ──────────────────────────
+ * Every other DB-backed suite in this package namespaces its fixtures under a
+ * fresh uuid and tears them down by deleting one git organization, which
+ * cascades. That works because `content_index` is PER CLASSROOM: a namespaced
+ * fixture is invisible to every statement that filters `classroom_id`, and the
+ * cascade reaches every row it created.
+ *
+ * `docs_index` is GLOBAL. There is no classroom column to namespace on, so:
+ *
+ *   - ranking is not isolated. `searchDocs` orders the whole table, so a
+ *     developer's real docs rows sit between the fixtures and change what
+ *     "the top hit" means;
+ *   - pagination is not isolated. `listDocs` counts every row in the table;
+ *   - `docsIndexIsEmpty()` cannot be tested at all against a table that has
+ *     anything else in it;
+ *   - and worst, a real `reconcileDocsIndex` test ends with a SWEEP —
+ *     `DELETE … WHERE slug <> ALL($1)` — which on a shared database deletes
+ *     every ordinary docs row the developer had indexed.
+ *
+ * Namespacing protects teardown. It does not protect any of those. So the docs
+ * suites get a database of their own, created from
+ * `packages/database/migrations` and dropped afterwards — which has the second
+ * benefit of proving the migration chain replays from empty on every run.
+ *
+ * ── FAIL, DO NOT SKIP ──────────────────────────────────────────────────────
+ * When the opt-in is set and the database is unreachable, this THROWS. The
+ * localhost gates on the existing suites otherwise permit a completely green
+ * run with no SQL exercised at all — which is how a broken statement ships
+ * while the suite that would have caught it silently skipped.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PrismaClient } from '@prisma/client';
+
+/** The deliberate opt-in. Without it, the docs DB suites do not run at all. */
+export const DOCS_DB_OPT_IN = 'DOCS_INDEX_INTEGRATION';
+
+export const docsDbOptedIn = (): boolean => process.env[DOCS_DB_OPT_IN] === '1';
+
+export interface DisposableDatabase {
+  /** Connection string for the freshly migrated database. */
+  url: string;
+  name: string;
+  /** Drops it. Safe to call twice. */
+  drop(): Promise<void>;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = resolve(here, '..', '..', '..', '..', '..', 'database', 'schema.prisma');
+
+/** Identifiers are built here, never supplied — assert it anyway. */
+const SAFE_NAME = /^[a-z][a-z0-9_]{0,62}$/;
+
+/**
+ * Create a database named after this run, migrate it, and hand back its URL.
+ *
+ * The admin connection is the ordinary `DATABASE_URL`: `CREATE DATABASE` may be
+ * issued from any other database on the same server, so no separate maintenance
+ * credential is needed, and the one thing that cannot happen — dropping the
+ * database you are connected to — is exactly what we never do.
+ *
+ * LOCAL ONLY. Creating and dropping databases is not something to do against a
+ * host somebody could have pointed at staging.
+ */
+export async function createDocsTestDatabase(): Promise<DisposableDatabase> {
+  const adminUrl = process.env.DATABASE_URL ?? '';
+  if (!adminUrl) {
+    throw new Error(
+      `[docsTestDatabase] ${DOCS_DB_OPT_IN}=1 but DATABASE_URL is unset. These suites FAIL rather than skip: load .env first.`
+    );
+  }
+  if (!/@(localhost|127\.0\.0\.1|0\.0\.0\.0|host\.docker\.internal)[:/]/.test(adminUrl)) {
+    throw new Error(
+      '[docsTestDatabase] refusing to create a database on a non-local host. DATABASE_URL must point at localhost.'
+    );
+  }
+
+  const name = `classmoji_docstest_${process.pid}_${Date.now().toString(36)}`;
+  if (!SAFE_NAME.test(name)) throw new Error(`[docsTestDatabase] unsafe database name: ${name}`);
+
+  const parsed = new URL(adminUrl);
+  const sourceName = parsed.pathname.replace(/^\//, '');
+  // Belt and braces: this must never be the database the developer is working
+  // in, because the suites that use it run a sweep that deletes unmatched rows.
+  if (sourceName === name)
+    throw new Error('[docsTestDatabase] refusing to reuse the source database');
+
+  const admin = new PrismaClient({ datasourceUrl: adminUrl });
+  try {
+    // `CREATE DATABASE` cannot run inside a transaction; `$executeRawUnsafe`
+    // issues it directly. The name is built above and shape-checked, never
+    // interpolated from input.
+    await admin.$executeRawUnsafe(`CREATE DATABASE "${name}"`);
+  } finally {
+    await admin.$disconnect();
+  }
+
+  const url = new URL(adminUrl);
+  url.pathname = `/${name}`;
+  const databaseUrl = url.toString();
+
+  try {
+    // The migrations ARE the schema under test. `db push` would build the table
+    // from `schema.prisma` and skip the migration this lane added, so a broken
+    // migration would pass a suite that never ran it.
+    execFileSync('npx', ['prisma', 'migrate', 'deploy', '--schema', SCHEMA], {
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: 'pipe',
+    });
+  } catch (error) {
+    await dropDatabase(adminUrl, name);
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`[docsTestDatabase] migrate deploy failed for ${name}: ${detail}`);
+  }
+
+  let dropped = false;
+  return {
+    url: databaseUrl,
+    name,
+    drop: async () => {
+      if (dropped) return;
+      dropped = true;
+      await dropDatabase(adminUrl, name);
+    },
+  };
+}
+
+async function dropDatabase(adminUrl: string, name: string): Promise<void> {
+  const admin = new PrismaClient({ datasourceUrl: adminUrl });
+  try {
+    // WITH (FORCE) terminates any connection the suite left open, so a leaked
+    // client cannot leave a database behind on every run.
+    await admin.$executeRawUnsafe(`DROP DATABASE IF EXISTS "${name}" WITH (FORCE)`);
+  } finally {
+    await admin.$disconnect();
+  }
+}

--- a/packages/services/src/classmoji/contentIndex.service.ts
+++ b/packages/services/src/classmoji/contentIndex.service.ts
@@ -358,7 +358,16 @@ async function resolveDoc(
   return { kind: target.kind, id: row.id, title: row.title };
 }
 
-interface StoredChunk {
+/**
+ * One stored row, as {@link isFresh} needs to see it.
+ *
+ * Exported because `docsIndex.service.ts` reuses `isFresh` verbatim over a
+ * DIFFERENT table. The freshness rule is the same rule — the stamps match,
+ * every chunk is present, every chunk is embedded, and all of them agree on how
+ * many there are — and keeping it in one function is what stops the two corpora
+ * drifting apart on what "already indexed" means.
+ */
+export interface StoredChunk {
   chunk_ix: number;
   chunk_count: number;
   source_sha: string;
@@ -384,10 +393,19 @@ async function storedChunks(
 /**
  * Is what is stored already this document, completely?
  *
- * All four have to hold: the stamps match, every chunk 0..n-1 is present, every
- * one of them has a vector, and they agree on how many there are. A partial
- * index — the write that died between chunk 3 and chunk 4 — reads as stale, not
- * as fresh, which is what makes the reconcile able to finish it.
+ * All five have to hold: the stamps match, every chunk 0..n-1 is present, every
+ * one of them has a vector, they agree on how many there are, and there are no
+ * EXTRA rows beyond that count. A partial index — the write that died between
+ * chunk 3 and chunk 4 — reads as stale, not as fresh, which is what makes the
+ * reconcile able to finish it.
+ *
+ * The extra-row check is the one that was missing. A document that shrank from
+ * two chunks to one leaves row 1 behind; if a later write then stamped row 0
+ * with `chunk_count: 1` and the shrink delete did not run, rows 0 and 1 both
+ * declare a count of 1, every index in 0..0 is present, and this returned true
+ * — pronouncing a document fresh while a stale chunk of its previous version
+ * was still in the corpus, answering questions out of text the page no longer
+ * has. Both corpora read this function, so the fix lands for both.
  */
 export function isFresh(
   rows: StoredChunk[],
@@ -404,6 +422,9 @@ export function isFresh(
   }
   const expected = zero.chunk_count;
   if (!Number.isInteger(expected) || expected < 1) return false;
+  // Both tables key on (…, chunk_ix), so there are no duplicate indices to make
+  // this count lie: more rows than the stamp claims means a leftover tail.
+  if (rows.length !== expected) return false;
 
   const seen = new Set<number>();
   for (const row of rows) {

--- a/packages/services/src/classmoji/docsIndex.service.ts
+++ b/packages/services/src/classmoji/docsIndex.service.ts
@@ -69,6 +69,7 @@ import {
 } from '../helpers/workersAi.ts';
 import { chunkDocument, isFresh, type StoredChunk } from './contentIndex.service.ts';
 import { toVectorLiteral } from './contentSearch.service.ts';
+import { DOCS_SEARCH_MIN_CHARS } from './docsSearch.service.ts';
 
 /** Where the documentation lives. Public, and read without credentials. */
 export const DOCS_REPO = {
@@ -426,6 +427,22 @@ export interface DocsReconcileReport {
   byReason: Record<string, number>;
   bySlug: DocsReconcileRow[];
   /**
+   * Slugs indexed but UNREACHABLE BY SEARCH, because every chunk they have is
+   * shorter than `DOCS_SEARCH_MIN_CHARS`.
+   *
+   * The two section-index pages are expected to be here — that is the whole
+   * point of the threshold. Anything ELSE appearing is the signal: a real page
+   * that got short, or a page whose extraction quietly collapsed to a title, is
+   * otherwise a page that stops answering questions with nothing anywhere
+   * saying so. `content_list` and `content_get` still reach every one of them.
+   *
+   * Read from the TABLE after the sweep, not from the chunks this run happened
+   * to build: on a steady-state run every page is `skipped: fresh` and never
+   * re-chunked, and a list assembled from those would come back empty on
+   * exactly the runs where it matters.
+   */
+  belowSearchMin: string[];
+  /**
    * Set when the run stopped before doing any work.
    *
    * READINESS IS `!halted && !error && failed === 0`, not `!error` alone:
@@ -455,6 +472,7 @@ const emptyReport = (): DocsReconcileReport => ({
   deleted: 0,
   byReason: {},
   bySlug: [],
+  belowSearchMin: [],
 });
 
 // ─── Storage ────────────────────────────────────────────────────────────────
@@ -710,6 +728,19 @@ export async function reconcileDocsIndex(
     report.deleted = await prisma.$executeRaw`
       DELETE FROM docs_index WHERE slug <> ALL(${slugs}::text[])
     `;
+
+    // After the sweep, so it describes the corpus a search will actually see.
+    // `max(length(text))` and not `min`: a page is only unsearchable when EVERY
+    // chunk is below the line, because `searchDocs` filters chunks and a page
+    // with one long chunk is still reachable through it.
+    const short = await prisma.$queryRaw<Array<{ slug: string }>>`
+      SELECT slug
+      FROM docs_index
+      GROUP BY slug
+      HAVING max(length(text)) < ${DOCS_SEARCH_MIN_CHARS}::int
+      ORDER BY slug
+    `;
+    report.belowSearchMin = short.map(row => row.slug);
 
     return report;
   } catch (error) {

--- a/packages/services/src/classmoji/docsIndex.service.ts
+++ b/packages/services/src/classmoji/docsIndex.service.ts
@@ -1,0 +1,765 @@
+/**
+ * docsIndex.service.ts — the product documentation → `docs_index` rows.
+ *
+ * THE ONLY WRITER OF THAT TABLE. One `.mdx` page under
+ * `apps/site/src/content/docs` in the public monorepo becomes one or more rows
+ * carrying its extracted text and its Workers AI vector, so `content_search`
+ * with `scope: 'docs'` can answer "how do I add a TA?" out of
+ * `classmoji.io/docs/instructors/roster` instead of guessing.
+ *
+ * ── What this reads, and what it is allowed to do with it ──────────────────
+ * Three unauthenticated GitHub reads against a PUBLIC repo: the head commit of
+ * `main`, a recursive tree at that commit rooted at the docs directory, and one
+ * raw body per stale page. Nothing here holds a credential, and nothing it
+ * fetches is executed — the extractor parses, and the text it produces is
+ * EVIDENCE a model may quote, never an instruction anything follows.
+ *
+ * Bodies are pinned to the COMMIT, not to `main`, so a push landing mid-run
+ * cannot serve bytes under a sha they do not have. What the index therefore
+ * holds is the latest `main`, which may be AHEAD of the deployed site by up to
+ * the nightly interval: `apps/site` deploys on its own `needs: changes` gate,
+ * not with this. That is accepted and made visible — the commit sha is logged
+ * and returned in the report.
+ *
+ * ── Two locks, because the failure they prevent is data loss ───────────────
+ * The run ends with a SWEEP: every slug not in this run's tree is deleted. Two
+ * runs overlapping is therefore not merely wasteful, it is destructive — a slow
+ * run for commit A finishing after a run for commit B deletes the pages B
+ * introduced, and the next nightly puts them back, so the damage is a day of
+ * wrong answers that heals itself before anybody looks.
+ *
+ *   1. `packages/tasks` puts BOTH task ids on one `concurrencyLimit: 1` queue.
+ *   2. This function takes a Postgres advisory lock BEFORE resolving the
+ *      commit, and releases it in a `finally`.
+ *
+ * The second exists because the first only covers Trigger.dev: a script, a
+ * local run or a future caller reaches this function directly.
+ *
+ * ── Fail closed, everywhere it matters ─────────────────────────────────────
+ * HTTP 200 is not authority to delete. `truncated: true` is a 200. An empty
+ * tree is a 200. And `slug <> ALL('{}'::text[])` matches EVERY row, so an empty
+ * tree taken at face value empties the corpus. So: the tree is validated before
+ * anything is written, any validation failure ends the run with NO writes and
+ * NO deletes, and there is no operational delete-everything path in v1 —
+ * emptying the corpus deliberately is a manual `DELETE`, done knowingly.
+ *
+ * Per page, the rule is the same one the course indexer uses: a page that
+ * cannot be fetched, or cannot be extracted, KEEPS ITS LAST GOOD ROWS. An
+ * unreadable page is a reason to go on answering out of the previous version,
+ * not to blank it out of the corpus.
+ *
+ * ── Startup graph ──────────────────────────────────────────────────────────
+ * This module is reached from `ClassmojiService`, which every app imports at
+ * boot. `extractMdxText` is therefore loaded with a dynamic `await import()` of
+ * the extract barrel — the same reason `contentIndex.service.ts` does it: that
+ * barrel statically imports `./html.ts`, which pulls in cheerio. Only the
+ * VERSION constant is imported statically, and only from `mdx.ts` directly,
+ * which has no dependencies at all.
+ */
+
+import getPrisma from '@classmoji/database';
+import { PrismaClient } from '@prisma/client';
+import { MDX_EXTRACT_VERSION } from '../content/extract/mdx.ts';
+import type { ExtractedMdx } from '../content/extract/mdx.ts';
+import {
+  EMBEDDING_MODEL,
+  MAX_BATCH_SIZE,
+  embedTexts,
+  isWorkersAiConfigured,
+} from '../helpers/workersAi.ts';
+import { chunkDocument, isFresh, type StoredChunk } from './contentIndex.service.ts';
+import { toVectorLiteral } from './contentSearch.service.ts';
+
+/** Where the documentation lives. Public, and read without credentials. */
+export const DOCS_REPO = {
+  owner: 'classmoji',
+  repo: 'classmoji',
+  ref: 'main',
+  path: 'apps/site/src/content/docs',
+} as const;
+
+/**
+ * The extractor version, RE-EXPORTED rather than redeclared.
+ *
+ * Two constants that must agree is a bug waiting for the day they do not: a
+ * second `DOCS_EXTRACT_VERSION = 1` next to a bumped `MDX_EXTRACT_VERSION = 2`
+ * would leave every row stamped 1 looking fresh forever, and the recovery path
+ * for an extractor mistake would silently stop working.
+ */
+export { MDX_EXTRACT_VERSION as DOCS_EXTRACT_VERSION } from '../content/extract/mdx.ts';
+
+/**
+ * The advisory-lock key.
+ *
+ * Session-scoped (`pg_try_advisory_lock`), taken before the head commit is
+ * resolved and released in a `finally`. An arbitrary but FIXED number: every
+ * caller has to pick the same one for the lock to mean anything.
+ */
+export const DOCS_INDEX_LOCK_KEY = 2026091201;
+
+/** How many pages may be fetched and embedded at once. */
+const DEFAULT_CONCURRENCY = 4;
+export const MAX_CONCURRENCY = 8;
+
+/** Per-request budget for the GitHub reads. */
+const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_REQUEST_ATTEMPTS = 3;
+/** Ceiling on how long a `Retry-After` may park a run. */
+const MAX_BACKOFF_MS = 30_000;
+
+// ─── The reader ─────────────────────────────────────────────────────────────
+
+/** One entry of the recursive tree, as GitHub returns it. */
+export interface DocsTreeEntry {
+  path: string;
+  type: string;
+  sha: string;
+}
+
+/**
+ * Everything this service needs from GitHub, as an interface.
+ *
+ * Injectable so the unit suite can drive every branch — a truncated tree, a
+ * duplicate slug, a 404 body, a 429 with a `Retry-After` — without a network,
+ * and so the contract tests never depend on github.com being reachable or on
+ * the docs being in any particular state today.
+ */
+export interface DocsReader {
+  /** The sha `main` currently points at. */
+  head(): Promise<string>;
+  /** The recursive tree under {@link DOCS_REPO.path} at `commit`. */
+  tree(commit: string): Promise<{ entries: DocsTreeEntry[]; truncated: boolean }>;
+  /** One file's bytes at `commit`, or null when it is not there (404). */
+  body(commit: string, relPath: string): Promise<string | null>;
+}
+
+/** A body read that failed in a way worth telling apart in the report. */
+export class DocsBodyError extends Error {
+  constructor(readonly reason: 'timeout' | 'rate_limited' | 'http_error' | 'network') {
+    super(`docs body read failed: ${reason}`);
+    this.name = 'DocsBodyError';
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * How long to wait before retrying, from the response's own headers.
+ *
+ * `Retry-After` is seconds or an HTTP date; `x-ratelimit-reset` is a unix
+ * second. Honouring them is the difference between backing off and hammering a
+ * limit that is already refusing us. Capped, because a rate limit that resets
+ * in an hour is a run to abandon, not one to sit inside `maxDuration: 900`.
+ */
+function retryDelayMs(response: Response, attempt: number): number {
+  const after = response.headers.get('retry-after');
+  if (after) {
+    const seconds = Number(after);
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.min(seconds * 1000, MAX_BACKOFF_MS);
+    const when = Date.parse(after);
+    if (Number.isFinite(when)) return Math.min(Math.max(when - Date.now(), 0), MAX_BACKOFF_MS);
+  }
+  const reset = Number(response.headers.get('x-ratelimit-reset'));
+  if (Number.isFinite(reset) && reset > 0) {
+    return Math.min(Math.max(reset * 1000 - Date.now(), 0), MAX_BACKOFF_MS);
+  }
+  // No guidance: plain exponential backoff.
+  return Math.min(500 * 2 ** attempt, MAX_BACKOFF_MS);
+}
+
+const isRetryableStatus = (status: number): boolean =>
+  status === 403 || status === 408 || status === 429 || status >= 500;
+
+/**
+ * One GET, with bounded retries.
+ *
+ * `trigger.config.js` sets `maxAttempts: 1`, so a task that throws is never
+ * retried by Trigger and a task that RETURNS an error report does not trigger
+ * one either. These in-run retries are therefore the only retries there are,
+ * which is why they exist at all rather than being left to the scheduler.
+ */
+async function getWithRetry(url: string, accept: string): Promise<Response> {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt < MAX_REQUEST_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        headers: { accept, 'user-agent': 'classmoji-docs-index' },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (response.ok || response.status === 404) return response;
+      if (!isRetryableStatus(response.status) || attempt === MAX_REQUEST_ATTEMPTS - 1) {
+        return response;
+      }
+      await sleep(retryDelayMs(response, attempt));
+    } catch (error) {
+      lastError = error;
+      if (attempt === MAX_REQUEST_ATTEMPTS - 1) break;
+      await sleep(Math.min(500 * 2 ** attempt, MAX_BACKOFF_MS));
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('docs read failed');
+}
+
+const isTimeout = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+
+/**
+ * The real reader: two REST calls in the normal case, plus one raw fetch per
+ * stale page.
+ *
+ * The tree-ish form `…/git/trees/<commit>:<url-encoded dir>?recursive=1` returns
+ * paths RELATIVE to that directory and a per-blob `sha`, which is exactly the
+ * freshness key — so nothing has to be fetched to find out whether it changed.
+ *
+ * A private docs repo would replace this with authenticated contents/blob reads
+ * under a `Contents: read` permission. That is documented, not built: public
+ * raw URLs are not assumed to keep working, and a credential here would widen
+ * what the indexer can see.
+ */
+export function createGitHubDocsReader(): DocsReader {
+  const api = 'https://api.github.com';
+  const { owner, repo, ref, path } = DOCS_REPO;
+
+  return {
+    async head(): Promise<string> {
+      const response = await getWithRetry(
+        `${api}/repos/${owner}/${repo}/commits/${ref}`,
+        'application/vnd.github+json'
+      );
+      if (!response.ok) throw new Error(`head commit: HTTP ${response.status}`);
+      const payload = (await response.json()) as { sha?: unknown };
+      if (typeof payload.sha !== 'string' || !/^[0-9a-f]{40}$/i.test(payload.sha)) {
+        throw new Error('head commit: response carried no sha');
+      }
+      return payload.sha;
+    },
+
+    async tree(commit: string) {
+      const response = await getWithRetry(
+        `${api}/repos/${owner}/${repo}/git/trees/${commit}:${encodeURIComponent(path)}?recursive=1`,
+        'application/vnd.github+json'
+      );
+      if (!response.ok) throw new Error(`tree: HTTP ${response.status}`);
+      const payload = (await response.json()) as { tree?: unknown; truncated?: unknown };
+      if (!Array.isArray(payload.tree)) throw new Error('tree: response carried no tree');
+      return {
+        entries: payload.tree as DocsTreeEntry[],
+        // Anything but an explicit `false` is treated as truncated, so a shape
+        // change cannot quietly turn "we did not see everything" into a sweep.
+        truncated: payload.truncated !== false,
+      };
+    },
+
+    async body(commit: string, relPath: string): Promise<string | null> {
+      try {
+        const response = await getWithRetry(
+          `https://raw.githubusercontent.com/${owner}/${repo}/${commit}/${path}/${relPath}`,
+          'text/plain'
+        );
+        if (response.status === 404) return null;
+        if (response.status === 429 || response.status === 403) {
+          throw new DocsBodyError('rate_limited');
+        }
+        if (!response.ok) throw new DocsBodyError('http_error');
+        return await response.text();
+      } catch (error) {
+        if (error instanceof DocsBodyError) throw error;
+        throw new DocsBodyError(isTimeout(error) ? 'timeout' : 'network');
+      }
+    },
+  };
+}
+
+// ─── Paths → slugs ──────────────────────────────────────────────────────────
+
+/**
+ * The repo path (relative to the collection root) → the URL path.
+ *
+ * `docs/instructors/roster.mdx` → `docs/instructors/roster`
+ * `docs/index.mdx`              → `docs`
+ * `docs/open-source/local-development/index.mdx` → `docs/open-source/local-development`
+ *
+ * The slug IS the id a search hit returns AND the path under classmoji.io, so
+ * there is no mapping table and no way for the two to disagree.
+ */
+export function slugForPath(relPath: string): string {
+  const withoutExtension = relPath.replace(/\.mdx$/, '');
+  return withoutExtension.endsWith('/index')
+    ? withoutExtension.slice(0, -'/index'.length)
+    : withoutExtension;
+}
+
+/**
+ * The top-level docs section, or null for a page sitting directly under the root.
+ *
+ * The paths all begin `docs/`, so the section is the SECOND segment of the
+ * directory: `docs/instructors/roster.mdx` → `instructors`, while
+ * `docs/index.mdx` and `docs/video-tutorials.mdx` have no section at all.
+ */
+export function sectionForPath(relPath: string): string | null {
+  const directory = relPath.includes('/') ? relPath.slice(0, relPath.lastIndexOf('/')) : '';
+  return directory.split('/')[1] ?? null;
+}
+
+// ─── Tree validation ────────────────────────────────────────────────────────
+
+/** A page the run has decided to consider. */
+interface EligiblePage {
+  relPath: string;
+  slug: string;
+  section: string | null;
+  sha: string;
+}
+
+const SHA = /^[0-9a-f]{40}$/i;
+
+/**
+ * Turn a tree into the eligible page list, or refuse the whole run.
+ *
+ * ONLY `.mdx` blobs under the collection root are eligible — the `.png` files
+ * and the directories beside them are not documentation pages. Everything else
+ * about an eligible entry is checked, and any violation ends the run: a
+ * malformed entry means the response is not the shape this code was written
+ * against, and continuing means sweeping on a list we do not understand.
+ *
+ * An EMPTY eligible list is a failure, not an instruction. `slug <> ALL('{}')`
+ * matches every row, so "the tree came back with nothing in it" and "delete the
+ * entire corpus" would otherwise be the same statement.
+ */
+function validateTree(
+  entries: unknown,
+  truncated: boolean
+): { pages: EligiblePage[] } | { error: string } {
+  // `!== false`, not `truncated === true`: a reader that forgot the field, or a
+  // response whose shape changed, must read as "we did not see everything"
+  // rather than as permission to sweep. The GitHub reader already normalizes
+  // this; restating it here means a second reader cannot get it wrong.
+  if (truncated !== false) return { error: 'tree_truncated' };
+  if (!Array.isArray(entries)) return { error: 'tree_malformed' };
+
+  const pages: EligiblePage[] = [];
+  const seen = new Map<string, string>();
+
+  for (const raw of entries) {
+    if (!raw || typeof raw !== 'object') return { error: 'tree_malformed' };
+    const entry = raw as Partial<DocsTreeEntry>;
+    if (typeof entry.path !== 'string' || typeof entry.type !== 'string') {
+      return { error: 'tree_malformed' };
+    }
+    if (entry.type !== 'blob' || !entry.path.endsWith('.mdx')) continue;
+
+    const relPath = entry.path;
+    if (
+      relPath.startsWith('/') ||
+      relPath.includes('\\') ||
+      relPath.split('/').some(segment => segment === '..' || segment === '')
+    ) {
+      return { error: 'tree_unsafe_path' };
+    }
+    if (typeof entry.sha !== 'string' || !SHA.test(entry.sha)) return { error: 'tree_malformed' };
+
+    const slug = slugForPath(relPath);
+    // `docs/foo.mdx` and `docs/foo/index.mdx` both normalize to `docs/foo`, and
+    // whichever wrote last would decide what that page says. Refuse rather than
+    // pick.
+    const existing = seen.get(slug);
+    if (existing) return { error: 'tree_duplicate_slug' };
+    seen.set(slug, relPath);
+
+    pages.push({ relPath, slug, section: sectionForPath(relPath), sha: entry.sha });
+  }
+
+  if (pages.length === 0) return { error: 'tree_empty' };
+  return { pages };
+}
+
+// ─── The report ─────────────────────────────────────────────────────────────
+
+export type DocsPageOutcome = 'indexed' | 'skipped' | 'failed';
+
+export interface DocsReconcileRow {
+  slug: string;
+  outcome: DocsPageOutcome;
+  reason?: string;
+  chunks?: number;
+}
+
+/** Why a run did no work at all. Absent when the run completed. */
+export type DocsReconcileHalt =
+  | 'lock_held'
+  | 'not_configured'
+  | 'tree_invalid'
+  | 'tree_unavailable';
+
+export interface DocsReconcileReport {
+  /** The commit everything in this run was read at. Null when it never resolved. */
+  commit: string | null;
+  /** Entries in the tree, before eligibility. */
+  pages: number;
+  /** `.mdx` pages the run considered. */
+  eligible: number;
+  indexed: number;
+  skipped: number;
+  failed: number;
+  /** Rows the sweep removed because their page is gone from the tree. */
+  deleted: number;
+  byReason: Record<string, number>;
+  bySlug: DocsReconcileRow[];
+  /**
+   * Set when the run stopped before doing any work.
+   *
+   * READINESS IS `!halted && !error && failed === 0`, not `!error` alone:
+   * `lock_held` and `not_configured` are not errors — the first is the
+   * serialization working and the second is an environment with no Workers AI
+   * credentials — but neither is a run that indexed anything.
+   */
+  halted?: DocsReconcileHalt;
+  /** A run-level failure. Absent on a healthy run. */
+  error?: string;
+}
+
+export interface ReconcileDocsOptions {
+  /** Defaults to {@link createGitHubDocsReader}. */
+  reader?: DocsReader;
+  /** Pages in flight at once, `[1, MAX_CONCURRENCY]`. */
+  concurrency?: number;
+}
+
+const emptyReport = (): DocsReconcileReport => ({
+  commit: null,
+  pages: 0,
+  eligible: 0,
+  indexed: 0,
+  skipped: 0,
+  failed: 0,
+  deleted: 0,
+  byReason: {},
+  bySlug: [],
+});
+
+// ─── Storage ────────────────────────────────────────────────────────────────
+
+async function storedChunks(slug: string): Promise<StoredChunk[]> {
+  return getPrisma().$queryRaw<StoredChunk[]>`
+    SELECT chunk_ix, chunk_count, source_sha, extract_version, embed_model,
+           (embedding IS NULL) AS embedding_null
+    FROM docs_index
+    WHERE slug = ${slug}
+    ORDER BY chunk_ix
+  `;
+}
+
+/** Embed every chunk, in batches the client will accept. */
+async function embedChunks(
+  chunks: string[]
+): Promise<{ ok: true; vectors: number[][] } | { ok: false; reason: string }> {
+  const vectors: number[][] = [];
+  for (let at = 0; at < chunks.length; at += MAX_BATCH_SIZE) {
+    const result = await embedTexts(chunks.slice(at, at + MAX_BATCH_SIZE));
+    // `chunkDocument` guarantees every piece is under the cap, so a refusal is
+    // a bug here rather than a document problem, and a retry reaches the same
+    // answer.
+    if (!result.ok) return { ok: false, reason: result.reason };
+    vectors.push(...result.vectors);
+  }
+  return { ok: true, vectors };
+}
+
+/**
+ * Write one page's chunks, and remove the tail a shrink left behind.
+ *
+ * One transaction, so a page is never half-replaced. `updated_at` is set by
+ * hand: `@updatedAt` is a Prisma CLIENT feature and a raw upsert goes straight
+ * past it, which would leave the column frozen at insert time.
+ */
+async function writePage(
+  page: EligiblePage,
+  extracted: ExtractedMdx,
+  chunks: string[],
+  vectors: number[][]
+): Promise<void> {
+  const chunkCount = chunks.length;
+
+  await getPrisma().$transaction(async tx => {
+    for (const [index, text] of chunks.entries()) {
+      const vector = toVectorLiteral(vectors[index]);
+      await tx.$executeRaw`
+        INSERT INTO docs_index
+          (slug, chunk_ix, chunk_count, title, description, section, text,
+           source_sha, extract_version, embed_model, embedding, updated_at)
+        VALUES
+          (${page.slug}, ${index}::int, ${chunkCount}::int, ${extracted.title},
+           ${extracted.description}, ${page.section}, ${text},
+           ${page.sha}, ${MDX_EXTRACT_VERSION}::int, ${EMBEDDING_MODEL},
+           ${vector}::vector, NOW())
+        ON CONFLICT (slug, chunk_ix) DO UPDATE SET
+          chunk_count     = EXCLUDED.chunk_count,
+          title           = EXCLUDED.title,
+          description     = EXCLUDED.description,
+          section         = EXCLUDED.section,
+          text            = EXCLUDED.text,
+          source_sha      = EXCLUDED.source_sha,
+          extract_version = EXCLUDED.extract_version,
+          embed_model     = EXCLUDED.embed_model,
+          embedding       = EXCLUDED.embedding,
+          updated_at      = NOW()
+      `;
+    }
+
+    // A page that SHRANK leaves its old tail behind, and chunk 7 of the
+    // previous version is a perfectly good row with a perfectly good vector
+    // that goes on answering out of text this page no longer has.
+    await tx.$executeRaw`
+      DELETE FROM docs_index WHERE slug = ${page.slug} AND chunk_ix >= ${chunkCount}::int
+    `;
+  });
+}
+
+// ─── The lock ───────────────────────────────────────────────────────────────
+
+/**
+ * Hold the docs-reconcile lock for the length of a run.
+ *
+ * ── WHY THIS OPENS ITS OWN CONNECTION ──────────────────────────────────────
+ * `pg_try_advisory_lock` is SESSION-scoped, and the shared Prisma client is a
+ * connection POOL: the `SELECT pg_try_advisory_lock(…)` and the matching
+ * `pg_advisory_unlock(…)` are two separate statements that the pool is free to
+ * run on two different connections.
+ *
+ * When it does, the unlock is a no-op — it returns false and Postgres logs a
+ * warning nobody reads — and the lock stays held on the first connection for as
+ * long as that connection lives. From then on, every reconcile that lands on a
+ * DIFFERENT pooled connection is refused with `lock_held`, and the nightly job
+ * quietly stops indexing. That is a lock working perfectly against the wrong
+ * thing: it serializes the job against ITSELF.
+ *
+ * A transaction-scoped lock (`pg_advisory_xact_lock`) is not the answer either,
+ * because the lock has to be held across 25 HTTP fetches and their embeddings —
+ * minutes — and that is not a transaction anybody should open.
+ *
+ * So the lock gets ONE connection of its own, opened when the run starts and
+ * closed when it ends. One extra connection, once a night, for a guarantee that
+ * is otherwise not a guarantee at all.
+ */
+interface DocsLock {
+  release(): Promise<void>;
+}
+
+async function acquireDocsLock(): Promise<DocsLock | null> {
+  // Reads DATABASE_URL at construction, exactly as `@classmoji/database` does,
+  // so a caller that redirected the environment is followed here too.
+  const session = new PrismaClient();
+  try {
+    const rows = await session.$queryRaw<Array<{ locked: boolean }>>`
+      SELECT pg_try_advisory_lock(${DOCS_INDEX_LOCK_KEY}::bigint) AS locked
+    `;
+    if (rows[0]?.locked !== true) {
+      await session.$disconnect();
+      return null;
+    }
+  } catch (error) {
+    await session.$disconnect().catch(() => {});
+    throw error;
+  }
+
+  return {
+    release: async () => {
+      try {
+        await session.$queryRaw`SELECT pg_advisory_unlock(${DOCS_INDEX_LOCK_KEY}::bigint)`;
+      } catch {
+        // Disconnecting drops the session, which drops the lock with it.
+      } finally {
+        await session.$disconnect().catch(() => {});
+      }
+    },
+  };
+}
+
+// ─── Concurrency ────────────────────────────────────────────────────────────
+
+async function mapWithLimit<T, R>(
+  items: T[],
+  limit: number,
+  run: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const at = next;
+      next += 1;
+      if (at >= items.length) return;
+      results[at] = await run(items[at]);
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+// ─── The reconcile ──────────────────────────────────────────────────────────
+
+/**
+ * Bring `docs_index` level with the documentation on `main`.
+ *
+ * NEVER THROWS. Everything it decides comes back in the report, because "is the
+ * docs index ready" has to be answerable without reading a log for individual
+ * lines — and because the caller is a Trigger task whose `maxAttempts: 1` means
+ * a thrown error is simply lost.
+ */
+export async function reconcileDocsIndex(
+  opts: ReconcileDocsOptions = {}
+): Promise<DocsReconcileReport> {
+  const report = emptyReport();
+  const bump = (reason: string): void => {
+    report.byReason[reason] = (report.byReason[reason] ?? 0) + 1;
+  };
+
+  // Before any DB work and before any lock: an environment with no Workers AI
+  // credentials is a normal state for most deployments, and it writes nothing.
+  if (!isWorkersAiConfigured()) {
+    report.halted = 'not_configured';
+    return report;
+  }
+
+  const prisma = getPrisma();
+  const reader = opts.reader ?? createGitHubDocsReader();
+  const concurrency = Math.min(
+    Math.max(Math.trunc(opts.concurrency ?? DEFAULT_CONCURRENCY) || DEFAULT_CONCURRENCY, 1),
+    MAX_CONCURRENCY
+  );
+
+  // THE LOCK, taken before the commit is resolved. Taking it afterwards would
+  // still let two runs resolve different commits and then serialize their
+  // sweeps, which is the exact interleaving that deletes a live page.
+  let lock: DocsLock | null;
+  try {
+    lock = await acquireDocsLock();
+  } catch (error) {
+    report.error = `lock: ${error instanceof Error ? error.message : String(error)}`;
+    return report;
+  }
+
+  if (!lock) {
+    report.halted = 'lock_held';
+    return report;
+  }
+
+  try {
+    let commit: string;
+    let tree: { entries: DocsTreeEntry[]; truncated: boolean };
+    try {
+      commit = await reader.head();
+      tree = await reader.tree(commit);
+    } catch (error) {
+      // Either REST call failing after its retries abandons the run WHOLE. It
+      // is not a per-page problem and there is nothing safe to sweep against.
+      report.halted = 'tree_unavailable';
+      report.error = error instanceof Error ? error.message : String(error);
+      return report;
+    }
+
+    report.commit = commit;
+    report.pages = Array.isArray(tree.entries) ? tree.entries.length : 0;
+
+    const validated = validateTree(tree.entries, tree.truncated);
+    if ('error' in validated) {
+      // NO WRITES AND NO DELETES. This is the branch that stands between a
+      // truncated or malformed response and an emptied corpus.
+      report.halted = 'tree_invalid';
+      report.error = validated.error;
+      return report;
+    }
+
+    const pages = validated.pages;
+    report.eligible = pages.length;
+
+    const rows = await mapWithLimit(pages, concurrency, page => indexPage(reader, commit, page));
+    for (const row of rows) {
+      report.bySlug.push(row);
+      if (row.outcome === 'indexed') report.indexed += 1;
+      else if (row.outcome === 'skipped') report.skipped += 1;
+      else report.failed += 1;
+      bump(row.reason ?? row.outcome);
+    }
+
+    // The sweep, LAST and only on a validated non-empty list. The array is a
+    // bound parameter; nothing about a slug reaches the statement as text.
+    const slugs = pages.map(page => page.slug);
+    report.deleted = await prisma.$executeRaw`
+      DELETE FROM docs_index WHERE slug <> ALL(${slugs}::text[])
+    `;
+
+    return report;
+  } catch (error) {
+    report.error = error instanceof Error ? error.message : String(error);
+    return report;
+  } finally {
+    await lock.release();
+  }
+}
+
+/**
+ * One page: is it stale, can it be read, can it be extracted, embed and write.
+ *
+ * Every failure keeps the page's LAST GOOD ROWS. The alternative — deleting on
+ * a failed read — turns a transient 429 into a documentation page that stops
+ * being findable until tomorrow morning.
+ */
+async function indexPage(
+  reader: DocsReader,
+  commit: string,
+  page: EligiblePage
+): Promise<DocsReconcileRow> {
+  try {
+    const stamp = {
+      sourceSha: page.sha,
+      extractVersion: MDX_EXTRACT_VERSION,
+      embedModel: EMBEDDING_MODEL,
+    };
+    // The tree already carried the blob sha, so an unchanged page costs one
+    // cheap query and NO body fetch at all.
+    if (isFresh(await storedChunks(page.slug), stamp)) {
+      return { slug: page.slug, outcome: 'skipped', reason: 'fresh' };
+    }
+
+    let body: string | null;
+    try {
+      body = await reader.body(commit, page.relPath);
+    } catch (error) {
+      const reason = error instanceof DocsBodyError ? error.reason : 'network';
+      return { slug: page.slug, outcome: 'failed', reason };
+    }
+    if (body === null) return { slug: page.slug, outcome: 'failed', reason: 'http_404' };
+
+    // Dynamic: the extract barrel reaches cheerio, and this module is on every
+    // app's startup graph. See the file docblock.
+    const { extractMdxText } = await import('../content/extract/index.ts');
+    const extracted = extractMdxText(body);
+    if (!extracted.ok) {
+      console.warn(`[docsIndex] Extraction failed for ${page.relPath}: ${extracted.error}`);
+      return { slug: page.slug, outcome: 'failed', reason: 'extract' };
+    }
+
+    const chunks = chunkDocument(extracted.text, extracted.title);
+    if (chunks.length === 0) return { slug: page.slug, outcome: 'skipped', reason: 'empty' };
+
+    const embedded = await embedChunks(chunks);
+    if (!embedded.ok) {
+      console.warn(`[docsIndex] Embedding refused ${page.relPath}: ${embedded.reason}`);
+      return { slug: page.slug, outcome: 'failed', reason: embedded.reason };
+    }
+
+    await writePage(page, extracted, chunks, embedded.vectors);
+    return { slug: page.slug, outcome: 'indexed', chunks: chunks.length };
+  } catch (error) {
+    console.warn(
+      `[docsIndex] Could not index ${page.relPath}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+    return { slug: page.slug, outcome: 'failed', reason: 'error' };
+  }
+}

--- a/packages/services/src/classmoji/docsIndex.service.ts
+++ b/packages/services/src/classmoji/docsIndex.service.ts
@@ -133,11 +133,29 @@ export interface DocsReader {
   body(commit: string, relPath: string): Promise<string | null>;
 }
 
-/** A body read that failed in a way worth telling apart in the report. */
+/** How a body read failed, in the terms the report buckets by. */
+export type DocsBodyFailure = 'timeout' | 'rate_limited' | 'http_error' | 'network';
+
+/**
+ * A body read that failed in a way worth telling apart in the report.
+ *
+ * The field is assigned explicitly rather than declared as a constructor
+ * PARAMETER PROPERTY (`constructor(readonly reason: …)`). Five apps in this
+ * monorepo — mcp, hook-station, admin, slides, pages — run TypeScript through
+ * `node --experimental-strip-types`, which erases types but cannot SYNTHESIZE
+ * the assignment a parameter property implies, and refuses the file outright
+ * with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`. Since this module hangs off
+ * `ClassmojiService`, which those apps import at boot, a parameter property
+ * here is a process that will not start — and neither `tsc`, vitest nor the
+ * vite build would have said so.
+ */
 export class DocsBodyError extends Error {
-  constructor(readonly reason: 'timeout' | 'rate_limited' | 'http_error' | 'network') {
+  readonly reason: DocsBodyFailure;
+
+  constructor(reason: DocsBodyFailure) {
     super(`docs body read failed: ${reason}`);
     this.name = 'DocsBodyError';
+    this.reason = reason;
   }
 }
 

--- a/packages/services/src/classmoji/docsSearch.service.ts
+++ b/packages/services/src/classmoji/docsSearch.service.ts
@@ -1,0 +1,312 @@
+/**
+ * docsSearch.service.ts — reads over `docs_index`.
+ *
+ * The documentation half of the retrieval surface: `searchDocs` (vector
+ * search), `listDocs` (enumeration), `getDocText` (one page in full), and
+ * `docsIndexIsEmpty` (the one question a zero-hit answer has to be able to
+ * distinguish).
+ *
+ * ── NO VISIBILITY RULE HERE, AND THAT IS THE POINT ─────────────────────────
+ * `contentSearch.service.ts` next door exists mostly to render one draft/publish
+ * predicate as SQL and as a TypeScript test, because course content is
+ * per-classroom and per-viewer. None of that applies here: the documentation is
+ * a public website. Every row is visible to every caller, there is no
+ * `classroom_id` to filter on and no record to join back to.
+ *
+ * That does NOT make the tools anonymous. The MCP tools these back are still
+ * `roles: MEMBER` against a supplied classroom — you have to be in a course to
+ * ask Ask Moji anything. What is global is the CORPUS, not the door.
+ *
+ * ── Barrel constraint, inherited from the module next door ─────────────────
+ * This module is flat-exported from `packages/services/src/index.ts`, which is
+ * on the startup path of every app in the monorepo. It must therefore NEVER
+ * statically import `./content/extract` (cheerio) or `./helpers/workersAi`. It
+ * needs neither: it takes an already-embedded query vector from its caller and
+ * reads `text` straight back out of the index, so both stay on the WRITE side.
+ */
+
+import getPrisma from '@classmoji/database';
+import { docsUrl } from '@classmoji/utils';
+import { toVectorLiteral } from './contentSearch.service.ts';
+
+/** Result bounds for `searchDocs`, matching the `content_search` tool schema. */
+export const DEFAULT_DOCS_SEARCH_LIMIT = 5;
+export const MAX_DOCS_SEARCH_LIMIT = 20;
+
+/**
+ * Row bounds for `listDocs`, which are ITS OWN and not search's.
+ *
+ * Search is ranked, so five results is a sensible answer. A listing is an
+ * enumeration, and a caller asking "what documentation is there?" wants the
+ * table of contents, not the first five entries of it — the whole corpus is 25
+ * pages, so the default comfortably covers it in one call. Clamping a listing
+ * to the search cap of 20 would truncate the catalogue by five pages and set
+ * `truncated`, which reads as "there is much more" rather than "there are five
+ * more".
+ */
+export const DEFAULT_DOCS_LIST_LIMIT = 100;
+export const MAX_DOCS_LIST_LIMIT = 200;
+
+/** How much of a chunk a hit carries back. Same budget as the course lane. */
+export const DOCS_SNIPPET_CHARS = 400;
+
+const cappedCount = (value: number | undefined, fallback: number, max: number): number =>
+  Math.min(Math.max(Math.trunc(value ?? fallback) || 0, 1), max);
+
+// ─── searchDocs ─────────────────────────────────────────────────────────────
+
+export interface DocsSearchHit {
+  /** The URL path under classmoji.io. Also the id `getDocText` takes. */
+  slug: string;
+  /** Which chunk matched — 0 for a whole-page row. */
+  chunkIx: number;
+  title: string;
+  description: string | null;
+  section: string | null;
+  /** A bounded slice of the matching chunk, never the whole page. */
+  snippet: string;
+  /** Cosine similarity in [-1, 1]; 1 is identical. */
+  score: number;
+}
+
+export interface SearchDocsArgs {
+  /** The embedded query, 1024 long. */
+  queryVector: readonly number[];
+  limit?: number;
+}
+
+/**
+ * Semantic search over the documentation.
+ *
+ * ── The two ORDER BYs are not interchangeable ──────────────────────────────
+ * `DISTINCT ON (slug)` collapses a chunked page to its single best chunk BEFORE
+ * the limit applies, so one long page cannot crowd out every other page. But
+ * Postgres REQUIRES the inner `ORDER BY` to lead with the `DISTINCT ON`
+ * expressions: `ORDER BY embedding <=> q.v` alone is not merely differently
+ * ordered, it is a syntax error ("SELECT DISTINCT ON expressions must match
+ * initial ORDER BY expressions"). Hence `ORDER BY slug, distance, chunk_ix`
+ * inside — which picks each page's nearest chunk, ties broken by the earlier
+ * chunk — and `ORDER BY distance, slug` outside, which is where the actual
+ * ranking happens.
+ *
+ * `WHERE embedding IS NOT NULL` keeps a row written before its embedding call
+ * succeeded from sorting first by accident.
+ *
+ * There is no approximate index and no score floor. 25 rows make an exact scan
+ * the cheapest correct plan, and a relevance threshold needs calibration data
+ * nobody has — abstention is handled in the prompt, where the model can see the
+ * document it is abstaining from.
+ */
+export async function searchDocs({
+  queryVector,
+  limit = DEFAULT_DOCS_SEARCH_LIMIT,
+}: SearchDocsArgs): Promise<DocsSearchHit[]> {
+  const literal = toVectorLiteral(queryVector);
+  const cappedLimit = cappedCount(limit, DEFAULT_DOCS_SEARCH_LIMIT, MAX_DOCS_SEARCH_LIMIT);
+
+  return getPrisma().$queryRaw<DocsSearchHit[]>`
+    WITH q AS (SELECT ${literal}::vector AS v)
+    SELECT best.slug        AS "slug",
+           best.chunk_ix    AS "chunkIx",
+           best.title       AS "title",
+           best.description AS "description",
+           best.section     AS "section",
+           best.snippet     AS "snippet",
+           best.score       AS "score"
+    FROM (
+      SELECT DISTINCT ON (di.slug)
+             di.slug,
+             di.chunk_ix,
+             di.title,
+             di.description,
+             di.section,
+             LEFT(di.text, ${DOCS_SNIPPET_CHARS}::int) AS snippet,
+             1 - (di.embedding <=> q.v) AS score,
+             (di.embedding <=> q.v)     AS distance
+      FROM docs_index di
+      CROSS JOIN q
+      WHERE di.embedding IS NOT NULL
+      ORDER BY di.slug, di.embedding <=> q.v, di.chunk_ix
+    ) AS best
+    ORDER BY best.distance ASC, best.slug
+    LIMIT ${cappedLimit}`;
+}
+
+// ─── listDocs ───────────────────────────────────────────────────────────────
+
+export interface DocsListEntry {
+  slug: string;
+  title: string;
+  description: string | null;
+  section: string | null;
+  /** The canonical page URL, built from the one shared origin. */
+  url: string | null;
+  updatedAt: Date;
+}
+
+export interface ListDocsArgs {
+  /** Rows to return. Clamped to `[1, MAX_DOCS_LIST_LIMIT]`. */
+  limit?: number;
+  /** Rows to skip. Negative and fractional values floor to 0. */
+  offset?: number;
+}
+
+export interface DocsListPage {
+  items: DocsListEntry[];
+  /** True when more rows matched than were returned. */
+  truncated: boolean;
+  /** The `offset` that continues this listing, or null when it is complete. */
+  nextOffset: number | null;
+}
+
+/**
+ * The documentation's table of contents.
+ *
+ * ONE ROW PER PAGE, not per chunk. `DISTINCT ON (slug) … ORDER BY slug,
+ * chunk_ix` takes each page's first chunk, which is the one carrying the title;
+ * without it a three-chunk page would appear three times and a model would
+ * report the corpus as half again as large as it is.
+ *
+ * The presentation order is then `section NULLS FIRST, lower(title), slug` —
+ * the root pages (`docs`, `docs/video-tutorials`) first, then each section's
+ * pages alphabetically. That order is TOTAL, which is what makes `OFFSET` safe
+ * to page on: no two rows tie, so the window cannot shift under a caller
+ * mid-listing unless the corpus itself changes.
+ *
+ * `limit + 1` rows are asked for and at most `limit` returned: one extra row is
+ * the cheapest possible answer to "is there more?", and a caller handed exactly
+ * `limit` rows otherwise cannot tell a complete catalogue from a truncated one.
+ *
+ * Unlike `listContent`, this reads the INDEX rather than a live record table,
+ * because the index is the only place these pages exist on this side of the
+ * wire. A page that has not been indexed yet is therefore simply absent — and
+ * `docsIndexIsEmpty` is how a caller tells "nothing indexed yet" from "nothing
+ * there".
+ */
+export async function listDocs({ limit, offset }: ListDocsArgs = {}): Promise<DocsListPage> {
+  const cappedLimit = cappedCount(limit, DEFAULT_DOCS_LIST_LIMIT, MAX_DOCS_LIST_LIMIT);
+  const cappedOffset = Math.max(Math.trunc(offset ?? 0) || 0, 0);
+
+  const rows = await getPrisma().$queryRaw<Array<Omit<DocsListEntry, 'url'>>>`
+    SELECT page.slug        AS "slug",
+           page.title       AS "title",
+           page.description AS "description",
+           page.section     AS "section",
+           page.updated_at  AS "updatedAt"
+    FROM (
+      SELECT DISTINCT ON (di.slug)
+             di.slug, di.title, di.description, di.section, di.updated_at
+      FROM docs_index di
+      ORDER BY di.slug, di.chunk_ix
+    ) AS page
+    ORDER BY page.section ASC NULLS FIRST, lower(page.title), page.slug
+    LIMIT ${cappedLimit + 1} OFFSET ${cappedOffset}`;
+
+  const truncated = rows.length > cappedLimit;
+  // The probe row is never handed out — it exists only to have been counted.
+  const items = (truncated ? rows.slice(0, cappedLimit) : rows).map(row => ({
+    ...row,
+    url: docsUrl(row.slug),
+  }));
+
+  return {
+    items,
+    truncated,
+    nextOffset: truncated ? cappedOffset + cappedLimit : null,
+  };
+}
+
+// ─── getDocText ─────────────────────────────────────────────────────────────
+
+/**
+ * No such documentation page.
+ *
+ * Deliberately NOT the same refusal as `ContentNotFoundError`. That one is
+ * uniform across "no such id", "another classroom's id" and "an id you may not
+ * see", because distinguishing them would turn `content_get` into a probe a
+ * student could enumerate drafts with. Documentation is public: there is
+ * nothing to enumerate and no cross-classroom boundary to defend, so this can
+ * say plainly what happened.
+ */
+export class DocsNotFoundError extends Error {
+  readonly code = 'DOC_NOT_FOUND';
+
+  constructor() {
+    super('Documentation page not found.');
+    this.name = 'DocsNotFoundError';
+  }
+}
+
+export interface DocsDocumentText {
+  slug: string;
+  title: string;
+  description: string | null;
+  section: string | null;
+  /** The canonical page URL. */
+  url: string | null;
+  /** Every chunk, concatenated in `chunk_ix` order. */
+  text: string;
+  chunkCount: number;
+  updatedAt: Date;
+}
+
+/**
+ * One documentation page's full extracted text.
+ *
+ * ONE SIGNATURE: a bare slug in, the page out, `DocsNotFoundError` when there
+ * is none. No options object and no viewer, because there is nothing to vary.
+ *
+ * `string_agg(text, … ORDER BY chunk_ix)` is what reassembles a chunked page in
+ * reading order; without the ORDER BY inside the aggregate, Postgres is free to
+ * concatenate the chunks in whatever order the scan produced, and a model
+ * reading a shuffled document answers confidently out of a paragraph that has
+ * lost its context.
+ *
+ * This returns the INDEXED text — what the extractor produced — never the raw
+ * `.mdx`, so no caller is ever handed component syntax or frontmatter markers.
+ */
+export async function getDocText(slug: string): Promise<DocsDocumentText> {
+  if (typeof slug !== 'string' || slug.length === 0) throw new DocsNotFoundError();
+
+  const rows = await getPrisma().$queryRaw<Array<Omit<DocsDocumentText, 'url'>>>`
+    SELECT di.slug AS "slug",
+           (array_agg(di.title       ORDER BY di.chunk_ix))[1] AS "title",
+           (array_agg(di.description ORDER BY di.chunk_ix))[1] AS "description",
+           (array_agg(di.section     ORDER BY di.chunk_ix))[1] AS "section",
+           string_agg(di.text, chr(10) || chr(10) ORDER BY di.chunk_ix) AS "text",
+           count(*)::int   AS "chunkCount",
+           max(di.updated_at) AS "updatedAt"
+    FROM docs_index di
+    WHERE di.slug = ${slug}
+    GROUP BY di.slug`;
+
+  const [document] = rows;
+  if (!document) throw new DocsNotFoundError();
+  return { ...document, url: docsUrl(document.slug) };
+}
+
+// ─── docsIndexIsEmpty ───────────────────────────────────────────────────────
+
+/**
+ * Has this deployment ever built the documentation index?
+ *
+ * THE ANSWER IS THE BOOLEAN THE STATEMENT RETURNS, not a property of the result
+ * array. Two tempting wrong shapes:
+ *
+ *   - `rows.length === 0` on `SELECT … FROM docs_index LIMIT 1` inverted, or
+ *     any variant that tests whether a row came BACK: `SELECT NOT EXISTS (…)`
+ *     always returns exactly one row, so testing the array is always `false`;
+ *   - `SELECT count(*) = 0`: counts rows, not USABLE rows. A table full of
+ *     rows whose embedding is null is not empty by that measure, and is
+ *     completely unsearchable.
+ *
+ * `NOT EXISTS (SELECT 1 … WHERE embedding IS NOT NULL)` answers the question
+ * the caller is actually asking: can a search find anything at all? It is the
+ * difference between telling a user "the docs say nothing about that" and
+ * telling them "documentation search has not been switched on here".
+ */
+export async function docsIndexIsEmpty(): Promise<boolean> {
+  const rows = await getPrisma().$queryRaw<Array<{ empty: boolean }>>`
+    SELECT NOT EXISTS (SELECT 1 FROM docs_index WHERE embedding IS NOT NULL) AS empty`;
+  return rows[0]?.empty === true;
+}

--- a/packages/services/src/classmoji/docsSearch.service.ts
+++ b/packages/services/src/classmoji/docsSearch.service.ts
@@ -27,28 +27,68 @@
 
 import getPrisma from '@classmoji/database';
 import { docsUrl } from '@classmoji/utils';
-import { toVectorLiteral } from './contentSearch.service.ts';
-
-/** Result bounds for `searchDocs`, matching the `content_search` tool schema. */
-export const DEFAULT_DOCS_SEARCH_LIMIT = 5;
-export const MAX_DOCS_SEARCH_LIMIT = 20;
+import {
+  DEFAULT_LIST_LIMIT,
+  DEFAULT_SEARCH_LIMIT,
+  MAX_LIST_LIMIT,
+  MAX_SEARCH_LIMIT,
+  SNIPPET_CHARS,
+  toVectorLiteral,
+} from './contentSearch.service.ts';
 
 /**
- * Row bounds for `listDocs`, which are ITS OWN and not search's.
+ * ONE SET OF BOUNDS FOR BOTH CORPORA, imported rather than re-declared.
  *
- * Search is ranked, so five results is a sensible answer. A listing is an
- * enumeration, and a caller asking "what documentation is there?" wants the
- * table of contents, not the first five entries of it — the whole corpus is 25
- * pages, so the default comfortably covers it in one call. Clamping a listing
- * to the search cap of 20 would truncate the catalogue by five pages and set
- * `truncated`, which reads as "there is much more" rather than "there are five
- * more".
+ * `content_search` and `content_list` are ONE tool each with a `scope` argument
+ * and a SINGLE `limit` field, so each zod schema can name exactly one maximum.
+ * It names the course one. This module used to declare a docs-prefixed copy of
+ * each bound with the same value, export them all, and have nobody import them
+ * — which made "the schema refuses at the threshold the service clamps at" true
+ * only by coincidence. Editing the docs copy would have moved the clamp and
+ * left the refusal where it was, and nothing would have said so.
+ *
+ * The numbers are shared because the reasons are, bound by bound:
+ *   - search is ranked, so five results is an answer and twenty a generous
+ *     ceiling;
+ *   - a listing is an enumeration, and a caller asking "what documentation is
+ *     there?" wants the table of contents rather than its first five entries.
+ *     The docs corpus is 25 pages against a default of 100, so one call covers
+ *     it, and clamping a listing to search's 20 would set `truncated` on a
+ *     complete catalogue — which reads as "there is much more";
+ *   - a snippet is a pointer to a document the caller is told to read in full,
+ *     and 400 characters is enough to tell whether it is the right one.
+ *
+ * If the two lanes ever genuinely need different ceilings, the tool schema has
+ * to grow a per-scope refinement in the SAME change — which is the point of
+ * there being no second constant to quietly edit first.
  */
-export const DEFAULT_DOCS_LIST_LIMIT = 100;
-export const MAX_DOCS_LIST_LIMIT = 200;
 
-/** How much of a chunk a hit carries back. Same budget as the course lane. */
-export const DOCS_SNIPPET_CHARS = 400;
+/**
+ * The shortest chunk `searchDocs` will return. A FLOOR ON LENGTH, NOT ON SCORE.
+ *
+ * Two pages in the corpus are section indexes — `docs/instructors` (253
+ * characters) and `docs/students` (187) — and both are a heading plus a list of
+ * link labels. They carry every topic word in their section and answer nothing,
+ * so they embed close to any question about that section: across the twelve
+ * questions this was measured on they took 35% of the available top-five slots,
+ * pushing out the page that does answer.
+ *
+ * 400 sits in a GAP rather than on a guess. The corpus's chunk lengths jump
+ * straight from 253 to 537, so the threshold separates the two navigation stubs
+ * from the shortest real page with room on either side. That is also why this
+ * is a length rule and not a relevance threshold: a score floor needs
+ * calibration data nobody has, while "this page is a list of links" is a fact
+ * about the text.
+ *
+ * It applies to `searchDocs` ONLY. `listDocs` still enumerates the stubs,
+ * `getDocText` still serves them whole, and `docsIndexIsEmpty` still counts
+ * them — a page search cannot reach is still a page a model may be pointed at
+ * by name, and the prompt tells it to follow a stub's labels to the page behind
+ * them. `reconcileDocsIndex` reports every slug that falls below this line in
+ * `belowSearchMin`, so a page that is short by ACCIDENT is visible rather than
+ * silently unsearchable.
+ */
+export const DOCS_SEARCH_MIN_CHARS = 400;
 
 const cappedCount = (value: number | undefined, fallback: number, max: number): number =>
   Math.min(Math.max(Math.trunc(value ?? fallback) || 0, 1), max);
@@ -90,7 +130,13 @@ export interface SearchDocsArgs {
  * ranking happens.
  *
  * `WHERE embedding IS NOT NULL` keeps a row written before its embedding call
- * succeeded from sorting first by accident.
+ * succeeded from sorting first by accident, and
+ * `length(di.text) >= DOCS_SEARCH_MIN_CHARS` keeps the two navigation stubs out
+ * — see that constant for why the rule is length rather than score, and why it
+ * lives HERE and not in `listDocs`, `getDocText` or `docsIndexIsEmpty`. It sits
+ * in the INNER query on purpose: applied outside, a page whose best chunk is
+ * short would be dropped entirely instead of falling back to a longer chunk of
+ * the same page.
  *
  * There is no approximate index and no score floor. 25 rows make an exact scan
  * the cheapest correct plan, and a relevance threshold needs calibration data
@@ -99,10 +145,10 @@ export interface SearchDocsArgs {
  */
 export async function searchDocs({
   queryVector,
-  limit = DEFAULT_DOCS_SEARCH_LIMIT,
+  limit = DEFAULT_SEARCH_LIMIT,
 }: SearchDocsArgs): Promise<DocsSearchHit[]> {
   const literal = toVectorLiteral(queryVector);
-  const cappedLimit = cappedCount(limit, DEFAULT_DOCS_SEARCH_LIMIT, MAX_DOCS_SEARCH_LIMIT);
+  const cappedLimit = cappedCount(limit, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
 
   return getPrisma().$queryRaw<DocsSearchHit[]>`
     WITH q AS (SELECT ${literal}::vector AS v)
@@ -120,12 +166,13 @@ export async function searchDocs({
              di.title,
              di.description,
              di.section,
-             LEFT(di.text, ${DOCS_SNIPPET_CHARS}::int) AS snippet,
+             LEFT(di.text, ${SNIPPET_CHARS}::int) AS snippet,
              1 - (di.embedding <=> q.v) AS score,
              (di.embedding <=> q.v)     AS distance
       FROM docs_index di
       CROSS JOIN q
       WHERE di.embedding IS NOT NULL
+        AND length(di.text) >= ${DOCS_SEARCH_MIN_CHARS}::int
       ORDER BY di.slug, di.embedding <=> q.v, di.chunk_ix
     ) AS best
     ORDER BY best.distance ASC, best.slug
@@ -145,7 +192,7 @@ export interface DocsListEntry {
 }
 
 export interface ListDocsArgs {
-  /** Rows to return. Clamped to `[1, MAX_DOCS_LIST_LIMIT]`. */
+  /** Rows to return. Clamped to `[1, MAX_LIST_LIMIT]`. */
   limit?: number;
   /** Rows to skip. Negative and fractional values floor to 0. */
   offset?: number;
@@ -184,7 +231,7 @@ export interface DocsListPage {
  * there".
  */
 export async function listDocs({ limit, offset }: ListDocsArgs = {}): Promise<DocsListPage> {
-  const cappedLimit = cappedCount(limit, DEFAULT_DOCS_LIST_LIMIT, MAX_DOCS_LIST_LIMIT);
+  const cappedLimit = cappedCount(limit, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
   const cappedOffset = Math.max(Math.trunc(offset ?? 0) || 0, 0);
 
   const rows = await getPrisma().$queryRaw<Array<Omit<DocsListEntry, 'url'>>>`

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -76,6 +76,7 @@ import * as contentAssetsService from './contentAssets.service.ts';
 import * as contentDeliveryService from './contentDelivery.service.ts';
 import * as contentIndexService from './contentIndex.service.ts';
 import * as contentSearchService from './contentSearch.service.ts';
+import * as docsIndexService from './docsIndex.service.ts';
 import * as deckRenderTokenService from './deckRenderToken.service.ts';
 import * as deckThumbnailContract from './deckThumbnail.contract.ts';
 import * as deckThumbnailService from './deckThumbnail.service.ts';
@@ -141,6 +142,11 @@ const ClassmojiService = {
   contentDelivery: contentDeliveryService,
   contentIndex: contentIndexService,
   contentSearch: contentSearchService,
+  // The PRODUCT DOCUMENTATION index — a second, classroom-independent corpus.
+  // Namespaced beside `contentIndex` rather than folded into it because it
+  // writes a different table with no `classroom_id`, and the one thing that
+  // must never happen is a global row reaching a per-classroom statement.
+  docsIndex: docsIndexService,
   deckRenderToken: deckRenderTokenService,
   // One namespace, two files. They read as a single thing to a caller
   // (`deckThumbnail.thumbnailPathFor`, `deckThumbnail.enqueueDeckThumbnail`)

--- a/packages/services/src/classmoji/index.ts
+++ b/packages/services/src/classmoji/index.ts
@@ -77,6 +77,7 @@ import * as contentDeliveryService from './contentDelivery.service.ts';
 import * as contentIndexService from './contentIndex.service.ts';
 import * as contentSearchService from './contentSearch.service.ts';
 import * as docsIndexService from './docsIndex.service.ts';
+import * as docsSearchService from './docsSearch.service.ts';
 import * as deckRenderTokenService from './deckRenderToken.service.ts';
 import * as deckThumbnailContract from './deckThumbnail.contract.ts';
 import * as deckThumbnailService from './deckThumbnail.service.ts';
@@ -147,6 +148,7 @@ const ClassmojiService = {
   // writes a different table with no `classroom_id`, and the one thing that
   // must never happen is a global row reaching a per-classroom statement.
   docsIndex: docsIndexService,
+  docsSearch: docsSearchService,
   deckRenderToken: deckRenderTokenService,
   // One namespace, two files. They read as a single thing to a caller
   // (`deckThumbnail.thumbnailPathFor`, `deckThumbnail.enqueueDeckThumbnail`)

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/index.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/index.mdx
@@ -1,0 +1,38 @@
+---
+title: Welcome to Classmoji Docs
+description: Find all the resources and guides you need to get started
+---
+
+import DocCards from '../../../components/DocCards.astro';
+
+<DocCards cards={[
+  {
+    emoji: "🚀",
+    title: "Get started",
+    description: "Create your account in under a minute",
+    href: "/docs/introduction/getting-started"
+  },
+  {
+    emoji: "👨‍🏫",
+    title: "For instructors",
+    description: "Classrooms, modules, assignments, grading",
+    href: "/docs/instructors"
+  },
+  {
+    emoji: "📖",
+    title: "Core concepts",
+    description: "How Classmoji maps to Github",
+    href: "/docs/introduction/fundamentals"
+  },
+  {
+    emoji: "🐳",
+    title: "Self-hosting",
+    description: "Run it on your own infrastructure",
+    href: "/docs/self-hosting/docker"
+  }
+]} />
+
+### What is Classmoji?
+Classmoji is a Git-native platform for CS courses, think Github Classroom but built for how CS is actually practiced. Every assignment lives in a repo, instructors get automated workflows and real teaching tools, and nobody has to fight a clunky interface to make it happen.
+
+We used to use Github Classroom and loved it, but we needed more, so we started this project almost 4 years ago. One small python script that started it all.

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/custom-domains.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/custom-domains.mdx
@@ -1,0 +1,66 @@
+---
+title: Use your own domain
+description: Serve your class website on a domain you own, like cs52.me
+---
+
+:::note
+Connecting your own domain is a **Pro** feature. A class website on a `classmoji.io` subdomain is not.
+:::
+
+### Before you start
+
+You need three things: a class website already live on a subdomain, a domain (or a subdomain of one) that you control, and access to that domain's DNS records. A departmental domain and a course domain you bought yourself both work.
+
+### Add the domain
+
+Go to **Settings → Website** and find the **Custom domain** section. Enter the domain you want the site served on, such as `cs52.me` or `cs52.department.edu`, and save it.
+
+Classmoji then shows the DNS records to add. Nothing changes for your visitors until those records exist.
+
+### Point the domain at Classmoji
+
+There are two groups of records, and they answer two different questions.
+
+**Routing — add ONE of these, not both**
+
+| Option | When to use it |
+|--------|---------------|
+| **A (and AAAA) records** | Point the name straight at our addresses. Works anywhere, including at a root domain like `cs52.me` where a CNAME often cannot go. |
+| **CNAME record** | One record, and it follows us if our addresses ever change. Many DNS hosts refuse a CNAME at a root domain: there, use their ALIAS, ANAME or CNAME flattening record with the same value (Cloudflare flattens automatically). |
+
+Adding both is not extra insurance. A CNAME alongside an A record for the same name is an invalid zone, so pick the row that fits your DNS host and add only that one.
+
+**Proof of ownership — any one of these**
+
+| Record | Name |
+|--------|------|
+| **CNAME** | `_acme-challenge.{your domain}` |
+| **TXT** | `_fly-ownership.{your domain}` |
+
+If your routing choice included an AAAA record, it does double duty: it routes IPv6 traffic and proves ownership, so you can skip this group entirely. The page tells you when that applies.
+
+### Watch the certificate
+
+Classmoji requests the TLS certificate for you as soon as the records resolve. The status chip next to the domain reports where it is:
+
+| Chip | Meaning |
+|------|---------|
+| **No certificate yet** | The request has not started |
+| **Pending DNS** | We are still waiting on your records |
+| **Issuing** | Records found, certificate being issued |
+| **Active** | The certificate is live and the domain is served over HTTPS |
+
+DNS changes take anywhere from a few minutes to a few hours to propagate, depending on your host and the record's previous TTL. Nothing here needs babysitting: leave the tab, come back later.
+
+The domain is marked verified once the site has actually served a request on that hostname, which is a stronger signal than a record merely existing.
+
+### Disconnect a domain
+
+Use the disconnect button in the same section. The site stays reachable at its `classmoji.io` subdomain, so disconnecting takes the custom address down without taking the course site down.
+
+Disconnecting stays available even if a Pro subscription lapses. A domain you pointed at us is one you must always be able to point somewhere else.
+
+### What's next
+
+- [Publish a class website](/docs/instructors/class-sites)
+- [Build pages](/docs/instructors/pages)

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/grading.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/grading.mdx
@@ -1,0 +1,65 @@
+---
+title: Grading
+description: How emoji grading works and how to grade assignments
+---
+
+import Screenshot from '~/components/Screenshot.astro';
+import GradeCalculationDiagram from '~/components/GradeCalculationDiagram.astro';
+import gradesImg from './img-grades.png';
+import gradingImg from './img-grading.png';
+import gradingQueueImg from './img-grading-queue.png';
+import settingsGradesImg from './img-settings-grades.png';
+
+Classmoji replaces numeric scores with emojis. Each emoji maps to a numeric value you configure, so grading stays expressive without losing precision.
+
+### Emoji mappings
+
+Before grading, set up your emoji mappings in **Settings > Grades**. Each emoji you add gets assigned a numeric value (0–100). You can click **Populate defaults** to start with a sensible set.
+
+<Screenshot src={settingsGradesImg} alt="Settings > Grades showing the emoji-to-value mappings and the Populate defaults button" frame url="app.classmoji.io/admin/cs-101/settings/grades" size="lg" />
+
+When you grade a submission, you pick from these emojis. If you assign multiple emojis to a submission, the grade is the average of their values.
+
+### Grading an assignment
+
+Open a repository from the sidebar and find the assignment you want to grade. Each student or team row has an emoji picker, click it to open, then click an emoji to add a grade. Click the same emoji again to remove it. Each row is one submission: a student's repository, their work on that assignment, and its status.
+
+<Screenshot src={gradingImg} alt="A repository's grading view with per-student submission rows, emoji grades, graders, and a release toggle" frame url="app.classmoji.io/admin/cs-101/repos/hello-world" size="lg" />
+
+Assignments are graded per submission (one repository per student or team). You can assign graders to specific submissions from the repository view, so grading responsibilities stay organized across large classes. Assistants get a dedicated grading queue that gathers every submission across the class, with tabs for what still needs grading.
+
+<Screenshot src={gradingQueueImg} alt="The assistant grading queue listing submissions by owner, repository, and assignment with status tabs" frame url="app.classmoji.io/assistant/cs-101/grading" size="lg" />
+
+### Releasing grades
+
+Grades are hidden from students by default. Each assignment has a **release toggle** in the repository view. Flip it to release grades for that assignment — students will see their grade immediately.
+
+Releasing is per-assignment, so you can release one assignment while keeping others hidden.
+
+### Grade calculations
+
+Grades nest from the emoji values you apply all the way up to the final grade:
+
+<GradeCalculationDiagram />
+
+**Assignment grade** — the average of all emoji values applied to that submission.
+
+**Repository grade** — the average of all assignment grades within the repository. If drop lowest is enabled for the repository, the single lowest assignment grade is excluded from the average.
+
+**Final grade** — the average of all repository grades. Each repository contributes equally unless you configure weights in **Settings > Grades**.
+
+### Letter grades
+
+Map numeric ranges to letter grades in **Settings > Grades** (for example, 90–100 = A, 80–89 = B). Once configured, letter grades appear alongside numeric grades in the gradebook.
+
+### Late penalties
+
+You can apply a late penalty per assignment. When enabled, submissions after the deadline are automatically docked by the configured percentage. The penalty is applied before the grade feeds into repository and final grade calculations.
+
+### Gradebook
+
+The **Grades** page shows a full gradebook: every student as a row, every assignment as a column. You can toggle between emoji view and numeric view, search by student name or login, and edit letter grades inline.
+
+<Screenshot src={gradesImg} alt="The gradebook showing students with letter grades, raw grades, and final grade columns" frame url="app.classmoji.io/admin/cs-101/grades" size="lg" />
+
+For each student you can also leave a grade comment — open the comment panel from the gradebook row to add notes visible only to staff.

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/mcp-server.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/mcp-server.mdx
@@ -1,0 +1,111 @@
+---
+title: Connect the MCP server
+description: Let Claude (and other AI assistants) act on your classroom through the Classmoji MCP server.
+---
+
+The Classmoji **MCP server** lets an AI assistant — Claude, or any Model Context Protocol client — work with your classroom on your behalf: read your roster, grades, assignments, and calendar, and take actions like grading submissions, resolving regrades, and managing pages, modules, and tokens.
+
+:::note
+The assistant acts **as you**, with **exactly your permissions** in each classroom — the same role rules the web app enforces. It can't see or do anything you couldn't already do yourself, and you can disconnect at any time.
+:::
+
+You sign in once with your normal Classmoji (GitHub) account and approve a consent screen; no API keys to copy or manage.
+
+## The server URL
+
+```
+https://mcp.classmoji.io/mcp
+```
+
+That's the only value you need for any client. When a client connects, it discovers everything else automatically and walks you through signing in.
+
+## Connect from Claude (claude.ai & desktop)
+
+1. In **claude.ai** (or the Claude desktop app), open **Settings → Connectors**.
+2. Click **Add custom connector**.
+3. Paste the server URL `https://mcp.classmoji.io/mcp` and click **Add**.
+4. Click **Connect** on the new connector. You'll be sent to Classmoji to sign in with GitHub and approve access (read and write). When it's done, the connector shows **Connected**.
+5. In a chat, click the **+** in the message box → **Connectors**, and toggle **Classmoji** on for that conversation. Claude can now use your classroom's tools.
+
+:::note
+Custom connectors are available on Free, Pro, Max, Team, and Enterprise plans (the Free plan allows one custom connector). On **Team/Enterprise**, an organization **Owner** adds the connector once under **Organization settings → Connectors**, and then each member connects their own Classmoji account. Connectors added on web are automatically available in the desktop and mobile apps — though new connectors can only be *added* from web or desktop, not mobile.
+:::
+
+## Connect from Claude Code
+
+```bash
+claude mcp add --transport http classmoji https://mcp.classmoji.io/mcp
+```
+
+Then, inside a Claude Code session, run `/mcp`, select **classmoji**, and choose **Authenticate** — your browser opens for the Classmoji sign-in and consent. Run `/mcp` again (or `claude mcp list`) to confirm the tools loaded.
+
+Add `--scope project` if you want the server checked into the repo's `.mcp.json` and shared with your team, instead of just your machine.
+
+## Connect from other tools
+
+The server works with any MCP client that supports remote (HTTP) servers with OAuth. The config differs slightly per tool — note the field names, they vary.
+
+**Cursor** — `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "classmoji": { "url": "https://mcp.classmoji.io/mcp" }
+  }
+}
+```
+
+Then open **Settings → MCP Servers**, click **Needs Login** next to Classmoji, and complete the sign-in.
+
+**VS Code** (Copilot agent mode, VS Code 1.101+) — `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "classmoji": { "type": "http", "url": "https://mcp.classmoji.io/mcp" }
+  }
+}
+```
+
+The root key is `servers` and `"type": "http"` is required. Click the **Auth** CodeLens above the entry to sign in.
+
+**Zed** — `settings.json`, under `context_servers`:
+
+```json
+{
+  "context_servers": {
+    "classmoji": { "url": "https://mcp.classmoji.io/mcp" }
+  }
+}
+```
+
+Zed prompts you to authenticate automatically the first time it connects.
+
+**Windsurf / Devin Desktop** — `~/.codeium/windsurf/mcp_config.json`. Note the field is **`serverUrl`**, not `url`:
+
+```json
+{
+  "mcpServers": {
+    "classmoji": { "serverUrl": "https://mcp.classmoji.io/mcp" }
+  }
+}
+```
+
+**MCP Inspector** (for testing) — run `npx @modelcontextprotocol/inspector`, set **Transport Type** to **Streamable HTTP**, enter the server URL, and click **Connect** to run the OAuth flow interactively.
+
+:::note
+For any other MCP client: point it at `https://mcp.classmoji.io/mcp`. A spec-compliant client discovers the sign-in flow on its own (RFC 9728 / OAuth 2.1 with PKCE), registers itself, and opens a browser for you to sign in to Classmoji and approve access — no manual app registration needed.
+:::
+
+## What you can do
+
+Once connected, the assistant has two kinds of capabilities, each limited to your role in each classroom:
+
+- **Read** — your classrooms, roster, teams, assignment containers and submissions, the grading queue, leaderboard, regrade requests, calendar, pages, modules, quizzes, forms and their responses, and your token ledger.
+- **Act** — add and remove emoji grades, assign graders, resolve regrade requests, update assignments, create and publish modules, create and edit pages, manage calendar events, and grant tokens. You can also create and publish forms, label responses as you work through them, and add responses you collected elsewhere — a spreadsheet, a previous term's list — as if the person had filled the form in.
+
+Staff-only surfaces (rosters, grading, the leaderboard) require the corresponding teaching-team or owner role, exactly as in the web app; students connecting the same server get only their own view.
+
+## Managing access
+
+Every action the assistant takes is recorded in your classroom's audit log, just like an action in the web app. To revoke access, remove the connector (in Claude, **Settings → Connectors**; in Claude Code, `claude mcp logout classmoji` or **Clear authentication** in the `/mcp` menu) — the access is cut off immediately.

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/roster.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/instructors/roster.mdx
@@ -1,0 +1,60 @@
+---
+title: Manage your roster
+description: How to add students and teaching staff to your classroom
+---
+
+import Screenshot from '~/components/Screenshot.astro';
+import studentsImg from './img-students.png';
+import assistantsImg from './img-assistants.png';
+
+### Adding students
+
+Go to the **Students** tab and click **Add Students** in the top right.
+
+Paste your student list into the textarea, one per line. Export it from your school's system and paste it straight in:
+
+```
+Name, Email
+John Doe, john@school.edu
+Jane Smith, jane@school.edu
+```
+
+Before adding, you'll see a preview: valid entries in green, skipped ones in gray with a reason (invalid email, already enrolled, etc.). Confirm to add them all.
+
+<Screenshot src={studentsImg} alt="The Students roster showing enrolled students with status and per-row actions" frame url="app.classmoji.io/admin/cs-101/students" size="lg" />
+
+What happens next depends on whether they're already on Classmoji:
+
+- **Already on Classmoji**: automatically added to the classroom.
+- **New to Classmoji**: sent an email invite to join the platform. Once they sign up, they'll be added to the classroom.
+
+When a student accesses the classroom for the first time, they'll receive a Github organization invite. They need to accept it to access their classroom dashboard and get repo access. (Yes, there's an extra step here. Github's rules, not ours.)
+
+### Adding teaching staff
+
+Go to the **Teaching Staff** tab and click **New staff member**.
+
+Pick the role, enter their Github username, and confirm. The username is the only thing you have to type — name and email are optional, and default to whatever their Github profile says.
+
+The three roles:
+
+- **Assistant**: grades the work assigned to them and helps run the class.
+- **Teacher**: teaches the class — content, quizzes, and grading — but not class settings.
+- **Co-owner**: full control of the classroom, including changing every setting, managing the whole teaching staff, and deleting the classroom and everything in it. Adding one asks you to confirm, because there's no undo for what they delete.
+
+Co-owner is a Classmoji role, not a Github organization admin. Anything that runs with your own Github credentials — such as the Github cleanup offered when a classroom is deleted — will fail for a co-owner who isn't an admin of the Github organization.
+
+Roles add up rather than replace: granting someone a second role in the same class leaves the first one alone, and they appear once per role they hold.
+
+<Screenshot src={assistantsImg} alt="A teaching staff list showing a TA with a grader-role toggle and status" frame caption="An earlier version of this screen, from when it listed assistants only." size="lg" />
+
+### Removing someone
+
+Find the person in the table and click **Remove** in the actions column. Pending invites can be revoked the same way. This removes them from the classroom and the Github organization, but any existing data they have stays intact.
+
+On the Teaching Staff tab you're removing the role on that row, so someone who holds two roles keeps the other one. A classroom always needs at least one owner, so removing the last one is refused.
+
+### Pending vs Active
+
+- **Pending**: added to the classroom but hasn't joined the Github organization yet
+- **Active**: part of both the Classmoji classroom and the Github organization

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/open-source/local-development/index.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/open-source/local-development/index.mdx
@@ -1,0 +1,196 @@
+---
+title: Local development
+description: Run Classmoji on your machine and contribute code.
+---
+
+import Screenshot from '~/components/Screenshot.astro';
+import wizardImg from './wizard.png';
+import classroomsImg from './classrooms.png';
+import environmentImg from './environment.png';
+import keyImg from './key.png';
+import neonDashboardImg from './neon_dashboard.png';
+import installAppImg from './install_app.png';
+import webhookImg from './webhook.png';
+import newSmeeImg from './new_app.png';
+
+:::note
+You clone the repo, copy the env file, run two commands, and you're in 🎉. 
+
+That's the goal, anyway. If reality diverges, we're on [GitHub](https://github.com/classmoji/classmoji) and happy to help.
+:::
+
+
+Minimal setup covers most contributions. Full setup is only needed if you're working on GitHub-integrated features like repository sync, webhooks, or background jobs.
+
+## Prerequisites
+
+- Node.js 22+
+- [Docker](https://www.docker.com/) (if using the Docker database option)
+- A GitHub account
+
+## 1. Fork and clone the repo
+
+Go to [github.com/classmoji/classmoji](https://github.com/classmoji/classmoji), fork it ([how to fork a repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)), then clone your fork:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/classmoji.git
+cd classmoji
+git remote add upstream https://github.com/classmoji/classmoji.git
+npm install
+```
+
+Adding `upstream` lets you pull in future changes from the main repo with `git fetch upstream`.
+
+## 2. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+:::note
+Whenever you manually edit `.env`, restart the dev server for changes to take effect: stop it with `Ctrl+C` and run it again.
+:::
+
+
+## 3. Database setup
+
+Choose one option. Both work with the rest of the setup.
+
+### Method 1: Docker
+
+No account needed, runs fully offline. Install [Docker](https://www.docker.com/) if you don't have it.
+
+```bash
+npm run db:start
+```
+
+The `DATABASE_URL` in `.env.example` already points to the Docker instance — no changes needed.
+
+### Method 2: Neon
+
+Neon is a serverless PostgreSQL platform with a generous free tier. It's a great option if you can't run Docker or want to visualize your database — Neon provides a built-in UI where you can browse tables and run queries directly in the browser.
+
+1. Sign up at [neon.com](https://neon.com) and create a new project
+2. On the project dashboard, click the **Connection string** card
+
+<Screenshot src={neonDashboardImg} alt="Neon project dashboard showing the Connection string card" />
+
+3. Copy the connection string and paste it as `DATABASE_URL` in your `.env`
+
+### Apply migrations and seed
+
+Regardless of which option you chose:
+
+```bash
+npm run db:generate # generates the Prisma client
+npm run db:deploy   # applies migrations
+npm run db:seed     # seeds dev classroom and fake users
+```
+
+## 4. Run the app
+
+To start the webapp service:
+
+```bash
+npm run web:dev
+```
+
+Open `http://localhost:3000` — you'll be taken to a setup wizard because `SETUP_GITHUB_APP=true` is set in your `.env`. Click **Create GitHub App on Github**, confirm on GitHub, and you'll be redirected back.
+
+<Screenshot src={wizardImg} alt="Classmoji setup wizard" frame url="localhost:3000/setup" />
+
+<Screenshot src={newSmeeImg} alt="GitHub App creation page on GitHub" />
+
+After the wizard completes, the GitHub App values are automatically written to your `.env` and the setup flag is cleared. Restart the dev server as prompted, then sign in with your GitHub account. You'll be automatically added to the dev classroom as Owner, TA, and Student.
+
+<Screenshot src={classroomsImg} alt="Dev classroom showing Owner, TA, and Student roles" frame url="localhost:3000/select-organization" />
+
+The organization, classroom, and student accounts shown are all seeded fake data — nothing connects to a real GitHub organization or real users.
+
+### What you can work on with this setup
+
+- UI changes — components, styles, dark mode, layouts
+- Database schema changes and migrations
+- Student, instructor, and TA views and workflows
+- Grading, tokens, calendar, and modules
+- Anything that doesn't require real GitHub repositories or live webhooks
+
+---
+
+## 5. Full setup (optional)
+
+:::note
+This section is only needed if you're working on GitHub-integrated features: repository creation, assignment auto-setup, feedback PRs, pages, webhook event handling, or background jobs in `packages/tasks`. Skip it if you're doing UI or database work.
+:::
+
+### Set up Trigger.dev
+
+Trigger.dev is the background job runner Classmoji uses for tasks like repository creation and assignment setup. Its dashboard lets you see the status of jobs as they run locally.
+
+1. Sign up at [trigger.dev](https://trigger.dev) and create a new project
+2. In the sidebar, make sure **Development** is selected as the environment
+
+<Screenshot src={environmentImg} alt="Trigger.dev sidebar showing Development environment and API Keys" />
+
+3. Click **API keys** in the sidebar menu and copy your development key — it starts with `tr_dev_`
+
+<Screenshot src={keyImg} alt="Trigger.dev API keys tab showing a development key" />
+
+4. Add it to your `.env`:
+
+```env
+TRIGGER_SECRET_KEY="tr_dev_your-key-here"
+```
+5. In the trigger sidebar, click on the **General** tab and copy the **Project ref** value (e.g. `proj_abccrutouxchmrddss`).
+6. Add it to your `/packages/tasks/trigger.config.js` file as the `project` value.
+
+```js
+export default defineConfig({
+  project: 'proj_abccrutouxchmrddss',
+  ...rest,
+});
+```
+### Set up the webhook tunnel
+
+GitHub needs a public URL to send webhook events to. But your local server isn't reachable from the internet — that's where [Smee](https://smee.io) comes in.
+
+Smee is a free webhook proxy. It gives you a public URL that receives events and forwards them to your local machine in real time.
+
+1. Go to [smee.io/new](https://smee.io/new) — it'll generate a unique channel URL for you (e.g. `https://smee.io/abc123`)
+2. Open [apps/hook-station/package.json](https://github.com/classmoji/classmoji/blob/main/apps/hook-station/package.json) and replace the `hook:github` URL with your channel URL:
+
+```json
+"hook:github": "smee -u https://smee.io/your-channel -p 4000 --path /webhooks/callback/github"
+```
+
+3. Go to your GitHub App settings at `https://github.com/settings/apps/YOUR_APP_NAME` — replace `YOUR_APP_NAME` with the value of `GITHUB_APP_NAME` in your `.env`. Set the **Webhook URL** to your Smee channel URL.
+
+<Screenshot src={webhookImg} alt="GitHub App settings showing the Webhook URL field" />
+
+4. Copy the value of `GITHUB_WEBHOOK_SECRET` from your `.env` into the **Webhook secret** field in the GitHub App settings.
+
+### Create a test GitHub organization
+
+Before doing the steps below, make sure to stop running the webapp service and run:
+
+```bash
+npm run dev # starts all services: webapp, slides, pages, hook, Trigger.dev worker, and the Smee tunnel
+```
+
+1. [Create a free GitHub organization](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch) to use for testing.
+
+2. Open `http://localhost:3000/select-organization` and click **Create new class**.
+
+3. Click **Install GitHub App on an organization**. This will open a new window to install the GitHub App on your organization.
+
+<Screenshot src={installAppImg} alt="GitHub App installation page for selecting an organization" frame url="github.com" />
+
+4. Select your organization and click **Install** and make sure to give it access to your repositories.
+
+5. Follow the [create a classroom guide](/docs/instructors/create-classroom) to set up your first classroom. After that, you're fully set up and ready to work on any part of the app.
+
+:::note
+You wired up a GitHub App, tunneled webhooks through the internet, and created a fake org just to test a button. You're not just a contributor — you're a legend 🏆.
+
+Now go break something (and fix it).
+:::

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/self-hosting/environment-variables.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/self-hosting/environment-variables.mdx
@@ -1,0 +1,75 @@
+---
+title: Environment variables
+description: All environment variables required to run Classmoji
+---
+
+### Core
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `DATABASE_URL` | Yes | | PostgreSQL connection string for the Classmoji database. |
+| `BETTER_AUTH_SECRET` | Yes | | Secret used to sign auth sessions and tokens. Generate with `openssl rand -base64 32`. |
+| `WEBAPP_URL` | Yes | | Public base URL of the main web app (e.g. `http://localhost:3000`). |
+| `SLIDES_URL` | Yes | | Public base URL of the slides service. |
+| `PAGES_URL` | Yes | | Public base URL of the pages service. |
+
+### Github integration
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `GITHUB_APP_NAME` | No | | Slug of your Github App, used to build install and authorization links. |
+| `GITHUB_APP_ID` | No | | Numeric ID of your Github App. |
+| `GITHUB_CLIENT_ID` | No | | OAuth client ID for Github sign-in. |
+| `GITHUB_CLIENT_SECRET` | No | | OAuth client secret for Github sign-in. |
+| `GITHUB_WEBHOOK_SECRET` | No | | Secret used to verify incoming Github webhook signatures. Generate with `openssl rand -base64 32`. |
+| `GITHUB_PRIVATE_KEY_BASE64` | No | | Base64-encoded private key for your Github App, used to authenticate API requests. |
+
+### AI features
+
+AI features (quizzes, syllabus bot, prompt assistant) run on **Anthropic Claude**. They are optional: when `AI_AGENT_URL` and `AI_AGENT_SHARED_SECRET` are unset, AI features are hidden and the related API routes return 503.
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `AI_AGENT_URL` | No | | URL of the AI agent service. Enables AI features when set with the shared secret. |
+| `AI_AGENT_SHARED_SECRET` | No | | Shared secret used to authenticate the webapp to the AI agent. |
+| `ANTHROPIC_API_KEY` | No | | Anthropic API key the AI agent uses to call Claude. |
+| `LLM_MODEL` | No | `claude-sonnet-4-5` | Claude model used for quiz and chat evaluation. |
+| `EXPLORATION_MODEL` | No | `claude-haiku-4-5` | Claude model used for code-aware quiz repository exploration. |
+| `EXPLORATION_MODE` | No | | Controls the code-aware exploration behavior for quizzes. |
+| `OPENAI_API_KEY` | No | | Reserved. Not used by any current feature. |
+| `LLM_PROVIDER` | No | | Reserved. Only Anthropic/Claude is wired today. |
+
+### Payments
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `STRIPE_SECRET_KEY` | No | | Stripe secret API key for subscription checkout and billing. |
+| `STRIPE_WEBHOOK_SECRET` | No | | Secret used to verify incoming Stripe webhook signatures. |
+
+### Email
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `EMAIL` | No | | Address used as the sender for outgoing email. |
+| `EMAIL_PASSWORD` | No | | Password (or app password) for the sending email account. |
+
+### Background jobs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `TRIGGER_API_URL` | No | | Base URL of the Trigger.dev API. Leave unset to use Trigger.dev cloud. |
+| `TRIGGER_SECRET_KEY` | No | | Trigger.dev secret key used to authenticate background job runs. |
+
+### Media
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `CLOUDINARY_CLOUD_NAME` | No | | Cloudinary cloud name for image and media uploads. |
+| `CLOUDINARY_API_KEY` | No | | Cloudinary API key for signed uploads. |
+| `CLOUDINARY_API_SECRET` | No | | Cloudinary API secret for signed uploads. |
+
+### Other
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `CALENDAR_SECRET` | No | | Secret used to sign calendar feed (iCal) URLs. Generate with `openssl rand -base64 32`. |

--- a/packages/services/src/content/extract/__tests__/fixtures/docs/video-tutorials.mdx
+++ b/packages/services/src/content/extract/__tests__/fixtures/docs/video-tutorials.mdx
@@ -1,0 +1,45 @@
+---
+title: Video tutorials
+description: Watch Classmoji in action
+---
+
+import Video from '~/components/Video.astro';
+import getStartedIntroImg from './introduction/img-get-started-intro.png';
+import createClassroomIntroImg from './instructors/img-create-classroom-intro.png';
+import importIntroImg from './instructors/img-import-intro.png';
+
+Short walkthroughs of Classmoji, all in one place. Click any video to play.
+
+## Getting started
+
+Create your account and get into Classmoji.
+
+<Video
+  id="iP_zxmqOrm8"
+  title="Getting started with Classmoji"
+  caption="Set up your Classmoji account"
+  size="lg"
+  poster={getStartedIntroImg.src}
+/>
+
+## For instructors
+
+Set up a new classroom from scratch.
+
+<Video
+  id="ZkwReXJmBVw"
+  title="Create a classroom in Classmoji"
+  caption="Create your first classroom"
+  size="lg"
+  poster={createClassroomIntroImg.src}
+/>
+
+Already on Github Classroom? Bring your classrooms, rosters, and grades across.
+
+<Video
+  id="o8174ZXQos0"
+  title="Importing from Github Classroom"
+  caption="Import your classrooms from Github Classroom"
+  size="lg"
+  poster={importIntroImg.src}
+/>

--- a/packages/services/src/content/extract/__tests__/mdx.test.ts
+++ b/packages/services/src/content/extract/__tests__/mdx.test.ts
@@ -1,0 +1,474 @@
+/**
+ * The MDX extractor's CONTRACT, pinned against real documentation pages.
+ *
+ * ── Why real pages and not hand-written snippets ───────────────────────────
+ * Every bug this extractor can have is a bug about a shape that actually occurs
+ * in `apps/site/src/content/docs`, and a snippet written by the same person who
+ * wrote the stripper tests only what they already thought of. The fixtures
+ * under `fixtures/docs/` are eight of the twenty-five pages, copied byte for
+ * byte from the public repo this indexes.
+ *
+ * ── EXACT PRESERVATION, not a length guard ─────────────────────────────────
+ * A blanket `expect(text.length).toBeGreaterThan(…)` passes for a stripper that
+ * has quietly turned `TRIGGER_SECRET_KEY` into `TRIGGERSECRETKEY`. Every
+ * assertion below names the exact string that must survive, or the exact string
+ * that must NOT appear, because those are the failures that reach a user as
+ * confident, wrong configuration advice.
+ *
+ * ── The live corpus sweep ──────────────────────────────────────────────────
+ * The last block runs the extractor over EVERY `.mdx` in the real docs tree
+ * when that tree is present. That is what catches the docs growing a ninth
+ * component, a block-scalar frontmatter or a paired tag — the cases the
+ * extractor refuses on purpose, which must surface as a failing test here
+ * rather than as a page that silently stops being searchable.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { extractMdxText, KNOWN_MDX_COMPONENTS, MDX_EXTRACT_VERSION } from '../mdx.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(here, 'fixtures', 'docs');
+
+const page = (relative: string): string => readFileSync(join(FIXTURES, relative), 'utf8');
+const textOf = (relative: string): string => {
+  const result = extractMdxText(page(relative));
+  expect(result.ok, `${relative} must extract`).toBe(true);
+  return result.text;
+};
+
+/** Every fixture's text, for the assertions that must hold across all of them. */
+const ALL_FIXTURES = [
+  'index.mdx',
+  'video-tutorials.mdx',
+  'instructors/roster.mdx',
+  'instructors/mcp-server.mdx',
+  'instructors/grading.mdx',
+  'instructors/custom-domains.mdx',
+  'self-hosting/environment-variables.mdx',
+  'open-source/local-development/index.mdx',
+] as const;
+
+describe('code survives verbatim, because it is protected before anything else runs', () => {
+  it('keeps an underscored env var out of a fenced block intact', () => {
+    // `TRIGGER_SECRET_KEY="tr_dev_your-key-here"` lives inside a fenced env
+    // block. An emphasis pass that ran before code was protected would eat both
+    // underscores and index `TRIGGERSECRETKEY`.
+    expect(textOf('open-source/local-development/index.mdx')).toContain(
+      'TRIGGER_SECRET_KEY="tr_dev_your-key-here"'
+    );
+  });
+
+  it('keeps an underscored identifier out of an INLINE code span intact', () => {
+    // `context_servers` appears twice in mcp-server.mdx: once as an inline span
+    // in prose and once inside a json fence. Both must survive.
+    const text = textOf('instructors/mcp-server.mdx');
+    expect(text).toContain('context_servers');
+    expect(text).not.toContain('contextservers');
+    expect(text).toContain('"context_servers": {');
+  });
+
+  it('keeps a leading-underscore DNS record name intact', () => {
+    // `_acme-challenge.{your domain}` is an inline span inside a table cell —
+    // two rules at once, either of which could mangle it.
+    const text = textOf('instructors/custom-domains.mdx');
+    expect(text).toContain('_acme-challenge');
+    expect(text).toContain('_fly-ownership');
+  });
+
+  it('keeps a whole shell command copyable', () => {
+    expect(textOf('instructors/mcp-server.mdx')).toContain(
+      'claude mcp add --transport http classmoji https://mcp.classmoji.io/mcp'
+    );
+  });
+
+  it('keeps an env-var name inside a table cell intact', () => {
+    expect(textOf('self-hosting/environment-variables.mdx')).toContain('TRIGGER_SECRET_KEY');
+  });
+
+  it('leaves the `{variable}` placeholders in code alone rather than reading them as JSX', () => {
+    expect(textOf('instructors/custom-domains.mdx')).toContain('{your domain}');
+  });
+});
+
+describe('a screenshot is attributed AND keeps its caption', () => {
+  const roster = () => textOf('instructors/roster.mdx');
+
+  it('harvests the alt text, labelled with the component it came from', () => {
+    expect(roster()).toContain(
+      'Screenshot: A teaching staff list showing a TA with a grader-role toggle and status'
+    );
+  });
+
+  it('keeps the caption that contradicts the alt, on the line after it', () => {
+    // THE case finding 2 is about. The alt describes a grader-role toggle; the
+    // caption says the screenshot is out of date. An index that carried the
+    // first without the second would answer "there is a grader-role toggle on
+    // the Teaching Staff list" as current product behaviour.
+    expect(roster()).toMatch(
+      /Screenshot: A teaching staff list showing a TA with a grader-role toggle and status\nAn earlier version of this screen, from when it listed assistants only\./
+    );
+  });
+
+  it('leaves the prose around the component exactly where it was', () => {
+    const text = roster();
+    const preceding =
+      'Roles add up rather than replace: granting someone a second role in the same class leaves the first one alone, and they appear once per role they hold.';
+    const following = 'Removing someone';
+    expect(text).toContain(preceding);
+    expect(text.indexOf(preceding)).toBeLessThan(text.indexOf('Screenshot: A teaching staff list'));
+    expect(text.indexOf('Screenshot: A teaching staff list')).toBeLessThan(text.indexOf(following));
+  });
+
+  it('NEVER harvests `url` — it is browser chrome, not a destination', () => {
+    // Screenshot.astro draws it as display text in a fake browser frame, over
+    // an example classroom that does not exist. Indexed, it becomes a link the
+    // assistant hands a real instructor.
+    expect(roster()).not.toContain('app.classmoji.io/admin/cs-101/students');
+    for (const fixture of ALL_FIXTURES) {
+      expect(textOf(fixture), `${fixture} must not carry a Screenshot url`).not.toContain(
+        'app.classmoji.io/admin/cs-101'
+      );
+    }
+  });
+
+  it('harvests an alt containing a `>` WHOLE, and leaves no tag debris behind', () => {
+    // `alt="Settings > Grades showing …"`. A depth-only scanner ends the tag at
+    // that `>`, truncating the alt and spilling `… frame url="…" size="lg" />`
+    // into the corpus as prose.
+    const text = textOf('instructors/grading.mdx');
+    expect(text).toContain(
+      'Screenshot: Settings > Grades showing the emoji-to-value mappings and the Populate defaults button'
+    );
+    expect(text).not.toContain('/>');
+    expect(text).not.toContain('size="lg"');
+    expect(text).not.toContain('frame url=');
+  });
+});
+
+describe('multiline components are consumed whole', () => {
+  it('consumes every multiline <Video> in video-tutorials.mdx', () => {
+    // A line-oriented scanner leaves `id="…"`, `title={…}` and `poster={…}`
+    // behind as prose when the opening `<Video` is alone on its line.
+    const text = textOf('video-tutorials.mdx');
+    expect(text).not.toContain('<Video');
+    expect(text).not.toContain('poster=');
+    expect(text).not.toContain('src=');
+    expect(text).not.toContain('title={');
+    expect(text.match(/^Video: /gm) ?? []).toHaveLength(3);
+    expect(text).toContain('Video: Getting started with Classmoji\nSet up your Classmoji account');
+  });
+
+  it('consumes the multiline <DocCards> array without emitting any href', () => {
+    // Its cards are an attribute EXPRESSION — a nested JS array. Harvesting it
+    // would mean evaluating an attribute and emitting navigation URLs.
+    const text = textOf('index.mdx');
+    expect(text).not.toContain('DocCards');
+    expect(text).not.toContain('href:');
+    expect(text).not.toContain('/docs/introduction/getting-started');
+    // The prose after it is still there, so the block was consumed rather than
+    // the rest of the file being swallowed with it.
+    expect(text).toContain('What is Classmoji?');
+  });
+});
+
+describe('tables are left exactly as they are', () => {
+  it('keeps a row’s pipes, its cells and its EMPTY cell', () => {
+    // The association between a name, whether it is required, its default and
+    // its description IS the content. An empty "Default" cell means "no
+    // default" — dropping it shifts every later cell under the wrong header.
+    const text = textOf('self-hosting/environment-variables.mdx');
+    expect(text).toContain(
+      '| TRIGGER_SECRET_KEY | No | | Trigger.dev secret key used to authenticate background job runs. |'
+    );
+    expect(text).toContain('| Name | Required | Default | Description |');
+  });
+
+  it('does not strip emphasis inside a table cell either', () => {
+    expect(textOf('instructors/custom-domains.mdx')).toContain('| **CNAME** | _acme-challenge');
+  });
+});
+
+describe('markdown syntax becomes prose', () => {
+  it('drops heading hashes, bullets, emphasis and link targets', () => {
+    const text = textOf('instructors/roster.mdx');
+    expect(text).toContain('Adding students');
+    expect(text).not.toMatch(/^#{1,6} /m);
+    expect(text).toContain('Go to the Students tab and click Add Students in the top right.');
+    expect(text).toContain('Assistant: grades the work assigned to them and helps run the class.');
+    expect(text).not.toMatch(/^- /m);
+  });
+
+  it('keeps the prose inside a ::: directive and drops only the markers', () => {
+    const text = textOf('instructors/mcp-server.mdx');
+    expect(text).not.toMatch(/^:::/m);
+    expect(text).toContain('The assistant acts as you, with exactly your permissions');
+  });
+
+  it('collapses a markdown link to its text, dropping the TARGET as well as the brackets', () => {
+    // Not merely "the `](` syntax is gone": a stripper that rewrote
+    // `[Docker](https://www.docker.com/)` to `Docker https://www.docker.com/`
+    // also satisfies that, and puts a wall of URLs into the embedded text.
+    const text = textOf('open-source/local-development/index.mdx');
+    expect(text).not.toMatch(/\]\(https?:/);
+    expect(text).toContain('Docker');
+    expect(text).not.toContain('https://www.docker.com/');
+    expect(text).not.toContain(
+      'https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo'
+    );
+    expect(text).toContain('how to fork a repo');
+  });
+
+  it('strips emphasis ONLY at word boundaries, so an identifier in plain prose survives', () => {
+    // The code-span protection does not cover this: an env var named in running
+    // prose without backticks reaches the emphasis rules unprotected, and a
+    // blanket `_` strip turns `AI_AGENT_URL` into `AIAGENTURL` — a name that
+    // matches nothing anyone can search for.
+    const result = extractMdxText(
+      '---\ntitle: Test\ndescription: d\n---\n\nSet AI_AGENT_URL and *also* __both__ of _these_ to enable it.\n'
+    );
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain('AI_AGENT_URL');
+    expect(result.text).toContain('also');
+    expect(result.text).not.toContain('*also*');
+    expect(result.text).toContain('these');
+    expect(result.text).not.toContain('_these_');
+  });
+
+  it('leaves an UNPAIRED asterisk alone — a glob is not emphasis', () => {
+    // `*.env` has one asterisk and no closing partner. A blanket `*` strip
+    // turns it into `.env`, which is a different filename.
+    const result = extractMdxText(
+      '---\ntitle: Test\ndescription: d\n---\n\nIgnore files matching *.env and keep **this** bold.\n'
+    );
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain('*.env');
+    expect(result.text).toContain('keep this bold.');
+    expect(result.text).not.toContain('**this**');
+  });
+});
+
+describe('no tag or import syntax reaches the corpus', () => {
+  it.each(ALL_FIXTURES)('%s carries no import, component or JSX debris', fixture => {
+    const text = textOf(fixture);
+    expect(text).not.toMatch(/^import /m);
+    expect(text).not.toContain('~/components');
+    expect(text).not.toContain('.astro');
+    expect(text).not.toContain('DocCards');
+    expect(text).not.toContain('href:');
+    for (const component of KNOWN_MDX_COMPONENTS) {
+      expect(text, `${fixture} still contains <${component}`).not.toContain(`<${component}`);
+    }
+  });
+});
+
+describe('the title and description lead the text', () => {
+  it('puts frontmatter title then description at the top', () => {
+    const result = extractMdxText(page('instructors/roster.mdx'));
+    expect(result.title).toBe('Manage your roster');
+    expect(result.description).toBe('How to add students and teaching staff to your classroom');
+    expect(result.text.startsWith('Manage your roster\nHow to add students')).toBe(true);
+  });
+});
+
+describe('an unfamiliar shape is a refusal, never a guess', () => {
+  const withFrontmatter = (body: string): string =>
+    `---\ntitle: Test page\ndescription: A fixture\n---\n\n${body}\n`;
+
+  it('refuses a component nobody has decided about', () => {
+    const result = extractMdxText(withFrontmatter('<NewThing prop="x" />'));
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('unknown_component');
+    expect(result.text).toBe('');
+  });
+
+  it('refuses a paired JSX element, whose children are an open question', () => {
+    const result = extractMdxText(withFrontmatter('<Screenshot alt="x">child</Screenshot>'));
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('paired_component');
+  });
+
+  it('refuses a tag that never closes', () => {
+    const result = extractMdxText(withFrontmatter('<Screenshot alt="x"'));
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('unclosed_component');
+  });
+
+  it('refuses a page with no frontmatter at all', () => {
+    const result = extractMdxText('Just some prose with no frontmatter.\n');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('frontmatter_missing');
+  });
+
+  it('refuses frontmatter with no closing delimiter', () => {
+    const result = extractMdxText('---\ntitle: Test page\ndescription: A fixture\n\nBody.\n');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('frontmatter_unterminated');
+  });
+
+  it('refuses a block scalar rather than indexing its first line', () => {
+    const result = extractMdxText(
+      '---\ntitle: Test\ndescription: |\n  line one\n  line two\n---\n\nBody.\n'
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('frontmatter_block_scalar');
+  });
+
+  it('refuses a value continued on the next line', () => {
+    const result = extractMdxText(
+      '---\ntitle: Test\ndescription: starts here\n  and continues\n---\n\nBody.\n'
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('frontmatter_unparsed');
+  });
+
+  it('refuses a page with no title', () => {
+    const result = extractMdxText('---\ndescription: A fixture\n---\n\nBody.\n');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('frontmatter_missing_title');
+  });
+
+  it('refuses an empty title, which is not the same as a page called ""', () => {
+    const result = extractMdxText('---\ntitle:\ndescription: A fixture\n---\n\nBody.\n');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('frontmatter_missing_title');
+  });
+
+  it('refuses an import shape it has not been taught', () => {
+    const result = extractMdxText(withFrontmatter("import { A, B } from '~/components/x.astro';"));
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('unknown_import');
+  });
+
+  it('refuses an empty source', () => {
+    expect(extractMdxText('').error).toBe('empty_source');
+    expect(extractMdxText('   \n  ').error).toBe('empty_source');
+  });
+
+  it('IGNORES an unknown frontmatter key whose shape is familiar', () => {
+    // Unknown keys are not a refusal — an unknown SHAPE is. A new scalar key is
+    // additive; a block scalar or a nested mapping is not.
+    const result = extractMdxText('---\ntitle: Test\nsidebar_order: 3\n---\n\nBody.\n');
+    expect(result.ok).toBe(true);
+    expect(result.title).toBe('Test');
+    expect(result.text).toContain('Body.');
+    expect(result.text).not.toContain('sidebar_order');
+  });
+
+  it('accepts a quoted frontmatter value, unquoted', () => {
+    const result = extractMdxText(
+      '---\ntitle: "Quoted title"\ndescription: \'Quoted\'\n---\n\nBody.\n'
+    );
+    expect(result.ok).toBe(true);
+    expect(result.title).toBe('Quoted title');
+    expect(result.description).toBe('Quoted');
+  });
+
+  it('is a SUCCESS, not a failure, when the body trims to nothing', () => {
+    const result = extractMdxText('---\ntitle: Stub page\ndescription: Nothing yet\n---\n');
+    expect(result.ok).toBe(true);
+    expect(result.text).toBe('Stub page\nNothing yet');
+  });
+
+  it('never throws, whatever it is handed', () => {
+    for (const input of ['---', '---\n---', '`'.repeat(9), '<', '{{{{', '---\ntitle: t\n---\n<']) {
+      expect(() => extractMdxText(input)).not.toThrow();
+    }
+  });
+});
+
+describe('the version constant', () => {
+  it('is a positive integer nothing else may redeclare', () => {
+    expect(Number.isInteger(MDX_EXTRACT_VERSION)).toBe(true);
+    expect(MDX_EXTRACT_VERSION).toBeGreaterThan(0);
+  });
+});
+
+// ─── The live corpus ────────────────────────────────────────────────────────
+
+/**
+ * The real `apps/site/src/content/docs` tree, when this checkout has it.
+ *
+ * Guarded rather than assumed, the same way the ai-agent's prompt tests guard
+ * their cross-package reads: a services test must not hard-fail because
+ * somebody moved an app. When it IS there, this is the assertion that turns a
+ * docs change the extractor refuses into a red test instead of a page that
+ * quietly stops being searchable.
+ */
+const DOCS_ROOT = join(
+  here,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  'apps',
+  'site',
+  'src',
+  'content',
+  'docs'
+);
+const haveDocs = existsSync(DOCS_ROOT);
+const describeLive = haveDocs ? describe : describe.skip;
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir).flatMap(entry => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return full.endsWith('.mdx') ? [full] : [];
+  });
+
+describeLive('every page in the live docs tree extracts', () => {
+  it('extracts all of them, and names any that do not', () => {
+    const files = walk(DOCS_ROOT).sort();
+    expect(files.length).toBeGreaterThan(0);
+
+    const refused = files
+      .map(file => ({ file, result: extractMdxText(readFileSync(file, 'utf8')) }))
+      .filter(entry => !entry.result.ok)
+      .map(entry => `${entry.file.slice(DOCS_ROOT.length)}: ${entry.result.error}`);
+
+    // A refusal here is not necessarily a bug in the extractor — it is the
+    // extractor reporting that the docs grew a shape nobody decided about.
+    // Either teach it the shape or change the page; do not loosen this.
+    expect(refused).toEqual([]);
+  });
+
+  it('leaves no page with tag or import debris', () => {
+    for (const file of walk(DOCS_ROOT)) {
+      const { text } = extractMdxText(readFileSync(file, 'utf8'));
+      expect(text, file).not.toMatch(/^import /m);
+      expect(text, file).not.toContain('/>');
+      expect(text, file).not.toContain('~/components');
+    }
+  });
+
+  it('consumes all six <Video> blocks across the whole corpus', () => {
+    // The plan says "video-tutorials.mdx: all six multiline <Video> blocks" —
+    // that file has three. The other three live in getting-started.mdx,
+    // create-classroom.mdx and import-github-classroom.mdx. Six is the CORPUS
+    // total, and this is where it is checked.
+    const videos = walk(DOCS_ROOT)
+      .map(file => extractMdxText(readFileSync(file, 'utf8')).text)
+      .join('\n')
+      .match(/^Video: /gm);
+    expect(videos ?? []).toHaveLength(6);
+  });
+
+  it('keeps the copied fixtures byte-identical to the live pages', () => {
+    // The fixtures are the stable contract; this is what says they still
+    // describe reality. A docs edit that changes one of them fails HERE, with a
+    // clear instruction, rather than leaving the contract tests green against
+    // text nobody serves any more.
+    for (const relative of ALL_FIXTURES) {
+      const live = join(DOCS_ROOT, 'docs', relative);
+      if (!existsSync(live)) continue;
+      expect(readFileSync(live, 'utf8'), `${relative} drifted — re-copy the fixture`).toBe(
+        page(relative)
+      );
+    }
+  });
+});

--- a/packages/services/src/content/extract/__tests__/mdx.test.ts
+++ b/packages/services/src/content/extract/__tests__/mdx.test.ts
@@ -88,6 +88,44 @@ describe('code survives verbatim, because it is protected before anything else r
     expect(textOf('self-hosting/environment-variables.mdx')).toContain('TRIGGER_SECRET_KEY');
   });
 
+  it('returns a fence BODY byte for byte, markdown syntax and all', () => {
+    // The four assertions above survive `protectCode` being deleted outright,
+    // because the emphasis rules already spare a lone `_` inside a word and a
+    // `**` with no partner. This one does not: every line here is a shape one
+    // of the markdown passes rewrites — `*stars*` and `_underscores_` are
+    // emphasis, `## not a heading` is a heading, `- not a bullet` is a bullet,
+    // `[not](a-link)` is a link. Inside a fence they are none of those, they
+    // are the file somebody is about to copy, and they must come back
+    // unchanged.
+    const fence = [
+      'echo *stars* and _underscores_',
+      '## not a heading',
+      '- not a bullet',
+      '[not](a-link)',
+      '',
+      '  indented  and  spaced',
+    ].join('\n');
+    const result = extractMdxText(
+      `---\ntitle: Fences\ndescription: d\n---\n\nBefore.\n\n\`\`\`bash\n${fence}\n\`\`\`\n\nAfter.\n`
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain(fence);
+    // The prose around it still went through the markdown passes.
+    expect(result.text).toContain('Before.');
+    expect(result.text).toContain('After.');
+  });
+
+  it('leaves no backtick and no fence marker anywhere in the output', () => {
+    // The delimiters are scaffolding, not content: a reader copies the command,
+    // not the ``` around it, and an embedded ``` is three tokens of noise on
+    // every fenced page. Asserted across every fixture, and the corpus has 18
+    // fences and inline spans throughout, so this is not vacuous.
+    for (const fixture of ALL_FIXTURES) {
+      expect(textOf(fixture), `${fixture} still carries a backtick`).not.toContain('`');
+    }
+  });
+
   it('leaves the `{variable}` placeholders in code alone rather than reading them as JSX', () => {
     expect(textOf('instructors/custom-domains.mdx')).toContain('{your domain}');
   });
@@ -201,6 +239,24 @@ describe('markdown syntax becomes prose', () => {
     expect(text).not.toMatch(/^- /m);
   });
 
+  it('keeps a numbered heading’s ORDINAL — a heading is not also a list item', () => {
+    // `## 1. Fork and clone the repo`. The heading strip fires first and leaves
+    // `1. Fork and clone the repo`, which the list strip then reads as a
+    // numbered bullet and eats. All five steps of the local-development guide
+    // came out unnumbered, so the prose's "step 3" pointed at nothing.
+    const text = textOf('open-source/local-development/index.mdx');
+    expect(text).toContain('1. Fork and clone the repo');
+    expect(text).toContain('2. Configure environment variables');
+    expect(text).toContain('5. Full setup (optional)');
+    // And an ordinary numbered LIST still loses its marker.
+    const list = extractMdxText(
+      '---\ntitle: T\ndescription: d\n---\n\n1. First thing\n2. Second thing\n'
+    );
+    expect(list.ok).toBe(true);
+    expect(list.text).toContain('First thing');
+    expect(list.text).not.toContain('1. First thing');
+  });
+
   it('keeps the prose inside a ::: directive and drops only the markers', () => {
     const text = textOf('instructors/mcp-server.mdx');
     expect(text).not.toMatch(/^:::/m);
@@ -282,6 +338,48 @@ describe('an unfamiliar shape is a refusal, never a guess', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBe('unknown_component');
     expect(result.text).toBe('');
+  });
+
+  it('refuses an INDENTED unknown component, not just one in column zero', () => {
+    // The scanner used to open a block only where `body[at - 1] === '\n'`, so
+    // an indented component — a nested list item, a `:::note` body — was copied
+    // out as prose and never reached this refusal at all. A component nobody
+    // has decided about is a refusal wherever it sits on the line.
+    for (const body of [
+      '  <NewThing prop="x" />',
+      '\t<NewThing prop="x" />',
+      'Steps:\n\n- First:\n    <NewThing prop="x" />',
+    ]) {
+      const result = extractMdxText(withFrontmatter(body));
+      expect(result.ok, `"${body}" must refuse`).toBe(false);
+      expect(result.error).toBe('unknown_component');
+    }
+  });
+
+  it('CONSUMES an indented known component, alt and all', () => {
+    const result = extractMdxText(
+      withFrontmatter('Steps:\n\n- First:\n  <Screenshot alt="An indented picture" size="lg" />')
+    );
+    expect(result.ok).toBe(true);
+    expect(result.text).toContain('Screenshot: An indented picture');
+    // No debris: the whole tag went, not just its opening angle bracket.
+    expect(result.text).not.toContain('/>');
+    expect(result.text).not.toContain('size=');
+    expect(result.text).not.toContain('<Screenshot');
+  });
+
+  it('still treats a `<` that follows anything but WHITESPACE as prose', () => {
+    // "First non-space characters of a line" is the rule, not "anywhere on a
+    // line". A component name mid-sentence is prose the corpus is allowed to
+    // contain, and a bullet marker is not whitespace either — teaching this
+    // scanner where a list item's content begins is a markdown parser's job.
+    // That is not a silent hole: an unconsumed tag leaves `/>` behind, and the
+    // live-corpus sweep at the bottom of this file fails on `/>` in any page.
+    for (const body of ['Compare a <Screenshot alt="x" /> inline.', '- <Screenshot alt="x" />']) {
+      const result = extractMdxText(withFrontmatter(body));
+      expect(result.ok).toBe(true);
+      expect(result.text).toContain('<Screenshot alt="x" />');
+    }
   });
 
   it('refuses a paired JSX element, whose children are an open question', () => {

--- a/packages/services/src/content/extract/index.ts
+++ b/packages/services/src/content/extract/index.ts
@@ -25,6 +25,16 @@ import { extractDeckHtmlText, extractPageHtmlText } from './html.ts';
 export type { ContentReference } from './blocknote.ts';
 export { KNOWN_BLOCK_TYPES } from './blocknote.ts';
 
+// The documentation extractor, re-exported through the SAME subpath so callers
+// need only one import specifier for "turn bytes into indexable text". It is
+// pure string work — no cheerio — but it rides this barrel because
+// `docsIndex.service.ts` reaches it by the same dynamic `await import()` the
+// course indexer uses, and a second subpath would be a second thing to keep in
+// step. `MDX_EXTRACT_VERSION` is the single version authority for the docs
+// corpus; nothing else may declare one.
+export { extractMdxText, MDX_EXTRACT_VERSION, KNOWN_MDX_COMPONENTS } from './mdx.ts';
+export type { ExtractedMdx } from './mdx.ts';
+
 export type ExtractSource =
   /**
    * `pages/<slug>/content.json`. Both stored shapes are accepted — the

--- a/packages/services/src/content/extract/mdx.ts
+++ b/packages/services/src/content/extract/mdx.ts
@@ -415,10 +415,17 @@ function stripJsx(body: string): { text: string } | { error: string } {
   let at = 0;
 
   while (at < body.length) {
-    // A block opens only where a line does: `<` mid-sentence is prose, and the
-    // corpus has no inline JSX.
-    const atLineStart = at === 0 || body[at - 1] === '\n';
-    if (!atLineStart || body[at] !== '<') {
+    // A block opens at the first NON-SPACE characters of a line: `<`
+    // mid-sentence is prose, and the corpus has no inline JSX.
+    //
+    // The indentation matters. Gating on `body[at - 1] === '\n'` — column zero
+    // only — means an indented component, the shape a nested list item or a
+    // `:::note` body produces, is never recognised as a component at all. It is
+    // copied out as prose, which silently defeats the whole fail-closed rule
+    // below: `  <NewThing prop="x" />` inside a list would reach the corpus as
+    // text instead of refusing the page, and a `<Screenshot>` indented the same
+    // way would spill `/>` and lose its alt.
+    if (!atFirstNonSpace(body, at) || body[at] !== '<') {
       out += body[at];
       at += 1;
       continue;
@@ -448,6 +455,18 @@ function stripJsx(body: string): { text: string } | { error: string } {
   return { text: out };
 }
 
+/**
+ * Is `at` the first character of its line that is not a space or a tab?
+ *
+ * Leading whitespace only — nothing else may intervene, so `text <Thing/>` and
+ * `- <Thing/>` are still prose and a bullet is not a licence to open a block.
+ */
+function atFirstNonSpace(body: string, at: number): boolean {
+  let back = at - 1;
+  while (back >= 0 && (body[back] === ' ' || body[back] === '\t')) back -= 1;
+  return back < 0 || body[back] === '\n';
+}
+
 /** The lines one component contributes, attributed, with its caption kept. */
 function harvest(component: string, tag: string): string {
   const rule = HARVEST[component];
@@ -470,6 +489,8 @@ const DIRECTIVE_MARKER = /^\s*:::[A-Za-z]*\s*$/;
 const THEMATIC_BREAK = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
 /** A pipe-table row, header separator included. */
 const TABLE_ROW = /^\s*\|/;
+/** A bullet or an ordered-list marker at the head of a line. */
+const LIST_MARKER = /^\s*(?:[-*+]|\d+[.)])\s+/;
 
 /**
  * Markdown syntax → prose, one line at a time.
@@ -489,8 +510,14 @@ function markdownToText(body: string): string {
       if (DIRECTIVE_MARKER.test(line)) return '';
       if (THEMATIC_BREAK.test(line)) return '';
 
-      let out = line.replace(/^\s*#{1,6}\s+/, '');
-      out = out.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, '');
+      // A HEADING IS NOT ALSO A LIST ITEM. Running both strips over the same
+      // line ate the ordinal of `## 1. Fork and clone the repo`: the heading
+      // rule left `1. Fork and clone the repo`, which the list rule then read
+      // as a numbered bullet. The five steps of the local-development guide all
+      // came out unnumbered, so "step 3" in the prose pointed at nothing and a
+      // model reassembling the order had to guess it.
+      const heading = /^\s*#{1,6}\s+/.exec(line);
+      let out = heading ? line.slice(heading[0].length) : line.replace(LIST_MARKER, '');
       out = stripEmphasis(out);
       out = collapseLinks(out);
       return out;

--- a/packages/services/src/content/extract/mdx.ts
+++ b/packages/services/src/content/extract/mdx.ts
@@ -1,0 +1,578 @@
+/**
+ * `.mdx` documentation page → plain text, for the docs index.
+ *
+ * ── What this is, and what it is NOT ───────────────────────────────────────
+ * The sibling `html.ts` / `blocknote.ts` extractors read COURSE content, which
+ * arrives as generated HTML or as a structured editor document. This one reads
+ * the product documentation: hand-written `.mdx` under
+ * `apps/site/src/content/docs`, which is Markdown plus a small, fully
+ * enumerated set of Astro components.
+ *
+ * It PARSES. It never executes, never imports a component, never resolves an
+ * import specifier and never fetches anything an attribute names. Retrieved
+ * documentation text is EVIDENCE for an answer, never an instruction to follow:
+ * a page that says "run this command" is a page the assistant may quote, not a
+ * page that makes anything run.
+ *
+ * ── Why hand-rolled rather than an MDX parser ──────────────────────────────
+ * Not because a real parser is impossible here — a dynamically imported one
+ * would stay off every app's startup graph, exactly as this file does. Because
+ * the corpus is 25 files that are fully enumerated below, the failure modes are
+ * named, and the resulting contract is testable line by line. A mistake is
+ * recoverable by bumping {@link MDX_EXTRACT_VERSION}, which re-indexes every
+ * page on the next reconcile.
+ *
+ * ── THE CORPUS, AS OF THE DAY THIS WAS WRITTEN ─────────────────────────────
+ * Frontmatter  25/25 single-line unquoted `title` + `description`, nothing else.
+ * Imports      55 single-line default imports (22 `.astro`, 33 `.png`).
+ * JSX          27 `Screenshot`, 6 `Video`, 1 `DocCards`, 6 diagrams across five
+ *              types. All self-closing; every `Video` and the `DocCards` block
+ *              is multiline.
+ * Fences       18 (9 bash, 5 json, 1 env, 1 js, 2 untyped). Tables: 15 pipe
+ *              tables, 8 of them env-var tables.
+ * Also         headings, nested lists, emphasis, inline code, links, one
+ *              thematic break, 8 `:::note` pairs.
+ * Absent       HTML/MDX comments, paired JSX tags, blockquotes, tilde fences,
+ *              `![](…)` images, `<img>`.
+ *
+ * Anything outside that inventory is a REFUSAL, not a guess — see the fail
+ * closed rules below. "Present in the repo" must not silently become
+ * "publishable", and a shape nobody has looked at is a reason to stop.
+ *
+ * ── ORDER IS THE WHOLE DESIGN ──────────────────────────────────────────────
+ * Code is protected FIRST, before any other rule runs. Strip emphasis before
+ * protecting code and `context_servers` becomes `contextservers`,
+ * `TRIGGER_SECRET_KEY` becomes `TRIGGERSECRETKEY`, and the index answers
+ * configuration questions with identifiers that do not exist. Every later pass
+ * therefore runs over opaque sentinels, and the originals are put back last,
+ * byte for byte.
+ *
+ * Pure: no DOM, no cheerio, no JSON, no `@classmoji/database`. Bytes in, text
+ * out, never throws.
+ */
+
+/**
+ * The extractor's version, stamped on every row it produces.
+ *
+ * THE SINGLE AUTHORITY. `docsIndex.service.ts` re-exports this constant rather
+ * than declaring one of its own: two version numbers that must agree is a bug
+ * waiting for the day they do not, and the whole recovery story for an
+ * extractor mistake is "bump this, the next reconcile re-indexes everything".
+ */
+export const MDX_EXTRACT_VERSION = 1;
+
+/** The eight components the docs actually use. Anything else is a refusal. */
+export const KNOWN_MDX_COMPONENTS = [
+  'Screenshot',
+  'Video',
+  'DocCards',
+  'ModulesDiagram',
+  'GithubMappingDiagram',
+  'RolesDiagram',
+  'GradeCalculationDiagram',
+  'RepositoryPublishDiagram',
+] as const;
+
+/**
+ * What a component contributes to the text, if anything.
+ *
+ * `alt` (and `Video`'s `title`) is the only attribute harvested, and it is
+ * harvested ATTRIBUTED — prefixed with the component name — and immediately
+ * followed by that component's own `caption`, because the two can say different
+ * things about the same picture. `roster.mdx` is the worked example: its alt
+ * describes "a TA with a grader-role toggle" while its caption says "An earlier
+ * version of this screen, from when it listed assistants only". Harvesting the
+ * alt alone would put a screenshot's description into the corpus as though it
+ * were current product behaviour.
+ *
+ * `url` is deliberately NOT harvested. `Screenshot.astro` renders it as display
+ * text inside a simulated browser frame, and the values are example classroom
+ * paths (`app.classmoji.io/admin/cs-101/students`) and localhost addresses — a
+ * picture of a URL, not a destination. Indexing them would have the assistant
+ * hand people links to a classroom that does not exist.
+ *
+ * Components with no entry here contribute NOTHING. `DocCards` is the notable
+ * one: its cards are a nested JS array of `{emoji, title, description, href}`,
+ * and harvesting those would mean evaluating an attribute expression and
+ * emitting navigation URLs. The diagrams are pure illustration with no text.
+ */
+const HARVEST: Record<string, { label: string; primary: string } | undefined> = {
+  Screenshot: { label: 'Screenshot', primary: 'alt' },
+  Video: { label: 'Video', primary: 'title' },
+};
+
+/** The second attribute harvested, always alongside (never instead of) the first. */
+const CAPTION_ATTR = 'caption';
+
+export interface ExtractedMdx {
+  /**
+   * False when the source is a shape this extractor has not been taught.
+   *
+   * `text` is '' in that case. The caller is expected to branch on this and
+   * KEEP whatever it had: an unreadable page is a reason to go on answering out
+   * of the previous version, not to blank the page out of the corpus.
+   */
+  ok: boolean;
+  /** Frontmatter `title`. '' when `ok` is false. */
+  title: string;
+  /** Frontmatter `description`, or null when the page has none. */
+  description: string | null;
+  /** Title, description and body as one string, ready to embed. */
+  text: string;
+  /** Why `ok` is false. Absent when `ok`. */
+  error?: string;
+}
+
+const fail = (error: string): ExtractedMdx => ({
+  ok: false,
+  title: '',
+  description: null,
+  text: '',
+  error,
+});
+
+// ─── Pass 0: protect code ───────────────────────────────────────────────────
+
+/**
+ * The sentinel wrapper.
+ *
+ * NUL is the one byte no rule below looks at: it is not `#`, `-`, `*`, `_`,
+ * `|`, `<`, `[`, `(` or a backtick, it is not a word character (so the
+ * word-boundary emphasis rules skip it), and it cannot occur in a `.mdx` file
+ * anybody wrote. A printable sentinel would eventually collide with prose.
+ */
+const SENTINEL_OPEN = '\u0000';
+const SENTINEL_CLOSE = '\u0000';
+const sentinel = (index: number): string => `${SENTINEL_OPEN}${index}${SENTINEL_CLOSE}`;
+
+/** Every code span and fenced block, in the order they were taken out. */
+type CodeStash = string[];
+
+/**
+ * Replace fenced blocks and inline code spans with sentinels.
+ *
+ * Fences first, because a fenced block may contain backticks that are not a
+ * code span (`json` bodies containing markdown, shell heredocs), and inline
+ * scanning inside one would tear it apart.
+ *
+ * The fence DELIMITERS and the language tag are discarded; the body is stashed.
+ * A code span's backticks are discarded the same way. What comes back at the
+ * end is what a reader would copy: the command, the identifier, the JSON — and
+ * nothing that only existed to mark it as code.
+ */
+function protectCode(source: string): { text: string; stash: CodeStash } {
+  const stash: CodeStash = [];
+  const lines = source.split('\n');
+  const out: string[] = [];
+
+  for (let at = 0; at < lines.length; at += 1) {
+    const open = /^(\s*)(`{3,})(.*)$/.exec(lines[at]);
+    if (!open) {
+      out.push(lines[at]);
+      continue;
+    }
+
+    // An opening fence. Its closer is the first later line that is nothing but
+    // at least as many backticks. No closer before EOF means the rest of the
+    // file is code — which is what a reader's editor shows too.
+    const ticks = open[2].length;
+    const body: string[] = [];
+    let cursor = at + 1;
+    for (; cursor < lines.length; cursor += 1) {
+      if (new RegExp(`^\\s*\`{${ticks},}\\s*$`).test(lines[cursor])) break;
+      body.push(lines[cursor]);
+    }
+    stash.push(body.join('\n'));
+    out.push(open[1] + sentinel(stash.length - 1));
+    at = cursor; // the closing fence line itself is consumed
+  }
+
+  return { text: protectInlineCode(out.join('\n'), stash), stash };
+}
+
+/**
+ * Inline code spans, with CommonMark's longest-run rule.
+ *
+ * A span opens with a run of N backticks and closes at the next run of EXACTLY
+ * N. That is what keeps `` `a ` b` `` — a span containing a backtick — in one
+ * piece instead of two. An unclosed run is not a span and is left alone.
+ */
+function protectInlineCode(source: string, stash: CodeStash): string {
+  let out = '';
+  let at = 0;
+
+  while (at < source.length) {
+    if (source[at] !== '`') {
+      out += source[at];
+      at += 1;
+      continue;
+    }
+
+    let openEnd = at;
+    while (openEnd < source.length && source[openEnd] === '`') openEnd += 1;
+    const ticks = openEnd - at;
+
+    // Look for a closing run of exactly this length.
+    let cursor = openEnd;
+    let closeStart = -1;
+    while (cursor < source.length) {
+      if (source[cursor] !== '`') {
+        cursor += 1;
+        continue;
+      }
+      let runEnd = cursor;
+      while (runEnd < source.length && source[runEnd] === '`') runEnd += 1;
+      if (runEnd - cursor === ticks) {
+        closeStart = cursor;
+        break;
+      }
+      cursor = runEnd;
+    }
+
+    if (closeStart === -1) {
+      // Not a span at all. Emit the backticks as the literal text they are.
+      out += source.slice(at, openEnd);
+      at = openEnd;
+      continue;
+    }
+
+    stash.push(source.slice(openEnd, closeStart));
+    out += sentinel(stash.length - 1);
+    at = closeStart + ticks;
+  }
+
+  return out;
+}
+
+/** Put every stashed original back, byte for byte. */
+function restoreCode(text: string, stash: CodeStash): string {
+  return text.replace(
+    new RegExp(`${SENTINEL_OPEN}(\\d+)${SENTINEL_CLOSE}`, 'g'),
+    (whole, index: string) => {
+      const original = stash[Number(index)];
+      return original === undefined ? whole : original;
+    }
+  );
+}
+
+// ─── Pass 1: frontmatter, fail closed ───────────────────────────────────────
+
+interface Frontmatter {
+  title: string;
+  description: string | null;
+  /** Where the body starts, as an index into the line array. */
+  bodyLine: number;
+}
+
+const isDelimiter = (line: string): boolean => /^---\s*$/.test(line);
+
+/**
+ * Parse the frontmatter block, refusing anything unfamiliar.
+ *
+ * Only single-line `key: value` is accepted, quoted with one matching pair of
+ * `'` or `"` or not at all. A block scalar (`|`, `>`), a value continued on the
+ * next line, a missing closing delimiter or a missing/empty `title` is a hard
+ * refusal, NOT a best guess.
+ *
+ * The reason is the one in the file header: a frontmatter shape nobody has
+ * looked at may carry a `draft: true`, an `excluded` flag or a custom `slug`,
+ * and an extractor that shrugs at unfamiliar keys is an extractor that
+ * publishes a draft. Unknown keys with a plain scalar value are ignored, which
+ * is safe; an unknown SHAPE is not.
+ */
+function parseFrontmatter(lines: string[]): Frontmatter | { error: string } {
+  if (lines.length === 0 || !isDelimiter(lines[0])) return { error: 'frontmatter_missing' };
+
+  let close = -1;
+  for (let at = 1; at < lines.length; at += 1) {
+    if (isDelimiter(lines[at])) {
+      close = at;
+      break;
+    }
+  }
+  if (close === -1) return { error: 'frontmatter_unterminated' };
+
+  let title = '';
+  let description: string | null = null;
+
+  for (let at = 1; at < close; at += 1) {
+    const line = lines[at];
+    if (line.trim() === '') continue;
+
+    const pair = /^([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*)$/.exec(line);
+    // No `key:` at the start of the line means this is a continuation of the
+    // one above, or a nested mapping, or a list item — all shapes this refuses.
+    if (!pair) return { error: 'frontmatter_unparsed' };
+
+    const key = pair[1];
+    const raw = pair[2].trim();
+    if (/^[|>][-+0-9]*$/.test(raw)) return { error: 'frontmatter_block_scalar' };
+
+    const value = unquote(raw);
+    if (key === 'title') title = value;
+    else if (key === 'description') description = value === '' ? null : value;
+  }
+
+  if (title === '') return { error: 'frontmatter_missing_title' };
+  return { title, description, bodyLine: close + 1 };
+}
+
+/** One matching pair of surrounding quotes, or the value unchanged. */
+function unquote(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    if ((first === '"' || first === "'") && value.endsWith(first)) return value.slice(1, -1);
+  }
+  return value;
+}
+
+// ─── Pass 2: imports ────────────────────────────────────────────────────────
+
+/** `import X from './y.png';` — the only import shape the corpus has. */
+const IMPORT_LINE = /^import\s+[A-Za-z_$][\w$]*\s+from\s+(['"])[^'"]+\1;?\s*$/;
+
+/** Anything that LOOKS like an import statement, for the refusal below. */
+const IMPORT_ISH = /^import\s.*\sfrom\s/;
+
+// ─── Pass 3: JSX ────────────────────────────────────────────────────────────
+
+interface TagScan {
+  /** Where the tag ends, exclusive, as an index into the whole body string. */
+  end: number;
+  /** True for `/>`; a bare `>` means a paired element, which is refused. */
+  selfClosing: boolean;
+}
+
+/**
+ * Find the end of a JSX tag that starts at `from`, string-aware.
+ *
+ * A depth-only scanner is not enough and the corpus proves it: `grading.mdx:19`
+ * carries `alt="Settings > Grades showing the emoji-to-value mappings…"`, and a
+ * scanner that stops at the first `>` truncates that alt mid-sentence and
+ * leaves `…button" frame url="…" size="lg" />` behind as prose. So quoted
+ * attribute strings are tracked, and `{}`/`[]`/`()` nesting is counted only
+ * OUTSIDE them — which is also what lets the multiline `<Video>` blocks and
+ * `DocCards`' nested array close correctly.
+ */
+function scanTag(body: string, from: number): TagScan | null {
+  let quote: string | null = null;
+  let depth = 0;
+
+  for (let at = from; at < body.length; at += 1) {
+    const ch = body[at];
+
+    if (quote) {
+      if (ch === '\\') at += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth += 1;
+      continue;
+    }
+    if (ch === '}' || ch === ']' || ch === ')') {
+      depth -= 1;
+      continue;
+    }
+    if (depth !== 0) continue;
+
+    if (ch === '/' && body[at + 1] === '>') return { end: at + 2, selfClosing: true };
+    if (ch === '>') return { end: at + 1, selfClosing: false };
+  }
+
+  return null;
+}
+
+/**
+ * Read one string-valued attribute out of a tag.
+ *
+ * String literals only. `src={img}` and `poster={getStartedIntroImg.src}` are
+ * expressions: this never evaluates one, never resolves what it names and never
+ * fetches it. An attribute whose value is an expression simply has no value
+ * here.
+ */
+function stringAttribute(tag: string, name: string): string | null {
+  const pattern = new RegExp(`\\b${name}\\s*=\\s*(['"])([\\s\\S]*?)\\1`);
+  const found = pattern.exec(tag);
+  return found ? found[2].trim() : null;
+}
+
+/**
+ * Replace every JSX element with its harvested text (usually nothing).
+ *
+ * Returns an error instead when the corpus has grown a shape nobody decided
+ * about: an unknown component name, a paired element, or a tag that never
+ * closes. A new component is a DECISION — does its text belong in the corpus,
+ * and under what attribution — not something to delete quietly and ship.
+ */
+function stripJsx(body: string): { text: string } | { error: string } {
+  let out = '';
+  let at = 0;
+
+  while (at < body.length) {
+    // A block opens only where a line does: `<` mid-sentence is prose, and the
+    // corpus has no inline JSX.
+    const atLineStart = at === 0 || body[at - 1] === '\n';
+    if (!atLineStart || body[at] !== '<') {
+      out += body[at];
+      at += 1;
+      continue;
+    }
+
+    const name = /^<([A-Za-z][A-Za-z0-9]*)/.exec(body.slice(at, at + 64));
+    if (!name || !/^[A-Z]/.test(name[1])) {
+      out += body[at];
+      at += 1;
+      continue;
+    }
+
+    const component = name[1];
+    if (!(KNOWN_MDX_COMPONENTS as readonly string[]).includes(component)) {
+      return { error: 'unknown_component' };
+    }
+
+    const scanned = scanTag(body, at);
+    if (!scanned) return { error: 'unclosed_component' };
+    if (!scanned.selfClosing) return { error: 'paired_component' };
+
+    const tag = body.slice(at, scanned.end);
+    out += harvest(component, tag);
+    at = scanned.end;
+  }
+
+  return { text: out };
+}
+
+/** The lines one component contributes, attributed, with its caption kept. */
+function harvest(component: string, tag: string): string {
+  const rule = HARVEST[component];
+  if (!rule) return '';
+
+  const lines: string[] = [];
+  const primary = stringAttribute(tag, rule.primary);
+  if (primary) lines.push(`${rule.label}: ${primary}`);
+  const caption = stringAttribute(tag, CAPTION_ATTR);
+  if (caption) lines.push(caption);
+
+  return lines.length ? lines.join('\n') : '';
+}
+
+// ─── Pass 4: markdown ───────────────────────────────────────────────────────
+
+/** `:::note`, `:::tip`, `:::caution`, `:::danger` and the bare `:::` closer. */
+const DIRECTIVE_MARKER = /^\s*:::[A-Za-z]*\s*$/;
+/** A thematic break, once frontmatter is already gone. */
+const THEMATIC_BREAK = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
+/** A pipe-table row, header separator included. */
+const TABLE_ROW = /^\s*\|/;
+
+/**
+ * Markdown syntax → prose, one line at a time.
+ *
+ * TABLES ARE LEFT EXACTLY AS THEY ARE. Eight of the fifteen tables in the
+ * corpus are env-var tables, where the association between a name, whether it
+ * is required, its default and its description IS the content. Reflowing those
+ * cells into a sentence, or dropping an empty "Default" cell, produces text
+ * that reads fluently and answers wrongly. Pipes cost a few characters and keep
+ * every row's columns lined up with its header.
+ */
+function markdownToText(body: string): string {
+  return body
+    .split('\n')
+    .map(line => {
+      if (TABLE_ROW.test(line)) return line;
+      if (DIRECTIVE_MARKER.test(line)) return '';
+      if (THEMATIC_BREAK.test(line)) return '';
+
+      let out = line.replace(/^\s*#{1,6}\s+/, '');
+      out = out.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, '');
+      out = stripEmphasis(out);
+      out = collapseLinks(out);
+      return out;
+    })
+    .join('\n');
+}
+
+/**
+ * Drop emphasis markers, ONLY at word boundaries.
+ *
+ * `snake_case_identifiers` and `__dunder__` names appear in prose outside code
+ * spans, and a naive `_` strip turns `_acme-challenge` into `acme-challenge` —
+ * a DNS record name that does not exist. Requiring a non-word character (or the
+ * line edge) on the outside of each marker is what separates emphasis from an
+ * identifier.
+ */
+function stripEmphasis(line: string): string {
+  return line
+    .replace(/\*\*(?=\S)([^*]*\S)\*\*/g, '$1')
+    .replace(/(^|[^*\w])\*(?=\S)([^*\n]*\S)\*(?![*\w])/g, '$1$2')
+    .replace(/(^|[^_\w])_(?=\S)([^_\n]*\S)_(?![_\w])/g, '$1$2');
+}
+
+/** `[text](url)` → `text`, and `![alt](url)` → `alt`. The URL is dropped. */
+function collapseLinks(line: string): string {
+  return line.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1').replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+}
+
+// ─── The extractor ──────────────────────────────────────────────────────────
+
+/**
+ * Extract plain text from one documentation `.mdx` page.
+ *
+ * NEVER THROWS. The indexer runs it over 25 files in a loop and reports per
+ * page; an exception there would abandon the pages after it.
+ */
+export function extractMdxText(source: string): ExtractedMdx {
+  if (typeof source !== 'string' || source.trim() === '') return fail('empty_source');
+
+  try {
+    // Pass 0 — code first, before any rule that could rewrite an identifier.
+    const protectedSource = protectCode(source.replace(/\r\n/g, '\n'));
+    const lines = protectedSource.text.split('\n');
+
+    // Pass 1 — frontmatter, fail closed.
+    const front = parseFrontmatter(lines);
+    if ('error' in front) return fail(front.error);
+
+    // Pass 2 — imports.
+    const bodyLines: string[] = [];
+    for (const line of lines.slice(front.bodyLine)) {
+      if (IMPORT_LINE.test(line)) continue;
+      // An import-shaped line that is not the shape above — a brace import, a
+      // multiline one — is a refusal rather than prose leaked into the corpus.
+      if (IMPORT_ISH.test(line)) return fail('unknown_import');
+      bodyLines.push(line);
+    }
+
+    // Pass 3 — JSX.
+    const stripped = stripJsx(bodyLines.join('\n'));
+    if ('error' in stripped) return fail(stripped.error);
+
+    // Pass 4 — markdown.
+    const prose = markdownToText(stripped.text);
+
+    // Pass 5 — assemble, then put the code back LAST so it is exactly what it
+    // was. (The plan collapses newlines after restoring; doing it before is
+    // strictly safer — a fence whose body contains a blank run keeps it.)
+    const collapsed = prose.replace(/\n{3,}/g, '\n\n');
+    const body = restoreCode(collapsed, protectedSource.stash).trim();
+    const title = restoreCode(front.title, protectedSource.stash);
+    const description =
+      front.description === null ? null : restoreCode(front.description, protectedSource.stash);
+
+    // A page whose body trims to nothing is still a SUCCESS with its title and
+    // description: that is a real (if thin) page, and §3 decides what to do
+    // with a thin one. Only an unreadable page is `ok: false`.
+    const header = description === null ? title : `${title}\n${description}`;
+    const text = body ? `${header}\n\n${body}` : header;
+
+    return { ok: true, title, description, text };
+  } catch (caught) {
+    return fail(`extraction failed: ${caught instanceof Error ? caught.message : String(caught)}`);
+  }
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -188,11 +188,10 @@ export {
   getDocText,
   docsIndexIsEmpty,
   DocsNotFoundError,
-  DEFAULT_DOCS_SEARCH_LIMIT,
-  MAX_DOCS_SEARCH_LIMIT,
-  DEFAULT_DOCS_LIST_LIMIT,
-  MAX_DOCS_LIST_LIMIT,
-  DOCS_SNIPPET_CHARS,
+  // The limit/snippet bounds are NOT re-declared here: both scopes share the
+  // course lane's `SNIPPET_CHARS`/`*_SEARCH_LIMIT`/`*_LIST_LIMIT` above, so the
+  // tool schema's single `limit` field cannot drift from the service's clamp.
+  DOCS_SEARCH_MIN_CHARS,
 } from './classmoji/docsSearch.service.ts';
 export type {
   DocsSearchHit,

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -169,6 +169,40 @@ export type {
   GetContentTextArgs,
 } from './classmoji/contentSearch.service.ts';
 
+// PRODUCT DOCUMENTATION search: the second, classroom-independent corpus behind
+// the same three MCP tools under `scope: 'docs'`. Exported flat for the same
+// reason `contentSearch` is — the tool layer consumes the argument and result
+// types directly.
+//
+// THE SAME CONSTRAINT APPLIES, for the same reason: `docsSearch.service.ts`
+// must never statically import `./content/extract` (cheerio) or
+// `./helpers/workersAi`. It takes an already-embedded vector and reads `text`
+// straight back out of the index, so it needs neither.
+//
+// The WRITE side (`docsIndex.service.ts`) is deliberately NOT here. It reaches
+// the extractor and the embedding client, and only the Trigger task calls it —
+// through `ClassmojiService.docsIndex`.
+export {
+  searchDocs,
+  listDocs,
+  getDocText,
+  docsIndexIsEmpty,
+  DocsNotFoundError,
+  DEFAULT_DOCS_SEARCH_LIMIT,
+  MAX_DOCS_SEARCH_LIMIT,
+  DEFAULT_DOCS_LIST_LIMIT,
+  MAX_DOCS_LIST_LIMIT,
+  DOCS_SNIPPET_CHARS,
+} from './classmoji/docsSearch.service.ts';
+export type {
+  DocsSearchHit,
+  SearchDocsArgs,
+  DocsListEntry,
+  ListDocsArgs,
+  DocsListPage,
+  DocsDocumentText,
+} from './classmoji/docsSearch.service.ts';
+
 // Instructor audience for the newsletter segment. The mail-provider mechanics
 // that act on the answer live in the scheduled task that consumes it.
 export {

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -15,6 +15,7 @@ import * as classroomImportTasks from './workflows/classroomImport.ts';
 import * as customDomainTasks from './workflows/customDomains.ts';
 import * as contentAssetTasks from './workflows/contentAssets.ts';
 import * as contentIndexTasks from './workflows/contentIndexReconcile.ts';
+import * as docsIndexTasks from './workflows/docsIndexReconcile.ts';
 import * as deckThumbnailTasks from './workflows/deckThumbnail.ts';
 import * as instructorContactTasks from './workflows/instructorContacts.ts';
 
@@ -38,6 +39,7 @@ const Tasks = {
   ...customDomainTasks,
   ...contentAssetTasks,
   ...contentIndexTasks,
+  ...docsIndexTasks,
   ...deckThumbnailTasks,
   ...instructorContactTasks,
 };

--- a/packages/tasks/src/workflows/__tests__/docsIndexReconcile.test.ts
+++ b/packages/tasks/src/workflows/__tests__/docsIndexReconcile.test.ts
@@ -1,0 +1,209 @@
+/**
+ * The docs-index tasks.
+ *
+ * The engine lives in `@classmoji/services` and has its own suites. What is
+ * asserted here is the WIRING — the part that is invisible until it is wrong in
+ * production:
+ *
+ *   - both task ids sit on ONE shared queue at `concurrencyLimit: 1`.
+ *     Trigger.dev gives each task id its own queue unless told otherwise, so
+ *     two separate `concurrencyLimit: 1` declarations would serialize each task
+ *     against itself and do nothing about a manual backfill racing the
+ *     schedule — which is the realistic case, because a backfill is triggered
+ *     by hand exactly when somebody is impatient. The run ends in a sweep, so
+ *     that race deletes live pages;
+ *   - the cron slot is clear of the six existing ones;
+ *   - the report is RETURNED, not only logged, and logged ONCE, whole;
+ *   - the payload is validated BEFORE `run`, and an unknown key is a HARD
+ *     FAILURE rather than a silent "use the defaults".
+ *
+ * `@trigger.dev/sdk` and `@classmoji/services` are mocked, so `run` is called
+ * directly and nothing reaches Trigger, Postgres, GitHub or Cloudflare.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reconcileDocsIndex = vi.fn();
+const loggerInfo = vi.fn();
+
+type SchemaTaskConfig = {
+  id: string;
+  schema: (input: unknown) => unknown;
+  run: (payload: unknown) => Promise<unknown>;
+};
+
+vi.mock('@trigger.dev/sdk', () => ({
+  schedules: { task: (config: unknown) => config },
+  // Keeps the real contract: the schema runs BEFORE `run`, which is the whole
+  // point of `schemaTask`.
+  schemaTask: (config: SchemaTaskConfig) => ({
+    ...config,
+    run: async (payload: unknown) => config.run(config.schema(payload)),
+  }),
+  logger: { info: (...a: unknown[]) => loggerInfo(...a), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@classmoji/services', () => ({
+  ClassmojiService: {
+    docsIndex: { reconcileDocsIndex: (...a: unknown[]) => reconcileDocsIndex(...a) },
+  },
+}));
+
+const {
+  DOCS_INDEX_QUEUE,
+  docsIndexBackfillTask,
+  docsIndexReconcileTask,
+  parseDocsBackfillPayload,
+} = await import('../docsIndexReconcile.ts');
+
+type TaskConfig = {
+  id: string;
+  cron?: string;
+  queue?: { name?: string; concurrencyLimit?: number };
+  run: (payload?: unknown) => Promise<unknown>;
+};
+
+const scheduled = docsIndexReconcileTask as unknown as TaskConfig;
+const backfill = docsIndexBackfillTask as unknown as TaskConfig;
+
+const REPORT = {
+  commit: 'a'.repeat(40),
+  pages: 30,
+  eligible: 25,
+  indexed: 25,
+  skipped: 0,
+  failed: 0,
+  deleted: 0,
+  byReason: { indexed: 25 },
+  bySlug: [],
+};
+
+beforeEach(() => {
+  reconcileDocsIndex.mockReset().mockResolvedValue(REPORT);
+  loggerInfo.mockReset();
+});
+
+describe('both tasks share ONE queue', () => {
+  it('declares the same queue name and a concurrency limit of 1 on both', () => {
+    expect(scheduled.queue).toEqual({ name: 'docs-index', concurrencyLimit: 1 });
+    expect(backfill.queue).toEqual({ name: 'docs-index', concurrencyLimit: 1 });
+    expect(scheduled.queue).toBe(backfill.queue);
+    expect(DOCS_INDEX_QUEUE).toEqual({ name: 'docs-index', concurrencyLimit: 1 });
+  });
+
+  it('says so in the SOURCE too, so a refactor cannot split them silently', () => {
+    // The object identity above is satisfied by two tasks sharing a constant
+    // that itself lost its `name`. This reads the file.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(resolve(here, '..', 'docsIndexReconcile.ts'), 'utf8');
+    // Comments talk about `concurrencyLimit: 1` at length; the count below is
+    // about the CODE.
+    const code = source
+      .split('\n')
+      .filter(line => !/^\s*(?:\/\/|\*|\/\*)/.test(line))
+      .join('\n');
+
+    expect(code).toMatch(/name:\s*'docs-index'/);
+    expect(code).toMatch(/concurrencyLimit:\s*1/);
+    // Exactly one queue declaration, referenced by both tasks.
+    expect(code.match(/queue:\s*DOCS_INDEX_QUEUE/g) ?? []).toHaveLength(2);
+    expect(code.match(/concurrencyLimit:/g) ?? []).toHaveLength(1);
+  });
+});
+
+describe('the schedule', () => {
+  it('runs at 06:10 UTC, clear of every existing cron', () => {
+    expect(scheduled.id).toBe('docs-index-reconcile');
+    expect(scheduled.cron).toBe('10 6 * * *');
+
+    // The six slots already taken, read from their own files rather than
+    // remembered: a sibling moving its cron onto this one must fail here.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const siblings = [
+      'notifications.ts',
+      'gitRepoAssignment.ts',
+      'customDomains.ts',
+      'contentAssets.ts',
+      'contentIndexReconcile.ts',
+      'instructorContacts.ts',
+    ];
+    const taken = siblings.flatMap(file => {
+      const source = readFileSync(resolve(here, '..', file), 'utf8');
+      return [...source.matchAll(/^\s*cron:\s*'([^']+)'/gm)].map(match => match[1]);
+    });
+    expect(taken.length).toBeGreaterThan(0);
+    expect(taken).not.toContain(scheduled.cron);
+  });
+
+  it('RETURNS the report as well as logging it, once, whole', async () => {
+    const returned = await scheduled.run();
+
+    expect(returned).toEqual(REPORT);
+    expect(loggerInfo).toHaveBeenCalledTimes(1);
+    const [, payload] = loggerInfo.mock.calls[0] as [string, Record<string, unknown>];
+    // The commit sha rides along: this indexes the latest `main`, which may be
+    // ahead of the deployed site, and that has to be visible rather than
+    // inferred.
+    expect(payload.commit).toBe(REPORT.commit);
+    expect(payload.indexed).toBe(25);
+  });
+
+  it('takes no payload of its own', async () => {
+    await scheduled.run();
+    expect(reconcileDocsIndex).toHaveBeenCalledWith();
+  });
+});
+
+describe('the backfill payload is validated before the run', () => {
+  it.each([[undefined], [null], [{}], [{ concurrency: 1 }], [{ concurrency: 8 }]])(
+    'accepts %j',
+    input => {
+      expect(() => parseDocsBackfillPayload(input)).not.toThrow();
+    }
+  );
+
+  it('keeps a valid concurrency and passes it through', async () => {
+    expect(parseDocsBackfillPayload({ concurrency: 2 })).toEqual({ concurrency: 2 });
+    await backfill.run({ concurrency: 2 });
+    expect(reconcileDocsIndex).toHaveBeenCalledWith({ concurrency: 2 });
+  });
+
+  it('passes NO options at all for an empty payload', async () => {
+    await backfill.run({});
+    expect(reconcileDocsIndex).toHaveBeenCalledWith({});
+  });
+
+  it.each([
+    [{ concurrency: 0 }, /between 1 and 8/],
+    [{ concurrency: 9 }, /between 1 and 8/],
+    [{ concurrency: -1 }, /between 1 and 8/],
+    [{ concurrency: 1.5 }, /between 1 and 8/],
+    [{ concurrency: '2' }, /between 1 and 8/],
+    // Copied from the CONTENT backfill, which does take it. The docs corpus is
+    // classroom-independent, so this key can only be a mistake — and silently
+    // ignoring it would run the whole fleet-wide job the operator thought they
+    // had narrowed.
+    [{ classroomIds: ['11111111-1111-4111-8111-111111111111'] }, /unknown payload key/],
+    [{ Concurrency: 2 }, /unknown payload key/],
+    [{ concurrency: 2, extra: true }, /unknown payload key/],
+    [[], /must be an object/],
+    ['2', /must be an object/],
+  ])('rejects %j', (input, message) => {
+    expect(() => parseDocsBackfillPayload(input)).toThrow(message);
+  });
+
+  it('refuses BEFORE the engine is called, not after', async () => {
+    await expect(backfill.run({ classroomIds: ['x'] })).rejects.toThrow(/unknown payload key/);
+    expect(reconcileDocsIndex).not.toHaveBeenCalled();
+  });
+
+  it('is the same engine as the schedule, not a second implementation', async () => {
+    await scheduled.run();
+    await backfill.run({});
+    expect(reconcileDocsIndex).toHaveBeenCalledTimes(2);
+    expect(backfill.id).toBe('docs-index-backfill');
+  });
+});

--- a/packages/tasks/src/workflows/docsIndexReconcile.ts
+++ b/packages/tasks/src/workflows/docsIndexReconcile.ts
@@ -1,0 +1,167 @@
+import { schemaTask, schedules, logger } from '@trigger.dev/sdk';
+import { ClassmojiService } from '@classmoji/services';
+
+/**
+ * Bring `docs_index` level with the documentation on `main`.
+ *
+ * ── What it does, and why the FIRST run is the whole feature ───────────────
+ * Unlike the course index, there is no save-time hook here and there never
+ * will be: the documentation lives in a git repo that this platform does not
+ * host, and nothing in the webapp knows when somebody merges a docs PR. This
+ * task is therefore the ONLY writer's only caller, and until it has run once on
+ * a deployment, `content_search` with `scope: 'docs'` answers with the
+ * `docs_index_empty` marker rather than with content.
+ *
+ * ── BOTH TASKS SHARE ONE QUEUE, AND THAT IS LOAD-BEARING ───────────────────
+ * The reconcile ends with a sweep — every slug not in that run's tree is
+ * deleted — so two overlapping runs are not merely wasteful, they are
+ * destructive: a slow run pinned to commit A finishing after a run pinned to
+ * commit B deletes the pages B introduced. The damage then heals itself at the
+ * next nightly, which is exactly why nobody would notice a day of wrong
+ * answers.
+ *
+ * Trigger.dev gives each task id its OWN queue unless they are told to share
+ * one, so `concurrencyLimit: 1` on two separate task definitions would serialize
+ * each task against itself and do nothing at all about the scheduled run and a
+ * manual backfill overlapping — which is the realistic case, because a backfill
+ * is triggered by hand precisely when somebody is impatient. Hence the explicit
+ * shared `name: 'docs-index'`.
+ *
+ * The advisory lock inside `reconcileDocsIndex` is the second belt, for callers
+ * that are not Trigger at all.
+ *
+ * ── The report is the readiness signal ─────────────────────────────────────
+ * Returned as well as logged, on ONE line, whole. "Is the docs index ready" has
+ * to be answerable without reading a log for individual lines. Readiness is
+ * `!halted && !error && failed === 0` — NOT `!error` alone: `lock_held` is the
+ * serialization working and `not_configured` is a deployment with no Workers AI
+ * credentials, and neither is an error, but neither indexed anything either.
+ */
+
+/**
+ * 06:10 UTC daily.
+ *
+ * Clear of all six existing crons (`15 3`, `1 4`, `40 4`, `25 5`, `45 5`,
+ * `50 5`) and twenty-five minutes after `content-index-reconcile`. With
+ * `maxDuration: 900` an ordinary on-time overlap is unlikely — but a delayed
+ * run and a manual backfill both remain possible, which is what the shared
+ * queue and the advisory lock are actually for. The gap is hygiene, not a
+ * guarantee.
+ */
+const RECONCILE_CRON = '10 6 * * *';
+
+/**
+ * The ONE queue both task ids sit on.
+ *
+ * Declared here rather than written out twice, so a future edit cannot move one
+ * task off it and leave the other looking fine.
+ */
+export const DOCS_INDEX_QUEUE = { name: 'docs-index', concurrencyLimit: 1 } as const;
+
+export const docsIndexReconcileTask = schedules.task({
+  id: 'docs-index-reconcile',
+  cron: RECONCILE_CRON,
+  queue: DOCS_INDEX_QUEUE,
+  run: async () => {
+    const report = await ClassmojiService.docsIndex.reconcileDocsIndex();
+    // ONE line, with the whole report on it — the commit sha included, because
+    // this indexes the latest `main`, which may be ahead of the deployed site.
+    logger.info('Reconciled the docs index', { ...report });
+    return report;
+  },
+});
+
+export interface DocsIndexBackfillPayload {
+  concurrency?: number;
+}
+
+/**
+ * Everything the payload may contain.
+ *
+ * Just the one. There is no `classroomIds` here and there cannot be: the docs
+ * corpus is fleet-wide and classroom-independent, which is the entire reason it
+ * is a separate table.
+ */
+const PAYLOAD_KEYS = ['concurrency'] as const;
+
+/**
+ * How many pages may be in flight at once.
+ *
+ * Each is a raw fetch plus a Workers AI embed call, so concurrency here is
+ * concurrency against github.com and Cloudflare. Eight is already past the
+ * point where a backfill starts competing with live traffic for the same rate
+ * limits.
+ */
+const MAX_CONCURRENCY = 8;
+
+const reject = (message: string): never => {
+  throw new Error(`[docs-index-backfill] ${message}`);
+};
+
+/**
+ * Strict payload validation, run by `schemaTask` BEFORE `run`.
+ *
+ * Hand-written rather than a Zod schema for the same reason as its siblings:
+ * `@classmoji/tasks` does not depend on Zod, and `schemaTask` accepts a plain
+ * validator.
+ *
+ * UNKNOWN KEYS ARE A HARD FAILURE. A payload the operator believed narrowed or
+ * shaped the run — `{ "classroomIds": [...] }` copied from the content
+ * backfill, `{ "Concurrency": 2 }` with a capital C — must fail loudly rather
+ * than quietly mean "the defaults" at whatever hour it was triggered.
+ */
+export const parseDocsBackfillPayload = (input: unknown): DocsIndexBackfillPayload => {
+  if (input === undefined || input === null) return {};
+
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    reject('payload must be an object');
+  }
+
+  const raw = input as Record<string, unknown>;
+  const unknown = Object.keys(raw).filter(
+    key => !(PAYLOAD_KEYS as readonly string[]).includes(key)
+  );
+  if (unknown.length > 0) {
+    reject(
+      `unknown payload key(s): ${unknown.join(', ')} — expected only ${PAYLOAD_KEYS.join(', ')}`
+    );
+  }
+
+  const payload: DocsIndexBackfillPayload = {};
+
+  if (raw.concurrency !== undefined) {
+    const value = raw.concurrency;
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 1 ||
+      value > MAX_CONCURRENCY
+    ) {
+      reject(`concurrency must be an integer between 1 and ${MAX_CONCURRENCY}`);
+    }
+    payload.concurrency = value as number;
+  }
+
+  return payload;
+};
+
+/**
+ * The same run, on demand.
+ *
+ * This is the one that matters on a fresh deployment: the schedule covers
+ * tomorrow, and "the docs index has not been built here yet" is a state that
+ * wants fixing now. Same engine, same report, so there is no second
+ * implementation to drift — and the same queue, so it cannot race the schedule.
+ */
+export const docsIndexBackfillTask = schemaTask({
+  id: 'docs-index-backfill',
+  schema: parseDocsBackfillPayload,
+  queue: DOCS_INDEX_QUEUE,
+  run: async (payload: DocsIndexBackfillPayload) => {
+    const report = await ClassmojiService.docsIndex.reconcileDocsIndex({
+      ...(payload?.concurrency ? { concurrency: payload.concurrency } : {}),
+    });
+    logger.info('Backfilled the docs index', { ...report });
+    return report;
+  },
+});

--- a/packages/utils/src/__tests__/docs.test.ts
+++ b/packages/utils/src/__tests__/docs.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The documentation URL builder.
+ *
+ * One definition serves the MCP's hit `url` and the Ask Moji widget's chip, so
+ * what is pinned here is that the two cannot produce different strings — and
+ * that a malformed slug produces NO link rather than a link to nowhere.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DOCS_SITE_BASE_URL, docsUrl, isDocsSlug } from '../docs.ts';
+
+describe('docsUrl', () => {
+  it.each([
+    ['docs', 'https://classmoji.io/docs'],
+    ['docs/instructors', 'https://classmoji.io/docs/instructors'],
+    ['docs/instructors/roster', 'https://classmoji.io/docs/instructors/roster'],
+    [
+      'docs/open-source/local-development',
+      'https://classmoji.io/docs/open-source/local-development',
+    ],
+    ['docs/video-tutorials', 'https://classmoji.io/docs/video-tutorials'],
+  ])('%s → %s', (slug, url) => {
+    expect(docsUrl(slug)).toBe(url);
+  });
+
+  it('builds on the one canonical origin, with no double slash', () => {
+    expect(docsUrl('docs/instructors/roster')).toBe(
+      `${DOCS_SITE_BASE_URL}/docs/instructors/roster`
+    );
+    expect(docsUrl('docs')).not.toContain('//docs');
+  });
+
+  it.each([
+    ['quizzes', 'a bare doc name from the old /docs/{name} scheme'],
+    ['assignments', 'another one'],
+    ['docs/../admin', 'traversal'],
+    ['../../etc/passwd', 'traversal from the root'],
+    ['/docs/instructors/roster', 'an absolute path — the slug carries no leading slash'],
+    ['docs/instructors/roster/', 'a trailing slash'],
+    ['docs/Instructors/Roster', 'uppercase — slugs are lowercase'],
+    ['docs/instructors/roster.mdx', 'the file extension, which the slug never carries'],
+    ['https://evil.example/docs', 'an absolute URL'],
+    ['docs//instructors', 'an empty segment'],
+    ['docs/-leading-dash', 'a segment starting with a dash'],
+    ['', 'empty'],
+  ])('refuses %s (%s)', slug => {
+    expect(docsUrl(slug)).toBeNull();
+    expect(isDocsSlug(slug)).toBe(false);
+  });
+
+  it('refuses anything that is not a string', () => {
+    for (const value of [null, undefined, 42, {}, ['docs']]) {
+      expect(docsUrl(value)).toBeNull();
+      expect(isDocsSlug(value)).toBe(false);
+    }
+  });
+
+  it('is a SHAPE guard, not an existence check — and says so', () => {
+    // Documented explicitly so nobody reads a passing slug as a live page.
+    expect(docsUrl('docs/instructors/made-up-feature')).toBe(
+      'https://classmoji.io/docs/instructors/made-up-feature'
+    );
+  });
+});

--- a/packages/utils/src/docs.ts
+++ b/packages/utils/src/docs.ts
@@ -1,0 +1,57 @@
+/**
+ * The product documentation's canonical origin and URL shape.
+ *
+ * ── Why this lives in `@classmoji/utils` and not in either caller ──────────
+ * Two places build a link to the same documentation page, and they must not be
+ * able to disagree:
+ *
+ *   - the MCP's `content_search` with `scope: 'docs'`, which puts a `url` on
+ *     every hit the model reads;
+ *   - the Ask Moji widget in the webapp, which turns a `platform_docs`
+ *     reference into the chip a student actually clicks.
+ *
+ * If those two ever produce different strings for the same slug, the model
+ * cites one link and the user is handed another. `@classmoji/utils` has zero
+ * dependencies and is already imported by client components, so one definition
+ * reaches both — which is why this is NOT an environment variable. A `SITE_URL`
+ * would need plumbing into the widget's init payload, a turbo `globalEnv`
+ * entry, an Infisical secret and a fallback for when it is missing, and the
+ * fallback is the thing that would drift.
+ *
+ * The docs site is one public origin for the whole fleet. It does not vary by
+ * deployment, and a staging build citing a staging docs site would be citing
+ * pages that do not exist.
+ */
+
+/** Where `classmoji.io/docs` is served from. One origin, fleet-wide. */
+export const DOCS_SITE_BASE_URL = 'https://classmoji.io';
+
+/**
+ * A documentation slug, as `docs_index` stores it and as search hands it back.
+ *
+ * `docs`, `docs/instructors`, `docs/instructors/roster`. No leading slash, no
+ * `.mdx`, no trailing `/index` — the slug IS the path under the origin above.
+ *
+ * THIS IS A SHAPE GUARD, NOT AN EXISTENCE CHECK. It blocks traversal
+ * (`docs/../admin`), absolute paths and anything outside the docs tree. It says
+ * nothing about whether the page is real: `docs/instructors/made-up-feature`
+ * passes, and so does the `/docs/docs/instructors` typo that exists in the
+ * corpus today. Only the index knows what exists, and a caller that has a hit
+ * from the index already knows.
+ */
+const DOCS_SLUG = /^docs(\/[a-z0-9][a-z0-9-]*)*$/;
+
+export const isDocsSlug = (slug: unknown): slug is string =>
+  typeof slug === 'string' && DOCS_SLUG.test(slug);
+
+/**
+ * The absolute URL for a documentation slug, or null when the slug is malformed.
+ *
+ * Returning null rather than a best-effort string is deliberate: the caller's
+ * choice is then "render a link" or "render text", and neither of those is a
+ * clickable link to nowhere.
+ */
+export function docsUrl(slug: unknown): string | null {
+  if (!isDocsSlug(slug)) return null;
+  return `${DOCS_SITE_BASE_URL}/${slug}`;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,6 +21,7 @@ export * from './grades.ts';
 export * from './emojis.ts';
 export * from './quiz.ts';
 export * from './content.ts';
+export * from './docs.ts';
 export * from './cloudinaryVideos.ts';
 export * from './repoNames.ts';
 export * from './subdomains.ts';


### PR DESCRIPTION
## What this does

Ask Moji (and any MCP client) can now search and read the Classmoji documentation site the same way it reads course pages, so "where do I add a TA?" is answered from the real docs page with a link instead of a guess.

- **`docs_index`** table (pgvector, same column pattern as `content_index`, no classroom, no visibility: docs are public to every member).
- **MDX extractor** for the 25 Starlight pages: code fences and inline code protected before any transform and restored byte-exact, string-aware JSX scanning, screenshot alt text kept with its caption, frontmatter fail-closed, unknown shapes refuse rather than leak. All 25 live pages extract clean.
- **Nightly reconcile** (`docs-index-reconcile`, 06:10 UTC, plus a manual task on the same single-concurrency queue) reads the public repo tree at a pinned commit, refuses truncated or empty trees, holds a Postgres advisory lock on one dedicated connection, and reports per page.
- **Tools:** `content_search` and `content_list` gain `scope: 'course' | 'docs'` (course stays the default); `content_get` accepts `kind: 'doc'` with the slug as id. Docs hits carry an absolute URL. A `docs_index_empty` marker is distinct from an empty result. Section-index navigation stubs are excluded from search hits by a 400-character minimum (still listable and readable).
- **Widget:** `platform_docs` references now link to `classmoji.io/<slug>`; a reference the widget cannot link renders as text, not a dead link.

## Rollout (two stages, on purpose)

This is Stage 1: migration, services, tasks, utils, MCP, webapp. The ai-agent prompt that teaches the bot the docs scope ships separately (classmoji/ai-agent#10 and a pointer bump) after the docs reconcile has run once on staging, so the prompt never references a scope the MCP can't serve. Run `docs-index-reconcile` on staging before Stage 2.

## Tests

services 2,091 · tasks 268 · utils 168 · mcp 685 unit + 27 integration (docs scenarios run credential-free against a fake embedder) · webapp 896 incl. a real render test for the chips. Docs DB suites run against a disposable database created from the migrations. Reviewed plan-vs-code by two agents; 83 mutation checks all caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hnzySrj9w9zUJZBtfDADd